### PR TITLE
fix: Add app-name compatibility with cxas create

### DIFF
--- a/src/cxas_scrapi/cli/app.py
+++ b/src/cxas_scrapi/cli/app.py
@@ -240,7 +240,7 @@ def app_create(args: argparse.Namespace) -> None:
     apps_client = Apps(project_id=args.project_id, location=args.location)
     try:
         app = apps_client.create_app(
-            app_id=getattr(args, "app_id", None),
+            app_id=getattr(args, "app_name", None),
             display_name=args.name,
             description=args.description,
         )

--- a/src/cxas_scrapi/cli/main.py
+++ b/src/cxas_scrapi/cli/main.py
@@ -1427,7 +1427,7 @@ def get_parser() -> argparse.ArgumentParser:
         "--description", help="Description for the new app."
     )
     parser_create.add_argument(
-        "--app-name", help="Optional specific app_name to use."
+        "--app-name", "--app-id", dest="app_name", help="The requested CXAS App ID. If omitted, a random UUID is generated."
     )
     _add_project_location_args(parser_create)
     parser_create.set_defaults(func=app_create)

--- a/src/cxas_scrapi/cli/main.py
+++ b/src/cxas_scrapi/cli/main.py
@@ -1427,7 +1427,13 @@ def get_parser() -> argparse.ArgumentParser:
         "--description", help="Description for the new app."
     )
     parser_create.add_argument(
-        "--app-name", "--app-id", dest="app_name", help="The requested CXAS App ID. If omitted, a random UUID is generated."
+        "--app-name",
+        "--app-id",
+        dest="app_name",
+        help=(
+            "The requested CXAS App ID. "
+            "If omitted, a random UUID is generated."
+        ),
     )
     _add_project_location_args(parser_create)
     parser_create.set_defaults(func=app_create)

--- a/tests/cxas_scrapi/cli/test_app.py
+++ b/tests/cxas_scrapi/cli/test_app.py
@@ -59,7 +59,7 @@ def test_app_create(
     args = argparse.Namespace(
         name="Test App",
         description="A test app",
-        app_id=None,
+        app_name=None,
         project_id="test-project",
         location="us",
     )
@@ -72,6 +72,28 @@ def test_app_create(
 
     mock_apps_client.create_app.assert_called_once_with(
         app_id=None, display_name="Test App", description="A test app"
+    )
+
+
+def test_app_create_with_app_name(
+    mock_apps_client, mock_common_get_project_id, mock_common_get_location
+):
+    args = argparse.Namespace(
+        name="Test App",
+        description="A test app",
+        app_name="custom-app-id",
+        project_id="test-project",
+        location="us",
+    )
+
+    mock_app_response = mock.MagicMock()
+    mock_app_response.name = "projects/test-project/locations/us/apps/custom-app-id"
+    mock_apps_client.create_app.return_value = mock_app_response
+
+    cli_app.app_create(args)
+
+    mock_apps_client.create_app.assert_called_once_with(
+        app_id="custom-app-id", display_name="Test App", description="A test app"
     )
 
 

--- a/tests/cxas_scrapi/cli/test_app.py
+++ b/tests/cxas_scrapi/cli/test_app.py
@@ -87,13 +87,17 @@ def test_app_create_with_app_name(
     )
 
     mock_app_response = mock.MagicMock()
-    mock_app_response.name = "projects/test-project/locations/us/apps/custom-app-id"
+    mock_app_response.name = (
+        "projects/test-project/locations/us/apps/custom-app-id"
+    )
     mock_apps_client.create_app.return_value = mock_app_response
 
     cli_app.app_create(args)
 
     mock_apps_client.create_app.assert_called_once_with(
-        app_id="custom-app-id", display_name="Test App", description="A test app"
+        app_id="custom-app-id",
+        display_name="Test App",
+        description="A test app",
     )
 
 

--- a/tests/cxas_scrapi/cli/test_main.py
+++ b/tests/cxas_scrapi/cli/test_main.py
@@ -36,6 +36,39 @@ def test_get_parser():
     assert args.location == "us"
 
 
+def test_create_app_id_alias():
+    """Test that --app-id is an alias for --app-name in 'create' command."""
+    parser = get_parser()
+
+    # Test with --app-name
+    args = parser.parse_args(
+        [
+            "create",
+            "My App",
+            "--app-name",
+            "custom-name",
+            "--project-id",
+            "p",
+            "--location",
+            "l",
+        ]
+    )
+    assert args.app_name == "custom-name"
+
+    # Test with --app-id
+    args = parser.parse_args(
+        [
+            "create",
+            "My App",
+            "--app-id",
+            "custom-id",
+            "--project-id",
+            "p",
+            "--location",
+            "l",
+        ]
+    )
+    assert args.app_name == "custom-id"
 def test_cli_installed_help():
     """Test that the 'cxas' command is installed and executable (verifies
     setup.py)."""


### PR DESCRIPTION
Fix issue #82: --app-name flag ignored in create command, and add --app-id alias

## Description
This PR fixes a issue where the `cxas create` command ignored the value provided to the `--app-name` flag and instead triggered the backend to generate a random UUID for the application ID.

The root cause was a variable mismatch between the argument parser (which stored the value in `args.app_name`) and the command handler (which looked for `args.app_id`). The change is backwards compatiable.

## Changes
-   **Fix**: Updated `app_create` in [src/cxas_scrapi/cli/app.py](file:///usr/local/google/home/bktsim/GitHub/cxas-scrapi/src/cxas_scrapi/cli/app.py) to read from `args.app_name` instead of `args.app_id`.
-   **Enhancement**: Added `--app-id` as an alias to `--app-name` in [src/cxas_scrapi/cli/main.py](file:///usr/local/google/home/bktsim/GitHub/cxas-scrapi/src/cxas_scrapi/cli/main.py) for the `create` command, and updated the help text to be clearer.
-   **Tests**: 
    *   Added tests in [tests/cxas_scrapi/cli/test_app.py](file:///usr/local/google/home/bktsim/GitHub/cxas-scrapi/tests/cxas_scrapi/cli/test_app.py) to verify `--app-name` correctly populates the ID.
    *   Added tests in [tests/cxas_scrapi/cli/test_main.py](file:///usr/local/google/home/bktsim/GitHub/cxas-scrapi/tests/cxas_scrapi/cli/test_main.py) to verify both flags correctly populate `args.app_name`.
    *   Functionality also tested on a real GCP project by running the command.
 
## Related Issues
Closes #82