### PR TITLE
feat: add progress bar for eval runs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pandas
 gspread
 gspread-dataframe
 PyYAML
-tqdm
+alive-progress
 pandas-gbq
 google-cloud-bigquery
 google-cloud-ces

--- a/src/cxas_scrapi/evals/guardrail_evals.py
+++ b/src/cxas_scrapi/evals/guardrail_evals.py
@@ -21,9 +21,9 @@ import time
 from typing import Annotated, Any, Dict, List, NamedTuple, Optional
 
 import pandas as pd
+from alive_progress import alive_it
 from google.protobuf.json_format import MessageToDict
 from pydantic import BaseModel, BeforeValidator, Field
-from tqdm import tqdm
 
 from cxas_scrapi.core.agents import Agents
 from cxas_scrapi.core.apps import Apps
@@ -194,8 +194,8 @@ class GuardrailEvals:
             )
 
         results = []
-        for index, row in tqdm(
-            df.iterrows(), total=len(df), desc="Running Guardrail Tests"
+        for index, row in alive_it(
+            df.iterrows(), total=len(df), title="Running Guardrail Tests"
         ):
             # Replace NaNs with None for Pydantic validation
             row_dict = {

--- a/src/cxas_scrapi/evals/simulation_evals.py
+++ b/src/cxas_scrapi/evals/simulation_evals.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, List, Optional
 
 import pandas as pd
 import pydantic
+from alive_progress import alive_it
 
 from cxas_scrapi.core.apps import Apps
 from cxas_scrapi.core.sessions import Sessions
@@ -673,7 +674,7 @@ class SimulationEvals(Apps):
                 }
 
         if parallel <= 1:
-            for tc, run_idx in jobs:
+            for tc, run_idx in alive_it(jobs, title="Running Simulations"):
                 results.append(_run_job(tc, run_idx))
         else:
             max_workers = min(parallel, 25)
@@ -685,7 +686,10 @@ class SimulationEvals(Apps):
                     )
                     for tc, run_idx in jobs
                 }
-                for future in as_completed(futures):
+                for future in alive_it(
+                    as_completed(futures), total=len(futures),
+                    title="Running Simulations"
+                ):
                     results.append(future.result())
 
         return results

--- a/src/cxas_scrapi/evals/turn_evals.py
+++ b/src/cxas_scrapi/evals/turn_evals.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, List, Optional
 
 import pandas as pd
 import yaml
+from alive_progress import alive_it
 from google.protobuf.json_format import MessageToDict
 from pydantic import BaseModel, Field, TypeAdapter, model_validator
 
@@ -665,7 +666,7 @@ class TurnEvals:
             print(f"Error in dependency resolution: {e}")
             raise
 
-        for case in sorted_cases:
+        for case in alive_it(sorted_cases, title="Running Turn Tests"):
             print(f"Running Turn Test: {case.name}")
 
             try:


### PR DESCRIPTION
Description

This PR introduces real-time terminal progress bars to the CXAS SCRAPI testing suite. Previously, running large sets of simulation or turn evaluations provided no immediate visual feedback on the completion rate, making it difficult to track the progress of long-running executions.

We have implemented alive-progress across all evaluation loops to provide a clean, animated progress bar with execution statistics.

Changes Made

Dependency Addition: Added alive-progress to requirements.txt.
Simulation Evals (simulation_evals.py): Wrapped both sequential and parallel execution loops with alive_it(..., title="Running Simulations").
Turn Evals (turn_evals.py): Wrapped the topological sort execution loop with alive_it(..., title="Running Turn Tests").
Guardrail Evals (guardrail_evals.py): Standardized by wrapping the dataframe iteration loop with alive_it(..., title="Running Guardrail Tests") and replaced tqdm.