### PR TITLE
feat: add GCS export and unified reporting path

### DIFF
--- a/.agents/skills/cxas-agent-foundry/scripts/scrapi-sim-runner.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/scrapi-sim-runner.py
@@ -321,8 +321,33 @@ def _format_trace_line(line, tools_map):
     return line
 
 
-def generate_html_report(results, output_path, modality, model, app_name="", wall_clock_s=None):
-    """Generate an HTML report with transcripts, tool calls, and failure details."""
+def _upload_to_gcs(output_path, html):
+    """Uploads report to GCS and returns mTLS URL or None."""
+    try:
+        from cxas_scrapi.utils.gcs_utils import GCSUtils
+        gcs = GCSUtils()
+        mtls_url = gcs.upload_string(output_path, html)
+        print(f"Report uploaded to GCS: {output_path}")
+        print(f"Authenticated URL: {mtls_url}")
+        return mtls_url
+    except Exception as e:
+        print(f"WARNING: GCS upload failed ({e}). Falling back to local file.")
+        return None
+
+
+def generate_html_report(
+    results,
+    output_path,
+    modality,
+    model,
+    app_name="",
+    wall_clock_s=None,
+):
+    """Generate an HTML report and save it locally or upload to GCS.
+
+    If output_path starts with 'gs://', the report is uploaded to GCS.
+    If the upload fails, it falls back to saving a local file.
+    """
     total = len(results)
     passed = sum(1 for r in results if r.get("passed"))
     errors = sum(1 for r in results if "error" in r)
@@ -562,8 +587,21 @@ function jumpToRun(evalName, runIdx) {{
         html += '</div></div>\n'
 
     html += "</body></html>"
+
+    if output_path.startswith("gs://"):
+        mtls_url = _upload_to_gcs(output_path, html)
+        if mtls_url:
+            return
+
+        # Fallback to local file if upload failed
+        filename = output_path.split("/")[-1]
+        if not filename.endswith(".html"):
+            filename = "report_fallback.html"
+        output_path = filename
+
     with open(output_path, "w") as f:
         f.write(html)
+    print(f"Report saved locally to: {output_path}")
 
 
 def _run_single_eval(app_name, tc, run_idx, runs, model, modality, verbose):
@@ -773,10 +811,19 @@ def cmd_run(args):
     with open(json_path, "w") as f:
         json.dump(output, f, indent=2, default=str)
 
-    html_path = os.path.join(REPORTS_DIR, f"sim_report_{ts}.html")
-    generate_html_report(all_results, html_path, modality, model, app_name, wall_clock_s=wall_clock_s)
+    report_path = getattr(args, "gcs_report_path", None) or os.path.join(
+        REPORTS_DIR, f"sim_report_{ts}.html"
+    )
+    generate_html_report(
+        all_results,
+        report_path,
+        modality,
+        model,
+        app_name,
+        wall_clock_s=wall_clock_s,
+    )
     print(f"\nResults: {json_path}")
-    print(f"Report:  {html_path}")
+    print(f"Report:  {report_path}")
 
 
 def main():
@@ -807,6 +854,12 @@ def main():
     p_run.add_argument("--runs", type=int, default=1)
     p_run.add_argument("--parallel", type=int, default=1, help="Number of concurrent sessions (default: 1)")
     p_run.add_argument("--verbose", action="store_true")
+    p_run.add_argument(
+        "--gcs-report-path",
+        type=str,
+        default=None,
+        help="GCS URI to upload report to (e.g. gs://bucket/report.html)",
+    )
 
     args = parser.parse_args()
     commands = {"list": cmd_list, "convert": cmd_convert, "run": cmd_run}

--- a/.agents/skills/cxas-sim-eval/scripts/run_evals.py
+++ b/.agents/skills/cxas-sim-eval/scripts/run_evals.py
@@ -296,7 +296,21 @@ def ansi_to_html(text):
         result += '</span>'
     return result
 
-def generate_html_report(results, evals_dir, app_name):
+def _upload_to_gcs(output_path, html_content):
+    """Uploads report to GCS and returns mTLS URL or None."""
+    try:
+        from cxas_scrapi.utils.gcs_utils import GCSUtils
+        gcs = GCSUtils()
+        mtls_url = gcs.upload_string(output_path, html_content)
+        print(f"Report uploaded to GCS: {output_path}")
+        print(f"Authenticated URL: {mtls_url}")
+        return mtls_url
+    except Exception as e:
+        print(f"WARNING: GCS upload failed ({e}). Falling back to local file.")
+        return None
+
+
+def generate_html_report(results, output_path, app_name):
     html_content = """
     <html>
     <head>
@@ -513,10 +527,20 @@ def generate_html_report(results, evals_dir, app_name):
     </html>
     """
     
-    output_path = os.path.abspath(os.path.join(evals_dir, "..", "summary.html"))
+    if output_path.startswith("gs://"):
+        mtls_url = _upload_to_gcs(output_path, html_content)
+        if mtls_url:
+            return
+
+        # Fallback to local file if upload failed
+        filename = output_path.split("/")[-1]
+        if not filename.endswith(".html"):
+            filename = "summary_fallback.html"
+        output_path = filename
+
     with open(output_path, "w", encoding="utf-8") as f:
         f.write(html_content)
-    print(f"\\nGenerated HTML summary report at: {output_path}")
+    print(f"\nGenerated HTML summary report at: {output_path}")
 
 def main():
     parser = argparse.ArgumentParser(description="Run CXAS Simulation Evaluations.")
@@ -528,6 +552,14 @@ def main():
     parser.add_argument("--skip-analysis", action="store_true", help="Skip cognitive diagnostics and LLM analysis")
     parser.add_argument("--modality", type=str, default="text", help="Simulation modality (text or audio)")
     parser.add_argument("--runs-per-eval", type=int, default=1, help="Number of times to run each evaluation")
+    parser.add_argument(
+        "--gcs-report-path",
+        type=str,
+        default=None,
+        help=(
+            "GCS URI to upload the report to (e.g. gs://bucket/report.html)"
+        ),
+    )
     args = parser.parse_args()
 
     evals_dir = os.path.join(args.output_dir, 'sim_evals')
@@ -570,7 +602,10 @@ def main():
                     "run_index": run_idx
                 })
 
-    generate_html_report(results_list, evals_dir, args.app_name)
+    report_path = args.gcs_report_path or os.path.abspath(
+        os.path.join(evals_dir, "..", "summary.html")
+    )
+    generate_html_report(results_list, report_path, args.app_name)
 
 if __name__ == "__main__":
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ graphviz
 rich
 ruff
 google-cloud-dialogflow-cx
+google-cloud-storage

--- a/src/cxas_scrapi/utils/__init__.py
+++ b/src/cxas_scrapi/utils/__init__.py
@@ -15,6 +15,7 @@
 
 from cxas_scrapi.utils.changelog_utils import ChangelogUtils
 from cxas_scrapi.utils.eval_utils import EvalUtils
+from cxas_scrapi.utils.gcs_utils import GCSUtils
 from cxas_scrapi.utils.google_sheets_utils import GoogleSheetsUtils
 from cxas_scrapi.utils.secret_manager_utils import SecretManagerUtils
 
@@ -22,5 +23,6 @@ __all__ = [
     "SecretManagerUtils",
     "ChangelogUtils",
     "EvalUtils",
+    "GCSUtils",
     "GoogleSheetsUtils",
 ]

--- a/src/cxas_scrapi/utils/gcs_utils.py
+++ b/src/cxas_scrapi/utils/gcs_utils.py
@@ -1,0 +1,83 @@
+"""Utility class for interacting with Google Cloud Storage."""
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+
+from google.cloud import storage
+
+from cxas_scrapi.core.common import Common
+
+
+class GCSUtils(Common):
+  """Utility class for Google Cloud Storage integrations."""
+
+  def __init__(
+      self,
+      creds_path: str | None = None,
+      creds_dict: dict[str, str] | None = None,
+      creds: Any = None,
+      scope: list[str] | None = None,
+  ):
+    """Initializes GCSUtils with common auth logic.
+
+        Args:
+            creds_path: Path to service account JSON file.
+            creds_dict: Service account credentials as a dictionary.
+            creds: Service account credentials object.
+            scope: List of scopes for the credentials.
+        """
+    super().__init__(
+        creds_path=creds_path,
+        creds_dict=creds_dict,
+        creds=creds,
+        scope=scope,
+    )
+    self.client = storage.Client(credentials=self.creds,
+                                 project=self.project_id)
+
+  def upload_string(
+      self,
+      gcs_uri: str,
+      content: str,
+      content_type: str = "text/html; charset=utf-8",
+  ) -> str:
+    """Uploads a string to a GCS URI and returns the mtls URL.
+
+        Args:
+            gcs_uri: The full GCS URI (e.g., gs://bucket/path/to/file).
+            content: The string content to upload.
+            content_type: The MIME type of the content.
+
+        Returns:
+            The authenticated URL for the uploaded file.
+
+        Raises:
+            ValueError: If the GCS URI is invalid.
+        """
+    if not gcs_uri.startswith("gs://"):
+      raise ValueError(f"Invalid GCS URI: {gcs_uri}")
+
+    # Remove gs:// and split into bucket and blob path
+    parts = gcs_uri[5:].split("/", 1)
+    if len(parts) < 2:
+      raise ValueError(f"Invalid GCS URI: {gcs_uri}")
+
+    bucket_name, blob_path = parts
+    bucket = self.client.get_bucket(bucket_name)
+    blob = bucket.blob(blob_path)
+    blob.upload_from_string(content, content_type=content_type)
+
+    return f"https://storage.mtls.cloud.google.com/{bucket_name}/{blob_path}"

--- a/src/cxas_scrapi/utils/reporting.py
+++ b/src/cxas_scrapi/utils/reporting.py
@@ -19,6 +19,7 @@ from datetime import datetime
 from typing import Any, Dict, List
 
 from cxas_scrapi.core.tools import Tools
+from cxas_scrapi.utils.gcs_utils import GCSUtils
 
 
 def _escape(text):
@@ -520,6 +521,19 @@ def _get_run_detail(r, ces_base, tools_map):
     return html
 
 
+def _upload_to_gcs(output_path: str, html: str) -> str | None:
+    """Uploads the report to GCS and returns the mTLS URL or None on failure."""
+    try:
+        gcs = GCSUtils()
+        mtls_url = gcs.upload_string(output_path, html)
+        print(f"Report uploaded to GCS: {output_path}")
+        print(f"Authenticated URL: {mtls_url}")
+        return mtls_url
+    except Exception as e:
+        print(f"WARNING: GCS upload failed ({e}). Falling back to local file.")
+        return None
+
+
 def generate_html_report(
     results: List[Dict[str, Any]],
     output_path: str,
@@ -528,9 +542,10 @@ def generate_html_report(
     app_name: str = "",
     wall_clock_s: float = None,
 ):
-    """Generate an HTML report with transcripts, tool calls,
+    """Generate an HTML report and save it locally or upload to GCS.
 
-    and failure details.
+    If output_path starts with 'gs://', the report is uploaded to GCS.
+    If the upload fails, it falls back to saving a local file.
     """
     total = len(results)
     passed = sum(1 for r in results if r.get("passed"))
@@ -593,5 +608,18 @@ def generate_html_report(
         html += "</div></div>\n"
 
     html += "</body></html>"
+
+    if output_path.startswith("gs://"):
+        mtls_url = _upload_to_gcs(output_path, html)
+        if mtls_url:
+            return
+
+        # Fallback to local file if upload failed
+        filename = output_path.rsplit("/", maxsplit=1)[-1]
+        if not filename.endswith(".html"):
+            filename = "report_fallback.html"
+        output_path = filename
+
     with open(output_path, "w") as f:
         f.write(html)
+    print(f"Report saved locally to: {output_path}")

--- a/tests/cxas_scrapi/utils/test_gcs_utils.py
+++ b/tests/cxas_scrapi/utils/test_gcs_utils.py
@@ -1,0 +1,54 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from cxas_scrapi.utils.gcs_utils import GCSUtils
+
+
+@patch("cxas_scrapi.utils.gcs_utils.storage.Client")
+def test_upload_string_success(mock_client_cls):
+  mock_client = mock_client_cls.return_value
+  mock_bucket = Mock()
+  mock_blob = Mock()
+  mock_client.get_bucket.return_value = mock_bucket
+  mock_bucket.blob.return_value = mock_blob
+
+  gcs = GCSUtils()
+  gcs_uri = "gs://test-bucket/reports/report.html"
+  content = "<html><body>Test</body></html>"
+
+  res_url = gcs.upload_string(gcs_uri, content)
+
+  mock_client.get_bucket.assert_called_once_with("test-bucket")
+  mock_bucket.blob.assert_called_once_with("reports/report.html")
+  mock_blob.upload_from_string.assert_called_once_with(
+      content, content_type="text/html; charset=utf-8")
+  assert "test-bucket/reports/report.html" in res_url
+
+
+@patch("cxas_scrapi.utils.gcs_utils.storage.Client")
+def test_upload_string_invalid_scheme(mock_client_cls):
+  gcs = GCSUtils()
+  with pytest.raises(ValueError, match="Invalid GCS URI"):
+    gcs.upload_string("https://storage.com/file", "content")
+
+
+@patch("cxas_scrapi.utils.gcs_utils.storage.Client")
+def test_upload_string_no_path(mock_client_cls):
+  gcs = GCSUtils()
+  with pytest.raises(ValueError, match="Invalid GCS URI"):
+    gcs.upload_string("gs://bucket", "content")

--- a/tests/cxas_scrapi/utils/test_reporting.py
+++ b/tests/cxas_scrapi/utils/test_reporting.py
@@ -1,0 +1,169 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import mock_open, patch
+
+from cxas_scrapi.utils.reporting import (
+    _escape,
+    _fmt_duration,
+    _format_trace_line,
+    _resolve_tool_name,
+    _upload_to_gcs,
+    generate_html_report,
+)
+
+
+@patch("cxas_scrapi.utils.reporting.GCSUtils")
+def test_upload_to_gcs_success(mock_gcs_cls):
+  mock_gcs = mock_gcs_cls.return_value
+  mock_gcs.upload_string.return_value = "https://storage.mtls.cloud.google.com/bucket/report.html"
+
+  res = _upload_to_gcs("gs://bucket/report.html", "<html></html>")
+  assert res == "https://storage.mtls.cloud.google.com/bucket/report.html"
+
+
+@patch("cxas_scrapi.utils.reporting.GCSUtils")
+def test_upload_to_gcs_failure(mock_gcs_cls):
+  mock_gcs = mock_gcs_cls.return_value
+  mock_gcs.upload_string.side_effect = Exception("error")
+
+  res = _upload_to_gcs("gs://bucket/report.html", "<html></html>")
+  assert res is None
+
+
+@patch("cxas_scrapi.utils.reporting._upload_to_gcs")
+@patch("builtins.open", new_callable=mock_open)
+def test_generate_html_report_gcs_success(mock_file, mock_upload):
+  mock_upload.return_value = "https://url"
+  results = [{"name": "test", "passed": True, "run": 1}]
+
+  generate_html_report(results, "gs://bucket/report.html", "text", "model")
+
+  mock_upload.assert_called_once()
+  mock_file.assert_not_called()
+
+
+@patch("cxas_scrapi.utils.reporting._upload_to_gcs")
+@patch("builtins.open", new_callable=mock_open)
+def test_generate_html_report_gcs_fallback_with_extension(
+    mock_file, mock_upload):
+  mock_upload.return_value = None
+  results = [{"name": "test", "passed": True, "run": 1}]
+
+  generate_html_report(results, "gs://bucket/fail_report.html", "text", "model")
+
+  mock_upload.assert_called_once()
+  mock_file.assert_called_once_with("fail_report.html", "w")
+
+
+@patch("cxas_scrapi.utils.reporting._upload_to_gcs")
+@patch("builtins.open", new_callable=mock_open)
+def test_generate_html_report_gcs_fallback_no_extension(mock_file, mock_upload):
+  mock_upload.return_value = None
+  results = [{"name": "test", "passed": True, "run": 1}]
+
+  # Path with no extension
+  generate_html_report(results, "gs://bucket/no_ext", "text", "model")
+
+  mock_upload.assert_called_once()
+  mock_file.assert_called_once_with("report_fallback.html", "w")
+
+
+@patch("cxas_scrapi.utils.reporting.Tools")
+@patch("builtins.open", new_callable=mock_open)
+def test_generate_html_report_tools_failure(mock_file, mock_tools_cls):
+  # Simulate Tools(app_name).get_tools_map() failing
+  mock_tools_cls.return_value.get_tools_map.side_effect = Exception(
+      "Tools failed")
+
+  results = [{"name": "test", "passed": True, "run": 1}]
+  generate_html_report(results,
+                       "local.html",
+                       "text",
+                       "model",
+                       app_name="projects/p")
+
+  mock_file.assert_called_once_with("local.html", "w")
+
+
+@patch("builtins.open", new_callable=mock_open)
+def test_generate_html_report_local(mock_file):
+  results = [{
+      "name":
+          "test_eval",
+      "passed":
+          False,
+      "error":
+          "Timeout",
+      "run":
+          1,
+      "session_id":
+          "sess123",
+      "turns":
+          5,
+      "detailed_trace": ["User: hello", "Agent Text: hi"],
+      "step_details": [{
+          "goal": "g",
+          "status": "Completed",
+          "success_criteria": "c",
+          "justification": "j"
+      }],
+      "expectation_details": [{
+          "expectation": "e",
+          "status": "Met",
+          "justification": "j2"
+      }]
+  }]
+
+  generate_html_report(results=results,
+                       output_path="local.html",
+                       modality="audio",
+                       model="gemini-3.1-pro-preview",
+                       app_name="projects/p1/locations/l1/apps/a1",
+                       wall_clock_s=120.5)
+
+  mock_file.assert_called_once_with("local.html", "w")
+  content = mock_file().write.call_args[0][0]
+  assert "Simulation Eval Report" in content
+  assert "0.0%" in content
+  assert "audio" in content
+  assert "gemini-3.1-pro-preview" in content
+  assert "2.0m" in content
+  assert "test_eval" in content
+  assert "Timeout" in content
+  assert "sess123" in content
+
+
+def test_fmt_duration():
+  assert _fmt_duration(None) == ""
+  assert _fmt_duration(30) == "30.0s"
+  assert _fmt_duration(90) == "1.5m"
+
+
+def test_escape():
+  assert _escape("<script>&\"") == "&lt;script&gt;&amp;&quot;"
+
+
+def test_resolve_tool_name():
+  tools_map = {"projects/p/tools/t1": "MyTool"}
+  assert _resolve_tool_name("projects/p/tools/t1", tools_map) == "MyTool"
+  assert _resolve_tool_name("projects/p/tools/t2", tools_map) == "t2"
+  assert _resolve_tool_name(None, tools_map) is None
+
+
+def test_format_trace_line():
+  tools_map = {"path/to/tool": "GreatTool"}
+  line = "Tool Call: path/to/tool with args {}"
+  assert "GreatTool" in _format_trace_line(line, tools_map)
+  assert "Unrelated" in _format_trace_line("Unrelated", tools_map)


### PR DESCRIPTION
Introduces the ability to export simulation HTML reports directly to Google  Cloud Storage. The reporting logic now uses a single output_path parameter  that dynamically handles both local file paths and gs:// URIs.

Key improvements:
- Added GCSUtils for authenticated string uploads to Cloud Storage.
- Implemented a graceful fallback that saves reports locally if a GCS  upload fails.
- Streamlined CLI arguments in simulation scripts to support the unified  output path logic.

Change-Id: I7a454639bcbe9be0a9d29ded72dfab086a6a6964