### PR TITLE
fix(linter): accept display names in S004 child agent references

### DIFF
--- a/src/cxas_scrapi/utils/lint_rules/structure.py
+++ b/src/cxas_scrapi/utils/lint_rules/structure.py
@@ -192,8 +192,11 @@ class ChildAgentReferences(Rule):
 
         results = []
         child_agents = agent_config.get("childAgents", [])
+        valid_agents = (
+            context.all_agent_names | context.all_agent_display_names
+        )
         for child_name in child_agents:
-            if child_name not in context.all_agent_names:
+            if child_name not in valid_agents:
                 results.append(
                     self.make_result(
                         str(file_path),
@@ -202,7 +205,7 @@ class ChildAgentReferences(Rule):
                             f" '{child_name}' but no"
                             " agent directory found."
                             " Available agents:"
-                            f" {sorted(context.all_agent_names)}"
+                            f" {sorted(valid_agents)}"
                         ),
                         fix="Create the agent directory or fix the reference",
                     )

--- a/tests/cxas_scrapi/utils/test_lint_rules.py
+++ b/tests/cxas_scrapi/utils/test_lint_rules.py
@@ -1389,3 +1389,16 @@ def test_s004_no_children(tmp_path, context):
 
     results = rule.check(f, f.read_text(), context)
     assert len(results) == 0
+
+
+def test_s004_child_agent_by_display_name(tmp_path, context):
+    """Reference by display name (with space) should be accepted (S004)."""
+    from cxas_scrapi.utils.lint_rules.structure import ChildAgentReferences  # noqa: PLC0415,I001
+
+    rule = ChildAgentReferences()
+    f = tmp_path / "root_agent.json"
+    # 'billing agent' is the display name for directory 'billing_agent'
+    f.write_text('{"childAgents": ["billing agent"]}')
+
+    results = rule.check(f, f.read_text(), context)
+    assert len(results) == 0


### PR DESCRIPTION
## Summary
- `ChildAgentReferences` (S004) now matches `childAgents` entries against both directory names and display names, mirroring the existing pattern in `instructions.py:333`.
- Adds regression test `test_s004_child_agent_by_display_name`.

Fixes #16

## Test plan
- [x] `uv run pytest tests/cxas_scrapi/utils/test_lint_rules.py -k s004` (4 passed)
