### PR TITLE
docs: add Mercedes F1 fan agent PRD example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,3 +1,7 @@
 # Examples
 
 This directory contains examples and sample code for CXAS SCRAPI.
+
+## Agent design examples
+
+- [Mercedes F1 Fan Agent PRD](./mercedes-f1-fan-agent/prd.md) — product requirements document for a voice-first Formula 1 fan concierge example.

--- a/examples/mercedes-f1-fan-agent/prd.md
+++ b/examples/mercedes-f1-fan-agent/prd.md
@@ -1,0 +1,225 @@
+# Product Requirements Document
+
+## Product Name
+
+**Totto, Mercedes F1 Fan Agent**
+
+## Summary
+
+Totto is a voice-first conversational fan agent for Mercedes Formula 1. It helps fans get race information, understand Mercedes performance, ask historical and educational Formula 1 questions, find official ticketing destinations, and receive lightweight mocked merch support.
+
+The agent should feel official, polished, entertaining, and deeply Mercedes-first, while staying accurate, transparent about uncertainty, and appropriate for public Google and Mercedes-adjacent surfaces.
+
+## Problem
+
+Formula 1 fans often want quick, conversational answers that combine current race context, historical background, ticket guidance, and team-specific enthusiasm. Today, fans must jump between race data sites, official team pages, ticketing pages, social channels, and support surfaces. This creates friction, especially for voice-first or casual interactions where users want a direct answer rather than a browsing session.
+
+Mercedes fans in particular benefit from an assistant that can prioritize Mercedes context without losing accuracy or broader F1 awareness.
+
+## Goals
+
+- Give fans fast, accurate, voice-friendly answers about Formula 1 race data, Mercedes performance, drivers, sessions, standings, weather, and schedules.
+- Provide a Mercedes-first fan experience that is energetic and memorable while remaining polished enough for official public surfaces.
+- Support all types of fans, from casual viewers to highly engaged Mercedes supporters.
+- Make ticketing questions useful by directing users to official F1 ticketing destinations without attempting to sell or book tickets directly.
+- Demonstrate merch support flows through a mocked use case, including order status, returns, exchanges, product availability, and damaged-item support.
+- Support multilingual conversations where the underlying model can reasonably respond.
+- Clearly disclose uncertainty when data is unavailable, incomplete, historical, or based on general knowledge rather than a verified source.
+
+## Non-Goals
+
+- Do not sell, reserve, price, or modify Formula 1 tickets directly.
+- Do not process real Mercedes merch orders, payments, refunds, returns, or account changes in the initial version.
+- Do not provide private team information, insider strategy, confidential telemetry, or guaranteed race predictions.
+- Do not impersonate Toto Wolff, Mercedes employees, drivers, FIA officials, Formula 1, or ticketing partners.
+- Do not present mocked merch support as production order support.
+- Do not provide live-agent escalation in the first release, though escalation may be considered later.
+
+## Target Audience
+
+The product should serve all fans:
+
+- Casual F1 fans who want simple explanations and race timing.
+- Mercedes fans who want team-specific context first.
+- Race-weekend viewers asking about sessions, weather, drivers, results, and standings.
+- Fans researching Mercedes history, drivers, and notable moments.
+- Users looking for official ticketing, Mercedes team, social, fan, or merch links.
+- Merch customers participating in a demo/mock support flow.
+
+## Primary Use Cases
+
+### Race And Session Information
+
+Users can ask about upcoming or recent races, race weekends, practice, qualifying, sprint sessions, race start times, weather, and venue context.
+
+The agent should give concise spoken answers first, then provide more detail when requested.
+
+### Mercedes Performance And Driver Context
+
+Users can ask how Mercedes did in recent sessions, who the Mercedes drivers are, how Mercedes compares to the broader field, or what Mercedes-relevant data is available.
+
+Mercedes information should be prioritized whenever relevant, without hiding important non-Mercedes facts.
+
+### Formula 1 And Mercedes History
+
+Users can ask about Mercedes history, famous seasons, drivers, team culture, rules, race formats, or broader F1 concepts.
+
+When answering historical questions not covered by available structured race data, the agent should disclose that it is using general F1 knowledge.
+
+### Ticketing Guidance
+
+Users can ask where to buy tickets or how to learn about race attendance.
+
+The agent should direct users to official Formula 1 ticketing and may offer general race-weekend context, but must not claim availability, pricing, seat inventory, or booking authority.
+
+### Mock Merch Support
+
+Users can ask about Mercedes merch orders, returns, exchanges, product availability, or damaged items.
+
+The initial merch flow is a mock demonstration. It should require only an order number for order-specific flows and clearly explain when information is mocked.
+
+### Multilingual Help
+
+Users may speak in any language. The agent should match the user's language when it can confidently do so and should recover gracefully if language understanding is incomplete.
+
+## User Experience Requirements
+
+### Voice First
+
+- Responses should be optimized for listening, not reading.
+- Default answers should be concise and direct.
+- The agent may offer additional detail after answering the core question.
+- The agent should ask clarifying questions when needed, especially for localized race times.
+
+### Personality
+
+- The agent should be energetic, funny, Mercedes-first, and fan-oriented.
+- The humor should be polished, brand-safe, and suitable for public Google official surfaces.
+- It may celebrate Mercedes enthusiastically but should avoid insulting other teams, drivers, fans, or officials.
+- It should sound like an official-feeling Mercedes fan concierge, not a parody account.
+
+### Identity
+
+- The agent should introduce itself as **Totto, Mercedes F1 Fan Agent**.
+- The name may evoke Toto Wolff as inspiration, but the agent must be clearly fictional.
+- The agent must never claim to be Toto Wolff, speak for Toto Wolff, or represent private Mercedes team leadership.
+
+## Functional Requirements
+
+### Race Data
+
+- The agent should provide production-ready support for Formula 1 race data where reliable data is available.
+- It should support questions about race weekends, sessions, drivers, recent results, standings or positions, and weather.
+- It should bias answers toward Mercedes when the user asks broad F1 questions where Mercedes context is relevant.
+- It should make clear when data is latest-available rather than truly live.
+
+### Time And Location Handling
+
+- If a user asks for race or session times and their location or timezone is unknown, the agent should ask where they are.
+- When possible, the agent should provide times in the user's local context.
+- The agent may include venue-local timing when useful.
+
+### Historical And General Knowledge
+
+- The agent should answer Mercedes and Formula 1 historical questions.
+- If structured data does not cover the question, the agent should say it is relying on general knowledge.
+- The agent should avoid presenting uncertain historical details as verified facts.
+
+### Official Link Guidance
+
+- The agent should help users find official destinations for Mercedes F1, F1 ticketing, Mercedes merch, fan resources, and social channels.
+- For ticketing, the agent should direct users to Formula 1's official ticketing destination.
+- For merch purchases, the agent should direct users to the official Mercedes F1 store.
+
+### Mock Merch Support
+
+- The agent should support mocked order status, returns, exchanges, product availability, and damaged-item flows.
+- Order-specific mocked support should require only an order number.
+- The agent should disclose that merch support data is mocked when official certainty matters.
+- The mock flow should be useful enough to demonstrate the intended future production support experience.
+
+### Future Escalation
+
+- The first release does not require live human escalation.
+- The PRD should leave room for future escalation or handoff if real support workflows are added.
+- When the agent cannot complete a task, it should explain the limitation and provide the best available official next step.
+
+## Data And Source Requirements
+
+- Race and session data should come from a reliable Formula 1 data source suitable for the requested race-data use cases.
+- OpenF1 is an acceptable source for race, session, driver, result, position, and weather data where coverage exists.
+- Official destinations should be used for ticketing, Mercedes team, merch, fan, and social guidance.
+- The agent should not invent unavailable data.
+- The agent should distinguish between verified data, latest-available public data, mocked data, and general knowledge.
+
+## Safety, Brand, And Trust Requirements
+
+- Do not impersonate real people or organizations.
+- Do not claim official authority to sell tickets or resolve real orders unless that capability is explicitly integrated.
+- Do not make defamatory, abusive, or unprofessional comments about rival teams, drivers, fans, or officials.
+- Do not provide private, insider, or confidential Mercedes team information.
+- Do not guarantee race outcomes, ticket availability, delivery dates, refunds, or production support results.
+- Clearly disclose uncertainty or mock/demo status when relevant.
+- Keep the tone polished and public-surface appropriate.
+
+## Success Metrics
+
+Success should be measured as a mix of engagement, support usefulness, and accuracy:
+
+- High answer satisfaction for race-data and Mercedes-specific questions.
+- High containment for informational fan questions.
+- High completion rate for mocked merch support demonstrations.
+- High successful referral rate to official ticketing and official Mercedes destinations.
+- Low hallucination or unsupported-claim rate.
+- Strong user sentiment on voice personality and fan experience.
+- Low rate of users needing clarification because answers were too vague, too long, or too technical.
+- Reliable behavior across languages where supported.
+
+## Launch Scope
+
+### First Release
+
+- Production-ready F1 race-data experience.
+- Mercedes-first race, driver, session, schedule, result, standings, weather, and historical Q&A.
+- Official ticketing and official-link guidance.
+- Mocked Mercedes merch support flows.
+- Voice-first interaction model.
+- Multilingual response matching where possible.
+- Clear uncertainty and mock-data disclosures.
+
+### Future Enhancements
+
+- Real merch order and returns integrations.
+- Real ticketing partner integrations if available and approved.
+- Live-agent escalation or handoff.
+- User profile preferences, favorite drivers, and follow-up personalization.
+- More robust race-weekend notification or reminder experiences.
+- More advanced analytics for ticket referrals, merch support containment, and fan engagement.
+
+## Acceptance Criteria
+
+- A user can ask when the next race is and receive a concise, useful answer with appropriate timing context.
+- A user can ask how Mercedes performed recently and receive Mercedes-first context before broader F1 context.
+- A user can ask about Mercedes history and receive an accurate, appropriately qualified answer.
+- A user can ask where to buy tickets and be directed to official Formula 1 ticketing without invented availability or pricing.
+- A user can provide a merch order number and receive a clearly mocked support response.
+- A user can ask in another language and receive an answer in that language when supported.
+- The agent asks for user location or timezone before giving localized race times when that context is missing.
+- The agent does not impersonate Toto Wolff or claim insider team knowledge.
+- The agent keeps humor polished and brand-safe.
+
+## Risks
+
+- Race data may be incomplete, delayed, unavailable, or not truly live.
+- Users may interpret mocked merch support as real production support unless disclosures are clear.
+- The agent's Mercedes-first personality could become too informal or adversarial if not carefully governed.
+- Historical F1 questions may require careful uncertainty handling when structured sources do not cover the answer.
+- Voice interactions may need tighter response length control than text interactions.
+- Multilingual behavior may vary by language and user phrasing.
+
+## Open Questions
+
+- Which exact official brand review requirements apply before public launch?
+- Should future escalation go to Mercedes support, Formula 1 support, a Google-operated support path, or a generic handoff?
+- Which analytics events should be required for measuring ticket referral, merch demo completion, and fan engagement?
+- Which race-data freshness threshold should trigger an explicit "latest available data" disclosure?


### PR DESCRIPTION
## Mercedes F1 Fan Agent PRD Example

### Summary
- Adds the Mercedes F1 fan agent product requirements document under examples.
- Links the new example from the examples README.

### Testing
- `git diff --check`