### PR TITLE
fix: (docs) changed underscores in terminal command params to hyphens

### DIFF
--- a/docs/guides/agent-development/index.md
+++ b/docs/guides/agent-development/index.md
@@ -85,10 +85,10 @@ If you're starting fresh and want to get to a running agent quickly, here's the 
 
 ```bash
 # 1. Create an app
-cxas create "My App" --app_name my-app --project_id my-gcp-project --location us
+cxas create "My App" --app-name my-app --project-id my-gcp-project --location us
 
 # 2. Pull it locally
-cxas pull "my-app" --project_id my-gcp-project --location us-central1
+cxas pull "my-app" --project-id my-gcp-project --location us-central1
 
 # 3. Edit the instruction
 # (edit cxas_app/my-app/agents/root/instruction.txt)


### PR DESCRIPTION
The terminal commands in the quickstart orientation - https://github.com/GoogleCloudPlatform/cxas-scrapi/blob/main/docs/guides/agent-development/index.md#quick-orientation has underscore in the command param for app_name instead of app-name and project_id instead project-id causing the command to break.