### PR TITLE
fix: update app_id to app_name in CLI

### DIFF
--- a/src/cxas_scrapi/cli/app.py
+++ b/src/cxas_scrapi/cli/app.py
@@ -124,22 +124,22 @@ def app_push(args: argparse.Namespace) -> Optional[str]:  # noqa: C901
     print(f"Pushing app from {app_dir}...")
 
     target_app = getattr(args, "to", None)
-    app_id_arg = getattr(args, "app_name", None)
-    identifier = target_app or app_id_arg
+    app_name_arg = getattr(args, "app_name", None)
+    identifier = target_app or app_name_arg
 
     if identifier:
-        apps_client, app_id, display_name = _resolve_app_args(identifier, args)
+        apps_client, app_name, display_name = _resolve_app_args(identifier, args)
         print("Pushing to existing app... Overwriting if supported.")
     else:
         apps_client = Apps(project_id=args.project_id, location=args.location)
-        app_id = None
+        app_name = None
         print("No target specified, using existing name if needed.")
         display_name = getattr(args, "display_name", None) or "Pushed Agent"
 
     _app_push(
         app_dir=app_dir,
         apps_client=apps_client,
-        target_app_name=getattr(args, "app_name", None) or app_id,
+        target_app_name=getattr(args, "app_name", None) or app_name,
         identifier=getattr(args, "to", None) or getattr(args, "app_name", None),
         display_name=getattr(args, "display_name", None) or display_name,
         env_file=getattr(args, "env_file", None),
@@ -238,7 +238,7 @@ def app_create(args: argparse.Namespace) -> None:
     apps_client = Apps(project_id=args.project_id, location=args.location)
     try:
         app = apps_client.create_app(
-            app_id=getattr(args, "app_name", None),
+            app_id=getattr(args, "app_id", None),
             display_name=args.name,
             description=args.description,
         )

--- a/src/cxas_scrapi/cli/app.py
+++ b/src/cxas_scrapi/cli/app.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 def _resolve_app_args(
     app_identifier: str, args: argparse.Namespace
 ) -> tuple[Apps, str, str]:
-    """Resolves project, location, Apps client, app_id, and display_name."""
+    """Resolves project, location, Apps client, app_name, and display_name."""
     project_id = (
         Common._get_project_id(app_identifier)
         if Common._get_project_id(app_identifier)
@@ -54,19 +54,19 @@ def _resolve_app_args(
         sys.exit(1)
 
     apps_client = Apps(project_id=project_id, location=location)
-    app_id = app_identifier
+    app_name = app_identifier
     display_name = app_identifier
 
     if "projects/" not in app_identifier:
         app = apps_client.get_app_by_display_name(app_identifier)
         if app:
-            app_id = app.name
+            app_name = app.name
             display_name = app.display_name
         else:
             print(f"App '{app_identifier}' not found.")
             sys.exit(1)
 
-    return apps_client, app_id, display_name
+    return apps_client, app_name, display_name
 
 
 def _handle_import_result(result: Any, success_verb: str) -> Optional[str]:
@@ -89,17 +89,17 @@ def app_pull(args: argparse.Namespace) -> None:
     """Handles the 'pull' command."""
     print(f"Pulling app: {args.app}")
 
-    apps_client, app_id, _ = _resolve_app_args(args.app, args)
+    apps_client, app_name, _ = _resolve_app_args(args.app, args)
 
-    _app_pull(apps_client, app_id, args.target_dir)
+    _app_pull(apps_client, app_name, args.target_dir)
 
 
-def _app_pull(apps_client: Apps, app_id: str, target_dir: str) -> None:
+def _app_pull(apps_client: Apps, app_name: str, target_dir: str) -> None:
     """Helper to pull an app from CXAS."""
     try:
         # Export the app
         print("Exporting app from CXAS...")
-        lro = apps_client.export_app(app_name=app_id)
+        lro = apps_client.export_app(app_name=app_name)
         response = lro.result()
 
         # Determine the target directory
@@ -217,7 +217,7 @@ def _app_push(
             if "apps/" in target_app_id:
                 target_app_id = target_app_id.rsplit("apps/", maxsplit=1)[-1]
             result = apps_client.import_app(
-                app_name=target_app_id, app_content=app_content
+                app_name=target_app_name, app_content=app_content
             )
         else:
             result = apps_client.import_as_new_app(
@@ -260,12 +260,12 @@ def app_delete(args: argparse.Namespace) -> None:
         print(f"Deleting App: {app_name_arg}")
         project_id = Common._get_project_id(app_name_arg)
         location = Common._get_location(app_name_arg)
-        app_id = app_name_arg
+        app_name = app_name_arg
     elif args.display_name and args.project_id and args.location:
         print(f"Deleting App by Display Name: {args.display_name}")
         project_id = args.project_id
         location = args.location
-        app_id = None
+        app_name = None
     else:
         print(
             "Error: Must provide either --app_name OR "
@@ -280,12 +280,12 @@ def app_delete(args: argparse.Namespace) -> None:
     apps_client = Apps(project_id=project_id, location=location)
 
     try:
-        if not app_id:
+        if not app_name:
             # Lookup by display name
             app = apps_client.get_app_by_display_name(args.display_name)
             if app:
-                app_id = app.name
-                print(f"Found app ID: {app_id}")
+                app_name = app.name
+                print(f"Found app ID: {app_name}")
             else:
                 print(
                     f"App with display name '{args.display_name}' "
@@ -293,8 +293,8 @@ def app_delete(args: argparse.Namespace) -> None:
                 )
                 return
 
-        apps_client.delete_app(app_name=app_id, force=args.force)
-        print(f"Successfully deleted {app_id}")
+        apps_client.delete_app(app_name=app_name, force=args.force)
+        print(f"Successfully deleted {app_name}")
     except Exception as e:
         print(f"Failed to delete app: {e}")
         sys.exit(1)
@@ -370,10 +370,10 @@ def apps_get(args: argparse.Namespace) -> None:
     """Handles the 'apps get' command."""
     print(f"Getting app: {args.app}")
 
-    apps_client, app_id, _ = _resolve_app_args(args.app, args)
+    apps_client, app_name, _ = _resolve_app_args(args.app, args)
 
     try:
-        app = apps_client.get_app(app_id=app_id)
+        app = apps_client.get_app(app_name=app_name)
         print("\nApp Details:")
         print(f"Name: {app.name}")
         print(f"Display Name: {app.display_name}")

--- a/src/cxas_scrapi/cli/app.py
+++ b/src/cxas_scrapi/cli/app.py
@@ -128,7 +128,8 @@ def app_push(args: argparse.Namespace) -> Optional[str]:  # noqa: C901
     identifier = target_app or app_name_arg
 
     if identifier:
-        apps_client, app_name, display_name = _resolve_app_args(identifier, args)
+        apps_client, app_name, display_name = _resolve_app_args(
+            identifier, args)
         print("Pushing to existing app... Overwriting if supported.")
     else:
         apps_client = Apps(project_id=args.project_id, location=args.location)

--- a/src/cxas_scrapi/cli/app.py
+++ b/src/cxas_scrapi/cli/app.py
@@ -124,7 +124,7 @@ def app_push(args: argparse.Namespace) -> Optional[str]:  # noqa: C901
     print(f"Pushing app from {app_dir}...")
 
     target_app = getattr(args, "to", None)
-    app_id_arg = getattr(args, "app_id", None)
+    app_id_arg = getattr(args, "app_name", None)
     identifier = target_app or app_id_arg
 
     if identifier:
@@ -139,8 +139,8 @@ def app_push(args: argparse.Namespace) -> Optional[str]:  # noqa: C901
     _app_push(
         app_dir=app_dir,
         apps_client=apps_client,
-        target_app_id=getattr(args, "app_id", None) or app_id,
-        identifier=getattr(args, "to", None) or getattr(args, "app_id", None),
+        target_app_name=getattr(args, "app_name", None) or app_id,
+        identifier=getattr(args, "to", None) or getattr(args, "app_name", None),
         display_name=getattr(args, "display_name", None) or display_name,
         env_file=getattr(args, "env_file", None),
     )
@@ -149,7 +149,7 @@ def app_push(args: argparse.Namespace) -> Optional[str]:  # noqa: C901
 def _app_push(
     app_dir: str,
     apps_client: Apps = None,
-    target_app_id: str = None,
+    target_app_name: str = None,
     identifier: str = None,
     display_name: str = None,
     env_file: str = None,
@@ -212,10 +212,7 @@ def _app_push(
         # provided display_name.
         print("Uploading to CES...")
 
-        if target_app_id:
-            # Extract UUID if full resource name provided.
-            if "apps/" in target_app_id:
-                target_app_id = target_app_id.rsplit("apps/", maxsplit=1)[-1]
+        if target_app_name:
             result = apps_client.import_app(
                 app_name=target_app_name, app_content=app_content
             )
@@ -305,13 +302,13 @@ def app_branch(args: argparse.Namespace) -> None:
     print(f"Branching from {args.source} to {args.new_name}")
     # Composite operation: pull existing, create new, push content.
 
-    apps_client, app_id, _ = _resolve_app_args(args.source, args)
+    apps_client, app_name, _ = _resolve_app_args(args.source, args)
     env_file = getattr(args, "env_file", None)
 
     with tempfile.TemporaryDirectory() as temp_dir:
         try:
             print("Pulling source app...")
-            _app_pull(apps_client, app_id, temp_dir)
+            _app_pull(apps_client, app_name, temp_dir)
 
             extracted_dirs = [
                 d

--- a/tests/cxas_scrapi/cli/test_app.py
+++ b/tests/cxas_scrapi/cli/test_app.py
@@ -27,7 +27,7 @@ from cxas_scrapi.cli import app as cli_app
 
 @pytest.fixture
 def mock_apps_client():
-    with mock.patch("cxas_scrapi.cli.app.Apps") as mock_apps_class:
+    with mock.patch("cxas_scrapi.cli.app.Apps", autospec=True) as mock_apps_class:
         mock_instance = mock_apps_class.return_value
         yield mock_instance
 
@@ -36,6 +36,7 @@ def mock_apps_client():
 def mock_common_get_project_id():
     with mock.patch(
         "cxas_scrapi.cli.app.Common._get_project_id",
+        autospec=True,
         return_value="dummy-project",
     ) as m:
         yield m
@@ -45,6 +46,7 @@ def mock_common_get_project_id():
 def mock_common_get_location():
     with mock.patch(
         "cxas_scrapi.cli.app.Common._get_location",
+        autospec=True,
         return_value="dummy-location",
     ) as m:
         yield m
@@ -117,7 +119,7 @@ def test_apps_get(
     cli_app.apps_get(args)
 
     mock_apps_client.get_app.assert_called_once_with(
-        app_id="projects/test-project/locations/us/apps/123"
+        app_name="projects/test-project/locations/us/apps/123"
     )
     captured = capsys.readouterr()
     assert "My App" in captured.out

--- a/tests/cxas_scrapi/cli/test_app.py
+++ b/tests/cxas_scrapi/cli/test_app.py
@@ -27,7 +27,8 @@ from cxas_scrapi.cli import app as cli_app
 
 @pytest.fixture
 def mock_apps_client():
-    with mock.patch("cxas_scrapi.cli.app.Apps", autospec=True) as mock_apps_class:
+    with mock.patch(
+        "cxas_scrapi.cli.app.Apps", autospec=True) as mock_apps_class:
         mock_instance = mock_apps_class.return_value
         yield mock_instance
 


### PR DESCRIPTION
Some CLI methods were still using the older `app_id` arg.  
Updated throughout to consistently use `app_name` 

Also updated pytests to catch this in future.