### PR TITLE
fix: add missing voice config to app.json template in foundry skill

### DIFF
--- a/.agents/skills/cxas-agent-foundry/assets/project-template/cxas_app/Sample_Support_Agent/app.json
+++ b/.agents/skills/cxas-agent-foundry/assets/project-template/cxas_app/Sample_Support_Agent/app.json
@@ -50,10 +50,19 @@
         "  tool calls concurrently instead of sequentially."
     ],
     "languageSettings": {
-        "defaultLanguageCode": "en"
+        "defaultLanguageCode": "en-US"
     },
     "timeZoneSettings": {
         "timeZone": "America/New_York"
+    },
+    "audioProcessingConfig": {
+        "synthesizeSpeechConfigs": {
+            "en-US": {
+                "speakingRate": 1.0
+            }
+        }
+    },
+    "defaultChannelProfile": {
     },
     "_comment_logging_settings": [
         "LOGGING SETTINGS:",


### PR DESCRIPTION
## Problem
Apps created programmatically using the `cxas-agent-foundry` skill template were causing errors in the CX Agent Studio UI (such as frozen voice settings) when configured for voice agents. We discovered that the API allows creating apps without specific voice configurations, but the UI expects them to be present.

## Fix
I have patched the `app.json` template within the `cxas-agent-foundry` skill assets to include the necessary defaults for voice agents:
*   Added `audioProcessingConfig` with default speech synthesis settings for `en-US`.
*   Added an empty `defaultChannelProfile` object.
*   Updated `defaultLanguageCode` to `en-US` to match the speech synthesis configuration.

This ensures that any new apps generated from the template will have the correct structure to load without errors in the UI.