### PR TITLE
chore: update telemetry tracking patterns

### DIFF
--- a/.agents/skills/cxas-agent-foundry/scripts/app-thresholds.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/app-thresholds.py
@@ -36,11 +36,13 @@ from config import load_app_name, load_config, get_project_path
 HALLUCINATION_VALUES = {"unspecified": 0, "disabled": 1, "enabled_strict": 2, "enabled": 2}
 EXTRA_TOOL_VALUES = {"allow": 1, "deny": 2}
 
+USER_AGENT_EXTENSION = "skill/cxas-agent-foundry/app-thresholds"
+
 
 def get_app(project, location):
     """Get the Apps client."""
     from cxas_scrapi.core.apps import Apps
-    return Apps(project_id=project, location=location, user_agent_extension="skill/cxas-agent-foundry/app-thresholds")
+    return Apps(project_id=project, location=location, user_agent_extension=USER_AGENT_EXTENSION)
 
 
 def cmd_show(args):
@@ -49,7 +51,7 @@ def cmd_show(args):
 
     from cxas_scrapi.core.evaluations import Evaluations
     try:
-        client = Evaluations(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/app-thresholds")
+        client = Evaluations(app_name=app_name, user_agent_extension=USER_AGENT_EXTENSION)
         client.get_evaluation_thresholds(print_console=True)
     except Exception as e:
         print(f"Error: Failed to get thresholds: {e}")

--- a/.agents/skills/cxas-agent-foundry/scripts/app-thresholds.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/app-thresholds.py
@@ -40,7 +40,7 @@ EXTRA_TOOL_VALUES = {"allow": 1, "deny": 2}
 def get_app(project, location):
     """Get the Apps client."""
     from cxas_scrapi.core.apps import Apps
-    return Apps(project_id=project, location=location)
+    return Apps(project_id=project, location=location, user_agent_extension="skill/cxas-agent-foundry/app-thresholds")
 
 
 def cmd_show(args):
@@ -49,7 +49,7 @@ def cmd_show(args):
 
     from cxas_scrapi.core.evaluations import Evaluations
     try:
-        client = Evaluations(app_name=app_name)
+        client = Evaluations(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/app-thresholds")
         client.get_evaluation_thresholds(print_console=True)
     except Exception as e:
         print(f"Error: Failed to get thresholds: {e}")

--- a/.agents/skills/cxas-agent-foundry/scripts/bootstrap-evals.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/bootstrap-evals.py
@@ -39,6 +39,8 @@ SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, SCRIPTS_DIR)
 from config import load_app_name, load_config, get_project_path
 
+USER_AGENT_EXTENSION = "skill/cxas-agent-foundry/bootstrap-evals"
+
 
 SIM_SKELETON = """\
 # Simulation eval definitions -- local sims run via SCRAPI Sessions API.
@@ -116,7 +118,7 @@ def _resolve_resource_paths(evals_dir, app_name):
 
     try:
         from cxas_scrapi.core.agents import Agents
-        agents_client = Agents(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/bootstrap-evals")
+        agents_client = Agents(app_name=app_name, user_agent_extension=USER_AGENT_EXTENSION)
         agents_map = agents_client.get_agents_map(reverse=False)
         resource_map.update(agents_map)
         for resource_path, display_name in agents_map.items():
@@ -126,7 +128,7 @@ def _resolve_resource_paths(evals_dir, app_name):
 
     try:
         from cxas_scrapi.core.tools import Tools
-        tools_client = Tools(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/bootstrap-evals")
+        tools_client = Tools(app_name=app_name, user_agent_extension=USER_AGENT_EXTENSION)
         tools_map = tools_client.get_tools_map()
         # get_tools_map returns {resource_path: display_name}
         for resource_path, display_name in tools_map.items():
@@ -231,7 +233,7 @@ def export_goldens(app_name, dry_run=False, keep_expectations=False):
 
     try:
         from cxas_scrapi.core.evaluations import Evaluations, ExportFormat
-        client = Evaluations(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/bootstrap-evals")
+        client = Evaluations(app_name=app_name, user_agent_extension=USER_AGENT_EXTENSION)
         evals_map = client.get_evaluations_map(reverse=True)
         goldens = evals_map.get("goldens", {})
 
@@ -282,7 +284,7 @@ def generate_tool_tests(app_name, dry_run=False):
 
     try:
         from cxas_scrapi.evals.tool_evals import ToolEvals
-        tool_evals = ToolEvals(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/bootstrap-evals")
+        tool_evals = ToolEvals(app_name=app_name, user_agent_extension=USER_AGENT_EXTENSION)
         tool_evals.generate_tool_tests(
             target_dir=output_dir,
             mine_tool_data=True,

--- a/.agents/skills/cxas-agent-foundry/scripts/bootstrap-evals.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/bootstrap-evals.py
@@ -116,7 +116,7 @@ def _resolve_resource_paths(evals_dir, app_name):
 
     try:
         from cxas_scrapi.core.agents import Agents
-        agents_client = Agents(app_name=app_name)
+        agents_client = Agents(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/bootstrap-evals")
         agents_map = agents_client.get_agents_map(reverse=False)
         resource_map.update(agents_map)
         for resource_path, display_name in agents_map.items():
@@ -126,7 +126,7 @@ def _resolve_resource_paths(evals_dir, app_name):
 
     try:
         from cxas_scrapi.core.tools import Tools
-        tools_client = Tools(app_name=app_name)
+        tools_client = Tools(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/bootstrap-evals")
         tools_map = tools_client.get_tools_map()
         # get_tools_map returns {resource_path: display_name}
         for resource_path, display_name in tools_map.items():
@@ -231,7 +231,7 @@ def export_goldens(app_name, dry_run=False, keep_expectations=False):
 
     try:
         from cxas_scrapi.core.evaluations import Evaluations, ExportFormat
-        client = Evaluations(app_name=app_name)
+        client = Evaluations(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/bootstrap-evals")
         evals_map = client.get_evaluations_map(reverse=True)
         goldens = evals_map.get("goldens", {})
 
@@ -282,7 +282,7 @@ def generate_tool_tests(app_name, dry_run=False):
 
     try:
         from cxas_scrapi.evals.tool_evals import ToolEvals
-        tool_evals = ToolEvals(app_name=app_name)
+        tool_evals = ToolEvals(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/bootstrap-evals")
         tool_evals.generate_tool_tests(
             target_dir=output_dir,
             mine_tool_data=True,

--- a/.agents/skills/cxas-agent-foundry/scripts/capture-golden-transcripts.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/capture-golden-transcripts.py
@@ -38,6 +38,8 @@ from config import load_app_name, get_project_path
 GOLDENS_DIR = get_project_path("evals", "goldens")
 TRANSCRIPTS_DIR = get_project_path("evals", "goldens", "transcripts")
 
+USER_AGENT_EXTENSION = "skill/cxas-agent-foundry/capture-golden-transcripts"
+
 
 def load_golden_scripts():
     """Load user turns and session parameters from golden YAML files."""
@@ -116,7 +118,7 @@ def parse_response_deduped(response) -> Dict[str, Any]:
 def capture(name: str, scripts: dict, app_name: str, channel: str = "text"):
     """Capture a single golden transcript."""
     config = scripts[name]
-    sessions = Sessions(app_name, user_agent_extension="skill/cxas-agent-foundry/capture-golden-transcripts")
+    sessions = Sessions(app_name, user_agent_extension=USER_AGENT_EXTENSION)
     session_id = str(uuid.uuid4())
     params = config["params"]
     user_turns = config["turns"]

--- a/.agents/skills/cxas-agent-foundry/scripts/capture-golden-transcripts.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/capture-golden-transcripts.py
@@ -116,7 +116,7 @@ def parse_response_deduped(response) -> Dict[str, Any]:
 def capture(name: str, scripts: dict, app_name: str, channel: str = "text"):
     """Capture a single golden transcript."""
     config = scripts[name]
-    sessions = Sessions(app_name)
+    sessions = Sessions(app_name, user_agent_extension="skill/cxas-agent-foundry/capture-golden-transcripts")
     session_id = str(uuid.uuid4())
     params = config["params"]
     user_turns = config["turns"]

--- a/.agents/skills/cxas-agent-foundry/scripts/configure.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/configure.py
@@ -39,6 +39,8 @@ from InquirerPy.base.control import Choice
 from InquirerPy.utils import get_style
 from InquirerPy.validator import EmptyInputValidator
 
+USER_AGENT_EXTENSION = "skill/cxas-agent-foundry/configure"
+
 console = Console()
 
 # Keybinding: map Escape to skip/cancel so fuzzy prompts can be aborted.
@@ -112,7 +114,7 @@ def fetch_cxas_apps(project_id, location):
     try:
         from cxas_scrapi.core.apps import Apps
 
-        apps_client = Apps(project_id=project_id, location=location, user_agent_extension="skill/cxas-agent-foundry/configure")
+        apps_client = Apps(project_id=project_id, location=location, user_agent_extension=USER_AGENT_EXTENSION)
         apps_list = apps_client.list_apps()
         results = []
         for app in apps_list:
@@ -247,7 +249,7 @@ def _create_new_app(project_id, location):
     try:
         from cxas_scrapi.core.apps import Apps
 
-        apps_client = Apps(project_id=project_id, location=location, user_agent_extension="skill/cxas-agent-foundry/configure")
+        apps_client = Apps(project_id=project_id, location=location, user_agent_extension=USER_AGENT_EXTENSION)
         app = apps_client.create_app(
             app_id=app_id_slug,
             display_name=display_name,
@@ -656,7 +658,7 @@ def main_non_interactive(args):
         console.print(f"  [dim]Creating app '{app_name}' in {project_id}/{location}...[/dim]")
         try:
             from cxas_scrapi.core.apps import Apps
-            apps_client = Apps(project_id=project_id, location=location, user_agent_extension="skill/cxas-agent-foundry/configure")
+            apps_client = Apps(project_id=project_id, location=location, user_agent_extension=USER_AGENT_EXTENSION)
             app = apps_client.create_app(
                 app_id=str(uuid.uuid4()),
                 display_name=app_name,

--- a/.agents/skills/cxas-agent-foundry/scripts/configure.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/configure.py
@@ -112,7 +112,7 @@ def fetch_cxas_apps(project_id, location):
     try:
         from cxas_scrapi.core.apps import Apps
 
-        apps_client = Apps(project_id=project_id, location=location)
+        apps_client = Apps(project_id=project_id, location=location, user_agent_extension="skill/cxas-agent-foundry/configure")
         apps_list = apps_client.list_apps()
         results = []
         for app in apps_list:
@@ -247,7 +247,7 @@ def _create_new_app(project_id, location):
     try:
         from cxas_scrapi.core.apps import Apps
 
-        apps_client = Apps(project_id=project_id, location=location)
+        apps_client = Apps(project_id=project_id, location=location, user_agent_extension="skill/cxas-agent-foundry/configure")
         app = apps_client.create_app(
             app_id=app_id_slug,
             display_name=display_name,
@@ -656,7 +656,7 @@ def main_non_interactive(args):
         console.print(f"  [dim]Creating app '{app_name}' in {project_id}/{location}...[/dim]")
         try:
             from cxas_scrapi.core.apps import Apps
-            apps_client = Apps(project_id=project_id, location=location)
+            apps_client = Apps(project_id=project_id, location=location, user_agent_extension="skill/cxas-agent-foundry/configure")
             app = apps_client.create_app(
                 app_id=str(uuid.uuid4()),
                 display_name=app_name,

--- a/.agents/skills/cxas-agent-foundry/scripts/gate-check.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/gate-check.py
@@ -35,6 +35,8 @@ import uuid
 
 from config import load_config, get_project_path
 
+USER_AGENT_EXTENSION = "skill/cxas-agent-foundry/gate-check"
+
 
 # ---------- Gate runner helpers ----------
 
@@ -164,9 +166,9 @@ def gate2_agent_hierarchy(app_name) -> GateResult:
     project_id, location = parts[1], parts[3]
 
     try:
-        apps = Apps(project_id=project_id, location=location, user_agent_extension="skill/cxas-agent-foundry/gate-check")
+        apps = Apps(project_id=project_id, location=location, user_agent_extension=USER_AGENT_EXTENSION)
         app = apps.get_app(app_name)
-        agents_client = Agents(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/gate-check")
+        agents_client = Agents(app_name=app_name, user_agent_extension=USER_AGENT_EXTENSION)
         agents_map = agents_client.get_agents_map(reverse=True)
     except Exception as e:
         r.passed = False
@@ -214,11 +216,11 @@ def gate3_tool_associations(app_name) -> GateResult:
     project_id, location = parts[1], parts[3]
 
     try:
-        apps = Apps(project_id=project_id, location=location, user_agent_extension="skill/cxas-agent-foundry/gate-check")
+        apps = Apps(project_id=project_id, location=location, user_agent_extension=USER_AGENT_EXTENSION)
         app = apps.get_app(app_name)
-        agents_client = Agents(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/gate-check")
+        agents_client = Agents(app_name=app_name, user_agent_extension=USER_AGENT_EXTENSION)
         agents_map = agents_client.get_agents_map(reverse=True)
-        tools_client = Tools(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/gate-check")
+        tools_client = Tools(app_name=app_name, user_agent_extension=USER_AGENT_EXTENSION)
         tools_map = {t.display_name: t.name for t in tools_client.list_tools()}
     except Exception as e:
         r.passed = False
@@ -276,9 +278,9 @@ def gate4_callback_inventory(app_name) -> GateResult:
     from cxas_scrapi.core.callbacks import Callbacks
 
     try:
-        agents_client = Agents(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/gate-check")
+        agents_client = Agents(app_name=app_name, user_agent_extension=USER_AGENT_EXTENSION)
         agents_map = agents_client.get_agents_map(reverse=True)
-        cb_client = Callbacks(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/gate-check")
+        cb_client = Callbacks(app_name=app_name, user_agent_extension=USER_AGENT_EXTENSION)
     except Exception as e:
         r.passed = False
         r.error = f"Failed to fetch callbacks: {e}"
@@ -370,7 +372,7 @@ def gate5_single_turn_smoke(app_name) -> GateResult:
     from cxas_scrapi.core.sessions import Sessions
 
     try:
-        sessions = Sessions(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/gate-check")
+        sessions = Sessions(app_name=app_name, user_agent_extension=USER_AGENT_EXTENSION)
         session_id = f"gate5-{uuid.uuid4().hex[:8]}"
         print(f"  session_id={session_id}, text='Hello'")
         result = sessions.run(session_id=session_id, text="Hello")
@@ -411,7 +413,7 @@ def gate6_multi_turn_smoke(app_name, prompts_file) -> GateResult:
 
     from cxas_scrapi.core.sessions import Sessions
 
-    sessions = Sessions(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/gate-check")
+    sessions = Sessions(app_name=app_name, user_agent_extension=USER_AGENT_EXTENSION)
     session_id = f"gate6-{uuid.uuid4().hex[:8]}"
     turns = []
 

--- a/.agents/skills/cxas-agent-foundry/scripts/gate-check.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/gate-check.py
@@ -164,9 +164,9 @@ def gate2_agent_hierarchy(app_name) -> GateResult:
     project_id, location = parts[1], parts[3]
 
     try:
-        apps = Apps(project_id=project_id, location=location)
+        apps = Apps(project_id=project_id, location=location, user_agent_extension="skill/cxas-agent-foundry/gate-check")
         app = apps.get_app(app_name)
-        agents_client = Agents(app_name=app_name)
+        agents_client = Agents(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/gate-check")
         agents_map = agents_client.get_agents_map(reverse=True)
     except Exception as e:
         r.passed = False
@@ -214,11 +214,11 @@ def gate3_tool_associations(app_name) -> GateResult:
     project_id, location = parts[1], parts[3]
 
     try:
-        apps = Apps(project_id=project_id, location=location)
+        apps = Apps(project_id=project_id, location=location, user_agent_extension="skill/cxas-agent-foundry/gate-check")
         app = apps.get_app(app_name)
-        agents_client = Agents(app_name=app_name)
+        agents_client = Agents(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/gate-check")
         agents_map = agents_client.get_agents_map(reverse=True)
-        tools_client = Tools(app_name=app_name)
+        tools_client = Tools(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/gate-check")
         tools_map = {t.display_name: t.name for t in tools_client.list_tools()}
     except Exception as e:
         r.passed = False
@@ -276,9 +276,9 @@ def gate4_callback_inventory(app_name) -> GateResult:
     from cxas_scrapi.core.callbacks import Callbacks
 
     try:
-        agents_client = Agents(app_name=app_name)
+        agents_client = Agents(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/gate-check")
         agents_map = agents_client.get_agents_map(reverse=True)
-        cb_client = Callbacks(app_name=app_name)
+        cb_client = Callbacks(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/gate-check")
     except Exception as e:
         r.passed = False
         r.error = f"Failed to fetch callbacks: {e}"
@@ -370,7 +370,7 @@ def gate5_single_turn_smoke(app_name) -> GateResult:
     from cxas_scrapi.core.sessions import Sessions
 
     try:
-        sessions = Sessions(app_name=app_name)
+        sessions = Sessions(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/gate-check")
         session_id = f"gate5-{uuid.uuid4().hex[:8]}"
         print(f"  session_id={session_id}, text='Hello'")
         result = sessions.run(session_id=session_id, text="Hello")
@@ -411,7 +411,7 @@ def gate6_multi_turn_smoke(app_name, prompts_file) -> GateResult:
 
     from cxas_scrapi.core.sessions import Sessions
 
-    sessions = Sessions(app_name=app_name)
+    sessions = Sessions(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/gate-check")
     session_id = f"gate6-{uuid.uuid4().hex[:8]}"
     turns = []
 

--- a/.agents/skills/cxas-agent-foundry/scripts/generate-combined-report.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/generate-combined-report.py
@@ -38,6 +38,8 @@ from cxas_scrapi.utils.reporting import (
 )
 
 REPORTS_DIR = get_project_path("eval-reports")
+
+USER_AGENT_EXTENSION = "skill/cxas-agent-foundry/generate-combined-report"
 SIM_EVALS_YAML = get_project_path("evals", "simulations", "simulations.yaml")
 
 
@@ -112,7 +114,7 @@ def main():
         golden_results = load_golden_results(
             args.golden_run,
             args.app_name,
-            user_agent_extension="skill/cxas-agent-foundry/generate-combined-report",
+            user_agent_extension=USER_AGENT_EXTENSION,
         )
         print(f"  {len(golden_results)} golden results")
 
@@ -157,7 +159,7 @@ def main():
         golden_modality=args.golden_modality,
         sim_modality=args.sim_modality,
         sim_wall_clock_s=sim_wall_clock_s,
-        user_agent_extension="skill/cxas-agent-foundry/generate-combined-report",
+        user_agent_extension=USER_AGENT_EXTENSION,
     )
     print(f"\nReport: {output_path}")
 

--- a/.agents/skills/cxas-agent-foundry/scripts/generate-combined-report.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/generate-combined-report.py
@@ -16,7 +16,8 @@
 """Generate a combined HTML report for golden + simulation eval results.
 
 Usage:
-  python scripts/generate-combined-report.py --golden-run <RUN_ID> --sim-results <JSON_PATH>
+  python scripts/generate-combined-report.py --golden-run <RUN_ID>
+    --sim-results <JSON_PATH>
   python scripts/generate-combined-report.py --golden-run <RUN_ID>
   python scripts/generate-combined-report.py --sim-results <JSON_PATH>
 """
@@ -26,7 +27,8 @@ import os
 import sys
 from datetime import datetime
 
-from config import get_project_path
+from config import get_project_path, load_app_name
+
 from cxas_scrapi.utils.reporting import (
     generate_combined_html_report,
     load_callback_test_results,
@@ -41,10 +43,11 @@ SIM_EVALS_YAML = get_project_path("evals", "simulations", "simulations.yaml")
 
 def main():
     try:
-        import cxas_scrapi  # noqa: F401
+        import cxas_scrapi  # noqa: F401, PLC0415
     except ImportError:
         print(
-            "Error: cxas-scrapi not installed. Activate venv (source .venv/bin/activate) and install cxas-scrapi first."
+            "Error: cxas-scrapi not installed. Activate venv "
+            "(source .venv/bin/activate) and install cxas-scrapi first."
         )
         sys.exit(1)
 
@@ -62,7 +65,8 @@ def main():
     parser.add_argument(
         "--app-name",
         default=None,
-        help="App resource name. If not provided, reads from gecx-config.json via config.py.",
+        help="App resource name. If not provided, reads from "
+        "gecx-config.json via config.py.",
     )
     parser.add_argument(
         "--golden-modality",
@@ -91,8 +95,6 @@ def main():
     # Resolve app_name from gecx-config.json if not provided
     if not args.app_name and args.golden_run:
         try:
-            from config import load_app_name
-
             args.app_name = load_app_name()
         except Exception:
             print(
@@ -107,7 +109,11 @@ def main():
 
     if args.golden_run:
         print(f"Loading golden results for run {args.golden_run}...")
-        golden_results = load_golden_results(args.golden_run, args.app_name)
+        golden_results = load_golden_results(
+            args.golden_run,
+            args.app_name,
+            user_agent_extension="skill/cxas-agent-foundry/generate-combined-report",
+        )
         print(f"  {len(golden_results)} golden results")
 
     sim_wall_clock_s = None
@@ -151,6 +157,7 @@ def main():
         golden_modality=args.golden_modality,
         sim_modality=args.sim_modality,
         sim_wall_clock_s=sim_wall_clock_s,
+        user_agent_extension="skill/cxas-agent-foundry/generate-combined-report",
     )
     print(f"\nReport: {output_path}")
 

--- a/.agents/skills/cxas-agent-foundry/scripts/generate-iteration-report.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/generate-iteration-report.py
@@ -34,6 +34,8 @@ from typing import Any, Dict, List, Optional, Tuple
 sys.path.insert(0, os.path.dirname(__file__))
 from config import load_config, load_app_name, get_project_path
 
+USER_AGENT_EXTENSION = "skill/cxas-agent-foundry/generate-iteration-report"
+
 
 ITERATIONS_DIR = get_project_path("eval-reports", "iterations")
 DIFF_EXTENSIONS = {".txt", ".py"}
@@ -203,7 +205,7 @@ def _fetch_eval_results() -> Optional[Dict[str, Any]]:
 
     try:
         app_name = load_app_name()
-        client = Evaluations(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/generate-iteration-report")
+        client = Evaluations(app_name=app_name, user_agent_extension=USER_AGENT_EXTENSION)
     except Exception as e:
         print(f"  Warning: Could not initialize Evaluations client: {e}")
         return None

--- a/.agents/skills/cxas-agent-foundry/scripts/generate-iteration-report.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/generate-iteration-report.py
@@ -203,7 +203,7 @@ def _fetch_eval_results() -> Optional[Dict[str, Any]]:
 
     try:
         app_name = load_app_name()
-        client = Evaluations(app_name=app_name)
+        client = Evaluations(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/generate-iteration-report")
     except Exception as e:
         print(f"  Warning: Could not initialize Evaluations client: {e}")
         return None

--- a/.agents/skills/cxas-agent-foundry/scripts/inspect-app.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/inspect-app.py
@@ -30,6 +30,8 @@ import textwrap
 
 from config import load_app_name
 
+USER_AGENT_EXTENSION = "skill/cxas-agent-foundry/inspect-app"
+
 
 def inspect(app_name, verbose=False):
     """Inspect app and return structured data."""
@@ -44,7 +46,7 @@ def inspect(app_name, verbose=False):
     location = parts[3]
 
     # App
-    apps = Apps(project_id=project, location=location, user_agent_extension="skill/cxas-agent-foundry/inspect-app")
+    apps = Apps(project_id=project, location=location, user_agent_extension=USER_AGENT_EXTENSION)
     try:
         app = apps.get_app(app_name=app_name)
     except Exception as e:
@@ -73,14 +75,14 @@ def inspect(app_name, verbose=False):
         }
 
     # Agents
-    agents_client = Agents(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/inspect-app")
+    agents_client = Agents(app_name=app_name, user_agent_extension=USER_AGENT_EXTENSION)
     try:
         agent_list = agents_client.list_agents()
     except Exception as e:
         print(f"Error: Failed to list agents: {e}")
         agent_list = []
 
-    callbacks_client = Callbacks(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/inspect-app")
+    callbacks_client = Callbacks(app_name=app_name, user_agent_extension=USER_AGENT_EXTENSION)
 
     for agent in agent_list:
         agent_info = {
@@ -118,7 +120,7 @@ def inspect(app_name, verbose=False):
         result["agents"].append(agent_info)
 
     # Tools
-    tools_client = Tools(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/inspect-app")
+    tools_client = Tools(app_name=app_name, user_agent_extension=USER_AGENT_EXTENSION)
     try:
         tools_map = tools_client.get_tools_map()
         for display_name, tool in tools_map.items():
@@ -132,7 +134,7 @@ def inspect(app_name, verbose=False):
         result["tools_error"] = str(e)
 
     # Existing evals
-    evals_client = Evaluations(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/inspect-app")
+    evals_client = Evaluations(app_name=app_name, user_agent_extension=USER_AGENT_EXTENSION)
     try:
         evals_list = evals_client.list_evaluations()
         for ev in evals_list:

--- a/.agents/skills/cxas-agent-foundry/scripts/inspect-app.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/inspect-app.py
@@ -44,7 +44,7 @@ def inspect(app_name, verbose=False):
     location = parts[3]
 
     # App
-    apps = Apps(project_id=project, location=location)
+    apps = Apps(project_id=project, location=location, user_agent_extension="skill/cxas-agent-foundry/inspect-app")
     try:
         app = apps.get_app(app_name=app_name)
     except Exception as e:
@@ -73,14 +73,14 @@ def inspect(app_name, verbose=False):
         }
 
     # Agents
-    agents_client = Agents(app_name=app_name)
+    agents_client = Agents(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/inspect-app")
     try:
         agent_list = agents_client.list_agents()
     except Exception as e:
         print(f"Error: Failed to list agents: {e}")
         agent_list = []
 
-    callbacks_client = Callbacks(app_name=app_name)
+    callbacks_client = Callbacks(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/inspect-app")
 
     for agent in agent_list:
         agent_info = {
@@ -118,7 +118,7 @@ def inspect(app_name, verbose=False):
         result["agents"].append(agent_info)
 
     # Tools
-    tools_client = Tools(app_name=app_name)
+    tools_client = Tools(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/inspect-app")
     try:
         tools_map = tools_client.get_tools_map()
         for display_name, tool in tools_map.items():
@@ -132,7 +132,7 @@ def inspect(app_name, verbose=False):
         result["tools_error"] = str(e)
 
     # Existing evals
-    evals_client = Evaluations(app_name=app_name)
+    evals_client = Evaluations(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/inspect-app")
     try:
         evals_list = evals_client.list_evaluations()
         for ev in evals_list:

--- a/.agents/skills/cxas-agent-foundry/scripts/run-all-evals.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/run-all-evals.py
@@ -156,7 +156,7 @@ def trigger_goldens(config, channel, runs):
         return None
 
     try:
-        client = Evaluations(app_name=app_name)
+        client = Evaluations(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/run-all-evals")
         response = client.run_evaluation(
             eval_type="goldens",
             app_name=app_name,
@@ -188,7 +188,7 @@ def _wait_for_run(app_name, run_name, timeout=GOLDEN_TIMEOUT):
     import time
     from cxas_scrapi.core.evaluations import Evaluations
 
-    client = Evaluations(app_name=app_name)
+    client = Evaluations(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/run-all-evals")
     start = time.time()
     poll_interval = 15
 

--- a/.agents/skills/cxas-agent-foundry/scripts/scrapi-eval-runner.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/scrapi-eval-runner.py
@@ -42,6 +42,8 @@ from cxas_scrapi.core.evaluations import Evaluations
 from cxas_scrapi.utils.eval_utils import EvalUtils
 from config import load_app_name, get_project_path
 
+USER_AGENT_EXTENSION = "skill/cxas-agent-foundry/scrapi-eval-runner"
+
 
 EVALS_YAML = get_project_path("evals", "scenarios", "scenarios.yaml")
 GOLDEN_EVALS_DIR = get_project_path("evals", "goldens")
@@ -67,7 +69,7 @@ def get_app_name():
 
 
 def get_evals_client():
-    return Evaluations(app_name=load_app_name(), user_agent_extension="skill/cxas-agent-foundry/scrapi-eval-runner")
+    return Evaluations(app_name=load_app_name(), user_agent_extension=USER_AGENT_EXTENSION)
 
 
 def get_eval_utils():

--- a/.agents/skills/cxas-agent-foundry/scripts/scrapi-eval-runner.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/scrapi-eval-runner.py
@@ -67,7 +67,7 @@ def get_app_name():
 
 
 def get_evals_client():
-    return Evaluations(app_name=load_app_name())
+    return Evaluations(app_name=load_app_name(), user_agent_extension="skill/cxas-agent-foundry/scrapi-eval-runner")
 
 
 def get_eval_utils():

--- a/.agents/skills/cxas-agent-foundry/scripts/scrapi-sim-runner.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/scrapi-sim-runner.py
@@ -51,6 +51,8 @@ from cxas_scrapi.prompts import llm_user_prompts
 
 from config import load_app_name, get_project_path
 
+USER_AGENT_EXTENSION = "skill/cxas-agent-foundry/scrapi-sim-runner"
+
 
 EVALS_YAML = get_project_path("evals", "scenarios", "scenarios.yaml")
 SIM_EVALS_YAML = get_project_path("evals", "simulations", "simulations.yaml")
@@ -375,7 +377,7 @@ def generate_html_report(
     if app_name:
         try:
             from cxas_scrapi.core.tools import Tools
-            tools_map = Tools(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/scrapi-sim-runner").get_tools_map()
+            tools_map = Tools(app_name=app_name, user_agent_extension=USER_AGENT_EXTENSION).get_tools_map()
         except Exception:
             pass
 
@@ -621,7 +623,7 @@ def _run_single_eval(app_name, tc, run_idx, runs, model, modality, verbose):
         # Each thread gets its own SimRunner instance (separate session client)
         import time as _time
         _start = _time.time()
-        sim = EnhancedSimRunner(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/scrapi-sim-runner")
+        sim = EnhancedSimRunner(app_name=app_name, user_agent_extension=USER_AGENT_EXTENSION)
         conv = sim.simulate_conversation(
             test_case=tc,
             model=model,

--- a/.agents/skills/cxas-agent-foundry/scripts/scrapi-sim-runner.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/scrapi-sim-runner.py
@@ -375,7 +375,7 @@ def generate_html_report(
     if app_name:
         try:
             from cxas_scrapi.core.tools import Tools
-            tools_map = Tools(app_name=app_name).get_tools_map()
+            tools_map = Tools(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/scrapi-sim-runner").get_tools_map()
         except Exception:
             pass
 
@@ -621,7 +621,7 @@ def _run_single_eval(app_name, tc, run_idx, runs, model, modality, verbose):
         # Each thread gets its own SimRunner instance (separate session client)
         import time as _time
         _start = _time.time()
-        sim = EnhancedSimRunner(app_name=app_name)
+        sim = EnhancedSimRunner(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/scrapi-sim-runner")
         conv = sim.simulate_conversation(
             test_case=tc,
             model=model,

--- a/.agents/skills/cxas-agent-foundry/scripts/sync-callbacks.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/sync-callbacks.py
@@ -45,6 +45,8 @@ import yaml
 
 from config import load_app_name, get_project_path
 
+USER_AGENT_EXTENSION = "skill/cxas-agent-foundry/sync-callbacks"
+
 
 AGENTS_DIR = get_project_path("evals", "callback_tests", "agents")
 TESTS_DIR = get_project_path("evals", "callback_tests", "tests")
@@ -65,7 +67,7 @@ def sync_agent_callbacks(app_name, agent_name, dry_run=False):
     """Sync callbacks for a single agent. Returns (synced, tests_found, tests_missing)."""
     from cxas_scrapi.core.callbacks import Callbacks
 
-    callbacks_client = Callbacks(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/sync-callbacks")
+    callbacks_client = Callbacks(app_name=app_name, user_agent_extension=USER_AGENT_EXTENSION)
     try:
         cb_map = callbacks_client.list_callbacks(agent_name)
     except Exception as e:
@@ -283,7 +285,7 @@ def main():
 
     # List agents
     from cxas_scrapi.core.agents import Agents
-    agents_client = Agents(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/sync-callbacks")
+    agents_client = Agents(app_name=app_name, user_agent_extension=USER_AGENT_EXTENSION)
     try:
         agent_list = agents_client.list_agents()
     except Exception as e:

--- a/.agents/skills/cxas-agent-foundry/scripts/sync-callbacks.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/sync-callbacks.py
@@ -65,7 +65,7 @@ def sync_agent_callbacks(app_name, agent_name, dry_run=False):
     """Sync callbacks for a single agent. Returns (synced, tests_found, tests_missing)."""
     from cxas_scrapi.core.callbacks import Callbacks
 
-    callbacks_client = Callbacks(app_name=app_name)
+    callbacks_client = Callbacks(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/sync-callbacks")
     try:
         cb_map = callbacks_client.list_callbacks(agent_name)
     except Exception as e:
@@ -283,7 +283,7 @@ def main():
 
     # List agents
     from cxas_scrapi.core.agents import Agents
-    agents_client = Agents(app_name=app_name)
+    agents_client = Agents(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/sync-callbacks")
     try:
         agent_list = agents_client.list_agents()
     except Exception as e:

--- a/.agents/skills/cxas-agent-foundry/scripts/triage-results.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/triage-results.py
@@ -34,6 +34,8 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from config import load_app_name
 
+USER_AGENT_EXTENSION = "skill/cxas-agent-foundry/triage-results"
+
 
 # --- Failure categories ---
 
@@ -1014,7 +1016,7 @@ def main():
     app_name = load_app_name()
 
     from cxas_scrapi.core.evaluations import Evaluations
-    client = Evaluations(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/triage-results")
+    client = Evaluations(app_name=app_name, user_agent_extension=USER_AGENT_EXTENSION)
 
     # Build eval name lookup (resource -> display_name)
     try:

--- a/.agents/skills/cxas-agent-foundry/scripts/triage-results.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/triage-results.py
@@ -1014,7 +1014,7 @@ def main():
     app_name = load_app_name()
 
     from cxas_scrapi.core.evaluations import Evaluations
-    client = Evaluations(app_name=app_name)
+    client = Evaluations(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/triage-results")
 
     # Build eval name lookup (resource -> display_name)
     try:

--- a/.agents/skills/cxas-sim-eval/scripts/fetch_app_data.py
+++ b/.agents/skills/cxas-sim-eval/scripts/fetch_app_data.py
@@ -20,6 +20,8 @@ import shutil
 from cxas_scrapi import Evaluations, Agents, Apps
 from google.protobuf.json_format import MessageToDict
 
+USER_AGENT_EXTENSION = "skill/cxas-sim-eval/fetch_app_data"
+
 def main():
     parser = argparse.ArgumentParser(description="Fetch evaluations and agent tools from CES API.")
     parser.add_argument("--app-name", required=True, help="Full resource name of the app, e.g., projects/.../locations/.../apps/...")
@@ -43,8 +45,8 @@ def main():
     location = parts[3]
     
     # Initialize clients
-    agents_client = Agents(app_name=app_name, user_agent_extension="skill/cxas-sim-eval/fetch_app_data")
-    apps_client = Apps(project_id=project_id, location=location, user_agent_extension="skill/cxas-sim-eval/fetch_app_data")
+    agents_client = Agents(app_name=app_name, user_agent_extension=USER_AGENT_EXTENSION)
+    apps_client = Apps(project_id=project_id, location=location, user_agent_extension=USER_AGENT_EXTENSION)
     
     # 1. Fetch Agent Tools
     print(f"Fetching agent tools for app: {app_name}...")

--- a/.agents/skills/cxas-sim-eval/scripts/fetch_app_data.py
+++ b/.agents/skills/cxas-sim-eval/scripts/fetch_app_data.py
@@ -43,8 +43,8 @@ def main():
     location = parts[3]
     
     # Initialize clients
-    agents_client = Agents(app_name=app_name)
-    apps_client = Apps(project_id=project_id, location=location)
+    agents_client = Agents(app_name=app_name, user_agent_extension="skill/cxas-sim-eval/fetch_app_data")
+    apps_client = Apps(project_id=project_id, location=location, user_agent_extension="skill/cxas-sim-eval/fetch_app_data")
     
     # 1. Fetch Agent Tools
     print(f"Fetching agent tools for app: {app_name}...")

--- a/.agents/skills/cxas-sim-eval/scripts/fetch_tool_schemas.py
+++ b/.agents/skills/cxas-sim-eval/scripts/fetch_tool_schemas.py
@@ -21,6 +21,8 @@ from google.protobuf.json_format import MessageToDict
 
 from cxas_scrapi import Tools
 
+USER_AGENT_EXTENSION = "skill/cxas-sim-eval/fetch_tool_schemas"
+
 def main():
     parser = argparse.ArgumentParser(description="Fetch tool schemas for a given app.")
     parser.add_argument("--app-name", required=True, help="The full resource name of the app (e.g., projects/.../locations/.../apps/...)")
@@ -34,7 +36,7 @@ def main():
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
         
-    tools_client = Tools(app_name, user_agent_extension="skill/cxas-sim-eval/fetch_tool_schemas")
+    tools_client = Tools(app_name, user_agent_extension=USER_AGENT_EXTENSION)
     print(f"Fetching tools map for app: {app_name}")
     
     # Get mapping of tool_name -> tool_display_name

--- a/.agents/skills/cxas-sim-eval/scripts/fetch_tool_schemas.py
+++ b/.agents/skills/cxas-sim-eval/scripts/fetch_tool_schemas.py
@@ -34,7 +34,7 @@ def main():
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
         
-    tools_client = Tools(app_name)
+    tools_client = Tools(app_name, user_agent_extension="skill/cxas-sim-eval/fetch_tool_schemas")
     print(f"Fetching tools map for app: {app_name}")
     
     # Get mapping of tool_name -> tool_display_name

--- a/.agents/skills/cxas-sim-eval/scripts/run_evals.py
+++ b/.agents/skills/cxas-sim-eval/scripts/run_evals.py
@@ -28,6 +28,8 @@ from google import genai
 
 import threading
 
+USER_AGENT_EXTENSION = "skill/cxas-sim-eval/run_evals"
+
 class ThreadLocalStream:
     def __init__(self, default_stream):
         self.default_stream = default_stream
@@ -84,7 +86,7 @@ def run_single_eval(item, evals_dir, app_name, run_index, skip_analysis=False, m
             test_case = json.load(f)
 
         # Initialize the Simulator per test case
-        sim_evals = SimulationEvals(app_name, user_agent_extension="skill/cxas-sim-eval/run_evals")
+        sim_evals = SimulationEvals(app_name, user_agent_extension=USER_AGENT_EXTENSION)
         eval_conv = sim_evals.simulate_conversation(
             test_case=test_case, console_logging=True, session_id=session_id, modality=modality
         )

--- a/.agents/skills/cxas-sim-eval/scripts/run_evals.py
+++ b/.agents/skills/cxas-sim-eval/scripts/run_evals.py
@@ -84,7 +84,7 @@ def run_single_eval(item, evals_dir, app_name, run_index, skip_analysis=False, m
             test_case = json.load(f)
 
         # Initialize the Simulator per test case
-        sim_evals = SimulationEvals(app_name)
+        sim_evals = SimulationEvals(app_name, user_agent_extension="skill/cxas-sim-eval/run_evals")
         eval_conv = sim_evals.simulate_conversation(
             test_case=test_case, console_logging=True, session_id=session_id, modality=modality
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.ruff]
 line-length = 80
 target-version = "py310"
-extend-exclude = ["*.ipynb", ".agents/skills/cxas-agent-foundry/assets/project-template/", ".agents/skills/cxas-agent-foundry/scripts", ".agents/skills/cxas-sim-eval/scripts"]
+extend-exclude = ["*.ipynb", ".agents/skills/cxas-agent-foundry/assets/project-template/", ".agents/skills/cxas-agent-foundry/scripts", ".agents/skills/cxas-sim-eval/scripts", "examples/"]
 
 [tool.ruff.lint]
 select = [

--- a/src/cxas_scrapi/core/agents.py
+++ b/src/cxas_scrapi/core/agents.py
@@ -54,8 +54,7 @@ class Agents(Apps):
         self.app_name = app_name
         self.resource_type = "agents"
         self.client = AgentServiceClient(
-            credentials=self.creds,
-            client_options=self.client_options,
+            transport=self.get_grpc_transport(AgentServiceClient),
             client_info=self.client_info,
         )
 
@@ -172,6 +171,7 @@ class Agents(Apps):
                 "Authorization": f"Bearer {self.creds.token}",
                 "Content-Type": "application/json",
                 "x-goog-user-project": self.project_id or "",  # Best effort
+                "User-Agent": self.user_agent,
             }
 
             response = requests.post(url, headers=headers, json=agent_data)

--- a/src/cxas_scrapi/core/apps.py
+++ b/src/cxas_scrapi/core/apps.py
@@ -48,10 +48,10 @@ class Apps(Common):
         self.parent = f"projects/{project_id}/locations/{location}"
 
         self.client_options = self._get_client_options(self.parent)
+
         self.client = AgentServiceClient(
-            credentials=self.creds,
-            client_options=self.client_options,
-            client_info=self.client_info,
+            transport=self.get_grpc_transport(AgentServiceClient),
+            client_info=self.client_info
         )
 
     def list_apps(self) -> List[types.App]:

--- a/src/cxas_scrapi/core/common.py
+++ b/src/cxas_scrapi/core/common.py
@@ -44,6 +44,7 @@ class Common:
         creds: Any = None,
         scope: List[str] = None,
         app_name: str = None,  # Optional: used to determine client_options
+        user_agent_extension: str = None,
     ):
         self.scopes = GLOBAL_SCOPES
         if scope:
@@ -100,7 +101,11 @@ class Common:
         except importlib.metadata.PackageNotFoundError:
             sdk_version = "unknown"
 
-        self.client_info = ClientInfo(user_agent=f"cxas-scrapi/{sdk_version}")
+        self.user_agent = f"cxas-scrapi/{sdk_version}"
+        if user_agent_extension:
+            self.user_agent += f":{user_agent_extension}"
+
+        self.client_info = ClientInfo(user_agent=self.user_agent)
 
     @staticmethod
     def empty_to_dict(v: Any) -> Any:
@@ -327,6 +332,23 @@ class Common:
             ):
                 agent_texts.append(output["text"])
         return separator.join(agent_texts)
+
+    def get_grpc_transport(self, client_class: type):
+        """Creates a customer gRPC transport for CXAS SCRAPI calls."""
+        transport_class = client_class.get_transport_class("grpc")
+
+        host = "ces.googleapis.com"
+        client_opts = getattr(self, "client_options", None)
+        if client_opts and "api_endpoint" in client_opts:
+            host = self.client_options["api_endpoint"]
+
+        channel = transport_class.create_channel(
+            host=host,
+            credentials=self.creds,
+            options=[("grpc.primary_user_agent", self.user_agent)]
+        )
+
+        return transport_class(channel=channel)
 
     def recurse_proto_repeated_composite(self, repeated_object):
         """Recursively converts RepeatedComposite objects to lists."""

--- a/src/cxas_scrapi/core/conversation_history.py
+++ b/src/cxas_scrapi/core/conversation_history.py
@@ -51,8 +51,7 @@ class ConversationHistory(Common):
         self.app_name = app_name
         self.client_options = self._get_client_options(self.app_name)
         self.client = AgentServiceClient(
-            credentials=self.creds,
-            client_options=self.client_options,
+            transport=self.get_grpc_transport(AgentServiceClient),
             client_info=self.client_info,
         )
 

--- a/src/cxas_scrapi/core/evaluations.py
+++ b/src/cxas_scrapi/core/evaluations.py
@@ -58,8 +58,7 @@ class Evaluations(Common):
 
         # Initialize SDK Client
         self.client = EvaluationServiceClient(
-            credentials=self.creds,
-            client_options=self.client_options,
+            transport=self.get_grpc_transport(EvaluationServiceClient),
             client_info=self.client_info,
         )
         self.resource_type = "evaluations"

--- a/src/cxas_scrapi/core/insights.py
+++ b/src/cxas_scrapi/core/insights.py
@@ -76,6 +76,7 @@ class Insights(Common):
             "Authorization": f"Bearer {self.creds.token}",
             "Content-Type": "application/json; charset=utf-8",
             "x-goog-user-project": self.project_id,
+            "User-Agent": self.user_agent,
         }
 
         response = requests.request(

--- a/src/cxas_scrapi/core/sessions.py
+++ b/src/cxas_scrapi/core/sessions.py
@@ -117,11 +117,13 @@ class BidiSessionHandler:
         token: str,
         config: Dict[str, Any],
         inputs: List[Dict[str, Any]],
+        user_agent: str = None,
     ):
         self.uri = BIDI_SESSION_URI + location
         self.token = token
         self.config = config
         self.inputs = inputs
+        self.user_agent = user_agent
         self.agent_turn_manager = AgentTurnManager()
         self.ws_app = None
         self.outputs = []
@@ -310,7 +312,10 @@ class BidiSessionHandler:
         logging.debug("Connecting to WebSocket: %s", self.uri)
         self.ws_app = websocket.WebSocketApp(
             self.uri,
-            header={"Authorization": f"Bearer {self.token}"},
+            header={
+                "Authorization": f"Bearer {self.token}",
+                "User-Agent": self.user_agent,
+            },
             on_open=self._on_open,
             on_message=self._on_message,
             on_error=self._on_error,
@@ -342,8 +347,7 @@ class Sessions(Common):
 
         # Initialize Sessions Client
         self.client = SessionServiceClient(
-            credentials=self.creds,
-            client_options=self.client_options,
+            transport=self.get_grpc_transport(SessionServiceClient),
             client_info=self.client_info,
         )
 
@@ -730,7 +734,13 @@ class Sessions(Common):
     def async_bidi_run_session(
         self, config: dict, inputs: list[dict[str, Any]]
     ):
-        handler = BidiSessionHandler(self.location, self.token, config, inputs)
+        handler = BidiSessionHandler(
+            self.location,
+            self.token,
+            config,
+            inputs,
+            user_agent=self.user_agent,
+        )
         return handler.run()
 
     def make_text_request(self, config: dict, inputs: list[dict[str, Any]]):

--- a/src/cxas_scrapi/core/tools.py
+++ b/src/cxas_scrapi/core/tools.py
@@ -59,13 +59,11 @@ class Tools(Apps):
         self.app_id = app_name.rsplit("/", maxsplit=1)[-1]
         self.resource_type = "tools"
         self.client = AgentServiceClient(
-            credentials=self.creds,
-            client_options=self.client_options,
+            transport=self.get_grpc_transport(AgentServiceClient),
             client_info=self.client_info,
         )
         self.tool_client = ToolServiceClient(
-            credentials=self.creds,
-            client_options=self.client_options,
+            transport=self.get_grpc_transport(ToolServiceClient),
             client_info=self.client_info,
         )
         self.var_client = Variables(
@@ -342,6 +340,7 @@ class Tools(Apps):
             "Authorization": f"Bearer {self.creds.token}",
             "Content-Type": "application/json",
             "x-goog-user-project": self.project_id,
+            "User-Agent": self.user_agent,
         }
 
         payload = {}

--- a/src/cxas_scrapi/evals/simulation_evals.py
+++ b/src/cxas_scrapi/evals/simulation_evals.py
@@ -339,7 +339,7 @@ class SimulationEvals(Apps):
         location = app_name.split("/")[3]
         super().__init__(project_id=project_id, location=location, **kwargs)
         self.sessions_client = Sessions(app_name, **kwargs)
-        self.tools_map = Tools(app_name=app_name).get_tools_map()
+        self.tools_map = Tools(app_name=app_name, **kwargs).get_tools_map()
 
         # Vertex AI requires a specific region (e.g. global), whereas CXAS
         # Apps use 'us' or 'eu'

--- a/src/cxas_scrapi/evals/tool_evals.py
+++ b/src/cxas_scrapi/evals/tool_evals.py
@@ -95,7 +95,12 @@ class Expectation(BaseModel):
 class ToolEvals:
     """Utility class for testing CXAS Tools."""
 
-    def __init__(self, app_name: str, creds: Any = None):
+    def __init__(
+        self,
+        app_name: str,
+        creds: Any = None,
+        user_agent_extension: str = None,
+    ):
         """Initializes the ToolEvals class.
 
         Args:
@@ -110,8 +115,17 @@ class ToolEvals:
         self.location = parts[3] if len(parts) > 3 else "us"
 
         self.creds = creds
-        self.tools_client = Tools(app_name=self.app_name, creds=self.creds)
-        self.var_client = Variables(app_name=self.app_name, creds=self.creds)
+        self.user_agent_extension = user_agent_extension
+        self.tools_client = Tools(
+            app_name=self.app_name,
+            creds=self.creds,
+            user_agent_extension=user_agent_extension,
+        )
+        self.var_client = Variables(
+            app_name=self.app_name,
+            creds=self.creds,
+            user_agent_extension=user_agent_extension,
+        )
         try:
             self.tool_map = self.tools_client.get_tools_map(reverse=True)
         except (AttributeError, KeyError, RuntimeError, ValueError) as e:
@@ -400,7 +414,9 @@ class ToolEvals:
         mined_data = {}
         try:
             history_client = ConversationHistory(
-                app_name=self.app_name, creds=self.creds
+                app_name=self.app_name,
+                creds=self.creds,
+                user_agent_extension=self.user_agent_extension,
             )
             convs = list(history_client.list_conversations())[:limit]
             for c in convs:
@@ -600,7 +616,10 @@ class ToolEvals:
 
         # Fetch app metadata and user info once per run
         app_client = Apps(
-            project_id=self.project_id, location=self.location, creds=self.creds
+            project_id=self.project_id,
+            location=self.location,
+            creds=self.creds,
+            user_agent_extension=self.user_agent_extension
         )
         app = app_client.get_app(self.app_name)
         app_display_name = app.display_name if app else "Unknown App"

--- a/src/cxas_scrapi/utils/gcs_utils.py
+++ b/src/cxas_scrapi/utils/gcs_utils.py
@@ -45,8 +45,11 @@ class GCSUtils(Common):
         creds=creds,
         scope=scope,
     )
-    self.client = storage.Client(credentials=self.creds,
-                                 project=self.project_id)
+    self.client = storage.Client(
+        credentials=self.creds,
+        project=self.project_id,
+        client_info=self.client_info,
+    )
 
   def upload_string(
       self,

--- a/src/cxas_scrapi/utils/google_sheets_utils.py
+++ b/src/cxas_scrapi/utils/google_sheets_utils.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, List, Optional
 
 import gspread
 import pandas as pd
+from google.auth.transport.requests import AuthorizedSession
 from gspread_dataframe import set_with_dataframe
 
 from cxas_scrapi.core.common import Common
@@ -54,7 +55,9 @@ class GoogleSheetsUtils(Common):
         )
 
         try:
-            self.sheets_client = gspread.authorize(self.creds)
+            session = AuthorizedSession(self.creds)
+            session.headers.update({"User-Agent": self.user_agent})
+            self.sheets_client = gspread.authorize(None, session=session)
             # Pre-flight check for local ADC auth
             if "google.colab" not in sys.modules:
                 self._preflight_api_checks()

--- a/src/cxas_scrapi/utils/reporting.py
+++ b/src/cxas_scrapi/utils/reporting.py
@@ -556,6 +556,7 @@ def generate_html_report(
     model: str,
     app_name: str = "",
     wall_clock_s: float = None,
+    user_agent_extension: str = None,
 ):
     """Generate an HTML report and save it locally or upload to GCS.
 
@@ -579,7 +580,9 @@ def generate_html_report(
     tools_map = {}
     if app_name:
         try:
-            tools_map = Tools(app_name=app_name).get_tools_map()
+            tools_map = Tools(
+                app_name=app_name, user_agent_extension=user_agent_extension
+            ).get_tools_map()
         except Exception:
             pass
 
@@ -650,6 +653,7 @@ def generate_combined_html_report(
     golden_modality="text",
     sim_modality="text",
     sim_wall_clock_s=None,
+    user_agent_extension=None,
 ):
     """Generate combined HTML report based on results from multiple sources."""
     ts = datetime.now().strftime("%Y-%m-%d %H:%M")
@@ -877,7 +881,9 @@ def generate_combined_html_report(
     tools_map = {}
     if app_name:
         try:
-            tools_map = Tools(app_name=app_name).get_tools_map()
+            tools_map = Tools(
+                app_name=app_name, user_agent_extension=user_agent_extension
+            ).get_tools_map()
         except Exception:
             pass
 
@@ -981,7 +987,9 @@ def _outcome_str(val):
     return str(val) if val else "?"
 
 
-def load_golden_results(run_id, app_name, include=None):
+def load_golden_results(
+    run_id, app_name, include=None, user_agent_extension=None
+):
     """Fetch golden results and parse into report-friendly format."""
     if include is None:
         include = ["goldens", "scenarios"]
@@ -1003,7 +1011,9 @@ def load_golden_results(run_id, app_name, include=None):
 
     tools_map = {}
     try:
-        tools_map = Tools(app_name=app_name).get_tools_map()
+        tools_map = Tools(
+            app_name=app_name, user_agent_extension=user_agent_extension
+        ).get_tools_map()
     except Exception:
         pass
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,8 +79,28 @@ def app_id():
 # running online
 if "--run-online" not in sys.argv:
     mock_ces = MagicMock()
-    mock_ces.AgentServiceClient = MagicMock
-    mock_ces.EvaluationServiceClient = MagicMock
+
+    def enforce_transport(*args, **kwargs):
+        if "transport" not in kwargs:
+            raise ValueError(
+                "Client must be initialized with a transport from "
+                "get_grpc_transport to ensure correct telemetry."
+            )
+        return MagicMock()
+
+    mock_ces.AgentServiceClient = MagicMock(side_effect=enforce_transport)
+    mock_ces.AgentServiceClient.get_transport_class.return_value = MagicMock()
+
+    mock_ces.EvaluationServiceClient = MagicMock(side_effect=enforce_transport)
+    mock_ces.EvaluationServiceClient.get_transport_class.return_value = (
+        MagicMock()
+    )
+
+    mock_ces.SessionServiceClient = MagicMock(side_effect=enforce_transport)
+    mock_ces.SessionServiceClient.get_transport_class.return_value = MagicMock()
+
+    mock_ces.ToolServiceClient = MagicMock(side_effect=enforce_transport)
+    mock_ces.ToolServiceClient.get_transport_class.return_value = MagicMock()
     mock_ces.types = real_ces.types
     sys.modules["google.cloud.ces_v1beta"] = mock_ces
 


### PR DESCRIPTION
* Core Telemetry Enhancement
  - Added support for a `user_agent_extension` parameter in the Common base class.
  - This allows all API calls made by the SDK to be traced back to specific skills or scripts by appending them to the default user agent string.
* gRPC and WebSocket Integration
  - Updated core clients (e.g. Sessions, etc.) to use a custom gRPC transport that injects the extended user agent into the `grpc.primary_user_agent header`.
  - Updated BidiSessionHandler to pass the extended user agent in WebSocket headers for Bidi sessions.
* Skill Usage Tracking
  - Updated all skill scripts across .`agents/skills/cxas-agent-foundry/` and `.agents/skills/cxas-sim-eval/` to pass their specific identifiers (e.g. `skill/cxas-agent-foundry/app-thresholds`) when instantiating SCRAPI resources like Apps, Sessions, and Evaluations.
* Test Enforcement
  - Updated the mock client factories in `tests/conftest.py` to enforce that clients are initialized with a custom transport, ensuring that all new and existing code adheres to this telemetry pattern.