### PR TITLE
chore: exclude examples from ruff lint checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.ruff]
 line-length = 80
 target-version = "py310"
-extend-exclude = ["*.ipynb", ".agents/skills/cxas-agent-foundry/assets/project-template/", ".agents/skills/cxas-agent-foundry/scripts", ".agents/skills/cxas-sim-eval/scripts"]
+extend-exclude = ["*.ipynb", ".agents/skills/cxas-agent-foundry/assets/project-template/", ".agents/skills/cxas-agent-foundry/scripts", ".agents/skills/cxas-sim-eval/scripts", "examples/"]
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
Fixes failing CI checks by excluding the `examples/` directory from `ruff` linting in `pyproject.toml`. Fixes #94