### PR TITLE
fix(linter): C009 false-positives on dict[str, Any] annotations

### DIFF
--- a/src/cxas_scrapi/utils/lint_rules/callbacks.py
+++ b/src/cxas_scrapi/utils/lint_rules/callbacks.py
@@ -17,6 +17,7 @@
 Validates agent callback Python files against GECX conventions.
 """
 
+import ast
 import re
 from pathlib import Path
 
@@ -485,53 +486,67 @@ class WrongCallbackSignature(Rule):
         if not expected:
             return []
 
-        fn_name = expected["fn"]
-        pattern = (
-            rf"def\s+{re.escape(fn_name)}"
-            r"\s*\(([^)]*)\)(\s*->\s*[^:]+)?:"
-        )
-        match = re.search(pattern, content, re.DOTALL)
-        if not match:
+        try:
+            tree = ast.parse(content)
+        except SyntaxError:
             return []
 
-        args_str = match.group(1)
-        return_str = match.group(2)
+        fn_name = expected["fn"]
+        func = next(
+            (
+                node
+                for node in ast.walk(tree)
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and node.name == fn_name
+            ),
+            None,
+        )
+        if func is None:
+            return []
+
         params_str = ", ".join(
             f"{k}: {v}" for k, v in expected["params"].items()
         )
         expected_sig = f"def {fn_name}({params_str}) -> {expected['return']}:"
 
+        def _norm(annotation: str) -> str:
+            return re.sub(r"\s+", "", annotation)
+
         results = []
-        for param in (p.strip() for p in args_str.split(",") if p.strip()):
-            parts = param.split(":")
-            param_name = parts[0].strip()
-            expected_type = expected["params"].get(param_name)
+        all_args = (
+            list(func.args.posonlyargs)
+            + list(func.args.args)
+            + list(func.args.kwonlyargs)
+        )
+        for arg in all_args:
+            expected_type = expected["params"].get(arg.arg)
             if not expected_type:
                 continue
-            if len(parts) < 2:  # noqa: PLR2004
+            if arg.annotation is None:
                 results.append(
                     self.make_result(
                         file=rel,
                         message=(
                             f"Parameter"
-                            f" '{param_name}'"
+                            f" '{arg.arg}'"
                             " missing type"
                             " annotation,"
                             f" expected"
-                            f" '{param_name}:"
+                            f" '{arg.arg}:"
                             f" {expected_type}'"
                         ),
                         fix=expected_sig,
                     )
                 )
-            elif parts[1].strip() != expected_type:
-                actual_t = parts[1].strip()
+                continue
+            actual_t = ast.unparse(arg.annotation)
+            if _norm(actual_t) != _norm(expected_type):
                 results.append(
                     self.make_result(
                         file=rel,
                         message=(
                             f"Parameter"
-                            f" '{param_name}'"
+                            f" '{arg.arg}'"
                             f" has type"
                             f" '{actual_t}',"
                             f" expected"
@@ -541,7 +556,7 @@ class WrongCallbackSignature(Rule):
                     )
                 )
 
-        if not return_str:
+        if func.returns is None:
             results.append(
                 self.make_result(
                     file=rel,
@@ -554,8 +569,8 @@ class WrongCallbackSignature(Rule):
                 )
             )
         else:
-            actual = return_str.strip().lstrip("->").strip()
-            if actual != expected["return"]:
+            actual = ast.unparse(func.returns)
+            if _norm(actual) != _norm(expected["return"]):
                 results.append(
                     self.make_result(
                         file=rel,

--- a/tests/cxas_scrapi/utils/test_lint_rules.py
+++ b/tests/cxas_scrapi/utils/test_lint_rules.py
@@ -603,6 +603,130 @@ def test_c009_correct_signature(tmp_path, context):
     assert len(results) == 0
 
 
+def test_c009_before_tool_dict_str_any_no_false_positive(tmp_path, context):
+    """A correctly typed before_tool_callback must not be flagged.
+
+    Regression test for issue #56: the comma inside `dict[str, Any]` used
+    to break the parameter splitter, producing a bogus
+    "Parameter 'input' has type 'dict[str'" error.
+    """
+    from cxas_scrapi.utils.lint_rules.callbacks import WrongCallbackSignature  # noqa: PLC0415,I001
+
+    rule = WrongCallbackSignature()
+    cb_dir = (
+        tmp_path
+        / "agents"
+        / "root"
+        / "before_tool_callbacks"
+        / "before_tool_callbacks_01"
+    )
+    cb_dir.mkdir(parents=True)
+    f = cb_dir / "python_code.py"
+    f.write_text(
+        "def before_tool_callback(\n"
+        "    tool: Tool,\n"
+        "    input: dict[str, Any],\n"
+        "    callback_context: CallbackContext,\n"
+        ") -> Optional[dict[str, Any]]:\n"
+        "    return None\n"
+    )
+
+    results = rule.check(f, f.read_text(), context)
+    assert results == [], [r.message for r in results]
+
+
+def test_c009_after_tool_dict_str_any_no_false_positive(tmp_path, context):
+    """A correctly typed after_tool_callback must not be flagged.
+
+    Covers the `tool_response: dict[str, Any]` parameter from issue #56.
+    """
+    from cxas_scrapi.utils.lint_rules.callbacks import WrongCallbackSignature  # noqa: PLC0415,I001
+
+    rule = WrongCallbackSignature()
+    cb_dir = (
+        tmp_path
+        / "agents"
+        / "root"
+        / "after_tool_callbacks"
+        / "after_tool_callbacks_01"
+    )
+    cb_dir.mkdir(parents=True)
+    f = cb_dir / "python_code.py"
+    f.write_text(
+        "def after_tool_callback(\n"
+        "    tool: Tool,\n"
+        "    input: dict[str, Any],\n"
+        "    callback_context: CallbackContext,\n"
+        "    tool_response: dict[str, Any],\n"
+        ") -> Optional[dict[str, Any]]:\n"
+        "    return None\n"
+    )
+
+    results = rule.check(f, f.read_text(), context)
+    assert results == [], [r.message for r in results]
+
+
+def test_c009_dict_str_any_no_space_no_false_positive(tmp_path, context):
+    """`dict[str,Any]` (no space) is semantically equal to `dict[str, Any]`.
+
+    Regression test for the whitespace-sensitive comparison from issue #56.
+    """
+    from cxas_scrapi.utils.lint_rules.callbacks import WrongCallbackSignature  # noqa: PLC0415,I001
+
+    rule = WrongCallbackSignature()
+    cb_dir = (
+        tmp_path
+        / "agents"
+        / "root"
+        / "before_tool_callbacks"
+        / "before_tool_callbacks_01"
+    )
+    cb_dir.mkdir(parents=True)
+    f = cb_dir / "python_code.py"
+    f.write_text(
+        "def before_tool_callback("
+        "tool: Tool, "
+        "input: dict[str,Any], "
+        "callback_context: CallbackContext"
+        ") -> Optional[dict[str,Any]]:\n"
+        "    return None\n"
+    )
+
+    results = rule.check(f, f.read_text(), context)
+    assert results == [], [r.message for r in results]
+
+
+def test_c009_genuinely_wrong_dict_type_still_caught(tmp_path, context):
+    """Ensure the fix does not silence real type mismatches."""
+    from cxas_scrapi.utils.lint_rules.callbacks import WrongCallbackSignature  # noqa: PLC0415,I001
+
+    rule = WrongCallbackSignature()
+    cb_dir = (
+        tmp_path
+        / "agents"
+        / "root"
+        / "before_tool_callbacks"
+        / "before_tool_callbacks_01"
+    )
+    cb_dir.mkdir(parents=True)
+    f = cb_dir / "python_code.py"
+    f.write_text(
+        "def before_tool_callback("
+        "tool: Tool, "
+        "input: dict[int, Any], "
+        "callback_context: CallbackContext"
+        ") -> Optional[dict[str, Any]]:\n"
+        "    return None\n"
+    )
+
+    results = rule.check(f, f.read_text(), context)
+    messages = [r.message for r in results]
+    assert any(
+        "input" in m and "dict[int, Any]" in m and "dict[str, Any]" in m
+        for m in messages
+    ), messages
+
+
 def test_c010_invalid_syntax(tmp_path, context):
     from cxas_scrapi.utils.lint_rules.callbacks import InvalidPythonSyntax  # noqa: PLC0415,I001
 


### PR DESCRIPTION
## Summary

- Rewrites the C009 callback-signature check to walk the function's AST instead of regex-splitting the parameter list, so commas inside annotations like `dict[str, Any]` no longer truncate the parsed type.
- Compares annotation strings after `ast.unparse` + whitespace normalization, so `dict[str,Any]` is treated as equal to `dict[str, Any]` (Python already does).
- Adds regression tests for `before_tool_callback`, `after_tool_callback`, the unspaced form, and a genuinely wrong type to lock the contract in.

Fixes #56

## Test plan

- [x] `python -m pytest tests/cxas_scrapi/utils/test_lint_rules.py -k c009 -v` — 6 passed (4 new + 2 pre-existing).
- [x] `python -m pytest tests/cxas_scrapi/utils/` — 186 passed, no regressions in neighboring rules.
- [x] Reviewer: spot-check that the C009 message for a real type mismatch now shows the full annotation (e.g. `'dict[int, Any]'`) instead of the truncated `'dict[int'`.
