### PR TITLE
fix: add missing alive-progress (Scrapi-wide fix) and nest_asyncio (migration specific) dependencies to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,8 @@ setup(
         "graphviz",
         "rich",
         "google-cloud-dialogflow-cx",
+        "nest_asyncio",
+        "alive-progress",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
## Summary
This PR adds the missing `alive-progress` and `nest_asyncio` dependencies to `setup.py`.
## Rationale
When trying to use the migration module in Google Public Colab by installing directly from the GitHub branch, we encountered a `ModuleNotFoundError: No module named 'alive_progress'`. 
This surfaces because the top-level `cxas_scrapi/__init__.py` eagerly imports `evals`, which in turn imports `guardrail_evals`, which depends on `alive_progress`. This makes it a Scrapi-wide fix.
I also included `nest_asyncio` which was required specifically by the migration service but was missing from the `main` branch's `setup.py`.
## Fixes
- Resolves `ModuleNotFoundError` when importing the package in Colab.