### PR TITLE
fix: init-github-action nested app dirs

### DIFF
--- a/src/cxas_scrapi/core/github.py
+++ b/src/cxas_scrapi/core/github.py
@@ -32,6 +32,8 @@ on:
       - '{path_filter}/*.yaml'
       - '{path_filter}/*.yml'
       - '{path_filter}/*.json'
+      - '{path_filter}/*.py'
+      - '{path_filter}/*.txt'
   workflow_call:
 
 env:
@@ -106,6 +108,8 @@ on:
       - '{path_filter}/*.yaml'
       - '{path_filter}/*.yml'
       - '{path_filter}/*.json'
+      - '{path_filter}/*.py'
+      - '{path_filter}/*.txt'
 
 env:
   PROJECT_ID: "{project_id}"
@@ -166,6 +170,8 @@ on:
       - '{path_filter}/*.yaml'
       - '{path_filter}/*.yml'
       - '{path_filter}/*.json'
+      - '{path_filter}/*.py'
+      - '{path_filter}/*.txt'
 
 env:
   PROJECT_ID: "{project_id}"
@@ -269,6 +275,20 @@ def _get_github_details(agent_dir: str) -> tuple[str | None, str | None]:
     except Exception:
         pass
     return None, None
+
+
+def _repo_relative_path(path: str, git_root: str) -> str:
+    """Returns a POSIX-style path to path relative to the Git repo root."""
+    abs_path = os.path.abspath(path)
+    abs_git_root = os.path.abspath(git_root)
+
+    if os.path.commonpath([abs_git_root, abs_path]) != abs_git_root:
+        raise ValueError("The app directory must be inside the Git repository.")
+
+    rel_path = os.path.relpath(abs_path, abs_git_root)
+    if rel_path == ".":
+        return "."
+    return rel_path.replace(os.sep, "/")
 
 
 def _auto_setup_wif(
@@ -563,11 +583,10 @@ def init_github_action(args: argparse.Namespace) -> None:
             "or use --auto-create-wif to let the CLI generate them for you."
         )
 
-    # Generate the path string. If they used an absolute path like
-    # `/Users/.../pilot`, just use `pilot/**`
-    agent_basename = os.path.basename(agent_dir.rstrip(os.sep))
-    path_filter = f"{agent_basename}/**" if agent_dir != "." else "**"
-    github_context_path = agent_basename if agent_dir != "." else "."
+    github_context_path = _repo_relative_path(agent_dir, git_root)
+    path_filter = (
+        "**" if github_context_path == "." else f"{github_context_path}/**"
+    )
 
     # Configure auth blocks
     auth_env = (

--- a/tests/cxas_scrapi/core/test_github.py
+++ b/tests/cxas_scrapi/core/test_github.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import argparse
+import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -20,8 +21,42 @@ import pytest
 from cxas_scrapi.core.github import (
     _auto_setup_wif,
     _get_github_details,
+    _repo_relative_path,
     init_github_action,
 )
+
+
+def _init_github_action_args(app_dir: str) -> argparse.Namespace:
+    return argparse.Namespace(
+        agent_name="testagent",
+        app_id="projects/my-project/locations/us/apps/test-app",
+        app_name="projects/my-project/locations/us/apps/test-app",
+        app_dir=app_dir,
+        output=None,
+        auth_method="wif",
+        workload_identity_provider=(
+            "projects/123/locations/global/workloadIdentityPools/pool/"
+            "providers/provider"
+        ),
+        service_account="github-actions-sa@my-project.iam.gserviceaccount.com",
+        project_id="my-project",
+        location="us",
+        branch="main",
+        no_cleanup=False,
+        install_hook=False,
+        auto_create_wif=False,
+        github_repo="owner/repo",
+    )
+
+
+def _init_git_repo(path):
+    subprocess.run(
+        ["git", "init"],
+        cwd=path,
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
 
 
 def test_get_github_details_https():
@@ -46,6 +81,27 @@ def test_get_github_details_fail():
         owner, repo = _get_github_details("/tmp")
         assert owner is None
         assert repo is None
+
+
+def test_repo_relative_path_preserves_nested_app_dir(tmp_path):
+    repo_root = tmp_path / "repo"
+    app_dir = repo_root / "customer-service-agent/cxas_app/App"
+    app_dir.mkdir(parents=True)
+
+    assert (
+        _repo_relative_path(str(app_dir), str(repo_root))
+        == "customer-service-agent/cxas_app/App"
+    )
+
+
+def test_repo_relative_path_rejects_paths_outside_repo(tmp_path):
+    repo_root = tmp_path / "repo"
+    app_dir = tmp_path / "app"
+    repo_root.mkdir()
+    app_dir.mkdir()
+
+    with pytest.raises(ValueError, match="inside the Git repository"):
+        _repo_relative_path(str(app_dir), str(repo_root))
 
 
 def test_auto_setup_wif_success():
@@ -126,3 +182,41 @@ def test_init_github_action_missing_wif():
         ),
     ):
         init_github_action(args)
+
+
+def test_init_github_action_preserves_nested_app_dir(tmp_path, monkeypatch):
+    repo_root = tmp_path / "repo"
+    app_dir = (
+        repo_root / "customer-service-agent/cxas_app/Customer_Service_Agent"
+    )
+    app_dir.mkdir(parents=True)
+    _init_git_repo(repo_root)
+    monkeypatch.chdir(repo_root)
+
+    args = _init_github_action_args(
+        "customer-service-agent/cxas_app/Customer_Service_Agent"
+    )
+    init_github_action(args)
+
+    workflow_path = repo_root / ".github/workflows/ci_test_testagent.yml"
+    deploy_path = repo_root / ".github/workflows/deploy_testagent.yml"
+    cleanup_path = repo_root / ".github/workflows/cleanup_testagent.yml"
+
+    ci_workflow = workflow_path.read_text()
+    deploy_workflow = deploy_path.read_text()
+    cleanup_workflow = cleanup_path.read_text()
+    workflows = "\n".join([ci_workflow, deploy_workflow, cleanup_workflow])
+
+    expected_app_dir = "customer-service-agent/cxas_app/Customer_Service_Agent"
+
+    assert f"context: {expected_app_dir}" in ci_workflow
+    assert f"ci-test --app-dir {expected_app_dir}" in ci_workflow
+    assert f"cxas push --app-dir {expected_app_dir}" in deploy_workflow
+    assert f"'{expected_app_dir}/**/*.py'" in workflows
+    assert f"'{expected_app_dir}/**/*.txt'" in workflows
+    assert "--project_id" not in workflows
+    assert "--app_id" not in workflows
+    assert "--display_name" not in workflows
+
+    assert (app_dir / "Dockerfile").exists()
+    assert (app_dir / "requirements.txt").exists()


### PR DESCRIPTION
## Summary
- Preserve the full repo-relative `--app-dir` when generating GitHub Actions workflows
- Use that path for Docker build context, `cxas ci-test`, `cxas push`, and workflow path filters
- Add `.py` and `.txt` path filters so tool code and instruction changes trigger CI
- Add regression tests for the nested Agent Foundry-style app layout

Fixes #34

## Tests
- `.venv/bin/python -m pytest tests/cxas_scrapi/core/test_github.py`
- `.venv/bin/python -m ruff check src/cxas_scrapi/core/github.py tests/cxas_scrapi/core/test_github.py`
- `.venv/bin/python -m ruff format --check src/cxas_scrapi/core/github.py tests/cxas_scrapi/core/test_github.py`