### PR TITLE
docs: scope DAG slot manager state to prevent cross-DAG-agent contamination

### DIFF
--- a/examples/bella_notte/slot_filling_dag_framework.md
+++ b/examples/bella_notte/slot_filling_dag_framework.md
@@ -126,8 +126,6 @@ The slots and tasks implicitly define a **directed acyclic graph**:
                ├──▶ MakeReservation ──▶ [confirmation]
 [date] ────────┤
                │
-[chosen_time] ─┤
-               │
 [open_slots]* ─┘
                (* open_slots is not an input to MakeReservation in this example,
                   but chosen_time requires it, so it's transitively required)
@@ -137,7 +135,7 @@ The framework walks this DAG on every callback invocation, deciding what to do n
 
 ### 2.4 State
 
-All state lives in a single session-scoped dict called `sm` (slot manager):
+All state lives in a scoped dict stored within the global session (e.g., `sm`). Do not use a generic "sm" key if your CXAS application uses multiple DAG-powered agents, as this may cause cross-DAG-agent state corruption. For the sake of readability in this document, we will refer to this dictionary simply as sm, but in practice, it must be uniquely namespaced. 
 
 ```python
 sm = {
@@ -171,7 +169,7 @@ The framework is structured as three layers, all in a single file (CES platform 
 
 1. **`_get_config()`** — agent-specific: slots, tasks, executors, formatters, conditions. Replace this per project.
 2. **`_run_slot_filling(config, sm)`** — the orchestrator. CES-agnostic: takes a config dict and state dict, returns `{"hide_tools": [...], "preempt": bool, "message": str|None}`. Never touches CES types (`LlmResponse`, `Part`, `llm_request`, `callback_context`).
-3. **`before_model_callback()`** — thin CES adapter (~15 lines). Calls `_get_config()` and `_validate_config()`, passes config + state to the orchestrator, writes the returned message to `sm["_system_message"]`, applies tool visibility via `llm_request.config.hide_tool()`, and optionally preempts the LLM via `LlmResponse.from_parts()`.
+3. **`before_model_callback()`** — thin CES adapter (~15 lines). Extracts the uniquely namespaced state for this agent (e.g., sm = context.state.setdefault("sm_bella_notte", {})), calls `_get_config()` and `_validate_config()`, passes config + state to the orchestrator, writes the returned message to `sm["_system_message"]`, applies tool visibility via `llm_request.config.hide_tool()`, and optionally preempts the LLM via `LlmResponse.from_parts()`.
 
 CES calls the callback before EACH model invocation, including after tool results within the same turn. This re-invocation is what lets the framework see state changes from setter tools and react immediately (e.g., fire a DAG task as soon as its inputs are filled).
 
@@ -446,7 +444,8 @@ When a setter tool detects invalid input, it writes an error signal to `sm["_slo
 
 ```python
 def set_num_guests(count: int) -> dict:
-    sm = context.state["sm"]
+    # Always use the unique namespace to prevent cross-DAG Agent pollution
+    sm = context.state["sm_bella_notte"]
     if not (1 <= count <= 8):
         sm.setdefault("_slot_errors", []).append(
             {"slot": "num_guests", "code": "out_of_range"}
@@ -499,8 +498,8 @@ def set_date(date: str) -> dict:
 
     Convert natural language ('this Friday', 'July 4th') to YYYY-MM-DD.
     """
-    sm = context.state["sm"]
-
+    # Always use the agent's unique namespace to prevent cross-DAG Agent pollution
+    sm = context.state["sm_bella_notte"]
     # 1. Validate format via strptime (catches impossible dates like 2026-13-45)
     date = str(date).strip()
     try:
@@ -1034,7 +1033,7 @@ When a task fires and we know exactly what to say, the LLM adds latency and rand
 
 2. **No partial readback.** When pending slots exist, ALL pending values are shown in readback. You can't confirm some and leave others pending.
 
-3. **Single-agent scope.** The framework manages one agent's flow. Multi-agent routing (e.g., transferring from a booking agent to a billing agent) is handled externally.
+3. **Single-agent scope.** The framework manages one agent's flow. Multi-agent routing (e.g., transferring from a booking agent to a billing agent) is handled externally. Note: When the overall application contains multiple DAG-powered agents, you must ensure each agent's callback and setter tools use uniquely namespaced state keys (e.g., sm_booking, sm_billing) to freeze and protect their DAG state during potential handoffs.
 
 4. **No undo after confirmation.** Once values move from pending to filled via `confirm_pending`, they can't be changed (the setter is hidden). The user would need to explicitly ask to start over, which the framework doesn't support.
 


### PR DESCRIPTION
### Summary

This PR updates the Slot Filling DAG Framework documentation to explicitly enforce namespacing for the Slot Manager (`sm`) state dictionary.

As currently documented, the framework instructs developers to store the DAG state in `context.state["sm"]`. Because `context.state` is globally scoped to the session in CX Agent Studio, if an application utilizes multi-agent orchestration where two or more agents implement this DAG framework, they will both read and write to the same `"sm"` key.

### Why This is Critical

Without namespacing, delegating from one DAG-powered agent to another creates a severe state corruption vulnerability:

1. Agent A (e.g., Flight Booking) populates `sm["filled"]` and `sm["pending"]`.
2. The user goes off-topic and is routed to Agent B (e.g., Rewards Check).
3. Agent B initializes its DAG using the exact same `context.state["sm"]` key, reading Agent A's variables, falsely triggering task inputs, and potentially clearing pending slots.
4. When control routes back to Agent A, its state is mangled, leading to broken readbacks, progress stalls, or infinite loops.

### Changes Made

By uniquely namespacing the dictionary per agent (e.g., `sm_bella_notte`), an agent's state safely "freezes" during delegation and perfectly resumes upon return.

* **Section 2.3 (DAG diagram):** Removed extra `"chosen_time"` slot in the MakeReservation example.
* **Section 2.4 (State):** Added a warning explaining the need for agent-scoped keys in the global session instead of a generic `"sm"`.
* **Section 3 (Callback Lifecycle):** Updated the adapter pattern text to show the `setdefault` extraction of a unique namespace.
* **Section 5b.2 & 6.1 (Setter Tools):** Updated the boilerplate code snippets to use `context.state["sm_bella_notte"]` to prevent developers from copy-pasting global state vulnerabilities.
* **Section 18 (Limitations):** Added a note under the "Single-agent scope" limitation clarifying that state scoping is required when routing between DAGs.

This is a documentation and boilerplate code update, it does not change the functions of the orchestrator or DAG evaluator.