### PR TITLE
feat(linter): add I014 rule to warn when current_date is missing from…

### DIFF
--- a/src/cxas_scrapi/utils/lint_rules/instructions.py
+++ b/src/cxas_scrapi/utils/lint_rules/instructions.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Instruction lint rules (I001-I013).
+"""Instruction lint rules (I001-I014).
 
 Validates agent instruction files against GECX design guide best practices.
 """
@@ -521,4 +521,72 @@ class ToolNotInConfig(Rule):
                 fix=f"Add '{ref}' to tools array, or remove the reference.",
             )
             for ref in sorted(missing)
+        ]
+
+
+@rule("instructions")
+class MissingCurrentDate(Rule):
+    id = "I014"
+    name = "missing-current-date"
+    description = (
+        "Instruction should reference ${current_date} so the"
+        " agent knows today's date"
+    )
+    default_severity = Severity.WARNING
+
+    VALID_PATTERNS = re.compile(r"\$\{current_date\}|\$\{\{current_date\}\}")
+
+    _APPLICABLE_FILES = {"instruction.txt", "global_instruction.txt"}
+
+    def _global_instruction_has_date(self, context: LintContext) -> bool:
+        """Check if global_instruction.txt already references current_date."""
+        global_inst = context.app_dir / "global_instruction.txt"
+        if global_inst.exists():
+            return bool(self.VALID_PATTERNS.search(global_inst.read_text()))
+        return False
+
+    def _all_agent_instructions_have_date(self, context: LintContext) -> bool:
+        """Check if every agent instruction.txt references current_date."""
+        agents_dir = context.app_dir / "agents"
+        if not agents_dir.exists():
+            return True
+        for agent_dir in sorted(agents_dir.iterdir()):
+            if not agent_dir.is_dir():
+                continue
+            inst = agent_dir / "instruction.txt"
+            if inst.exists() and not self.VALID_PATTERNS.search(
+                inst.read_text()
+            ):
+                return False
+        return True
+
+    def check(
+        self, file_path: Path, content: str, context: LintContext
+    ) -> list[LintResult]:
+        if file_path.name not in self._APPLICABLE_FILES:
+            return []
+        if self.VALID_PATTERNS.search(content):
+            return []
+        # global_instruction.txt has current_date → all agents covered
+        if self._global_instruction_has_date(context):
+            return []
+        # Every agent instruction.txt has current_date → also fine
+        if self._all_agent_instructions_have_date(context):
+            return []
+        rel = str(file_path.relative_to(context.project_root))
+        return [
+            self.make_result(
+                file=rel,
+                message=(
+                    "No current_date reference found"
+                    " — without it the agent will"
+                    " not know today's date"
+                ),
+                fix=(
+                    "Add ${current_date} or"
+                    " ${{current_date}} to the"
+                    " instruction or global"
+                    " instruction"
+                ),
+            )
         ]

--- a/src/cxas_scrapi/utils/linter.py
+++ b/src/cxas_scrapi/utils/linter.py
@@ -398,6 +398,13 @@ class Discovery:
                     return d
         return None
 
+    def discover_global_instruction(self) -> Optional[Path]:
+        """Return path to ``global_instruction.txt`` if it exists."""
+        if not self.app_root:
+            return None
+        p = self.app_root / "global_instruction.txt"
+        return p if p.exists() else None
+
     def discover_agents(self) -> dict[str, Path]:
         """Return ``{dir_name: instruction_or_config_path}`` for all agents."""
         if not self.app_root:
@@ -625,12 +632,15 @@ def run_rules(  # noqa: C901
             r for r in registry.rules_for_category(category) if should_run(r)
         ]
 
-    # Instructions — only instruction.txt files
+    # Instructions — instruction.txt files + global_instruction.txt
     instruction_files = {
         k: v
         for k, v in discovery.discover_agents().items()
         if v.name == "instruction.txt"
     }
+    global_inst = discovery.discover_global_instruction()
+    if global_inst:
+        instruction_files["global_instruction"] = global_inst
     _lint_files(_get_rules("instructions"), instruction_files)
 
     # Callbacks

--- a/tests/cxas_scrapi/utils/test_lint_rules.py
+++ b/tests/cxas_scrapi/utils/test_lint_rules.py
@@ -172,6 +172,153 @@ def test_i008_valid_agent_ref(tmp_path, context):
     assert len(results) == 0
 
 
+def test_i014_no_date_anywhere(tmp_path, context):
+    """No current_date in global or any instruction → flag."""
+    from cxas_scrapi.utils.lint_rules.instructions import MissingCurrentDate  # noqa: PLC0415,I001
+
+    rule = MissingCurrentDate()
+    agent_dir = tmp_path / "agents" / "root_agent"
+    agent_dir.mkdir(parents=True)
+    f = agent_dir / "instruction.txt"
+    content = "Just some instructions."
+    f.write_text(content)
+
+    results = rule.check(f, content, context)
+    assert len(results) == 1
+    assert "No current_date reference" in results[0].message
+
+
+def test_i014_in_global_only(tmp_path, context):
+    """current_date in global_instruction.txt → no flag on agent."""
+    from cxas_scrapi.utils.lint_rules.instructions import MissingCurrentDate  # noqa: PLC0415,I001
+
+    rule = MissingCurrentDate()
+    (tmp_path / "global_instruction.txt").write_text(
+        "Today is ${current_date}."
+    )
+    f = tmp_path / "instruction.txt"
+    f.write_text("No date here.")
+
+    results = rule.check(f, f.read_text(), context)
+    assert len(results) == 0
+
+
+def test_i014_in_global_and_agent(tmp_path, context):
+    """current_date in both global and agent → no flag."""
+    from cxas_scrapi.utils.lint_rules.instructions import MissingCurrentDate  # noqa: PLC0415,I001
+
+    rule = MissingCurrentDate()
+    (tmp_path / "global_instruction.txt").write_text(
+        "Today is ${current_date}."
+    )
+    f = tmp_path / "instruction.txt"
+    f.write_text("Date: ${current_date}.")
+
+    results = rule.check(f, f.read_text(), context)
+    assert len(results) == 0
+
+
+def test_i014_in_all_agents_not_global(tmp_path, context):
+    """current_date in all agent instructions but not global → no flag."""
+    from cxas_scrapi.utils.lint_rules.instructions import MissingCurrentDate  # noqa: PLC0415,I001
+
+    rule = MissingCurrentDate()
+    # Two agents, both have current_date
+    for name in ("agent_a", "agent_b"):
+        d = tmp_path / "agents" / name
+        d.mkdir(parents=True)
+        (d / "instruction.txt").write_text("Date: ${current_date}.")
+    # Global does not have it
+    gi = tmp_path / "global_instruction.txt"
+    gi.write_text("No date here.")
+
+    results = rule.check(gi, gi.read_text(), context)
+    assert len(results) == 0
+
+
+def test_i014_in_some_agents_not_global(tmp_path, context):
+    """current_date in one agent but not another, not global → flag both."""
+    from cxas_scrapi.utils.lint_rules.instructions import MissingCurrentDate  # noqa: PLC0415,I001
+
+    rule = MissingCurrentDate()
+    # agent_a has it, agent_b does not
+    a = tmp_path / "agents" / "agent_a"
+    a.mkdir(parents=True)
+    (a / "instruction.txt").write_text("Date: ${current_date}.")
+    b = tmp_path / "agents" / "agent_b"
+    b.mkdir(parents=True)
+    (b / "instruction.txt").write_text("No date here.")
+    # Global does not have it
+    gi = tmp_path / "global_instruction.txt"
+    gi.write_text("No date here.")
+
+    # global_instruction.txt should be flagged
+    results_gi = rule.check(gi, gi.read_text(), context)
+    assert len(results_gi) == 1
+
+    # agent_b should be flagged
+    f_b = b / "instruction.txt"
+    results_b = rule.check(f_b, f_b.read_text(), context)
+    assert len(results_b) == 1
+
+    # agent_a should NOT be flagged (it has current_date)
+    f_a = a / "instruction.txt"
+    results_a = rule.check(f_a, f_a.read_text(), context)
+    assert len(results_a) == 0
+
+
+def test_i014_accepts_double_brace_syntax(tmp_path, context):
+    """${{current_date}} syntax is also valid."""
+    from cxas_scrapi.utils.lint_rules.instructions import MissingCurrentDate  # noqa: PLC0415,I001
+
+    rule = MissingCurrentDate()
+    f = tmp_path / "global_instruction.txt"
+    f.write_text("Today is ${{current_date}}.")
+
+    results = rule.check(f, f.read_text(), context)
+    assert len(results) == 0
+
+
+def test_i014_skips_non_instruction_files(tmp_path, context):
+    """Rule only applies to instruction.txt and global_instruction.txt."""
+    from cxas_scrapi.utils.lint_rules.instructions import MissingCurrentDate  # noqa: PLC0415,I001
+
+    rule = MissingCurrentDate()
+    f = tmp_path / "python_code.py"
+    f.write_text("# no date here")
+
+    results = rule.check(f, f.read_text(), context)
+    assert len(results) == 0
+
+
+def test_i014_no_global_instruction_file(tmp_path, context):
+    """No global_instruction.txt exists, agent missing date → flag."""
+    from cxas_scrapi.utils.lint_rules.instructions import MissingCurrentDate  # noqa: PLC0415,I001
+
+    rule = MissingCurrentDate()
+    agent_dir = tmp_path / "agents" / "root_agent"
+    agent_dir.mkdir(parents=True)
+    f = agent_dir / "instruction.txt"
+    f.write_text("No date here.")
+
+    results = rule.check(f, f.read_text(), context)
+    assert len(results) == 1
+
+
+def test_i014_no_agents_directory(tmp_path, context):
+    """No agents/ dir, global missing date → flag global."""
+    from cxas_scrapi.utils.lint_rules.instructions import MissingCurrentDate  # noqa: PLC0415,I001
+
+    rule = MissingCurrentDate()
+    f = tmp_path / "global_instruction.txt"
+    f.write_text("No date here.")
+
+    results = rule.check(f, f.read_text(), context)
+    # No agents dir means _all_agent_instructions_have_date returns True
+    # (vacuously), so global is not flagged
+    assert len(results) == 0
+
+
 # ── Callback Rules ───────────────────────────────────────────────────────
 
 

--- a/tests/cxas_scrapi/utils/test_linter.py
+++ b/tests/cxas_scrapi/utils/test_linter.py
@@ -229,7 +229,7 @@ def test_reset_registry():
         importlib.reload(mod)
 
     registry_restored = build_registry()
-    assert len(registry_restored.all_rules()) == 62  # noqa: PLR2004
+    assert len(registry_restored.all_rules()) == 63  # noqa: PLR2004
 
 
 # ── LintConfig ───────────────────────────────────────────────────────────
@@ -469,7 +469,7 @@ def test_discovery_tool_callbacks(tmp_path):
 def test_build_registry_all_rules():
     registry = build_registry()
     all_rules = registry.all_rules()
-    assert len(all_rules) == 62  # noqa: PLR2004
+    assert len(all_rules) == 63  # noqa: PLR2004
 
 
 def test_build_context(tmp_path):


### PR DESCRIPTION
Without current_date in instructions, agents don't know today's date. This rule warns when it's missing so users can decide whether to add it.

The rule checks both instruction.txt and global_instruction.txt files:
- If global_instruction.txt has current_date, all agents are covered
- If all agent instructions individually have it, also fine
- Otherwise, flags the files that are missing it

Also adds discover_global_instruction() to Discovery and includes global_instruction.txt in the instruction lint pass.