### PR TITLE
fix: scope TOOL_INPUT/OUTPUT justification to failure  and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ Authentication can vary depending on how and where you are interacting with SCRA
 
 ## Google Colab
 If you're using CXAS SCRAPI with a [Google Colab](https://colab.research.google.com/) notebook, you can add the following to the top of your notebook for easy authentication:
+
+```py
+pip install cxas-scrapi
+```
+
 ```py
 project_id = '<YOUR_GCP_PROJECT_ID>'
 
@@ -155,6 +160,8 @@ The `src/cxas_scrapi/migration` directory contains tools to facilitate transitio
 
 <!-- DOCUMENTATION -->
 # Documentation
+
+The full documentation site [CXAS SCRAPI](https://googlecloudplatform.github.io/cxas-scrapi)
 
 The full documentation site is built with [MkDocs Material](https://squidfunk.github.io/mkdocs-material/). To run it locally:
 

--- a/src/cxas_scrapi/evals/turn_evals.py
+++ b/src/cxas_scrapi/evals/turn_evals.py
@@ -515,11 +515,11 @@ class TurnEvals:
                             break
                     if not match_found:
                         status = "FAILURE"
-                    justification = (
-                        f"TOOL_INPUT failed: No tool call contained "
-                        f"matching arguments {expected}. Actual tool "
-                        f"inputs: {tool_inputs}"
-                    )
+                        justification = (
+                            f"TOOL_INPUT failed: No tool call contained "
+                            f"matching arguments {expected}. Actual tool "
+                            f"inputs: {tool_inputs}"
+                        )
             elif op == TurnOperator.TOOL_OUTPUT:
                 actual = str(tool_outputs)
                 if not isinstance(expected, dict):
@@ -542,11 +542,11 @@ class TurnEvals:
                             break
                     if not match_found:
                         status = "FAILURE"
-                    justification = (
-                        f"TOOL_OUTPUT failed: No tool response "
-                        f"contained matching outputs {expected}. "
-                        f"Actual tool outputs: {tool_outputs}"
-                    )
+                        justification = (
+                            f"TOOL_OUTPUT failed: No tool response "
+                            f"contained matching outputs {expected}. "
+                            f"Actual tool outputs: {tool_outputs}"
+                        )
 
             results.append(
                 {


### PR DESCRIPTION
## Summary

This PR ships eval bug fix alongside README improvements for
better user onboarding and documentation discoverability.

## Bug Fix — `turn_evals.py`

`justification` for `TOOL_INPUT` and `TOOL_OUTPUT` checks in
`validate_turn_test` was unconditionally assigned after the
`if not match_found:` block, so passing tests still carried a failure
message in the results. Indented both `justification = (...)` assignments
inside their `if not match_found:` blocks so the string is only written
on actual failure.

**Root cause:** Off-by-one indentation at lines 518 and 545 in
`src/cxas_scrapi/evals/turn_evals.py` — the justification string was a
sibling of the `if` statement rather than its body.

**Impact:** Every `TOOL_INPUT` and `TOOL_OUTPUT` eval result previously
carried a non-empty failure justification regardless of outcome, making
sim reports misleading and causing downstream consumers to misread passing
tests as failures.

## Documentation — `README.md`

**User onboarding improvements:**
- Added a `pip install cxas-scrapi` snippet to the Google Colab section
  so users can set up the package without hunting for install instructions

**Documentation enhancements:**
- Added a prominent link to the full documentation site at the top of the
  Documentation section for easier discoverability

## Testing
- [x] Passing `TOOL_INPUT`/`TOOL_OUTPUT` expectation → `justification` is empty
- [x] Failing `TOOL_INPUT`/`TOOL_OUTPUT` expectation → `justification` contains the failure detail
- [x] README renders correctly on GitHub — Colab snippet and docs link display as expected
