### PR TITLE
docs: fix setup instructions across documentation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
-    -   id: trail-whitespace
+    -   id: trailing-whitespace
     -   id: end-of-file-fixer
 #    -   id: check-yaml
 #    -   id: check-added-large-files

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ history.
 
 
 <!-- AUTHENTICATION -->
-# Authentication  
+# Authentication
 Authentication can vary depending on how and where you are interacting with SCRAPI.
 
 ## Google Colab
@@ -64,7 +64,7 @@ apps_map = app_client.get_apps_map()
 ```
 ---
 ## Cloud Functions / Cloud Run
-If you're using CXAS SCRAPI with [Cloud Functions](https://cloud.google.com/functions) or [Cloud Run](https://cloud.google.com/run), CXAS SCRAPI can pick up on the default environment creds used by these services without any additional configuration! 
+If you're using CXAS SCRAPI with [Cloud Functions](https://cloud.google.com/functions) or [Cloud Run](https://cloud.google.com/run), CXAS SCRAPI can pick up on the default environment creds used by these services without any additional configuration!
 
 1. Add `cxas-scrapi` to your `requirements.txt` file
 2. Ensure the Cloud Function / Cloud Run service account has the appropriate Custom Agent / Conversational Agents IAM Role
@@ -88,7 +88,7 @@ Similar to Cloud Functions / Cloud Run, CXAS SCRAPI can pick up on your local au
 4. Run `gcloud auth application-default login`
 5. Run `gcloud auth list` to ensure your principal account is active.
 
-This will authenticate your principal GCP account with the gcloud CLI, and SCRAPI can pick up the creds from here.  
+This will authenticate your principal GCP account with the gcloud CLI, and SCRAPI can pick up the creds from here.
 
 ---
 ## Exceptions and Misc.
@@ -113,8 +113,8 @@ gcloud auth application-default login
 gcloud config set project <project name>
 ```
 ```sh
-python3 -m venv venv
-source ./venv/bin/activate
+python3 -m venv .venv
+source ./.venv/bin/activate
 pip install -r requirements.txt
 ```
 
@@ -194,7 +194,7 @@ Distributed under the Apache 2.0 License. See [LICENSE](LICENSE.txt) for more in
 
 <!-- CONTACT -->
 # Contact
-Patrick Marlow - [pmarlow@google.com](mailto:pmarlow@google.com) - [@kmaphoenix](https://github.com/kmaphoenix)  
+Patrick Marlow - [pmarlow@google.com](mailto:pmarlow@google.com) - [@kmaphoenix](https://github.com/kmaphoenix)
 
 Project Link: [https://github.com/GoogleCloudPlatform/cxas-scrapi](https://github.com/GoogleCloudPlatform/cxas-scrapi)
 

--- a/docs/api/core/common.md
+++ b/docs/api/core/common.md
@@ -1,0 +1,13 @@
+---
+title: Common
+---
+
+# Common
+
+`Common` is the authentication base class that all other CXAS SCRAPI classes inherit from. It handles GCP credential management and shared utilities, so you don't need to worry about authentication plumbing in subclasses.
+
+You typically won't instantiate `Common` directly — instead, you'll use classes like `Apps`, `Agents`, or `Sessions` that inherit from it.
+
+## Reference
+
+::: cxas_scrapi.core.common.Common

--- a/docs/contributing/development-setup.md
+++ b/docs/contributing/development-setup.md
@@ -26,8 +26,8 @@ cd cxas-scrapi
 We recommend using a virtual environment to keep your dependencies isolated:
 
 ```bash
-python3 -m venv venv
-source venv/bin/activate  # On Windows: venv\Scripts\activate
+python3 -m venv .venv
+source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 ```
 
 ## Install in Editable Mode
@@ -35,10 +35,11 @@ source venv/bin/activate  # On Windows: venv\Scripts\activate
 Install the package in editable mode so that your code changes are immediately reflected without reinstalling:
 
 ```bash
-pip install -e ".[dev]"
+pip install -e .
+pip install -r requirements.txt
 ```
 
-This installs SCRAPI along with all development dependencies (ruff, pytest, etc.).
+This installs SCRAPI along with all development dependencies (ruff, pytest, etc.) and additional runtime dependencies.
 
 If you also want to build the documentation locally:
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -39,15 +39,15 @@ It's a good habit to install Python packages inside a virtual environment rather
 === "venv (built-in)"
 
     ```sh
-    # Create a virtual environment called "venv"
-    python -m venv venv
+    # Create a virtual environment called ".venv"
+    python -m venv .venv
 
     # Activate it
     # On macOS / Linux:
-    source venv/bin/activate
+    source .venv/bin/activate
 
     # On Windows:
-    venv\Scripts\activate
+    .venv\Scripts\activate
     ```
 
 === "conda"
@@ -78,7 +78,7 @@ That's it. pip will download and install `cxas-scrapi` and all of its dependenci
 
 ## Install from source
 
-If you want to work with the latest unreleased code, or if you're contributing to SCRAPI itself, you can install directly from the GitHub repository:
+If you want to work with the latest unreleased code, you can install directly from the GitHub repository. If you're contributing to SCRAPI, see the [Development Setup](../contributing/development-setup.md) guide instead.
 
 ```sh
 # Clone the repository
@@ -87,6 +87,7 @@ cd cxas-scrapi
 
 # Install in editable mode (changes to the source are reflected immediately)
 pip install -e .
+pip install -r requirements.txt
 ```
 
 The `-e` flag (editable install) means Python points directly to the source files in your cloned directory, so any edits you make are picked up immediately without reinstalling.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -201,6 +201,7 @@ nav:
   - API Reference:
     - api/index.md
     - Core:
+      - api/core/common.md
       - api/core/apps.md
       - api/core/agents.md
       - api/core/sessions.md

--- a/src/cxas_scrapi/core/apps.py
+++ b/src/cxas_scrapi/core/apps.py
@@ -89,7 +89,7 @@ class Apps(Common):
 
         Args:
             display_name: human-readable display name of CX Agent Studio App as
-            a string.
+                a string.
 
         Returns:
             CX Agent Studio App resource object. If no app is found,

--- a/src/cxas_scrapi/core/evaluations.py
+++ b/src/cxas_scrapi/core/evaluations.py
@@ -248,7 +248,7 @@ class Evaluations(Common):
         return out_yaml
 
     @staticmethod
-    def process_export_operation(export_op) -> Optional[bytes]:
+    def process_export_operation(export_op: Any) -> Optional[bytes]:
         """Processes the export operation and returns app content bytes.
 
         Args:

--- a/src/cxas_scrapi/core/sessions.py
+++ b/src/cxas_scrapi/core/sessions.py
@@ -767,37 +767,37 @@ class Sessions(Common):
 
         Args:
             session_id: Unique UUID string or identifying string (e.g. 'test1')
-            for the session.
+                for the session.
             text: Text input from the user. Can give a single string or list of
-            strings.
+                strings.
             dtmf: DTMF input from the user.
             event: Name of a system event to trigger (e.g. 'WELCOME').
             event_vars: Key-value map of variables to inject alongside the
-            event.
+                event.
             blob: Raw binary content (image, pdf, etc.) for multimodal inputs.
             blob_mime_type: Mime type for the blob (defaults to
-            'application/octet-stream').
+                'application/octet-stream').
             variables: Key-value state maps to inject for the session turn.
             tool_responses: Pre-computed tool run outputs if mocking tool
-            execution.
+                execution.
             audio: Raw audio bytes to send as user input.
             audio_config: Custom turn-specific audio configurations.
             input_audio_config: Custom gRPC properties for input audio
-            (defaults to 16kHz linear PCM).
+                (defaults to 16kHz linear PCM).
             output_audio_config: Custom gRPC properties for output audio
-            (defaults to 16kHz linear PCM).
+                (defaults to 16kHz linear PCM).
             deployment_id: Overrides the default deployment ID setting for this
-            turn run.
+                turn run.
             version_id: Overrides the default app version setting for this turn
-            run.
+                run.
             historical_contexts: An existing conversation ID (string) or raw
-            list of dictionaries to pre-set past history.
+                list of dictionaries to pre-set past history.
             turn_count: Truncates historical context limits when pulling from a
-            saved conversation ID.
+                saved conversation ID.
             modality: Running via text (synced) or audio (asynchronous
-            bidirectional streaming). Defaults to Modality.TEXT.
+                bidirectional streaming). Defaults to Modality.TEXT.
             use_tool_fakes: Use fake tools for the session if available.
-            Defaults to False.
+                Defaults to False.
         """
 
         if isinstance(modality, str):

--- a/src/cxas_scrapi/evals/tool_evals.py
+++ b/src/cxas_scrapi/evals/tool_evals.py
@@ -95,7 +95,7 @@ class Expectation(BaseModel):
 class ToolEvals:
     """Utility class for testing CXAS Tools."""
 
-    def __init__(self, app_name: str, creds=None):
+    def __init__(self, app_name: str, creds: Any = None):
         """Initializes the ToolEvals class.
 
         Args:


### PR DESCRIPTION
Rename venv directory from "venv" to ".venv" to follow modern Python conventions, add missing "pip install -r requirements.txt" step, correct "pip install -e .[dev]" to "pip install -e ." (no dev extras defined), and redirect contributors from install-from-source to the development setup guide.

Also fix typo in .pre-commit-config.yaml: "trail-whitespace" ->
"trailing-whitespace".