### PR TITLE
feat: create deployment updates

### DIFF
--- a/src/cxas_scrapi/core/callbacks.py
+++ b/src/cxas_scrapi/core/callbacks.py
@@ -21,6 +21,7 @@ import traceback
 from typing import Any, Callable, Dict, List, Optional, Union
 
 from google.cloud.ces_v1beta import types
+from google.protobuf import field_mask_pb2
 
 from cxas_scrapi.core.agents import Agents
 
@@ -139,7 +140,7 @@ class Callbacks(Agents):
         getattr(agent, field_name).append(new_callback)
 
         # Use field mask so we only update the specific callback field
-        mask = types.field_mask_pb2.FieldMask(paths=[field_name])
+        mask = field_mask_pb2.FieldMask(paths=[field_name])
         request = types.UpdateAgentRequest(agent=agent, update_mask=mask)
         return self.client.update_agent(request=request)
 
@@ -174,7 +175,7 @@ class Callbacks(Agents):
         if disabled is not None:
             callbacks[index].disabled = disabled
 
-        mask = types.field_mask_pb2.FieldMask(paths=[field_name])
+        mask = field_mask_pb2.FieldMask(paths=[field_name])
         request = types.UpdateAgentRequest(agent=agent, update_mask=mask)
         return self.client.update_agent(request=request)
 
@@ -197,7 +198,7 @@ class Callbacks(Agents):
         # Remove the specific element
         del callbacks[index]
 
-        mask = types.field_mask_pb2.FieldMask(paths=[field_name])
+        mask = field_mask_pb2.FieldMask(paths=[field_name])
         request = types.UpdateAgentRequest(agent=agent, update_mask=mask)
         return self.client.update_agent(request=request)
 

--- a/src/cxas_scrapi/core/deployments.py
+++ b/src/cxas_scrapi/core/deployments.py
@@ -14,6 +14,7 @@
 
 """Core Deployments class for CXAS Scrapi."""
 
+from enum import Enum
 from typing import Any, Dict, List
 
 from google.cloud.ces_v1beta import types
@@ -24,6 +25,25 @@ from cxas_scrapi.core.apps import Apps
 
 class Deployments(Apps):
     """Core Class for managing Deployment Resources."""
+
+    class ChannelType(Enum):
+        WEB_UI = "WEB_UI"
+        API = "API"
+        TWILIO = "TWILIO"
+        GOOGLE_TELEPHONY_PLATFORM = "GOOGLE_TELEPHONY_PLATFORM"
+        CONTACT_CENTER_AS_A_SERVICE = "CONTACT_CENTER_AS_A_SERVICE"
+        FIVE9 = "FIVE9"
+        AUDIOCODES = "CONTACT_CENTER_INTEGRATION"
+
+    class Modality(Enum):
+        CHAT_AND_VOICE = "CHAT_AND_VOICE"
+        VOICE_ONLY = "VOICE_ONLY"
+        CHAT_ONLY = "CHAT_ONLY"
+        CHAT_VOICE_AND_VIDEO = "CHAT_VOICE_AND_VIDEO"
+
+    class Theme(Enum):
+        LIGHT = "LIGHT"
+        DARK = "DARK"
 
     def __init__(
         self,
@@ -49,6 +69,46 @@ class Deployments(Apps):
         )
         self.resource_type = "deployments"
         self.app_name = app_name
+
+    @classmethod
+    def _build_web_widget_config(
+        cls, kwargs: Dict[str, Any], mask_paths: List[str] | None = None
+    ) -> types.ChannelProfile.WebWidgetConfig | None:
+        """Helper to build WebWidgetConfig and update mask paths."""
+        wwc_fields = ["modality", "theme", "web_widget_title"]
+        has_wwc_update = any(k in kwargs for k in wwc_fields)
+
+        if not has_wwc_update:
+            return None
+
+        wwc = types.ChannelProfile.WebWidgetConfig()
+
+        if "modality" in kwargs:
+            modality = kwargs.pop("modality")
+            if isinstance(modality, str):
+                modality = cls.Modality[modality.upper()]
+            wwc.modality = getattr(
+                types.ChannelProfile.WebWidgetConfig.Modality, modality.value
+            )
+            if mask_paths is not None:
+                mask_paths.append("channel_profile.web_widget_config.modality")
+
+        if "theme" in kwargs:
+            theme = kwargs.pop("theme")
+            if isinstance(theme, str):
+                theme = cls.Theme[theme.upper()]
+            wwc.theme = getattr(
+                types.ChannelProfile.WebWidgetConfig.Theme, theme.value
+            )
+            if mask_paths is not None:
+                mask_paths.append("channel_profile.web_widget_config.theme")
+
+        if "web_widget_title" in kwargs:
+            wwc.web_widget_title = kwargs.pop("web_widget_title")
+            if mask_paths is not None:
+                mask_paths.append("channel_profile.web_widget_config.web_widget_title")
+
+        return wwc
 
     def list_deployments(self) -> List[types.Deployment]:
         """Lists deployments within a specific app."""
@@ -87,18 +147,49 @@ class Deployments(Apps):
         deployment_id: str,
         display_name: str,
         app_version: str,
-        channel_profile: str = "WEB_AND_MOBILE",
+        channel_type: ChannelType | str = ChannelType.API,
+        modality: Modality | str | None = None,
+        theme: Theme | str | None = None,
+        web_widget_title: str = None,
+        disable_dtmf: bool = False,
+        disable_barge_in_control: bool = False,
     ) -> types.Deployment:
-        """Creates a new deployment."""
+        """Creates a new deployment with specified configuration.
+
+        Note: `modality`, `theme`, and `web_widget_title` are only applicable
+        when `channel_type` is `ChannelType.WEB_UI`.
+        """
+
         deployment = types.Deployment(
             display_name=display_name, app_version=app_version
         )
 
-        # Optionally set channel profile if we want to be explicit
-        if channel_profile:
-            deployment.channel_profile.channel_type = getattr(
-                types.common.ChannelProfile.ChannelType, channel_profile.upper()
-            )
+        # Convert string to enum if needed
+        if isinstance(channel_type, str):
+            channel_type = self.ChannelType[channel_type.upper()]
+
+        channel_profile = types.ChannelProfile()
+
+        channel_profile.channel_type = getattr(
+            types.common.ChannelProfile.ChannelType, channel_type.value
+        )
+
+        channel_profile.disable_dtmf = disable_dtmf
+        channel_profile.disable_barge_in_control = disable_barge_in_control
+
+        if channel_type == self.ChannelType.WEB_UI:
+            wwc_kwargs = {
+                "modality": modality or self.Modality.CHAT_AND_VOICE,
+                "theme": theme or self.Theme.LIGHT,
+            }
+            if web_widget_title:
+                wwc_kwargs["web_widget_title"] = web_widget_title
+
+            wwc = self._build_web_widget_config(wwc_kwargs)
+            if wwc:
+                channel_profile.web_widget_config = wwc
+
+        deployment.channel_profile = channel_profile
 
         request = types.CreateDeploymentRequest(
             parent=self.app_name,
@@ -106,6 +197,7 @@ class Deployments(Apps):
             deployment=deployment,
         )
         return self.client.create_deployment(request=request)
+
 
     def update_deployment(
         self, deployment_id: str, **kwargs
@@ -116,6 +208,48 @@ class Deployments(Apps):
         )
         mask_paths = []
 
+        channel_profile_fields = [
+            "channel_type",
+            "modality",
+            "theme",
+            "web_widget_title",
+            "disable_dtmf",
+            "disable_barge_in_control",
+        ]
+
+        has_channel_profile_update = any(
+            k in kwargs for k in channel_profile_fields
+        )
+
+        if has_channel_profile_update:
+            channel_profile = types.ChannelProfile()
+
+            if "channel_type" in kwargs:
+                channel_type = kwargs.pop("channel_type")
+                if isinstance(channel_type, str):
+                    channel_type = self.ChannelType[channel_type.upper()]
+                channel_profile.channel_type = getattr(
+                    types.common.ChannelProfile.ChannelType, channel_type.value
+                )
+                mask_paths.append("channel_profile.channel_type")
+
+            if "disable_dtmf" in kwargs:
+                channel_profile.disable_dtmf = kwargs.pop("disable_dtmf")
+                mask_paths.append("channel_profile.disable_dtmf")
+
+            if "disable_barge_in_control" in kwargs:
+                channel_profile.disable_barge_in_control = kwargs.pop(
+                    "disable_barge_in_control"
+                )
+                mask_paths.append("channel_profile.disable_barge_in_control")
+
+            wwc = self._build_web_widget_config(kwargs, mask_paths)
+            if wwc:
+                channel_profile.web_widget_config = wwc
+
+            deployment.channel_profile = channel_profile
+
+        # Handle remaining kwargs as top-level fields
         for key, value in kwargs.items():
             setattr(deployment, key, value)
             mask_paths.append(key)

--- a/src/cxas_scrapi/core/sessions.py
+++ b/src/cxas_scrapi/core/sessions.py
@@ -28,7 +28,6 @@ import certifi
 import requests
 import websocket
 from google.auth.transport.requests import Request
-from google.cloud import ces_v1beta
 from google.cloud.ces_v1beta import SessionServiceClient, types
 from google.protobuf import json_format
 
@@ -130,8 +129,8 @@ class BidiSessionHandler:
     def _send_silence(self, num_chunks: int):
         silence_chunk = b"\x00" * AUDIO_CHUNK_SIZE
         for _ in range(num_chunks):
-            query_message = ces_v1beta.BidiSessionClientMessage(
-                realtime_input=ces_v1beta.SessionInput(audio=silence_chunk)
+            query_message = types.BidiSessionClientMessage(
+                realtime_input=types.SessionInput(audio=silence_chunk)
             )
             query_json = json_format.MessageToJson(
                 query_message._pb,
@@ -161,8 +160,8 @@ class BidiSessionHandler:
             if i == 0 and variables:
                 input_args["variables"] = variables
 
-            query_message = ces_v1beta.BidiSessionClientMessage(
-                realtime_input=ces_v1beta.SessionInput(**input_args)
+            query_message = types.BidiSessionClientMessage(
+                realtime_input=types.SessionInput(**input_args)
             )
             query_json = json_format.MessageToJson(
                 query_message._pb,
@@ -190,8 +189,8 @@ class BidiSessionHandler:
     def _send_inputs(self):
         try:
             logging.debug("Config dict: %s", self.config)
-            config_message = ces_v1beta.BidiSessionClientMessage(
-                config=ces_v1beta.SessionConfig(
+            config_message = types.BidiSessionClientMessage(
+                config=types.SessionConfig(
                     session=self.config["session"],
                     input_audio_config=self.config.get("input_audio_config"),
                     output_audio_config=self.config.get("output_audio_config"),
@@ -219,15 +218,15 @@ class BidiSessionHandler:
 
                 # Handle non-audio structured inputs (event, text, variables)
                 try:
-                    session_input_pb = ces_v1beta.SessionInput()._pb
+                    session_input_pb = types.SessionInput()._pb
                     json_format.ParseDict(
                         input_item,
                         session_input_pb,
                         ignore_unknown_fields=False,
                     )
-                    session_input = ces_v1beta.SessionInput(session_input_pb)
+                    session_input = types.SessionInput(session_input_pb)
 
-                    query_message = ces_v1beta.BidiSessionClientMessage(
+                    query_message = types.BidiSessionClientMessage(
                         realtime_input=session_input
                     )
                     query_json = json_format.MessageToJson(
@@ -271,13 +270,13 @@ class BidiSessionHandler:
         logging.debug("===============")
         logging.debug("Received message: %s...", message[:100])
         try:
-            response_pb = ces_v1beta.BidiSessionServerMessage()._pb
+            response_pb = types.BidiSessionServerMessage()._pb
             json_format.Parse(
                 message,
                 response_pb,
                 ignore_unknown_fields=True,
             )
-            response = ces_v1beta.BidiSessionServerMessage(response_pb)
+            response = types.BidiSessionServerMessage(response_pb)
 
             if response.session_output:
                 self.outputs.append(response.session_output)
@@ -328,7 +327,7 @@ class BidiSessionHandler:
         logging.debug("Waiting for session to complete...")
         wst.join()
 
-        return ces_v1beta.RunSessionResponse(outputs=self.outputs)
+        return types.RunSessionResponse(outputs=self.outputs)
 
 
 class Sessions(Common):
@@ -336,7 +335,6 @@ class Sessions(Common):
         self,
         app_name: str,
         deployment_id: str = None,
-        version_id: str = None,
         **kwargs,
     ):
         """Initializes the Sessions client."""
@@ -351,7 +349,6 @@ class Sessions(Common):
 
         self.app_name = app_name
         self.deployment_id = deployment_id
-        self.version_id = version_id
 
     def _check_audio_requirements(self):
         """Checks if the necessary APIs are enabled and user has permissions."""
@@ -756,7 +753,6 @@ class Sessions(Common):
         input_audio_config: Optional[Dict[str, Any]] = None,
         output_audio_config: Optional[Dict[str, Any]] = None,
         deployment_id: Optional[str] = None,
-        version_id: Optional[str] = None,
         historical_contexts: Optional[List[Dict[str, Any]] | str] = None,
         turn_count: Optional[int] = None,
         modality: Modality | str = Modality.TEXT,
@@ -788,8 +784,7 @@ class Sessions(Common):
                 (defaults to 16kHz linear PCM).
             deployment_id: Overrides the default deployment ID setting for this
                 turn run.
-            version_id: Overrides the default app version setting for this turn
-                run.
+
             historical_contexts: An existing conversation ID (string) or raw
                 list of dictionaries to pre-set past history.
             turn_count: Truncates historical context limits when pulling from a
@@ -817,15 +812,15 @@ class Sessions(Common):
             self._check_audio_requirements()
             config["input_audio_config"] = (
                 input_audio_config
-                or ces_v1beta.InputAudioConfig(
-                    audio_encoding=ces_v1beta.AudioEncoding.LINEAR16,
+                or types.InputAudioConfig(
+                    audio_encoding=types.AudioEncoding.LINEAR16,
                     sample_rate_hertz=SAMPLE_RATE,
                 )
             )
             config["output_audio_config"] = (
                 output_audio_config
-                or ces_v1beta.OutputAudioConfig(
-                    audio_encoding=ces_v1beta.AudioEncoding.LINEAR16,
+                or types.OutputAudioConfig(
+                    audio_encoding=types.AudioEncoding.LINEAR16,
                     sample_rate_hertz=SAMPLE_RATE,
                 )
             )
@@ -836,10 +831,7 @@ class Sessions(Common):
                 f"{self.app_name}/deployments/"
                 f"{deployment_id or self.deployment_id}"
             )
-        if version_id or self.version_id:
-            config["app_version"] = (
-                f"{self.app_name}/app_versions/{version_id or self.version_id}"
-            )
+        # app_version is not supported in SessionConfig, only deployment is.
 
         if historical_contexts:
             parsed_contexts = []
@@ -904,10 +896,9 @@ class Sessions(Common):
             inputs.append({"dtmf": dtmf})
 
         if event is not None:
-            event_payload = {"event": event}
             if event_vars:
-                event_payload["variables"] = event_vars
-            inputs.append({"event": event_payload})
+                inputs.append({"variables": event_vars})
+            inputs.append({"event": {"event": event}})
 
         # Wrap blob input correctly
         if blob is not None:
@@ -1004,7 +995,7 @@ class Sessions(Common):
         self, unique_id: str, event_name: str, event_vars: Dict[str, Any]
     ):
         config = {"session": f"{self.app_name}/sessions/{unique_id}"}
-        inputs = [{"event": {"event": event_name, "variables": event_vars}}]
+        inputs = [{"variables": event_vars}, {"event": {"event": event_name}}]
 
         request = types.RunSessionRequest(config=config, inputs=inputs)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,10 +16,11 @@ import os
 import sys
 from unittest.mock import MagicMock
 
+import google.cloud.ces_v1beta as real_ces
 import pytest
 
 # Global Test Constants
-TEST_APP_ID = "projects/df-reference/locations/us/apps/f39d3ab5-a463-4025-8437-31fd09685d6b"  # noqa: E501
+TEST_APP_NAME = "projects/mock-project/locations/mock-location/apps/mock-app-id"
 
 # Mock the oauth token globally so tests don't try to
 # invoke Application Default Credentials
@@ -71,7 +72,7 @@ def pytest_collection_modifyitems(config, items):
 
 @pytest.fixture
 def app_id():
-    return TEST_APP_ID
+    return TEST_APP_NAME
 
 
 # Create a mock module structure for google.cloud.ces_v1beta if not
@@ -80,7 +81,7 @@ if "--run-online" not in sys.argv:
     mock_ces = MagicMock()
     mock_ces.AgentServiceClient = MagicMock
     mock_ces.EvaluationServiceClient = MagicMock
-    mock_ces.types = MagicMock()
+    mock_ces.types = real_ces.types
     sys.modules["google.cloud.ces_v1beta"] = mock_ces
 
     # Mock google.cloud.dialogflowcx_v3beta1 for dfcx_exporter offline tests

--- a/tests/cxas_scrapi/cli/test_main.py
+++ b/tests/cxas_scrapi/cli/test_main.py
@@ -42,8 +42,17 @@ def test_cli_installed_help():
     # When running tests via 'conda run -n cxas-scrapi pytest', 'cxas'
     # should be in the PATH.
     try:
+        py_code = (
+            "import sys; "
+            "sys.argv[0]='cxas'; "
+            "from cxas_scrapi.cli.main import main; "
+            "main()"
+        )
         result = subprocess.run(
-            ["cxas", "--help"], capture_output=True, text=True, check=True
+            ["python3", "-c", py_code, "--help"],
+            capture_output=True,
+            text=True,
+            check=True,
         )
         assert result.returncode == 0
         assert "usage: cxas" in result.stdout

--- a/tests/cxas_scrapi/core/test_callbacks.py
+++ b/tests/cxas_scrapi/core/test_callbacks.py
@@ -14,6 +14,8 @@
 
 from unittest.mock import MagicMock, patch
 
+from google.cloud.ces_v1beta import types
+
 from cxas_scrapi.core.callbacks import Callbacks
 
 
@@ -59,24 +61,9 @@ def test_get_callback(mock_client_cls, mock_get_agent):
 
 @patch("cxas_scrapi.core.callbacks.Agents.get_agent")
 @patch("cxas_scrapi.core.agents.AgentServiceClient")
-@patch("cxas_scrapi.core.callbacks.types.Callback")
-def test_create_callback(mock_callback_cls, mock_client_cls, mock_get_agent):
-    def side_effect(**kwargs):
-        m = MagicMock()
-        for k, v in kwargs.items():
-            setattr(m, k, v)
-        return m
-
-    mock_callback_cls.side_effect = side_effect
-
+def test_create_callback(mock_client_cls, mock_get_agent):
     """Test create_callback."""
-    mock_agent = MagicMock()
-
-    class MockRepeatedList(list):
-        pass
-
-    callbacks_list = MockRepeatedList()
-    mock_agent.before_model_callbacks = callbacks_list
+    mock_agent = types.Agent()
     mock_get_agent.return_value = mock_agent
 
     cb_client = Callbacks(app_name="projects/p/locations/l/apps/a")
@@ -86,8 +73,9 @@ def test_create_callback(mock_callback_cls, mock_client_cls, mock_get_agent):
 
     cb_client.create_callback("agent1", "before_model", my_cool_func)
 
-    assert len(callbacks_list) == 1
-    assert "def beforeModelCallback" in callbacks_list[0].python_code
+    assert len(mock_agent.before_model_callbacks) == 1
+    cb_code = mock_agent.before_model_callbacks[0].python_code
+    assert "def beforeModelCallback" in cb_code
     cb_client.client.update_agent.assert_called_once()
 
 
@@ -95,11 +83,9 @@ def test_create_callback(mock_callback_cls, mock_client_cls, mock_get_agent):
 @patch("cxas_scrapi.core.agents.AgentServiceClient")
 def test_update_callback(mock_client_cls, mock_get_agent):
     """Test update_callback."""
-    mock_agent = MagicMock()
-    mock_cb = MagicMock()
-    mock_cb.python_code = "old"
-    mock_cb.description = "old"
-    mock_agent.before_model_callbacks = [mock_cb]
+    mock_agent = types.Agent()
+    cb = types.Callback(python_code="old", description="old")
+    mock_agent.before_model_callbacks.append(cb)
     mock_get_agent.return_value = mock_agent
 
     cb_client = Callbacks(app_name="projects/p/locations/l/apps/a")
@@ -112,8 +98,8 @@ def test_update_callback(mock_client_cls, mock_get_agent):
         description="new_desc",
     )
 
-    assert mock_cb.python_code == "new_code"
-    assert mock_cb.description == "new_desc"
+    assert mock_agent.before_model_callbacks[0].python_code == "new_code"
+    assert mock_agent.before_model_callbacks[0].description == "new_desc"
     cb_client.client.update_agent.assert_called_once()
 
 
@@ -121,23 +107,18 @@ def test_update_callback(mock_client_cls, mock_get_agent):
 @patch("cxas_scrapi.core.agents.AgentServiceClient")
 def test_delete_callback(mock_client_cls, mock_get_agent):
     """Test delete_callback."""
-    mock_agent = MagicMock()
-    mock_cb1 = MagicMock()
-    mock_cb2 = MagicMock()
-
-    class MockRepeatedList(list):
-        pass
-
-    callbacks_list = MockRepeatedList([mock_cb1, mock_cb2])
-    mock_agent.before_model_callbacks = callbacks_list
+    mock_agent = types.Agent()
+    cb1 = types.Callback(python_code="c1")
+    cb2 = types.Callback(python_code="c2")
+    mock_agent.before_model_callbacks.extend([cb1, cb2])
     mock_get_agent.return_value = mock_agent
 
     cb_client = Callbacks(app_name="projects/p/locations/l/apps/a")
 
     cb_client.delete_callback("agent1", "before_model", index=0)
 
-    assert len(callbacks_list) == 1
-    assert callbacks_list[0] == mock_cb2
+    assert len(mock_agent.before_model_callbacks) == 1
+    assert mock_agent.before_model_callbacks[0].python_code == "c2"
     cb_client.client.update_agent.assert_called_once()
 
 

--- a/tests/cxas_scrapi/core/test_deployments.py
+++ b/tests/cxas_scrapi/core/test_deployments.py
@@ -14,6 +14,9 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+from google.cloud.ces_v1beta import types
+
 from cxas_scrapi.core.deployments import Deployments
 
 
@@ -64,19 +67,10 @@ def test_get_deployment(mock_client_cls):
     mock_client.get_deployment.assert_called_once()
 
 
-@patch("cxas_scrapi.core.deployments.types.CreateDeploymentRequest")
 @patch("cxas_scrapi.core.apps.AgentServiceClient")
-def test_create_deployment(mock_client_cls, mock_req_cls):
+def test_create_deployment(mock_client_cls):
     mock_client = mock_client_cls.return_value
     mock_client.create_deployment.return_value = MagicMock()
-
-    def side_effect(**kwargs):
-        m = MagicMock()
-        for k, v in kwargs.items():
-            setattr(m, k, v)
-        return m
-
-    mock_req_cls.side_effect = side_effect
 
     deps = Deployments("projects/p/locations/l/apps/A")
     deps.create_deployment("dep_id", "my_dep", "v1")
@@ -86,21 +80,52 @@ def test_create_deployment(mock_client_cls, mock_req_cls):
     assert args.deployment_id == "dep_id"
 
 
-@patch("cxas_scrapi.core.deployments.types.Deployment")
-@patch("cxas_scrapi.core.deployments.types.UpdateDeploymentRequest")
 @patch("cxas_scrapi.core.apps.AgentServiceClient")
-def test_update_deployment(mock_client_cls, mock_req_cls, mock_dep_cls):
+def test_create_deployment_with_options(mock_client_cls):
+    mock_client = mock_client_cls.return_value
+    mock_client.create_deployment.return_value = MagicMock()
+
+    deps = Deployments("projects/p/locations/l/apps/A")
+    deps.create_deployment(
+        "dep_id",
+        "my_dep",
+        "v1",
+        channel_type=Deployments.ChannelType.WEB_UI,
+        modality=Deployments.Modality.CHAT_ONLY,
+        theme=Deployments.Theme.DARK,
+        web_widget_title="My Title",
+        disable_dtmf=True,
+        disable_barge_in_control=True,
+    )
+
+    mock_client.create_deployment.assert_called_once()
+
+    args = mock_client.create_deployment.call_args[1]["request"]
+
+    assert args.parent == "projects/p/locations/l/apps/A"
+    assert args.deployment_id == "dep_id"
+
+    dep = args.deployment
+    assert dep.display_name == "my_dep"
+    assert dep.app_version == "v1"
+
+    cp = dep.channel_profile
+    assert cp.disable_dtmf is True
+    assert cp.disable_barge_in_control is True
+
+    wwc = cp.web_widget_config
+    assert wwc.web_widget_title == "My Title"
+    assert wwc.modality == (
+        types.ChannelProfile.WebWidgetConfig.Modality.CHAT_ONLY
+    )
+    assert wwc.theme == types.ChannelProfile.WebWidgetConfig.Theme.DARK
+
+
+
+@patch("cxas_scrapi.core.apps.AgentServiceClient")
+def test_update_deployment(mock_client_cls):
     mock_client = mock_client_cls.return_value
     mock_client.update_deployment.return_value = MagicMock()
-
-    def side_effect(**kwargs):
-        m = MagicMock()
-        for k, v in kwargs.items():
-            setattr(m, k, v)
-        return m
-
-    mock_req_cls.side_effect = side_effect
-    mock_dep_cls.side_effect = side_effect
 
     deps = Deployments("projects/p/locations/l/apps/A")
     deps.update_deployment("dep_id", display_name="new_name")
@@ -113,10 +138,14 @@ def test_update_deployment(mock_client_cls, mock_req_cls, mock_dep_cls):
     assert args.deployment.display_name == "new_name"
 
 
-@patch("cxas_scrapi.core.deployments.types.DeleteDeploymentRequest")
+@patch("cxas_scrapi.core.deployments.types.Deployment")
+@patch("cxas_scrapi.core.deployments.types.UpdateDeploymentRequest")
 @patch("cxas_scrapi.core.apps.AgentServiceClient")
-def test_delete_deployment(mock_client_cls, mock_req_cls):
+def test_update_deployment_with_options(
+    mock_client_cls, mock_req_cls, mock_dep_cls
+):
     mock_client = mock_client_cls.return_value
+    mock_client.update_deployment.return_value = MagicMock()
 
     def side_effect(**kwargs):
         m = MagicMock()
@@ -126,8 +155,173 @@ def test_delete_deployment(mock_client_cls, mock_req_cls):
 
     mock_req_cls.side_effect = side_effect
 
+    mock_dep = MagicMock()
+    mock_dep_cls.return_value = mock_dep
+
+    deps = Deployments("projects/p/locations/l/apps/A")
+    deps.update_deployment(
+        "dep_id",
+        modality=Deployments.Modality.CHAT_ONLY,
+        theme=Deployments.Theme.DARK,
+    )
+    mock_client.update_deployment.assert_called_once()
+
+    mock_dep_cls.assert_called_once_with(
+        name="projects/p/locations/l/apps/A/deployments/dep_id"
+    )
+
+    assert mock_dep.channel_profile is not None
+    cp = mock_dep.channel_profile
+
+    wwc = cp.web_widget_config
+    assert wwc.modality == (
+        types.ChannelProfile.WebWidgetConfig.Modality.CHAT_ONLY
+    )
+    assert wwc.theme == types.ChannelProfile.WebWidgetConfig.Theme.DARK
+
+    args = mock_client.update_deployment.call_args[1]["request"]
+    mask = args.update_mask
+    assert "channel_profile.web_widget_config.modality" in mask.paths
+    assert "channel_profile.web_widget_config.theme" in mask.paths
+
+
+def test_build_web_widget_config():
+    kwargs = {
+        "modality": "CHAT_ONLY",
+        "theme": "DARK",
+        "web_widget_title": "New Title",
+        "other_arg": "value",
+    }
+    mask_paths = []
+
+    wwc = Deployments._build_web_widget_config(kwargs, mask_paths)
+
+    assert wwc is not None
+    assert wwc.web_widget_title == "New Title"
+    assert wwc.modality == (
+        types.ChannelProfile.WebWidgetConfig.Modality.CHAT_ONLY
+    )
+    assert wwc.theme == types.ChannelProfile.WebWidgetConfig.Theme.DARK
+
+    assert "channel_profile.web_widget_config.modality" in mask_paths
+    assert "channel_profile.web_widget_config.theme" in mask_paths
+    assert "channel_profile.web_widget_config.web_widget_title" in mask_paths
+
+    assert "modality" not in kwargs
+    assert "theme" not in kwargs
+    assert "web_widget_title" not in kwargs
+    assert kwargs["other_arg"] == "value"
+
+
+@patch("cxas_scrapi.core.apps.AgentServiceClient")
+def test_create_deployment_with_strings(mock_client_cls):
+    mock_client = mock_client_cls.return_value
+    mock_client.create_deployment.return_value = MagicMock()
+
+    deps = Deployments("projects/p/locations/l/apps/A")
+    deps.create_deployment(
+        "dep_id",
+        "my_dep",
+        "v1",
+        channel_type="WEB_UI",
+        modality="CHAT_ONLY",
+        theme="DARK",
+    )
+    mock_client.create_deployment.assert_called_once()
+
+    args = mock_client.create_deployment.call_args[1]["request"]
+    dep = args.deployment
+
+    cp = dep.channel_profile
+    wwc = cp.web_widget_config
+    assert wwc.modality == (
+        types.ChannelProfile.WebWidgetConfig.Modality.CHAT_ONLY
+    )
+    assert wwc.theme == types.ChannelProfile.WebWidgetConfig.Theme.DARK
+
+
+@patch("cxas_scrapi.core.apps.AgentServiceClient")
+def test_update_deployment_all_options(mock_client_cls):
+    mock_client = mock_client_cls.return_value
+    mock_client.update_deployment.return_value = MagicMock()
+
+    deps = Deployments("projects/p/locations/l/apps/A")
+    deps.update_deployment(
+        "dep_id",
+        channel_type=Deployments.ChannelType.API,
+        disable_dtmf=True,
+        disable_barge_in_control=True,
+    )
+    mock_client.update_deployment.assert_called_once()
+
+    args = mock_client.update_deployment.call_args[1]["request"]
+    dep = args.deployment
+
+    cp = dep.channel_profile
+    assert cp.channel_type == types.common.ChannelProfile.ChannelType.API
+    assert cp.disable_dtmf is True
+    assert cp.disable_barge_in_control is True
+
+    mask = args.update_mask
+    assert "channel_profile.channel_type" in mask.paths
+    assert "channel_profile.disable_dtmf" in mask.paths
+    assert "channel_profile.disable_barge_in_control" in mask.paths
+
+
+@patch("cxas_scrapi.core.apps.AgentServiceClient")
+def test_delete_deployment(mock_client_cls):
+    mock_client = mock_client_cls.return_value
+
     deps = Deployments("projects/p/locations/l/apps/A")
     deps.delete_deployment("dep_id")
     mock_client.delete_deployment.assert_called_once()
     args = mock_client.delete_deployment.call_args[1]["request"]
     assert args.name == "projects/p/locations/l/apps/A/deployments/dep_id"
+
+
+@pytest.mark.parametrize(
+    "channel_type_enum, expected_proto_value",
+    [
+        (
+            Deployments.ChannelType.GOOGLE_TELEPHONY_PLATFORM,
+            types.common.ChannelProfile.ChannelType.GOOGLE_TELEPHONY_PLATFORM,
+        ),
+        (
+            Deployments.ChannelType.CONTACT_CENTER_AS_A_SERVICE,
+            types.common.ChannelProfile.ChannelType.CONTACT_CENTER_AS_A_SERVICE,
+        ),
+        (
+            Deployments.ChannelType.AUDIOCODES,
+            types.common.ChannelProfile.ChannelType.CONTACT_CENTER_INTEGRATION,
+        ),
+        (
+            Deployments.ChannelType.API,
+            types.common.ChannelProfile.ChannelType.API,
+        ),
+        (
+            Deployments.ChannelType.FIVE9,
+            types.common.ChannelProfile.ChannelType.FIVE9,
+        ),
+        (
+            Deployments.ChannelType.TWILIO,
+            types.common.ChannelProfile.ChannelType.TWILIO,
+        ),
+    ],
+)
+@patch("cxas_scrapi.core.apps.AgentServiceClient")
+def test_create_deployment_different_channels(
+    mock_client_cls, channel_type_enum, expected_proto_value
+):
+    mock_client = mock_client_cls.return_value
+    mock_client.create_deployment.return_value = MagicMock()
+
+    deps = Deployments("projects/p/locations/l/apps/A")
+    deps.create_deployment(
+        "dep_id",
+        "my_dep",
+        "v1",
+        channel_type=channel_type_enum,
+    )
+    mock_client.create_deployment.assert_called_once()
+    args = mock_client.create_deployment.call_args[1]["request"]
+    assert args.deployment.channel_profile.channel_type == expected_proto_value

--- a/tests/cxas_scrapi/core/test_evaluations.py
+++ b/tests/cxas_scrapi/core/test_evaluations.py
@@ -336,8 +336,7 @@ def test_update_evaluation_expectation(mock_client_cls):
     mock_client = mock_client_cls.return_value
 
     evals_client = Evaluations(app_name="projects/p/locations/l/apps/a")
-    mock_exp = MagicMock()
-
+    mock_exp = types.EvaluationExpectation(display_name="Exp 1")
     evals_client.update_evaluation_expectation(mock_exp)
 
     mock_client.update_evaluation_expectation.assert_called_once()

--- a/tests/cxas_scrapi/core/test_sessions.py
+++ b/tests/cxas_scrapi/core/test_sessions.py
@@ -45,11 +45,9 @@ def test_sessions_init(mock_client_cls):
     sessions = Sessions(
         app_name="projects/p/locations/l/apps/a",
         deployment_id="d1",
-        version_id="v1",
     )
     assert sessions.app_name == "projects/p/locations/l/apps/a"
     assert sessions.deployment_id == "d1"
-    assert sessions.version_id == "v1"
 
 
 def test_get_file_data(tmp_path):
@@ -108,7 +106,6 @@ def test_run_session_advanced(mock_client_cls):
         blob_mime_type="image/jpeg",
         variables={"var1": "value1"},
         deployment_id="dep1",
-        version_id="ver1",
     )
 
     mock_client.run_session.assert_called_once()
@@ -123,6 +120,13 @@ def test_send_event(mock_client_cls):
     sessions.send_event("unique_id", "my_event", {"var1": "val1"})
 
     mock_client.run_session.assert_called_once()
+
+    call_kwargs = mock_client.run_session.call_args.kwargs
+    args = mock_client.run_session.call_args.args
+    request = call_kwargs.get("request") or args[0]
+
+    assert dict(request.inputs[0].variables) == {"var1": "val1"}
+    assert request.inputs[1].event.event == "my_event"
 
 
 @patch("cxas_scrapi.core.sessions.SessionServiceClient")
@@ -367,10 +371,9 @@ def test_create_session_id(mock_client_cls):
 
 
 @patch("cxas_scrapi.core.sessions.json_format.MessageToJson")
-@patch("cxas_scrapi.core.sessions.ces_v1beta.SessionInput")
 @patch("cxas_scrapi.core.sessions.time.sleep")
 def test_bidi_session_handler_send_audio_message_with_variables(
-    mock_sleep, mock_session_input, mock_to_json
+    mock_sleep, mock_to_json
 ):
     mock_to_json.return_value = "{}"
     config = {"session": "session_123"}
@@ -391,14 +394,21 @@ def test_bidi_session_handler_send_audio_message_with_variables(
 
     handler._send_inputs()
 
-    # Verify that SessionInput was called with variables
-    calls = mock_session_input.call_args_list
+    # Verify that MessageToJson was called with variables in SessionInput
+    calls = mock_to_json.call_args_list
     found_vars = False
     for call in calls:
-        kwargs = call[1]
-        if "variables" in kwargs and kwargs["variables"] == {"var": "val"}:
-            found_vars = True
-            break
+        args = call.args
+        if args:
+            msg_pb = args[0]
+            try:
+                msg_dict = json_format.MessageToDict(msg_pb)
+                ri = msg_dict.get("realtimeInput", {})
+                if ri.get("variables") == {"var": "val"}:
+                    found_vars = True
+                    break
+            except Exception:
+                pass
     assert found_vars is True
 
 
@@ -437,10 +447,9 @@ def test_run_session_audio_modality_variables_all_turns(
 
 
 @patch("cxas_scrapi.core.sessions.time.sleep")
-@patch("cxas_scrapi.core.sessions.ces_v1beta.SessionConfig")
 @patch("cxas_scrapi.core.sessions.json_format.MessageToJson")
 def test_bidi_session_handler_send_inputs_with_historical_contexts(
-    mock_message_to_json, mock_session_config, mock_sleep
+    mock_message_to_json, mock_sleep
 ):
     mock_message_to_json.return_value = '{"mocked": "json"}'
 
@@ -461,12 +470,20 @@ def test_bidi_session_handler_send_inputs_with_historical_contexts(
 
     handler._send_inputs()
 
-    mock_session_config.assert_called_once()
-    kwargs = mock_session_config.call_args[1]
-    assert kwargs["session"] == "session_123"
-    assert kwargs["historical_contexts"] == [
-        {"role": "user", "chunks": [{"text": "hi"}]}
-    ]
+    assert mock_message_to_json.call_count >= 1
+    first_call = mock_message_to_json.call_args_list[0]
+    args = first_call.args
+    assert len(args) > 0
+    msg_pb = args[0]
+    msg_dict = json_format.MessageToDict(msg_pb)
+
+    config = msg_dict.get("config", {})
+    assert config.get("session") == "session_123"
+    assert "historicalContexts" in config
+    hc = config["historicalContexts"]
+    assert len(hc) == 1
+    assert hc[0].get("role") == "user"
+    assert hc[0].get("chunks")[0].get("text") == "hi"
 
     assert handler.ws_app.send.call_count > 0
     # First send should be the mocked JSON
@@ -492,10 +509,9 @@ def test_run_session_use_tool_fakes(mock_client_cls, mock_run_session_request):
 
 
 @patch("cxas_scrapi.core.sessions.time.sleep")
-@patch("cxas_scrapi.core.sessions.ces_v1beta.SessionConfig")
 @patch("cxas_scrapi.core.sessions.json_format.MessageToJson")
 def test_bidi_session_handler_send_inputs_use_tool_fakes(
-    mock_message_to_json, mock_session_config, mock_sleep
+    mock_message_to_json, mock_sleep
 ):
     """Test BidiSessionHandler sends use_tool_fakes in config."""
     mock_message_to_json.return_value = "{}"
@@ -509,9 +525,15 @@ def test_bidi_session_handler_send_inputs_use_tool_fakes(
 
     handler._send_inputs()
 
-    mock_session_config.assert_called_once()
-    kwargs = mock_session_config.call_args[1]
-    assert kwargs["use_tool_fakes"] is True
+    assert mock_message_to_json.call_count >= 1
+    first_call = mock_message_to_json.call_args_list[0]
+    args = first_call.args
+    assert len(args) > 0
+    msg_pb = args[0]
+    msg_dict = json_format.MessageToDict(msg_pb)
+
+    config = msg_dict.get("config", {})
+    assert config.get("useToolFakes") is True
 
 
 @patch("cxas_scrapi.core.sessions.requests.get")

--- a/tests/cxas_scrapi/utils/local/test_create_utils.py
+++ b/tests/cxas_scrapi/utils/local/test_create_utils.py
@@ -303,21 +303,13 @@ def test_create_tool_add_to_agent(tmp_path):
 
     display_name = "My Added Tool"
     safe_name = "My_Added_Tool"
-    mock_dict = {"displayName": agent_name, "tools": [display_name]}
-    patch_path = (
-        "cxas_scrapi.utils.local.create_utils.json_format.MessageToDict"
-    )
 
-    with mock.patch(
-        "cxas_scrapi.utils.local.create_utils.json_format.ParseDict"
-    ):
-        with mock.patch(patch_path, return_value=mock_dict):
-            result_path = utils.create_tool(
-                display_name,
-                app_dir,
-                tool_type="GOOGLE_SEARCH",
-                add_to_agent=agent_name,
-            )
+    result_path = utils.create_tool(
+        display_name,
+        app_dir,
+        tool_type="GOOGLE_SEARCH",
+        add_to_agent=agent_name,
+    )
 
     # Verify tool created
     assert Path(result_path) == tmp_path / "tools" / safe_name


### PR DESCRIPTION
# Core SDK Updates

- Fixed oneof constraint violation in SessionInput: Updated run and send_event methods in sessions.py to send event and variables as separate items in the inputs list, as the SDK restricts them from being set in the same object.
- Consolidated imports in sessions.py: Removed from google.cloud import ces_v1beta and migrated all message type references to use types.MessageName directly for cleaner code.
- Removed unsupported version_id: Removed references to version_id in Sessions.__init__ and run methods, and stopped trying to set app_version in SessionConfig (as it is an internal field not exposed in the public SDK).
- Renamed Enum for UI alignment: Renamed ChannelType.CONTACT_CENTER_INTEGRATION to ChannelType.AUDIOCODES in deployments.py to match the semantic name used in the CX Agent Studio UI, while preserving the correct string value for the API.

# Testing Improvements

- Adhered to Testing Guidelines (No Structural Mocks): Removed patches on structural types like SessionInput and SessionConfig in test_sessions.py and test_create_utils.py. Instead, tests now inspect the data passed to serialization functions or clients, ensuring real types are tested.
- Added Parametrized Tests for Deployments: Created new tests in test_deployments.py to verify the creation of deployments across all supported channel types (GTP, CCAAS, AudioCodes, API, Five9, Twilio).
- Fixed CLI Test Environment Pollution: Updated test_cli_installed_help in test_main.py to use python3 -c and fake sys.argv[0]='cxas', ensuring it tests the environment's local code rather than falling back to a broken system-wide installation.
- Fixed Linter Issues: Resolved all "line too long" warnings in test_callbacks.py, test_sessions.py, and test_deployments.py.
- Renamed Constants: Renamed TEST_APP_ID to TEST_APP_NAME in conftest.py for consistency across the project.