### PR TITLE
docs(skills): add multilingual agent patterns to cxas-agent-foundry s…

### DIFF
--- a/.agents/skills/cxas-agent-foundry/references/eval-templates.md
+++ b/.agents/skills/cxas-agent-foundry/references/eval-templates.md
@@ -398,6 +398,146 @@ expectations:
 
 ---
 
+## Multilingual Eval Patterns
+
+Use these patterns for any agent with multi-language support. The key distinction: **explicit language switch = golden** (deterministic), **auto-detect reliability = sim** (non-deterministic by nature).
+
+### Golden: Explicit Language Switch
+
+Tests the happy path: user explicitly requests a language and the agent calls `update_language` before responding.
+
+```yaml
+conversations:
+  - conversation: explicit_switch_english_to_german
+    session_parameters:
+      active_language: "English"
+    turns:
+      - user: "<event>welcome</event>"
+        agent: "Hello, how can I help you today?"
+      - user: "Can you speak German please?"
+        agent: "Natürlich, wie kann ich Ihnen helfen?"
+        tool_calls:
+          - action: update_language
+            args:
+              new_language: "German"
+      - user: "Ich möchte mein Konto überprüfen."
+        agent: "Gerne helfe ich Ihnen dabei."
+    expectations:
+      - "The agent must call update_language before its first response in German."
+      - "The agent must respond in German for all turns after the switch."
+      - "The agent must NOT revert to English unless the user explicitly requests it."
+    tags: [P0, multilingual, explicit-switch]
+
+  - conversation: explicit_switch_back_to_english
+    session_parameters:
+      active_language: "German"
+    turns:
+      - user: "<event>welcome</event>"
+        agent: "Hallo, wie kann ich Ihnen helfen?"
+      - user: "English please."
+        agent: "Of course, how can I help you?"
+        tool_calls:
+          - action: update_language
+            args:
+              new_language: "English"
+    expectations:
+      - "The agent must call update_language when the user switches back to English."
+      - "The agent must respond in English after the switch."
+    tags: [P0, multilingual, explicit-switch]
+```
+
+### Golden: Language Guardrails (Stay in Current Language)
+
+Tests that the agent does NOT switch on ambiguous or short utterances.
+
+```yaml
+conversations:
+  - conversation: guardrail_single_word_stays
+    session_parameters:
+      active_language: "English"
+    turns:
+      - user: "<event>welcome</event>"
+        agent: "Hello, how can I help you today?"
+      - user: "I need help with my bill. Danke."
+        agent: "Of course, I'd be happy to help with your bill."
+    expectations:
+      - "The agent must NOT call update_language."
+      - "The agent must stay in English despite the isolated German word 'danke'."
+    tags: [P0, multilingual, guardrail]
+
+  - conversation: guardrail_cognate_stays
+    session_parameters:
+      active_language: "English"
+    turns:
+      - user: "<event>welcome</event>"
+        agent: "Hello, how can I help you today?"
+      - user: "No."
+        agent: "I understand. Is there anything else I can help you with?"
+    expectations:
+      - "The agent must NOT call update_language."
+      - "The agent must stay in English for short ambiguous utterances."
+    tags: [P0, multilingual, guardrail]
+```
+
+### Simulation: Language Switch Reliability (Auto-Detect)
+
+Use a sim for auto-detect stress testing — agent phrasing and detection vary. Run with high parallelism to surface intermittent failures.
+
+```yaml
+- name: multilingual_explicit_switch_stress
+  tags: [P0, multilingual]
+  steps:
+    - goal: Start in English, explicitly switch to German, then explicitly switch back to English
+      success_criteria: Agent responds in the correct language in every phase without reverting
+      response_guide: "Start in English asking about account balance. After the agent responds, say 'Können Sie auf Deutsch antworten?' to switch to German. After 2 German turns, say 'English please.' to switch back."
+      max_turns: 14
+  expectations:
+    - "The agent must call update_language exactly twice — once when switching to German and once when switching back to English."
+    - "The agent must respond in German after the first switch."
+    - "The agent must respond in English after the second switch."
+    - "The agent must NOT switch language spontaneously without the user requesting it."
+
+- name: multilingual_guardrail_stress
+  tags: [P1, multilingual]
+  steps:
+    - goal: Attempt to confuse the agent with mixed-language sentences and short ambiguous utterances
+      success_criteria: Agent stays in English throughout without calling update_language
+      response_guide: "Conduct the conversation in English but pepper responses with isolated German words: 'danke', 'ja', 'nein', 'bitte'. Use mixed sentences like 'My account number? Keine Ahnung.' Do NOT explicitly ask to switch."
+      max_turns: 10
+  expectations:
+    - "The agent must NOT call update_language at any point."
+    - "The agent must respond in English throughout."
+    - "The agent must NOT switch languages based on isolated foreign words in otherwise English sentences."
+```
+
+### Tool Test: `update_language`
+
+```yaml
+- test: update_language_sets_active_language_german
+  tool: update_language
+  input:
+    new_language: "German"
+  expectations:
+    - key: success
+      value: true
+    - key: active_language
+      value: "German"
+    - key: agent_action
+      value: "Continue the entire conversation in German."
+
+- test: update_language_sets_active_language_english
+  tool: update_language
+  input:
+    new_language: "English"
+  expectations:
+    - key: success
+      value: true
+    - key: active_language
+      value: "English"
+```
+
+---
+
 ## Customer Profile Management
 
 Evals need mock customer profiles for session parameters. When creating evals:

--- a/.agents/skills/cxas-agent-foundry/references/gecx-design-guide.md
+++ b/.agents/skills/cxas-agent-foundry/references/gecx-design-guide.md
@@ -586,3 +586,166 @@ See `examples/bella_notte/` for a complete working example (restaurant reservati
 - `tools/` — all setter tools
 
 To build a new agent: copy `callback.py`, replace `_get_config()` with your slots/tasks/executors, create matching setter tools.
+
+## Multilingual Agents
+
+Multi-language voice agents on `gemini-3.1-flash-live` have two documented failure modes that require specific patterns to mitigate. Both are confirmed production issues (b/484305525, b/506098142).
+
+### Failure Mode 1: Language-Polluted Context
+
+**Root cause:** When agent instructions are in Language A (e.g., English) and a datastore or tool returns content in Language B (e.g., German), the LLM receives mixed-language context. This causes the agent to spontaneously switch languages mid-response — even with explicit instructions not to. The model loses track of which language to use once it sees both languages in the same context window.
+
+**Fix:** Translate at the tool boundary. Never let tool responses in a different language pass directly into the LLM context.
+
+#### Translate-Around-Tool-Calls Pattern
+
+In any tool that queries a datastore or API whose content is in a different language than the instructions, perform explicit translation before returning:
+
+```python
+def search_knowledge_base(user_query: str) -> dict:
+    """Searches the knowledge base for answers to the user's question.
+    Internally translates the query to German for the datastore and
+    translates the result back to English before returning.
+
+    Args:
+        user_query: The user's question in English (REQUIRED).
+
+    Returns:
+        dict with 'result' (str) and 'agent_action' (str).
+    """
+    # 1. Translate query to datastore language
+    german_query = translate_to_german(user_query)
+
+    # 2. Fetch from datastore (German content)
+    raw_result = kb.search(german_query)
+
+    # 3. Translate result back to working language before returning to LLM
+    english_result = translate_to_english(raw_result)
+
+    return {
+        "result": english_result,
+        "agent_action": "Respond to the user using the information in 'result'."
+    }
+```
+
+**Key principle:** All content that enters the LLM context (tool results, system messages, instructions) must be in one language. The translation happens inside the tool, invisibly to the LLM.
+
+---
+
+### Failure Mode 2: Non-Deterministic Language Switch Detection
+
+**Root cause:** `gemini-3.1-flash-live` does not reliably auto-detect language switches. Detection is non-deterministic — it works on some utterances and silently fails on others. The model is especially likely to miss switches on: short utterances, phonetically ambiguous words (e.g., "nein" vs "nine"), and cognates (words shared between languages).
+
+**Fix:** Use a structured `<language_detection>` instruction block with conservative guardrails, plus an `update_language` tool to gate the switch deterministically.
+
+#### Explicit-Only vs Auto-Detect
+
+For MVP and production: **always use explicit-switch-only mode first.** Auto-detection has a known model-level limitation requiring a model revision to fully fix. The explicit-only path (user says "speak German") is reliable; auto-detection from utterance language alone is not.
+
+Only add auto-detection if it's a hard requirement, and stress-test it with sims before shipping (see `references/eval-templates.md` → Multilingual Eval Patterns).
+
+#### The `update_language` Tool
+
+Create this tool in the app. It gates the switch and keeps `active_language` in session state:
+
+```python
+def update_language(new_language: str) -> dict:
+    """Updates the active conversation language when the user requests a switch.
+    Call this BEFORE generating your first response in the new language.
+
+    Args:
+        new_language: Language to switch to. One of: "English", "German",
+                      "French", "Italian", "Spanish" (REQUIRED).
+
+    Returns:
+        dict with 'success' (bool), 'active_language' (str), 'agent_action' (str).
+    """
+    context["session"]["active_language"] = new_language
+    return {
+        "success": True,
+        "active_language": new_language,
+        "agent_action": f"Continue the entire conversation in {new_language}."
+    }
+```
+
+#### Language Detection Instruction Block
+
+Add this block at the **END** of the agent instructions (after all other instructions). Customize `[Language A]` and `[Language B]` for your use case:
+
+```xml
+<language_detection>
+  <goal>Determine if the primary language of the current user utterance is [Language A] or [Language B], and update the context if a switch occurs.</goal>
+
+  <evaluation_rules>
+    - **Fresh Evaluation (CRITICAL):** Re-evaluate the language for EVERY new user utterance.
+    - **Contextual Inertia (CRITICAL):** Heavily weight the ongoing conversation language. Users rarely switch for single words.
+    - **Ambiguity Rule:** If the utterance is short, ambiguous, or contains cognates, DEFAULT to the language of the PREVIOUS turn.
+    - **Length Guardrail:** Do NOT switch for utterances shorter than 3 words unless the user makes an explicit request (e.g., "German please" / "Auf Deutsch bitte").
+    - **Switching Threshold:** You may ONLY switch if the user EXPLICITLY requests it OR speaks a complete, grammatically unambiguous sentence in the new language.
+    - **Cognate Guardrail:** Words spelled identically in both languages MUST NEVER trigger a switch on their own.
+    - **Noisy Audio Guardrail:** If there is background noise, default to the language of the previous turn.
+    - **Current Language Trumps Single Words:** Isolated words or politeness markers from the other language (e.g., "danke" in an English sentence) must NOT trigger a switch.
+  </evaluation_rules>
+
+  <execution_steps>
+    <step>
+      1. State the language of the previous turn (Contextual Inertia baseline).
+      2. Analyze Grammar: Is the utterance a grammatically complete sentence in the new language, or just a fragment or noun phrase?
+      3. Check for Cognates: Are primary words shared between both languages?
+      4. Check Mistranscription: Could this be a phonetic confusion for the current language?
+      5. Lock in your language decision for this turn.
+    </step>
+    <step>
+      <trigger>User's input language is DIFFERENT from previous turn AND meets the Switching Threshold above.</trigger>
+      <action>Immediately invoke {@TOOL: update_language}. Do not provide a verbal response until the tool succeeds.</action>
+    </step>
+    <step>
+      <trigger>Locked language decision is [Language B].</trigger>
+      <action>Translate the user utterance to [Language A] for any tool parameters. Generate your final response in [Language B].</action>
+    </step>
+  </execution_steps>
+
+  <examples>
+    <example>
+      <previous_lang>[Language A]</previous_lang>
+      <user_input>[Language B] please.</user_input>
+      <analysis>Explicit language request. Meets switching threshold regardless of word count.</analysis>
+      <decision>Switch to [Language B]. Call update_language.</decision>
+    </example>
+    <example>
+      <previous_lang>English</previous_lang>
+      <user_input>Ich brauche Hilfe bei meiner Rechnung für diesen Monat.</user_input>
+      <analysis>Complete German sentence with verb and object. Audio confirms German. Meets switching threshold.</analysis>
+      <decision>Switch to German. Call update_language.</decision>
+    </example>
+    <example>
+      <previous_lang>English</previous_lang>
+      <user_input>danke</user_input>
+      <analysis>Single word, politeness marker that exists in both contexts. Length guardrail applies. Context is English.</analysis>
+      <decision>Stay in English. Do NOT call update_language.</decision>
+    </example>
+    <example>
+      <previous_lang>English</previous_lang>
+      <user_input>I want to cancel my account, danke.</user_input>
+      <analysis>Clear English sentence with a trailing German word. Current language trumps single words.</analysis>
+      <decision>Stay in English. Do NOT call update_language.</decision>
+    </example>
+    <example>
+      <previous_lang>English</previous_lang>
+      <user_input>nein</user_input>
+      <analysis>Single word, phonetically identical to English "nine". Length guardrail applies. Context is English.</analysis>
+      <decision>Stay in English. Do NOT call update_language.</decision>
+    </example>
+  </examples>
+</language_detection>
+```
+
+---
+
+### Voice / Audio: Voice Identity Across Languages (b/506098142)
+
+**Separate issue:** On `gemini-3.1-flash-live`, a non-default voice (e.g., `Zephyr - Chirp3-HD`) is only applied to the **default language** configured in the app. Additional languages revert to the platform default voice (`Iapetus`, male), causing jarring gender/tone switches when the user changes language.
+
+**Fix:** This was resolved in the CES Console (CL 908383873, deployed 2026-04-30). When you set a voice in the Console for one language, it is now propagated to all configured additional languages automatically. If you observe voice identity changes after a language switch, re-save your app's voice settings to trigger the propagation.
+
+**Temporary workaround** (if you need to unblock before re-saving): Switch to the default voice (`Iapetus`) for the agent. The default voice is consistent across all languages. This is not ideal for agents with board-approved persona voices but eliminates the jarring switch.

--- a/.agents/skills/cxas-agent-foundry/references/interview-guide.md
+++ b/.agents/skills/cxas-agent-foundry/references/interview-guide.md
@@ -17,6 +17,11 @@
    - **Text**: `gemini-3-flash` (text-only, lower latency)
 3. **Requirements source** -- Ask for the PRD, spec doc, or requirements. Can be a file path, URL, or pasted text. If they don't have a formal doc, interview them to build one.
 4. **Existing resources** -- Do they have sample conversations, mock data, customer profiles, or an existing agent to reference?
+5. **Multilingual requirements** -- Does this agent need to support more than one language?
+   - **Which languages?** (e.g., English + German, English + Spanish)
+   - **Switching mode:** Should switching be **explicit-only** (user must say "speak German") or **auto-detected** (agent detects from utterance)? **Default to explicit-only** -- auto-detection is non-deterministic on `gemini-3.1-flash-live` and is not recommended for production (b/484305525).
+   - **Datastore language:** Is the knowledge base / datastore in a different language than the agent instructions? If yes, the translate-around-tool-calls pattern is required (see `references/gecx-design-guide.md` → Multilingual Agents).
+   - **Voice persona:** Is there a specific approved voice? Non-default voices have a known issue where additional languages revert to the default voice. Re-saving app voice settings in the Console fixes this (see `references/gecx-design-guide.md` → Voice / Audio).
 
 ## Round 2: Write the Technical Design Document (TDD)
 


### PR DESCRIPTION
Changes:
- gecx-design-guide.md: new Multilingual Agents section covering the translate-around-tool-calls pattern (mixed-language context pollution), the <language_detection> XML instruction block with full guardrails, the update_language tool design, explicit-only vs auto-detect guidance, and the voice seed token issue with its Console fix.
- interview-guide.md: new Round 1 question #5 to surface multilingual requirements early — which languages, switching mode, datastore language mismatch, and voice persona risks.
- eval-templates.md: new Multilingual Eval Patterns section with goldens for explicit switches and guardrail assertions, sims for auto-detect stress testing, and tool tests for update_language.