### PR TITLE
feat(evals): capture and render agent transfers and custom payloads i…

### DIFF
--- a/.agents/skills/cxas-agent-foundry/scripts/scrapi-sim-runner.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/scrapi-sim-runner.py
@@ -506,6 +506,10 @@ function jumpToRun(evalName, runIdx) {{
                                 parsed_lines.append(("tool_call", line))
                             elif line.startswith("Tool Response"):
                                 parsed_lines.append(("tool_resp", line))
+                            elif line.startswith("Agent Transfer:"):
+                                parsed_lines.append(("agent_transfer", line[len("Agent Transfer:"):].strip()))
+                            elif line.startswith("Custom Payload:"):
+                                parsed_lines.append(("custom_payload", line[len("Custom Payload:"):].strip()))
                             else:
                                 parsed_lines.append(("system", line))
 
@@ -544,6 +548,11 @@ function jumpToRun(evalName, runIdx) {{
                             if result:
                                 html += f'<pre class="tool-data">{_escape(result)}</pre>'
                             html += '</details>\n'
+                        elif kind == "agent_transfer":
+                            html += f'<div class="tool-details" style="background:#e8f4fd;border-left-color:#2980b9;"><div class="tool-summary" style="color:#2471a3;">&#10132; <b>Agent Transfer:</b> {_escape(item[1])}</div></div>\n'
+                        elif kind == "custom_payload":
+                            html += f'<details class="tool-details" style="background:#fff8e1;border-left-color:#f39c12;"><summary class="tool-summary" style="color:#b7950b;">&#128230; <b>Custom Payload</b></summary>'
+                            html += f'<pre class="tool-data">{_escape(item[1])}</pre></details>\n'
                         else:
                             html += f'<div class="system">{_escape(item[1])}</div>\n'
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
 #    -   id: check-added-large-files
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.5
+    rev: v0.15.12
     hooks:
     -   id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
-    -   id: trail-whitespace
+    -   id: trailing-whitespace
     -   id: end-of-file-fixer
 #    -   id: check-yaml
 #    -   id: check-added-large-files

--- a/src/cxas_scrapi/evals/simulation_evals.py
+++ b/src/cxas_scrapi/evals/simulation_evals.py
@@ -403,6 +403,15 @@ class SimulationEvals(Apps):
             trace_chunks.append(
                 f"Tool Response: {tool_name} with result {expanded_response}"
             )
+        elif chunk_type == "agent_transfer":
+            at = chunk.agent_transfer
+            display_name = getattr(at, "display_name", "unknown")
+            trace_chunks.append(
+                f"Agent Transfer: Transferred to {display_name}"
+            )
+        elif chunk_type == "payload":
+            expanded_payload = Sessions._expand_pb_struct(chunk.payload)
+            trace_chunks.append(f"Custom Payload: {expanded_payload}")
         elif chunk_type == "text":
             agent_text_add = chunk.text + " "
             trace_chunks.append(f"Agent Text (Diag): {chunk.text}")
@@ -687,8 +696,9 @@ class SimulationEvals(Apps):
                     for tc, run_idx in jobs
                 }
                 for future in alive_it(
-                    as_completed(futures), total=len(futures),
-                    title="Running Simulations"
+                    as_completed(futures),
+                    total=len(futures),
+                    title="Running Simulations",
                 ):
                     results.append(future.result())
 

--- a/src/cxas_scrapi/utils/reporting.py
+++ b/src/cxas_scrapi/utils/reporting.py
@@ -365,6 +365,20 @@ def _parse_trace(trace, tools_map):
                 parsed_lines.append(("tool_call", formatted_line))
             elif formatted_line.startswith("Tool Response"):
                 parsed_lines.append(("tool_resp", formatted_line))
+            elif formatted_line.startswith("Agent Transfer:"):
+                parsed_lines.append(
+                    (
+                        "agent_transfer",
+                        formatted_line[len("Agent Transfer:") :].strip(),
+                    )
+                )
+            elif formatted_line.startswith("Custom Payload:"):
+                parsed_lines.append(
+                    (
+                        "custom_payload",
+                        formatted_line[len("Custom Payload:") :].strip(),
+                    )
+                )
             else:
                 parsed_lines.append(("system", formatted_line))
     return parsed_lines
@@ -428,6 +442,19 @@ def _render_merged_items(merged):
             if result:
                 html += f'<pre class="tool-data">{_escape(result)}</pre>'
             html += "</details>\n"
+        elif kind == "agent_transfer":
+            html += (
+                f'<div class="system">&#128256; <b>Agent Transfer:</b>'
+                f" {_escape(item[1])}</div>\n"
+            )
+        elif kind == "custom_payload":
+            html += (
+                f'<details class="tool-details">'
+                f'<summary class="tool-summary">'
+                f"&#128230; <b>Custom Payload</b></summary>"
+                f'<pre class="tool-data">{_escape(item[1])}</pre>'
+                f"</details>\n"
+            )
         else:
             html += f'<div class="system">{_escape(item[1])}</div>\n'
     return html

--- a/tests/cxas_scrapi/evals/test_simulation_evals.py
+++ b/tests/cxas_scrapi/evals/test_simulation_evals.py
@@ -17,6 +17,7 @@
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
+
 from cxas_scrapi.evals.simulation_evals import (
     LLMUserConversation,
     SimulationEvals,

--- a/tests/cxas_scrapi/evals/test_simulation_evals.py
+++ b/tests/cxas_scrapi/evals/test_simulation_evals.py
@@ -17,7 +17,6 @@
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
-
 from cxas_scrapi.evals.simulation_evals import (
     LLMUserConversation,
     SimulationEvals,
@@ -307,6 +306,73 @@ def test_parse_agent_response_standard():
 
     assert agent_text == "Hello there"
     assert any("Tool Call (Output): some_tool" in c for c in trace_chunks)
+    assert not session_ended
+
+
+def test_parse_agent_response_agent_transfer():
+    mock_response = MagicMock()
+    mock_output = MagicMock()
+    mock_output.text = ""
+
+    mock_msg = MagicMock()
+    mock_msg.role = "model"
+    mock_chunk = MagicMock()
+    mock_chunk._pb.WhichOneof.return_value = "agent_transfer"
+    mock_chunk.agent_transfer.display_name = "Billing Agent"
+    mock_msg.chunks = [mock_chunk]
+
+    mock_diag = MagicMock()
+    mock_diag.messages = [mock_msg]
+    mock_output.diagnostic_info = mock_diag
+    mock_response.outputs = [mock_output]
+
+    app_name = "projects/test/locations/us/apps/123-abc"
+    with patch("cxas_scrapi.evals.simulation_evals.GeminiGenerate"):
+        with patch("cxas_scrapi.core.apps.AgentServiceClient"):
+            simulator = SimulationEvals(app_name=app_name)
+
+    agent_text, trace_chunks, session_ended = simulator._parse_agent_response(
+        mock_response
+    )
+
+    assert any(
+        "Agent Transfer: Transferred to Billing Agent" in c
+        for c in trace_chunks
+    )
+    assert not session_ended
+
+
+def test_parse_agent_response_custom_payload():
+    mock_response = MagicMock()
+    mock_output = MagicMock()
+    mock_output.text = ""
+
+    mock_msg = MagicMock()
+    mock_msg.role = "model"
+    mock_chunk = MagicMock()
+    mock_chunk._pb.WhichOneof.return_value = "payload"
+    mock_chunk.payload = {"key": "value"}
+    mock_msg.chunks = [mock_chunk]
+
+    mock_diag = MagicMock()
+    mock_diag.messages = [mock_msg]
+    mock_output.diagnostic_info = mock_diag
+    mock_response.outputs = [mock_output]
+
+    app_name = "projects/test/locations/us/apps/123-abc"
+    with patch("cxas_scrapi.evals.simulation_evals.GeminiGenerate"):
+        with patch("cxas_scrapi.core.apps.AgentServiceClient"):
+            simulator = SimulationEvals(app_name=app_name)
+
+    with patch(
+        "cxas_scrapi.evals.simulation_evals.Sessions._expand_pb_struct",
+        return_value={"key": "value"},
+    ):
+        agent_text, trace_chunks, session_ended = (
+            simulator._parse_agent_response(mock_response)
+        )
+
+    assert any("Custom Payload:" in c for c in trace_chunks)
     assert not session_ended
 
 


### PR DESCRIPTION
Add agent_transfer and custom payload chunk handling to the simulation trace pipeline so these events are visible in HTML reports alongside tool calls — transfers as styled inline blocks, payloads as collapsible dropdowns.