### PR TITLE
ci: declare workflow-level permissions on the two CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint code

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -7,6 +7,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read   # amannn/action-semantic-pull-request reads the PR title
+
 jobs:
   main:
     name: Validate PR title


### PR DESCRIPTION
Two workflows declared no `permissions:` block.

- `ci.yml` — ruff + pytest, pure read. `contents: read` covers checkout.
- `commitlint.yml` — uses `amannn/action-semantic-pull-request@v5` which only reads the PR title to check conventional-commit format. `pull-requests: read` is the minimum needed. The `pull_request_target` trigger runs the action in the default-branch context, and the scope keeps it strictly read-only.