### PR TITLE
feat: add `cxas trace` for end-to-end conversation observability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ z_adhoc/
 .agent/
 *.tar
 
+# `cxas trace` workspace — local audio downloads, smoke-test outputs,
+# and per-developer trace.yaml. Users create their own.
+.cxas/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -57,3 +57,4 @@ When you pass a display name (e.g., `"My Support Agent"`) instead of a resource 
 | [`cxas lint`](lint.md) | Lint your app directory for best-practice violations. |
 | [`cxas init`](init.md) | Bootstrap a project with AI agent development skills. |
 | [`cxas insights`](insights.md) | Manage QA scorecards via the Insights API. |
+| [`cxas trace`](trace.md) | Inspect, analyze, and report on individual conversations (deployed/build/eval) — list, fetch report, merge Cloud Logs, download/analyze audio with Gemini, replay against current agent, aggregate stats, and flag platform bugs. |

--- a/docs/cli/trace.md
+++ b/docs/cli/trace.md
@@ -1,0 +1,135 @@
+# `cxas trace`
+
+`cxas trace` is the observability and debugging surface for past conversations.
+It composes the Conversational Agents API, Cloud Logging, GCS, and Gemini into
+a single, scriptable workflow so you can debug a flaky live conversation, audit
+an eval failure, replay a conversation against the current agent, or flag a
+platform bug — all from your terminal.
+
+All `cxas trace` subcommands share a few flags:
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--app-name` | yes | Full CXAS App ID (`projects/.../locations/.../apps/...`). |
+| `--app-dir` | no | Path to the pulled app directory. Defaults to `.`. Used to read `app.json` (audio bucket, Cloud Logging enablement, model version) and `environment.json`. |
+| `--env-file` | no | Explicit path to an `environment.json` file (mirrors the existing `cxas push --env-file` flag). |
+| `--environment` | no | Named environment, resolved to `<app-dir>/environment.<name>.json`. |
+| `--config` | no | Path to a trace config YAML. Defaults to `./.cxas/trace.yaml`, then `~/.cxas/trace.yaml`, then built-in defaults. |
+
+## Subcommands
+
+| Subcommand | Purpose |
+|-----------|---------|
+| `cxas trace list` | List conversations filtered by time / source / channel. |
+| `cxas trace get <id>` | Fetch a conversation and render a trace report (JSON / Markdown / text / HTML). |
+| `cxas trace logs <id>` | Fetch Cloud Logging entries correlated to a conversation. |
+| `cxas trace audio download <id>` | Download the GCS audio recording. |
+| `cxas trace audio analyze <id>` | Run configured Gemini audio metrics over the recording. |
+| `cxas trace triage <id>` | Run text-only Gemini triage prompts over the transcript. |
+| `cxas trace replay <id>` | Replay user inputs against the current agent and diff. |
+| `cxas trace stats` | Aggregate stats over recent conversations. |
+| `cxas trace bundle <id>` | Zip transcript + logs + audio + report into a single archive. |
+| `cxas trace bug-report <id>` | Flag a conversation as a platform bug; uploads bundle to a configured GCS bucket. |
+| `cxas trace open <id>` | Print (and on macOS, open) the CES Console deep link. |
+
+## Examples
+
+List the 10 most recent audio conversations from the last day:
+
+```
+cxas trace list \
+  --app-name projects/p/locations/l/apps/a \
+  --time-filter 24h --channel AUDIO --limit 10
+```
+
+Build a Markdown trace report with merged Cloud Logs, downloaded audio, and
+Gemini audio + transcript analysis — written to a file:
+
+```
+cxas trace get conv-id-1 \
+  --app-name projects/p/locations/l/apps/a \
+  --format md --with-logs --with-audio --with-analysis --with-triage \
+  --out trace.md
+```
+
+Compare a deployed conversation against the current agent:
+
+```
+cxas trace replay conv-id-1 --app-name projects/p/locations/l/apps/a --diff
+```
+
+Generate a 7-day stats report grouped by source, written as Markdown:
+
+```
+cxas trace stats --time-filter 7d --source LIVE \
+  --app-name projects/p/locations/l/apps/a --out stats.md
+```
+
+Flag a conversation as a platform bug with reason and severity:
+
+```
+cxas trace bug-report conv-id-1 \
+  --app-name projects/p/locations/l/apps/a \
+  --reason "agent hallucinated the refund amount" --severity high
+```
+
+## Configuration: `./.cxas/trace.yaml`
+
+`cxas trace` is fully configurable. Drop a `trace.yaml` next to your agent in
+`./.cxas/trace.yaml` (or globally at `~/.cxas/trace.yaml`) to override prompts,
+log filters, audio behavior, and the bug-report destination. Every field has
+a sensible default, so the file is optional.
+
+```yaml
+audio:
+  bucket_override: null            # leave null to use app.json's gcsBucket
+  uri_pattern: "{bucket}/{conversation_id}.wav"
+  download_dir: ./.cxas/audio
+  mime_type: audio/wav
+
+cloud_logging:
+  default_level: WARNING
+  time_padding_seconds: 30
+  filter_template: |
+    severity >= "{level}"
+    AND timestamp >= "{start_time}" AND timestamp <= "{end_time}"
+    AND (jsonPayload.conversation_id="{conversation_id}"
+         OR labels.conversation_id="{conversation_id}")
+
+gemini:
+  model: gemini-2.5-flash
+  # Audio analyses come from `cxas_scrapi.utils.audio_analysis.ANALYSIS_REGISTRY`
+  # (5 built-ins: agent_voice_consistency, no_long_pauses,
+  # agent_having_trouble, agent_looping, agent_cutoff). Each declares which
+  # files it needs (e.g. `agent-turn-*.wav` vs `full-session.wav`) and a
+  # default prompt. Override a prompt per-project by listing the metric here:
+  audio_metrics: {}
+  # Example override:
+  #   agent_cutoff:
+  #     prompt: "Custom cutoff prompt for our agent..."
+  triage_metrics:
+    hallucination:        { prompt: "..." }
+    off_topic:            { prompt: "..." }
+    failed_understanding: { prompt: "..." }
+
+ui:
+  ces_console_base: https://ces.cloud.google.com
+  ccai_insights_base: https://ccai.cloud.google.com/insights
+
+bug_report:
+  bucket: gs://cxas-platform-bugs
+  path_template: "{model_version}/{date}/{user}/{severity}/{conversation_id}/"
+  include: [transcript, logs, audio, gemini_analysis, environment]
+```
+
+## App-side discovery
+
+`cxas trace` reads the same `app.json` and `environment.json` files that `cxas
+pull` writes — no extra setup required. From `app.loggingSettings`:
+
+- `audioRecordingConfig.gcsBucket` → audio download source
+- `cloudLoggingSettings.enableCloudLogging` → gates `--with-logs`
+- `bigqueryExportSettings` → surfaced in metadata (informational)
+
+`$env_var` placeholders are resolved against the chosen `environment.json` —
+the same convention used by `cxas push`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
   "rich",
   "google-cloud-dialogflow-cx",
   "google-cloud-storage",
+  "google-cloud-logging",
   "nest_asyncio",
   "jinja2",
 ]
@@ -89,7 +90,7 @@ packages = ["src/cxas_scrapi"]
 [tool.ruff]
 line-length = 80
 target-version = "py310"
-extend-exclude = ["*.ipynb", ".agents/skills/cxas-agent-foundry/assets/project-template/", ".agents/skills/cxas-agent-foundry/scripts", ".agents/skills/cxas-sim-eval/scripts", "examples/"]
+extend-exclude = ["*.ipynb", ".agents/skills/cxas-agent-foundry/assets/project-template/", ".agents/skills/cxas-agent-foundry/scripts", ".agents/skills/cxas-sim-eval/scripts", ".agents/skills/cxas-cuj-report-generator/", "examples/"]
 
 [tool.ruff.lint]
 select = [
@@ -114,6 +115,9 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "src/cxas_scrapi/migration/prompts.py" = ["E501"]
+# Audio-analysis prompts are verbatim text intended for Gemini and must not be
+# reflowed; line-length doesn't apply to prompt content.
+"src/cxas_scrapi/utils/tracing/audio_analysis.py" = ["E501"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/src/cxas_scrapi/cli/main.py
+++ b/src/cxas_scrapi/cli/main.py
@@ -40,6 +40,7 @@ from cxas_scrapi.cli.app import (
 from cxas_scrapi.cli.create_local import handle_local_create
 from cxas_scrapi.cli.insights_cli import populate_insights_parser
 from cxas_scrapi.cli.migration_cli import MigrationCLI
+from cxas_scrapi.cli.trace_cli import register as register_trace_subparser
 from cxas_scrapi.core.apps import Apps
 from cxas_scrapi.core.evaluations import Evaluations, ExportFormat
 from cxas_scrapi.core.github import init_github_action
@@ -1564,6 +1565,9 @@ def get_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawTextHelpFormatter,
     )
     populate_insights_parser(parser_insights)
+
+    # Subparsers for 'trace' — observability/debugging for past conversations.
+    register_trace_subparser(subparsers)
 
     return parser
 

--- a/src/cxas_scrapi/cli/trace_cli.py
+++ b/src/cxas_scrapi/cli/trace_cli.py
@@ -1,0 +1,631 @@
+"""Argparse subcommand handlers for `cxas trace`.
+
+The handlers are intentionally thin: they only build a `Traces` instance and
+print results. All non-trivial logic lives in `core/traces.py` and
+`utils/trace_*.py`. Output formatting uses Rich tables for the human-friendly
+default (`list`, `stats`) and plain JSON / Markdown / text for everything else.
+"""
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import csv
+import io
+import json
+import logging
+import platform
+import subprocess
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from cxas_scrapi.core.traces import Traces
+
+logger = logging.getLogger(__name__)
+console = Console()
+
+
+def add_trace_args(subparser: argparse.ArgumentParser) -> None:
+    """Adds the common trace flags shared by every subcommand."""
+    subparser.add_argument(
+        "--app-name",
+        required=True,
+        help="The CXAS App ID (projects/.../locations/.../apps/...).",
+    )
+    subparser.add_argument(
+        "--app-dir",
+        default=".",
+        help=(
+            "Path to the pulled app directory (used to read app.json and "
+            "environment.json). Defaults to current directory."
+        ),
+    )
+    subparser.add_argument(
+        "--env-file",
+        help="Explicit path to an environment.json file.",
+    )
+    subparser.add_argument(
+        "--environment",
+        help=(
+            "Named environment, resolved to <app-dir>/environment.<name>.json."
+        ),
+    )
+    subparser.add_argument(
+        "--config",
+        help=(
+            "Path to a trace.yaml config file. Defaults to "
+            "./.cxas/trace.yaml or ~/.cxas/trace.yaml."
+        ),
+    )
+
+
+def _build_traces(args: argparse.Namespace) -> Traces:
+    return Traces(
+        app_name=args.app_name,
+        app_dir=getattr(args, "app_dir", "."),
+        env_file=getattr(args, "env_file", None),
+        environment=getattr(args, "environment", None),
+        trace_config_path=getattr(args, "config", None),
+    )
+
+
+# --------------------------------- list -------------------------------------
+
+
+def trace_list(args: argparse.Namespace) -> None:
+    try:
+        traces = _build_traces(args)
+        rows = traces.list(
+            time_filter=args.time_filter,
+            source_filter=args.source,
+            channel_filter=args.channel,
+            limit=args.limit,
+        )
+    except Exception as e:
+        print(f"Failed to list conversations: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    fmt = args.format
+    if fmt == "json":
+        print(json.dumps(rows, indent=2, default=str))
+        return
+    if fmt == "csv":
+        if not rows:
+            return
+        writer = csv.DictWriter(sys.stdout, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+        return
+    # default: table
+    table = Table(title=f"Conversations ({len(rows)})")
+    for col in (
+        "id",
+        "source",
+        "channel",
+        "start_time",
+        "end_time",
+        "ces_url",
+    ):
+        table.add_column(col)
+    for r in rows:
+        table.add_row(
+            *(
+                str(r.get(c) or "")
+                for c in (
+                    "id",
+                    "source",
+                    "channel",
+                    "start_time",
+                    "end_time",
+                    "ces_url",
+                )
+            )
+        )
+    console.print(table)
+
+
+# ---------------------------------- get -------------------------------------
+
+
+def trace_get(args: argparse.Namespace) -> None:
+    try:
+        traces = _build_traces(args)
+        out = traces.get_report(
+            args.conversation_id,
+            fmt=args.format,
+            with_logs=args.with_logs,
+            log_level=args.log_level,
+            with_audio=args.with_audio,
+            with_analysis=args.with_analysis,
+            with_triage=args.with_triage,
+        )
+    except Exception as e:
+        print(f"Failed to get trace: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.out:
+        with open(args.out, "w") as f:
+            f.write(out)
+        print(f"Wrote {args.out}")
+    else:
+        print(out)
+
+
+# ---------------------------------- logs ------------------------------------
+
+
+def trace_logs(args: argparse.Namespace) -> None:
+    try:
+        traces = _build_traces(args)
+        rows = traces.get_logs(args.conversation_id, level=args.level)
+    except Exception as e:
+        print(f"Failed to fetch logs: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if isinstance(rows, str):
+        print(rows)
+        return
+
+    if args.format == "json":
+        print(json.dumps(rows, indent=2, default=str))
+        return
+
+    for r in rows:
+        print(f"{r.get('timestamp')}  {r.get('severity')}  {r.get('message')}")
+
+
+# ---------------------------------- audio -----------------------------------
+
+
+def trace_audio_download(args: argparse.Namespace) -> None:
+    try:
+        traces = _build_traces(args)
+        path = traces.download_audio(args.conversation_id, dest_dir=args.out)
+    except Exception as e:
+        print(f"Audio download failed: {e}", file=sys.stderr)
+        sys.exit(1)
+    if path:
+        print(f"Downloaded to: {path}")
+    else:
+        print("No audio URI could be resolved.", file=sys.stderr)
+        sys.exit(2)
+
+
+def trace_audio_analyze(args: argparse.Namespace) -> None:
+    metrics = (
+        [m.strip() for m in args.metric.split(",")] if args.metric else None
+    )
+    try:
+        traces = _build_traces(args)
+        results = traces.analyze_audio(args.conversation_id, metrics=metrics)
+    except Exception as e:
+        print(f"Audio analysis failed: {e}", file=sys.stderr)
+        sys.exit(1)
+    print(json.dumps(results, indent=2, default=str))
+
+
+# --------------------------------- triage -----------------------------------
+
+
+def trace_triage(args: argparse.Namespace) -> None:
+    metrics = (
+        [m.strip() for m in args.metric.split(",")] if args.metric else None
+    )
+    try:
+        traces = _build_traces(args)
+        results = traces.triage(args.conversation_id, metrics=metrics)
+    except Exception as e:
+        print(f"Triage failed: {e}", file=sys.stderr)
+        sys.exit(1)
+    print(json.dumps(results, indent=2, default=str))
+
+
+# --------------------------------- replay -----------------------------------
+
+
+def trace_replay(args: argparse.Namespace) -> None:
+    try:
+        traces = _build_traces(args)
+        result = traces.replay(args.conversation_id, diff=args.diff)
+    except Exception as e:
+        print(f"Replay failed: {e}", file=sys.stderr)
+        sys.exit(1)
+    if args.format == "json":
+        print(json.dumps(result, indent=2, default=str))
+    elif "diff" in result:
+        print("# Replay diff\n```diff")
+        print(result["diff"] or "(no differences)")
+        print("```")
+    else:
+        print(json.dumps(result, indent=2, default=str))
+
+
+# ---------------------------------- stats -----------------------------------
+
+
+def trace_stats(args: argparse.Namespace) -> None:
+    try:
+        traces = _build_traces(args)
+        stats = traces.aggregate_stats(
+            time_filter=args.time_filter,
+            source_filter=args.source,
+            channel_filter=args.channel,
+            limit=args.limit,
+        )
+    except Exception as e:
+        print(f"Stats failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.format == "json":
+        out = json.dumps(stats, indent=2, default=str)
+    else:
+        out = _stats_to_markdown(stats)
+
+    if args.out:
+        with open(args.out, "w") as f:
+            f.write(out)
+        print(f"Wrote {args.out}")
+    else:
+        print(out)
+
+
+def _stats_to_markdown(stats: dict) -> str:
+    """Renders aggregate stats as Markdown with ASCII bar charts and units."""
+    buf = io.StringIO()
+    total = stats.get("total", 0)
+    buf.write(f"# Trace stats — last {stats['time_filter']}\n\n")
+    buf.write("## Summary\n\n")
+    buf.write("| Metric | Value |\n|---|---|\n")
+    buf.write(f"| Conversations analyzed | {total} |\n")
+    sr = stats.get("success_rate_no_transfer")
+    if sr is not None:
+        buf.write(
+            f"| Completed without escalation/transfer | "
+            f"{sr:.1%} ({int(sr * total)} of {total}) |\n"
+        )
+    dur = stats.get("duration_seconds", {})
+
+    def _fmt_sec(v):
+        return "n/a" if v is None else f"{v:.2f} s"
+
+    buf.write(
+        f"| Conversation duration p50 / p95 / median | "
+        f"{_fmt_sec(dur.get('p50'))} / "
+        f"{_fmt_sec(dur.get('p95'))} / "
+        f"{_fmt_sec(dur.get('median'))} |\n"
+    )
+    buf.write("\n")
+
+    buf.write(
+        "**Legend:** `LIVE` = deployed-agent traffic · `SIMULATOR` = "
+        "build/preview · `EVAL` = evaluation runs · "
+        "channel = derived from `Conversation.input_types`.\n\n"
+    )
+
+    buf.write("## Conversations by source\n\n")
+    buf.write(
+        _bar_block(
+            stats.get("per_source", {}),
+            unit="conversation",
+            total=total,
+        )
+    )
+
+    buf.write("\n## Conversations by channel\n\n")
+    buf.write(
+        _bar_block(
+            stats.get("per_channel", {}),
+            unit="conversation",
+            total=total,
+        )
+    )
+
+    buf.write("\n## Top tool calls\n\n")
+    buf.write(
+        "_Counts include every invocation across every conversation; "
+        "a single conversation may invoke a tool multiple times._\n\n"
+    )
+    buf.write(
+        _bar_block(
+            dict(stats.get("top_tools", [])),
+            unit="call",
+        )
+    )
+
+    buf.write("\n## Top transfer targets\n\n")
+    targets = dict(stats.get("top_transfer_targets", []))
+    if targets:
+        buf.write(_bar_block(targets, unit="transfer"))
+    else:
+        buf.write("_(no transfers in this window)_\n")
+    return buf.getvalue()
+
+
+def _bar_block(
+    counts: dict,
+    unit: str = "",
+    total: int | None = None,
+    width: int = 30,
+) -> str:
+    """Renders {label: count} as an ASCII bar block, scaled to the max value.
+
+    Optionally shows percentage of `total` next to each bar.
+    """
+    if not counts:
+        return "_(no data)_\n"
+    items = sorted(counts.items(), key=lambda kv: kv[1], reverse=True)
+    peak = max(v for _, v in items) or 1
+    label_w = min(40, max(len(str(k)) for k, _ in items))
+    out: list[str] = ["```"]
+    for label, n in items:
+        bar = "█" * max(1, int(round(width * n / peak)))
+        pct = ""
+        if total:
+            pct = f"  ({n / total:.0%})"
+        unit_label = f" {unit}{'s' if n != 1 else ''}"
+        out.append(f"{str(label).ljust(label_w)}  {bar}  {n}{unit_label}{pct}")
+    out.append("```")
+    return "\n".join(out) + "\n"
+
+
+# --------------------------------- bundle -----------------------------------
+
+
+def trace_bundle(args: argparse.Namespace) -> None:
+    try:
+        traces = _build_traces(args)
+        path = traces.bundle(
+            args.conversation_id,
+            out_path=args.out,
+            with_logs=not args.no_logs,
+            with_audio=not args.no_audio,
+            with_analysis=args.with_analysis,
+            with_triage=args.with_triage,
+        )
+    except Exception as e:
+        print(f"Bundle failed: {e}", file=sys.stderr)
+        sys.exit(1)
+    print(f"Wrote bundle to: {path}")
+
+
+# ------------------------------- bug-report ---------------------------------
+
+
+def trace_bug_report(args: argparse.Namespace) -> None:
+    try:
+        traces = _build_traces(args)
+        info = traces.report_bug(
+            args.conversation_id,
+            reason=args.reason,
+            severity=args.severity,
+        )
+    except Exception as e:
+        print(f"Bug report failed: {e}", file=sys.stderr)
+        sys.exit(1)
+    print(json.dumps(info, indent=2, default=str))
+
+
+# --------------------------------- open ------------------------------------
+
+
+def trace_open(args: argparse.Namespace) -> None:
+    try:
+        traces = _build_traces(args)
+        url = traces.console_url(args.conversation_id)
+    except Exception as e:
+        print(f"Open failed: {e}", file=sys.stderr)
+        sys.exit(1)
+    print(url)
+    if platform.system() == "Darwin":
+        try:
+            subprocess.run(["open", url], check=False)
+        except Exception:
+            pass
+
+
+# ----------------------------- argparse wiring ------------------------------
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:
+    """Adds the `trace` subcommand tree to the top-level CLI."""
+    parser_trace = subparsers.add_parser(
+        "trace",
+        help=(
+            "Inspect, analyze, and report on individual conversations "
+            "(deployed/build/eval)."
+        ),
+    )
+    trace_subparsers = parser_trace.add_subparsers(
+        title="trace commands", dest="trace_command", required=True
+    )
+
+    # list
+    p_list = trace_subparsers.add_parser(
+        "list", help="List conversations filtered by time/source/channel."
+    )
+    add_trace_args(p_list)
+    p_list.add_argument("--time-filter", default="7d")
+    p_list.add_argument(
+        "--source",
+        choices=["LIVE", "SIMULATOR", "EVAL"],
+        help="Filter by conversation source.",
+    )
+    p_list.add_argument(
+        "--channel",
+        choices=["TEXT", "AUDIO", "MULTIMODAL", "OTHER"],
+        help="Filter by input channel (client-side over input_types).",
+    )
+    p_list.add_argument("--limit", type=int)
+    p_list.add_argument(
+        "--format", choices=["table", "json", "csv"], default="table"
+    )
+    p_list.set_defaults(func=trace_list)
+
+    # get
+    p_get = trace_subparsers.add_parser(
+        "get", help="Fetch a conversation and render a trace report."
+    )
+    add_trace_args(p_get)
+    p_get.add_argument("conversation_id")
+    p_get.add_argument(
+        "--format",
+        choices=["json", "md", "markdown", "text", "html"],
+        default="md",
+    )
+    p_get.add_argument("--with-logs", action="store_true")
+    p_get.add_argument(
+        "--log-level",
+        help="Cloud Logging severity threshold (default WARNING).",
+    )
+    p_get.add_argument("--with-audio", action="store_true")
+    p_get.add_argument("--with-analysis", action="store_true")
+    p_get.add_argument("--with-triage", action="store_true")
+    p_get.add_argument("--out", help="File path to write the report to.")
+    p_get.set_defaults(func=trace_get)
+
+    # logs
+    p_logs = trace_subparsers.add_parser(
+        "logs", help="Fetch Cloud Logging entries for a conversation."
+    )
+    add_trace_args(p_logs)
+    p_logs.add_argument("conversation_id")
+    p_logs.add_argument(
+        "--level",
+        default="WARNING",
+        help="Severity threshold (default WARNING).",
+    )
+    p_logs.add_argument("--format", choices=["text", "json"], default="text")
+    p_logs.set_defaults(func=trace_logs)
+
+    # audio
+    p_audio = trace_subparsers.add_parser(
+        "audio", help="Audio recording subcommands."
+    )
+    audio_subparsers = p_audio.add_subparsers(
+        title="audio commands", dest="audio_command", required=True
+    )
+
+    p_audio_download = audio_subparsers.add_parser(
+        "download", help="Download a conversation's audio recording."
+    )
+    add_trace_args(p_audio_download)
+    p_audio_download.add_argument("conversation_id")
+    p_audio_download.add_argument(
+        "--out",
+        help="Destination directory (default: ./.cxas/audio/).",
+    )
+    p_audio_download.set_defaults(func=trace_audio_download)
+
+    p_audio_analyze = audio_subparsers.add_parser(
+        "analyze",
+        help="Run configured Gemini audio metrics over the recording.",
+    )
+    add_trace_args(p_audio_analyze)
+    p_audio_analyze.add_argument("conversation_id")
+    p_audio_analyze.add_argument(
+        "--metric",
+        help=(
+            "Comma-separated metric names from trace.yaml gemini.audio_metrics."
+        ),
+    )
+    p_audio_analyze.set_defaults(func=trace_audio_analyze)
+
+    # triage
+    p_triage = trace_subparsers.add_parser(
+        "triage",
+        help="Run configured Gemini text-only triage over the transcript.",
+    )
+    add_trace_args(p_triage)
+    p_triage.add_argument("conversation_id")
+    p_triage.add_argument(
+        "--metric",
+        help=(
+            "Comma-separated metric names from trace.yaml "
+            "gemini.triage_metrics."
+        ),
+    )
+    p_triage.set_defaults(func=trace_triage)
+
+    # replay
+    p_replay = trace_subparsers.add_parser(
+        "replay",
+        help="Replay user inputs against the current agent and diff.",
+    )
+    add_trace_args(p_replay)
+    p_replay.add_argument("conversation_id")
+    p_replay.add_argument(
+        "--no-diff",
+        dest="diff",
+        action="store_false",
+        help="Skip the diff and only print the replayed turns.",
+    )
+    p_replay.add_argument("--format", choices=["md", "json"], default="md")
+    p_replay.set_defaults(func=trace_replay, diff=True)
+
+    # stats
+    p_stats = trace_subparsers.add_parser(
+        "stats", help="Aggregate stats over recent conversations."
+    )
+    add_trace_args(p_stats)
+    p_stats.add_argument("--time-filter", default="7d")
+    p_stats.add_argument("--source", choices=["LIVE", "SIMULATOR", "EVAL"])
+    p_stats.add_argument(
+        "--channel", choices=["TEXT", "AUDIO", "MULTIMODAL", "OTHER"]
+    )
+    p_stats.add_argument("--limit", type=int, default=200)
+    p_stats.add_argument("--format", choices=["md", "json"], default="md")
+    p_stats.add_argument("--out", help="Write stats to file instead of stdout.")
+    p_stats.set_defaults(func=trace_stats)
+
+    # bundle
+    p_bundle = trace_subparsers.add_parser(
+        "bundle",
+        help="Zip transcript + logs + audio + report into a single archive.",
+    )
+    add_trace_args(p_bundle)
+    p_bundle.add_argument("conversation_id")
+    p_bundle.add_argument("--out", required=True, help="Output zip path.")
+    p_bundle.add_argument("--no-logs", action="store_true")
+    p_bundle.add_argument("--no-audio", action="store_true")
+    p_bundle.add_argument("--with-analysis", action="store_true")
+    p_bundle.add_argument("--with-triage", action="store_true")
+    p_bundle.set_defaults(func=trace_bundle)
+
+    # bug-report
+    p_bug = trace_subparsers.add_parser(
+        "bug-report",
+        help=(
+            "Flag a conversation as a platform bug; uploads bundle to the "
+            "configured GCS bucket."
+        ),
+    )
+    add_trace_args(p_bug)
+    p_bug.add_argument("conversation_id")
+    p_bug.add_argument("--reason", required=True)
+    p_bug.add_argument(
+        "--severity",
+        choices=["low", "medium", "high"],
+        default="medium",
+    )
+    p_bug.set_defaults(func=trace_bug_report)
+
+    # open
+    p_open = trace_subparsers.add_parser(
+        "open", help="Print (and on macOS, open) the CES Console URL."
+    )
+    add_trace_args(p_open)
+    p_open.add_argument("conversation_id")
+    p_open.set_defaults(func=trace_open)

--- a/src/cxas_scrapi/core/traces.py
+++ b/src/cxas_scrapi/core/traces.py
@@ -1,0 +1,917 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Public `Traces` API for the `cxas trace` CLI surface.
+
+Composes existing pieces (`ConversationHistory`, `Sessions`, `LatencyParser`,
+`GeminiGenerate`, `GCSUtils`) with new helpers (`AppConfig`, `TraceConfig`,
+`CloudLogsClient`, `trace_report` formatters) into one orchestration class
+analogous to `ConversationHistory` and `Sessions`.
+
+Methods are intentionally small and composable so they can also be called from
+notebooks / SDK consumers, not only from the CLI.
+"""
+
+# `Traces.list` shadows the built-in `list` inside the class body, so we defer
+# all annotation evaluation to keep `list[...]` parsing as a generic.
+from __future__ import annotations
+
+import datetime
+import difflib
+import json
+import logging
+import os
+import subprocess
+import zipfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from statistics import median
+from typing import Any
+
+from google import genai
+
+from cxas_scrapi.core.common import Common
+from cxas_scrapi.core.conversation_history import ConversationHistory
+from cxas_scrapi.core.sessions import Modality, Sessions
+from cxas_scrapi.utils.gcs_utils import GCSUtils
+from cxas_scrapi.utils.gemini import GeminiGenerate
+from cxas_scrapi.utils.tracing import trace_report
+from cxas_scrapi.utils.tracing.app_config import AppConfig
+from cxas_scrapi.utils.tracing.audio_analysis import (
+    ANALYSIS_REGISTRY,
+    AudioAnalysis,
+)
+from cxas_scrapi.utils.tracing.cloud_logging import CloudLogsClient
+from cxas_scrapi.utils.tracing.trace_config import TraceConfig
+
+logger = logging.getLogger(__name__)
+
+
+class Traces(Common):
+    """Orchestrates listing, fetching, enriching and analyzing conversations.
+
+    Construction is cheap: it loads the trace config and (optionally) the
+    pulled-app config, and instantiates a `ConversationHistory` client. The
+    heavier clients (Cloud Logging, Gemini, GCS) are lazily created on first
+    use so a `cxas trace list` call does not require any of those packages
+    to be reachable.
+    """
+
+    def __init__(
+        self,
+        app_name: str,
+        app_dir: str = ".",
+        env_file: str | None = None,
+        environment: str | None = None,
+        trace_config_path: str | None = None,
+        creds_path: str | None = None,
+        creds_dict: dict[str, str] | None = None,
+        creds: Any = None,
+        scope: list[str] | None = None,
+        **kwargs: Any,
+    ):
+        super().__init__(
+            creds_path=creds_path,
+            creds_dict=creds_dict,
+            creds=creds,
+            scope=scope,
+            app_name=app_name,
+            **kwargs,
+        )
+        self.history = ConversationHistory(
+            app_name=app_name,
+            creds_path=creds_path,
+            creds_dict=creds_dict,
+            creds=creds,
+            scope=scope,
+            **kwargs,
+        )
+        self.trace_config = TraceConfig.load(trace_config_path)
+        # AppConfig is optional — `cxas trace list` works without a pulled app.
+        self.app_config: AppConfig | None
+        try:
+            self.app_config = AppConfig.load(
+                app_dir=app_dir,
+                env_file=env_file,
+                environment=environment,
+            )
+        except FileNotFoundError as e:
+            logger.info(
+                f"No local app.json found ({e}); audio/log discovery will "
+                f"depend on `--bucket-override` / `trace.yaml` settings only."
+            )
+            self.app_config = None
+
+    # -------------------------- listing & fetching --------------------------
+
+    def list(
+        self,
+        time_filter: str | None = "7d",
+        source_filter: str | None = None,
+        channel_filter: str | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Lists conversations as summary dicts ready for rendering."""
+        convs = self.history.list_conversations(
+            time_filter=time_filter,
+            source_filter=source_filter,
+        )
+        rows: list[dict[str, Any]] = []
+        for c in convs:
+            normalized_channel = trace_report._channel_label(
+                getattr(c, "input_types", []) or []
+            )
+            if channel_filter and normalized_channel != channel_filter.upper():
+                continue
+            rows.append(
+                {
+                    "id": c.name.split("/")[-1],
+                    "name": c.name,
+                    "source": _enum_name(getattr(c, "source", None)),
+                    "channel": normalized_channel,
+                    "start_time": _ts_iso(getattr(c, "start_time", None)),
+                    "end_time": _ts_iso(getattr(c, "end_time", None)),
+                    "ces_url": self.console_url(c.name.split("/")[-1]),
+                }
+            )
+            if limit and len(rows) >= limit:
+                break
+        return rows
+
+    def get_normalized(self, conversation_id: str) -> dict[str, Any]:
+        """Fetches and normalizes a single conversation."""
+        conv = self.history.get_conversation(conversation_id)
+        return trace_report.normalize(conv)
+
+    # ----------------------------- reporting --------------------------------
+
+    def get_report(
+        self,
+        conversation_id: str,
+        fmt: str = "json",
+        with_logs: bool = False,
+        log_level: str | None = None,
+        with_audio: bool = False,
+        with_analysis: bool = False,
+        with_triage: bool = False,
+    ) -> str:
+        """Builds a single trace report in the requested format."""
+        normalized = self.get_normalized(conversation_id)
+        extras: dict[str, Any] = {}
+        audio_local_path: str | None = None
+
+        if with_logs:
+            cloud_default = self.trace_config.cloud_logging.default_level
+            extras["Cloud Logs"] = self.get_logs(
+                conversation_id,
+                level=log_level or cloud_default,
+                normalized=normalized,
+            )
+        if with_audio:
+            try:
+                audio_local_path = self.download_audio(
+                    conversation_id, normalized=normalized
+                )
+                extras["Audio"] = (
+                    f"Saved to: {audio_local_path}"
+                    if audio_local_path
+                    else "No audio available."
+                )
+            except Exception as e:
+                extras["Audio"] = f"Download failed: {e}"
+        if with_analysis:
+            extras["Audio Analysis"] = self.analyze_audio(
+                conversation_id,
+                normalized=normalized,
+                audio_local_path=audio_local_path,
+            )
+        if with_triage:
+            extras["Transcript Triage"] = self.triage(
+                conversation_id, normalized=normalized
+            )
+
+        url = self.console_url(conversation_id)
+        if fmt == "json":
+            return trace_report.to_json(normalized, extras=extras)
+        if fmt in ("md", "markdown"):
+            return trace_report.to_markdown(
+                normalized, console_url=url, extras=extras
+            )
+        if fmt == "text":
+            return trace_report.to_text(normalized, extras=extras)
+        if fmt == "html":
+            return trace_report.to_html(
+                normalized,
+                console_url=url,
+                extras=extras,
+                audio_path=audio_local_path,
+            )
+        raise ValueError(f"Unknown format: {fmt}")
+
+    # ----------------------------- cloud logs -------------------------------
+
+    def get_logs(
+        self,
+        conversation_id: str,
+        level: str = "WARNING",
+        normalized: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]] | str:
+        """Fetches Cloud Logging entries for a conversation."""
+        if self.app_config and not self.app_config.cloud_logging_enabled():
+            msg = (
+                "Cloud Logging is not enabled in app.json "
+                "(loggingSettings.cloudLoggingSettings.enableCloudLogging=false)."
+            )
+            logger.warning(msg)
+            return msg
+
+        if not self.project_id:
+            return "Cannot fetch logs: project ID is unknown."
+
+        client = CloudLogsClient(
+            project_id=self.project_id,
+            filter_template=self.trace_config.cloud_logging.filter_template,
+            time_padding_seconds=(
+                self.trace_config.cloud_logging.time_padding_seconds
+            ),
+            credentials=self.creds,
+        )
+        normalized = normalized or self.get_normalized(conversation_id)
+        start = _parse_iso(normalized.get("start_time"))
+        end = _parse_iso(normalized.get("end_time"))
+        return client.fetch(
+            conversation_id=conversation_id,
+            start_time=start,
+            end_time=end,
+            level=level,
+        )
+
+    # ------------------------------- audio ----------------------------------
+
+    def resolve_audio_uri(
+        self,
+        conversation_id: str,
+        normalized: dict[str, Any] | None = None,
+    ) -> str | None:
+        """Resolves the GCS URI for a conversation's audio recording.
+
+        Order:
+          1. Read directly from a chunk on the conversation proto if any
+             carries an `audioUri` (per-turn audio playback URIs sometimes
+             appear in `payload` chunks).
+          2. `audio.bucket_override` (from `trace.yaml`) or
+             `app.loggingSettings.audioRecordingConfig.gcsBucket`
+             (from `app.json`) formatted via `audio.uri_pattern`.
+          3. If `audio.search_bucket` is enabled and the simple URI does
+             not exist, list the bucket and return the first object whose
+             name ends with `/{conversation_id}/{search_filename}`.
+        """
+        normalized = normalized or self.get_normalized(conversation_id)
+        for entry in normalized.get("entries", []):
+            payload = entry.get("payload") if isinstance(entry, dict) else None
+            if isinstance(payload, dict) and payload.get("audioUri"):
+                return payload["audioUri"]
+
+        bucket = self.trace_config.audio.bucket_override or (
+            self.app_config.audio_bucket() if self.app_config else None
+        )
+        if not bucket:
+            return None
+        pattern = self.trace_config.audio.uri_pattern
+        candidate = pattern.format(
+            bucket=bucket.rstrip("/"),
+            project=self.project_id or "",
+            location=self.location or "",
+            app=(self.app_name or "").split("/")[-1],
+            conversation_id=conversation_id,
+        )
+
+        if self.trace_config.audio.search_bucket:
+            gcs = GCSUtils(creds=self.creds)
+            try:
+                if gcs.exists(candidate):
+                    return candidate
+            except Exception:
+                pass
+            suffix = (
+                f"/{conversation_id}/{self.trace_config.audio.search_filename}"
+            )
+            found = gcs.find_first(bucket, suffix=suffix)
+            if found:
+                logger.info(f"Resolved audio via bucket search: {found}")
+                return found
+            return None
+        return candidate
+
+    def download_audio(
+        self,
+        conversation_id: str,
+        dest_dir: str | None = None,
+        normalized: dict[str, Any] | None = None,
+    ) -> str | None:
+        """Downloads audio to disk and returns the local path."""
+        gcs_uri = self.resolve_audio_uri(conversation_id, normalized=normalized)
+        if not gcs_uri:
+            logger.warning(
+                "No audio URI could be resolved. Set "
+                "`loggingSettings.audioRecordingConfig.gcsBucket` in app.json "
+                "or `audio.bucket_override` in .cxas/trace.yaml."
+            )
+            return None
+
+        gcs = GCSUtils(creds=self.creds)
+        dest_dir = dest_dir or self.trace_config.audio.download_dir
+        os.makedirs(dest_dir, exist_ok=True)
+        ext = os.path.splitext(gcs_uri)[1] or ".wav"
+        dest_path = os.path.join(dest_dir, f"{conversation_id}{ext}")
+        return gcs.download_to_file(gcs_uri, dest_path)
+
+    def list_audio_files(self, conversation_id: str) -> list[str]:
+        """Returns the list of GCS URIs of every audio file recorded for a
+        conversation.
+
+        Conversations are stored as a directory of files
+        (`METADATA.json`, `full-session.wav`, `agent-turn-N.wav`,
+        `user-turn-N.wav`); this method discovers the directory by scanning
+        the configured audio bucket for an object matching
+        `*/{conversation_id}/METADATA.json`, then lists everything under that
+        prefix.
+        """
+        bucket = self.trace_config.audio.bucket_override or (
+            self.app_config.audio_bucket() if self.app_config else None
+        )
+        if not bucket:
+            return []
+        gcs = GCSUtils(creds=self.creds)
+        prefix = gcs.find_dir_for_conversation(
+            bucket, conversation_id=conversation_id
+        )
+        if not prefix:
+            return []
+        return gcs.list_with_prefix(bucket, prefix=prefix)
+
+    # ----------------------------- analysis ---------------------------------
+
+    def analyze_audio(
+        self,
+        conversation_id: str,
+        metrics: list[str] | None = None,
+        normalized: dict[str, Any] | None = None,
+        audio_local_path: str | None = None,
+    ) -> dict[str, Any]:
+        """Runs configured audio analyses over the conversation recording.
+
+        Uses the analysis registry in `utils.audio_analysis` (5 built-in
+        analyses: voice consistency, no long pauses, agent having trouble,
+        agent looping, agent cutoff). Each analysis declares which audio
+        files it needs (e.g. `agent-turn-*.wav` vs `full-session.wav`).
+        Prompt overrides may be supplied via `trace.yaml` under
+        `gemini.audio_metrics.<analysis_name>.prompt`.
+
+        Returns `{analysis_name: {result: PASS|FAIL|SKIP|ERROR, justification,
+        files_analyzed}}`.
+        """
+        files = self.list_audio_files(conversation_id)
+        if not files:
+            return {"error": "No audio files found for this conversation."}
+
+        if metrics:
+            selected: list[AudioAnalysis] = [
+                ANALYSIS_REGISTRY[m] for m in metrics if m in ANALYSIS_REGISTRY
+            ]
+            unknown = [m for m in metrics if m not in ANALYSIS_REGISTRY]
+            if unknown:
+                logger.warning(
+                    f"Skipping unknown audio analyses: {unknown}. "
+                    f"Available: {sorted(ANALYSIS_REGISTRY)}"
+                )
+        else:
+            selected = list(ANALYSIS_REGISTRY.values())
+
+        gem = GeminiGenerate(
+            project_id=self.project_id,
+            credentials=self.creds,
+            model_name=self.trace_config.gemini.model,
+        )
+        overrides = self.trace_config.gemini.audio_metrics
+        mime_type = self.trace_config.audio.mime_type
+
+        results: dict[str, Any] = {}
+        for analysis in selected:
+            analysis_files = analysis.filter_files(files)
+            if not analysis_files:
+                results[str(analysis.name)] = {
+                    "result": "SKIP",
+                    "justification": (
+                        "No audio files matched this analysis filter."
+                    ),
+                    "files_analyzed": [],
+                }
+                continue
+            prompt = analysis.prompt
+            override = overrides.get(str(analysis.name))
+            if override is not None:
+                prompt = override.prompt
+            parts = [
+                genai.types.Part.from_uri(file_uri=f, mime_type=mime_type)
+                for f in analysis_files
+            ]
+            parts.append(prompt)
+            response = gem.generate_with_parts(
+                parts=parts,
+                thinking_level=self.trace_config.gemini.thinking_level,
+            )
+            results[str(analysis.name)] = {
+                **_parse_pass_fail(response),
+                "files_analyzed": analysis_files,
+            }
+        return results
+
+    def triage(
+        self,
+        conversation_id: str,
+        metrics: list[str] | None = None,
+        normalized: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Runs configured Gemini text-only triage over the transcript."""
+        normalized = normalized or self.get_normalized(conversation_id)
+        transcript = trace_report.to_text(normalized)
+
+        gem = GeminiGenerate(
+            project_id=self.project_id,
+            credentials=self.creds,
+            model_name=self.trace_config.gemini.model,
+        )
+        all_metrics = self.trace_config.gemini.triage_metrics
+        if metrics:
+            selected = {k: v for k, v in all_metrics.items() if k in metrics}
+        else:
+            selected = all_metrics
+
+        results: dict[str, Any] = {}
+        for metric_name, metric in selected.items():
+            prompt = (
+                f"{metric.prompt}\n\nConversation transcript:\n{transcript}\n"
+            )
+            results[metric_name] = gem.generate(
+                prompt=prompt,
+                thinking_level=self.trace_config.gemini.thinking_level,
+            )
+        return results
+
+    # ------------------------------- replay ---------------------------------
+
+    def replay(
+        self,
+        conversation_id: str,
+        diff: bool = True,
+    ) -> dict[str, Any]:
+        """Re-runs original user inputs against the current agent.
+
+        Returns `{"original": [...], "replay": [...], "diff": "..."}`. The
+        diff is a unified diff of the agent text per turn.
+        """
+        normalized = self.get_normalized(conversation_id)
+        user_turns = [
+            e
+            for e in normalized["entries"]
+            if e["kind"] == "user" and e.get("text")
+        ]
+
+        sess = Sessions(app_name=self.app_name, creds=self.creds)
+        session_id = sess.create_session_id()
+
+        original_agents = _agent_text_per_turn(normalized)
+        replay_agents: list[str] = []
+        for ut in user_turns:
+            try:
+                response = sess.run(
+                    session_id=session_id,
+                    text=ut["text"],
+                    modality=Modality.TEXT,
+                )
+                structured = sess.get_structured_response(response)
+                replay_agents.append(structured.get("agent_text", ""))
+            except Exception as e:
+                replay_agents.append(f"<replay error: {e}>")
+
+        result: dict[str, Any] = {
+            "conversation_id": conversation_id,
+            "original": original_agents,
+            "replay": replay_agents,
+        }
+        if diff:
+            result["diff"] = "\n".join(
+                difflib.unified_diff(
+                    original_agents,
+                    replay_agents,
+                    fromfile="original",
+                    tofile="replay",
+                    lineterm="",
+                )
+            )
+        return result
+
+    # ------------------------------ stats -----------------------------------
+
+    def aggregate_stats(
+        self,
+        time_filter: str = "7d",
+        source_filter: str | None = None,
+        channel_filter: str | None = None,
+        limit: int = 200,
+        max_workers: int = 8,
+    ) -> dict[str, Any]:
+        """Aggregates counts/latencies/top-N across recent conversations."""
+        rows = self.list(
+            time_filter=time_filter,
+            source_filter=source_filter,
+            channel_filter=channel_filter,
+            limit=limit,
+        )
+        normalized_list: list[dict[str, Any]] = []
+        with ThreadPoolExecutor(max_workers=max_workers) as ex:
+            futures = {
+                ex.submit(self.get_normalized, r["id"]): r["id"] for r in rows
+            }
+            for fut in as_completed(futures):
+                try:
+                    normalized_list.append(fut.result())
+                except Exception as e:
+                    logger.warning(f"Failed to fetch {futures[fut]}: {e}")
+
+        per_source: dict[str, int] = {}
+        per_channel: dict[str, int] = {}
+        per_tool: dict[str, int] = {}
+        per_transfer: dict[str, int] = {}
+        durations: list[float] = []
+        success_total = 0
+
+        for n in normalized_list:
+            per_source[n.get("source") or "?"] = (
+                per_source.get(n.get("source") or "?", 0) + 1
+            )
+            per_channel[n.get("channel") or "?"] = (
+                per_channel.get(n.get("channel") or "?", 0) + 1
+            )
+            transferred = False
+            for e in n.get("entries", []):
+                if e["kind"] == "tool_call":
+                    per_tool[e.get("tool") or "?"] = (
+                        per_tool.get(e.get("tool") or "?", 0) + 1
+                    )
+                if e["kind"] == "agent_transfer":
+                    transferred = True
+                    per_transfer[str(e.get("target") or "?")] = (
+                        per_transfer.get(str(e.get("target") or "?"), 0) + 1
+                    )
+            if not transferred:
+                success_total += 1
+            d = _duration_seconds(n.get("start_time"), n.get("end_time"))
+            if d is not None:
+                durations.append(d)
+
+        return {
+            "time_filter": time_filter,
+            "total": len(normalized_list),
+            "per_source": per_source,
+            "per_channel": per_channel,
+            "success_rate_no_transfer": (
+                success_total / len(normalized_list)
+                if normalized_list
+                else None
+            ),
+            "duration_seconds": {
+                "p50": _percentile(durations, 50),
+                "p95": _percentile(durations, 95),
+                "median": median(durations) if durations else None,
+            },
+            "top_tools": _top_n(per_tool, 10),
+            "top_transfer_targets": _top_n(per_transfer, 10),
+        }
+
+    # ----------------------------- bundle/bug -------------------------------
+
+    def bundle(
+        self,
+        conversation_id: str,
+        out_path: str,
+        with_logs: bool = True,
+        with_audio: bool = True,
+        with_analysis: bool = False,
+        with_triage: bool = False,
+    ) -> str:
+        """Creates a zip with transcript, logs, audio, and report."""
+        normalized = self.get_normalized(conversation_id)
+        out_path = os.path.abspath(out_path)
+        os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
+
+        audio_path: str | None = None
+        if with_audio:
+            try:
+                audio_path = self.download_audio(
+                    conversation_id, normalized=normalized
+                )
+            except Exception as e:
+                logger.warning(f"Audio download failed: {e}")
+
+        logs: list[dict[str, Any]] | str | None = None
+        if with_logs:
+            logs = self.get_logs(conversation_id, normalized=normalized)
+
+        analysis = (
+            self.analyze_audio(conversation_id, normalized=normalized)
+            if with_analysis
+            else None
+        )
+        triage_result = (
+            self.triage(conversation_id, normalized=normalized)
+            if with_triage
+            else None
+        )
+
+        with zipfile.ZipFile(out_path, "w", zipfile.ZIP_DEFLATED) as z:
+            z.writestr(
+                "transcript.json",
+                trace_report.to_json(normalized, include_raw=True),
+            )
+            z.writestr(
+                "transcript.md",
+                trace_report.to_markdown(
+                    normalized, console_url=self.console_url(conversation_id)
+                ),
+            )
+            z.writestr(
+                "report.html",
+                trace_report.to_html(
+                    normalized,
+                    console_url=self.console_url(conversation_id),
+                    audio_path=(
+                        os.path.basename(audio_path) if audio_path else None
+                    ),
+                ),
+            )
+            if logs is not None:
+                z.writestr("logs.json", json.dumps(logs, indent=2, default=str))
+            if analysis is not None:
+                z.writestr(
+                    "gemini_analysis.json",
+                    json.dumps(analysis, indent=2, default=str),
+                )
+            if triage_result is not None:
+                z.writestr(
+                    "triage.json",
+                    json.dumps(triage_result, indent=2, default=str),
+                )
+            if audio_path and os.path.exists(audio_path):
+                z.write(audio_path, arcname=os.path.basename(audio_path))
+            z.writestr(
+                "metadata.json",
+                json.dumps(self._metadata(), indent=2, default=str),
+            )
+        return out_path
+
+    def report_bug(
+        self,
+        conversation_id: str,
+        reason: str,
+        severity: str = "medium",
+    ) -> dict[str, Any]:
+        """Bundles the conversation and uploads it to the bug-report bucket."""
+        bug_cfg = self.trace_config.bug_report
+        if not bug_cfg.bucket:
+            raise ValueError(
+                "trace.yaml: bug_report.bucket is not set; cannot upload."
+            )
+
+        # Build a temp bundle in memory and upload artifacts individually.
+        normalized = self.get_normalized(conversation_id)
+        path = bug_cfg.path_template.format(
+            model_version=(
+                self.app_config.model_version() if self.app_config else None
+            )
+            or "unknown_model",
+            date=datetime.date.today().isoformat(),
+            user=_gcloud_account() or os.environ.get("USER") or "unknown_user",
+            severity=severity,
+            conversation_id=conversation_id,
+        )
+        base_uri = f"{bug_cfg.bucket.rstrip('/')}/{path.lstrip('/')}"
+
+        gcs = GCSUtils(creds=self.creds)
+
+        uploaded: dict[str, str] = {}
+        if "transcript" in bug_cfg.include:
+            uploaded["transcript.json"] = gcs.upload_string(
+                f"{base_uri}transcript.json",
+                trace_report.to_json(normalized, include_raw=True),
+                content_type="application/json",
+            )
+            uploaded["transcript.md"] = gcs.upload_string(
+                f"{base_uri}transcript.md",
+                trace_report.to_markdown(
+                    normalized,
+                    console_url=self.console_url(conversation_id),
+                ),
+                content_type="text/markdown",
+            )
+        if "logs" in bug_cfg.include:
+            try:
+                logs = self.get_logs(conversation_id, normalized=normalized)
+                uploaded["logs.json"] = gcs.upload_string(
+                    f"{base_uri}logs.json",
+                    json.dumps(logs, indent=2, default=str),
+                    content_type="application/json",
+                )
+            except Exception as e:
+                logger.warning(f"Skipping logs in bug report: {e}")
+        if "audio" in bug_cfg.include:
+            try:
+                local = self.download_audio(
+                    conversation_id, normalized=normalized
+                )
+                if local and os.path.exists(local):
+                    uploaded["audio"] = gcs.upload_file(
+                        f"{base_uri}{os.path.basename(local)}",
+                        local,
+                        content_type="audio/wav",
+                    )
+            except Exception as e:
+                logger.warning(f"Skipping audio in bug report: {e}")
+        if "gemini_analysis" in bug_cfg.include:
+            try:
+                analysis = self.analyze_audio(
+                    conversation_id, normalized=normalized
+                )
+                uploaded["gemini_analysis.json"] = gcs.upload_string(
+                    f"{base_uri}gemini_analysis.json",
+                    json.dumps(analysis, indent=2, default=str),
+                    content_type="application/json",
+                )
+            except Exception as e:
+                logger.warning(f"Skipping Gemini analysis in bug report: {e}")
+        if "environment" in bug_cfg.include:
+            uploaded["environment.json"] = gcs.upload_string(
+                f"{base_uri}environment.json",
+                json.dumps(self._metadata(), indent=2, default=str),
+                content_type="application/json",
+            )
+
+        bug_meta = {
+            "conversation_id": conversation_id,
+            "reason": reason,
+            "severity": severity,
+            "model_version": (
+                self.app_config.model_version() if self.app_config else None
+            ),
+            "reporter": _gcloud_account() or os.environ.get("USER"),
+            "reported_at": datetime.datetime.utcnow().isoformat() + "Z",
+            "app_name": self.app_name,
+        }
+        uploaded["bug_report.json"] = gcs.upload_string(
+            f"{base_uri}bug_report.json",
+            json.dumps(bug_meta, indent=2, default=str),
+            content_type="application/json",
+        )
+        return {"gcs_uri": base_uri, "uploaded": uploaded, **bug_meta}
+
+    # ---------------------------- ui / helpers ------------------------------
+
+    def console_url(self, conversation_id: str) -> str:
+        base = self.trace_config.ui.ces_console_base.rstrip("/")
+        return (
+            f"{base}/projects/{self.project_id}/locations/{self.location}"
+            f"/apps/{(self.app_name or '').split('/')[-1]}/conversations/"
+            f"{conversation_id}"
+        )
+
+    def _metadata(self) -> dict[str, Any]:
+        return {
+            "app_name": self.app_name,
+            "project_id": self.project_id,
+            "location": self.location,
+            "model_version": (
+                self.app_config.model_version() if self.app_config else None
+            ),
+            "display_name": (
+                self.app_config.display_name() if self.app_config else None
+            ),
+            "git_sha": _git_sha(),
+            "gcloud_account": _gcloud_account(),
+            "captured_at": datetime.datetime.utcnow().isoformat() + "Z",
+        }
+
+
+# ----------------------------- module helpers -------------------------------
+
+
+def _enum_name(v: Any) -> str | None:
+    if v is None:
+        return None
+    return getattr(v, "name", str(v))
+
+
+def _ts_iso(ts: Any) -> str | None:
+    if ts is None:
+        return None
+    if hasattr(ts, "isoformat"):
+        return ts.isoformat()
+    return str(ts)
+
+
+def _parse_iso(s: str | None) -> datetime.datetime | None:
+    if not s:
+        return None
+    try:
+        return datetime.datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+
+def _duration_seconds(start: str | None, end: str | None) -> float | None:
+    s = _parse_iso(start)
+    e = _parse_iso(end)
+    if s and e:
+        return (e - s).total_seconds()
+    return None
+
+
+def _percentile(values: list[float], p: int) -> float | None:
+    if not values:
+        return None
+    s = sorted(values)
+    k = max(0, min(len(s) - 1, int(round((p / 100) * (len(s) - 1)))))
+    return s[k]
+
+
+def _top_n(counts: dict[str, int], n: int) -> list[tuple[str, int]]:
+    return sorted(counts.items(), key=lambda kv: kv[1], reverse=True)[:n]
+
+
+def _agent_text_per_turn(normalized: dict[str, Any]) -> list[str]:
+    by_turn: dict[int, list[str]] = {}
+    for e in normalized.get("entries", []):
+        if e["kind"] == "agent" and e.get("text"):
+            by_turn.setdefault(e.get("turn", 0), []).append(e["text"])
+    return [" ".join(by_turn[k]) for k in sorted(by_turn.keys())]
+
+
+def _git_sha() -> str | None:
+    try:
+        return (
+            subprocess.check_output(
+                ["git", "rev-parse", "HEAD"], stderr=subprocess.DEVNULL
+            )
+            .decode()
+            .strip()
+        )
+    except Exception:
+        return None
+
+
+def _parse_pass_fail(response: Any) -> dict[str, str]:
+    """Best-effort parser for the `PASS / FAIL + justification` Gemini reply.
+
+    Falls back to `{result: ERROR, ...}` if Gemini returned None, and to
+    `{result: UNKNOWN, justification: <full text>}` if neither PASS nor FAIL
+    appears in the response.
+    """
+    if response is None:
+        return {
+            "result": "ERROR",
+            "justification": "Gemini returned no response.",
+        }
+    text = response if isinstance(response, str) else str(response)
+    upper = text.upper()
+    if "PASS" in upper.split():
+        result = "PASS"
+    elif "FAIL" in upper.split():
+        result = "FAIL"
+    elif text.lstrip().upper().startswith("PASS"):
+        result = "PASS"
+    elif text.lstrip().upper().startswith("FAIL"):
+        result = "FAIL"
+    else:
+        return {"result": "UNKNOWN", "justification": text.strip()}
+    return {"result": result, "justification": text.strip()}
+
+
+def _gcloud_account() -> str | None:
+    try:
+        out = subprocess.check_output(
+            ["gcloud", "config", "get-value", "account"],
+            stderr=subprocess.DEVNULL,
+        )
+        return out.decode().strip() or None
+    except Exception:
+        return None

--- a/src/cxas_scrapi/utils/gcs_utils.py
+++ b/src/cxas_scrapi/utils/gcs_utils.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from typing import Any
 
 from google.cloud import storage
@@ -70,15 +71,7 @@ class GCSUtils(Common):
         Raises:
             ValueError: If the GCS URI is invalid.
         """
-        if not gcs_uri.startswith("gs://"):
-            raise ValueError(f"Invalid GCS URI: {gcs_uri}")
-
-        # Remove gs:// and split into bucket and blob path
-        parts = gcs_uri[5:].split("/", 1)
-        if len(parts) < 2:
-            raise ValueError(f"Invalid GCS URI: {gcs_uri}")
-
-        bucket_name, blob_path = parts
+        bucket_name, blob_path = self._parse_gcs_uri(gcs_uri)
         bucket = self.client.get_bucket(bucket_name)
         blob = bucket.blob(blob_path)
         blob.upload_from_string(content, content_type=content_type)
@@ -86,3 +79,124 @@ class GCSUtils(Common):
         return (
             f"https://storage.mtls.cloud.google.com/{bucket_name}/{blob_path}"
         )
+
+    def upload_file(
+        self,
+        gcs_uri: str,
+        local_path: str,
+        content_type: str | None = None,
+    ) -> str:
+        """Uploads a local file to a GCS URI and returns the mtls URL."""
+        bucket_name, blob_path = self._parse_gcs_uri(gcs_uri)
+        bucket = self.client.get_bucket(bucket_name)
+        blob = bucket.blob(blob_path)
+        blob.upload_from_filename(local_path, content_type=content_type)
+        return (
+            f"https://storage.mtls.cloud.google.com/{bucket_name}/{blob_path}"
+        )
+
+    def download_blob(self, gcs_uri: str) -> bytes:
+        """Downloads a blob from GCS and returns its raw bytes."""
+        bucket_name, blob_path = self._parse_gcs_uri(gcs_uri)
+        bucket = self.client.bucket(bucket_name)
+        blob = bucket.blob(blob_path)
+        return blob.download_as_bytes()
+
+    def download_string(self, gcs_uri: str, encoding: str = "utf-8") -> str:
+        """Downloads a blob from GCS and decodes it as text."""
+        return self.download_blob(gcs_uri).decode(encoding)
+
+    def download_to_file(self, gcs_uri: str, dest_path: str) -> str:
+        """Downloads a blob from GCS to a local file path.
+
+        Creates parent directories as needed. Returns the absolute dest path.
+        """
+        bucket_name, blob_path = self._parse_gcs_uri(gcs_uri)
+        bucket = self.client.bucket(bucket_name)
+        blob = bucket.blob(blob_path)
+        os.makedirs(os.path.dirname(os.path.abspath(dest_path)), exist_ok=True)
+        blob.download_to_filename(dest_path)
+        return os.path.abspath(dest_path)
+
+    def exists(self, gcs_uri: str) -> bool:
+        """Returns True if the GCS object exists."""
+        bucket_name, blob_path = self._parse_gcs_uri(gcs_uri)
+        bucket = self.client.bucket(bucket_name)
+        return bucket.blob(blob_path).exists(self.client)
+
+    def find_first(
+        self,
+        gcs_bucket_uri: str,
+        suffix: str,
+        max_results: int = 5000,
+    ) -> str | None:
+        """Lists the bucket and returns the first object whose name ends with
+        `suffix` (a fragment like `{conversation_id}/full-session.wav`).
+        Returns the full `gs://...` URI or None.
+        """
+        bucket_name, _ = self._parse_gcs_uri(gcs_bucket_uri, require_path=False)
+        for blob in self.client.list_blobs(
+            bucket_name, max_results=max_results
+        ):
+            if blob.name.endswith(suffix):
+                return f"gs://{bucket_name}/{blob.name}"
+        return None
+
+    def list_with_prefix(
+        self,
+        gcs_bucket_uri: str,
+        prefix: str,
+        max_results: int = 5000,
+    ) -> list[str]:
+        """Lists all objects in a bucket whose name starts with `prefix`.
+
+        Returns a sorted list of full `gs://bucket/path` URIs.
+        """
+        bucket_name, _ = self._parse_gcs_uri(gcs_bucket_uri, require_path=False)
+        blobs = self.client.list_blobs(
+            bucket_name, prefix=prefix, max_results=max_results
+        )
+        return sorted(f"gs://{bucket_name}/{b.name}" for b in blobs)
+
+    def find_dir_for_conversation(
+        self,
+        gcs_bucket_uri: str,
+        conversation_id: str,
+        marker_filename: str = "METADATA.json",
+        max_results: int = 5000,
+    ) -> str | None:
+        """Locates the GCS "directory" prefix that holds a conversation's
+        recordings, by scanning the bucket for an object whose path matches
+        `*/{conversation_id}/{marker_filename}`. Returns the prefix
+        (everything up to and including `{conversation_id}/`) or None.
+        """
+        bucket_name, _ = self._parse_gcs_uri(gcs_bucket_uri, require_path=False)
+        suffix = f"/{conversation_id}/{marker_filename}"
+        for blob in self.client.list_blobs(
+            bucket_name, max_results=max_results
+        ):
+            if blob.name.endswith(suffix):
+                # Trim off the marker filename, keep the trailing slash.
+                return blob.name[: -len(marker_filename)]
+        return None
+
+    @staticmethod
+    def _parse_gcs_uri(
+        gcs_uri: str, *, require_path: bool = True
+    ) -> tuple[str, str]:
+        """Splits a `gs://bucket[/path...]` URI into `(bucket, blob_path)`.
+
+        Always requires the `gs://` prefix and a non-empty bucket. By
+        default also requires a non-empty object path (for upload/download).
+        Pass `require_path=False` for bucket-level operations (listing).
+        """
+        if not gcs_uri or not gcs_uri.startswith("gs://"):
+            raise ValueError(f"Invalid GCS URI: {gcs_uri!r}")
+        parts = gcs_uri[5:].split("/", 1)
+        bucket = parts[0]
+        if not bucket:
+            raise ValueError(f"Invalid GCS URI: {gcs_uri!r}")
+        path = parts[1] if len(parts) == 2 else ""
+        if require_path and not path:
+            raise ValueError(f"Invalid GCS URI: {gcs_uri!r}")
+        return bucket, path

--- a/src/cxas_scrapi/utils/gemini.py
+++ b/src/cxas_scrapi/utils/gemini.py
@@ -65,6 +65,7 @@ class GeminiGenerate:
         response_mime_type: Optional[str] = None,
         response_schema: Optional[Any] = None,
         temperature: Optional[float] = 1.0,
+        thinking_level: Optional[str] = None,
     ) -> Optional[Any]:
         """Generates content using the Gemini model.
 
@@ -77,6 +78,8 @@ class GeminiGenerate:
             response_schema: Optional Pydantic model or schema for structured
               output.
             temperature: Optional temperature setting. Defaults to 1.0.
+            thinking_level: Optional Vertex `ThinkingConfig` budget; one of
+              "low" / "medium" / "high". `None` disables thinking entirely.
 
         Returns:
             The generated text response or parsed object, or None on failure.
@@ -92,6 +95,10 @@ class GeminiGenerate:
             config_args["response_schema"] = response_schema
         if temperature is not None:
             config_args["temperature"] = temperature
+        if thinking_level:
+            config_args["thinking_config"] = genai.types.ThinkingConfig(
+                thinking_level=thinking_level
+            )
 
         config = None
         if config_args:
@@ -107,6 +114,72 @@ class GeminiGenerate:
             return response.text
         except Exception as e:
             logger.error(f"Gemini generation failed: {e}")
+            return None
+
+    def generate_with_parts(
+        self,
+        parts: list[Any],
+        system_prompt: Optional[str] = None,
+        model_name: Optional[str] = None,
+        response_mime_type: Optional[str] = None,
+        response_schema: Optional[Any] = None,
+        temperature: Optional[float] = 1.0,
+        thinking_level: Optional[str] = None,
+    ) -> Optional[Any]:
+        """Generates content from a list of multimodal Parts.
+
+        Useful for audio analysis where one part is a `genai.types.Part`
+        constructed via `from_uri(gs://..., mime_type='audio/wav')` or
+        `from_bytes(data=..., mime_type=...)`, and another part is a text
+        prompt.
+
+        Args:
+            parts: List of `genai.types.Part` (or strings — converted to text
+              parts automatically).
+            system_prompt: Optional system instruction.
+            model_name: Optional override for the model name.
+            response_mime_type: Optional MIME type (e.g. 'application/json').
+            response_schema: Optional schema for structured output.
+            temperature: Sampling temperature.
+            thinking_level: Optional Vertex `ThinkingConfig` budget; one of
+              "low" / "medium" / "high". `None` disables thinking entirely.
+        """
+        target_model = model_name or self.model_name
+
+        contents = []
+        for part in parts:
+            if isinstance(part, str):
+                contents.append(genai.types.Part.from_text(text=part))
+            else:
+                contents.append(part)
+
+        config_args = {}
+        if system_prompt:
+            config_args["system_instruction"] = system_prompt
+        if response_mime_type:
+            config_args["response_mime_type"] = response_mime_type
+        if response_schema:
+            config_args["response_schema"] = response_schema
+        if temperature is not None:
+            config_args["temperature"] = temperature
+        if thinking_level:
+            config_args["thinking_config"] = genai.types.ThinkingConfig(
+                thinking_level=thinking_level
+            )
+
+        config = None
+        if config_args:
+            config = genai.types.GenerateContentConfig(**config_args)
+
+        try:
+            response = self.client.models.generate_content(
+                model=target_model, contents=contents, config=config
+            )
+            if response_mime_type == "application/json" and response_schema:
+                return response.parsed
+            return response.text
+        except Exception as e:
+            logger.error(f"Gemini multimodal generation failed: {e}")
             return None
 
     async def generate_async(

--- a/src/cxas_scrapi/utils/tracing/__init__.py
+++ b/src/cxas_scrapi/utils/tracing/__init__.py
@@ -1,0 +1,20 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Trace-specific helpers for the `cxas trace` command surface.
+
+Grouped here (instead of the flat `utils/`) to keep observability-related
+modules separate from generic shared utilities. The orchestration class
+`Traces` lives in `cxas_scrapi.core.traces` and composes these helpers.
+"""

--- a/src/cxas_scrapi/utils/tracing/app_config.py
+++ b/src/cxas_scrapi/utils/tracing/app_config.py
@@ -1,0 +1,228 @@
+"""Loader for a pulled CXAS app's local app.json + environment.json files.
+
+Reads the same files `cxas pull` writes to disk and the same files `cxas push`
+sends back, so a `cxas trace` user does not need to re-declare audio buckets,
+Cloud Logging settings, or BigQuery export settings — they are picked up from
+the agent's own configuration.
+
+`app.json` may reference per-environment values via the literal string
+`"$env_var"`. The matching key is looked up in `environment.json` (typed as
+a flat key→value map). Missing keys are left as `None` and a warning is logged.
+"""
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+ENV_VAR_PLACEHOLDER = "$env_var"
+
+
+class AppConfig:
+    """Reads `app.json` (+ `environment.json`) from a pulled-app directory."""
+
+    def __init__(
+        self,
+        app_data: dict[str, Any],
+        env_data: dict[str, Any] | None,
+        app_dir: str,
+        env_path: str | None,
+    ):
+        self._app = app_data or {}
+        self._env = env_data or {}
+        self.app_dir = app_dir
+        self.env_path = env_path
+
+    @classmethod
+    def load(
+        cls,
+        app_dir: str = ".",
+        env_file: str | None = None,
+        environment: str | None = None,
+    ) -> "AppConfig":
+        """Loads `app.json` and the resolved `environment.json` from disk.
+
+        Resolution order for environment.json:
+          1. `env_file` (explicit path)
+          2. `environment=<name>` -> `<app_dir>/environment.<name>.json`
+          3. `<app_dir>/environment.json`
+          4. None (env_var placeholders left unresolved with a warning)
+        """
+        app_path = os.path.join(app_dir, "app.json")
+        if not os.path.isfile(app_path):
+            raise FileNotFoundError(
+                f"app.json not found in {os.path.abspath(app_dir)}. "
+                f"Run `cxas pull` first or pass --app-dir."
+            )
+        with open(app_path) as f:
+            app_data = json.load(f)
+
+        env_path = cls._resolve_env_path(app_dir, env_file, environment)
+        env_data: dict[str, Any] | None = None
+        if env_path and os.path.isfile(env_path):
+            with open(env_path) as f:
+                env_data = json.load(f)
+        elif env_path:
+            logger.warning(
+                f"Environment file not found: {env_path}. "
+                f"$env_var placeholders will be left unresolved."
+            )
+
+        return cls(
+            app_data=app_data,
+            env_data=env_data,
+            app_dir=app_dir,
+            env_path=env_path,
+        )
+
+    @staticmethod
+    def _resolve_env_path(
+        app_dir: str,
+        env_file: str | None,
+        environment: str | None,
+    ) -> str | None:
+        if env_file:
+            return env_file
+        if environment:
+            return os.path.join(app_dir, f"environment.{environment}.json")
+        default = os.path.join(app_dir, "environment.json")
+        return default if os.path.exists(default) else None
+
+    def _resolve(self, value: Any, key_hint: str | None = None) -> Any:
+        """Substitutes `$env_var` placeholders using environment.json.
+
+        The CXAS convention stores the literal string "$env_var" in app.json
+        and looks up the matching field name in environment.json. The matching
+        is done by the JSON-path key (e.g. `loggingSettings.audioRecordingConfig
+        .gcsBucket`) — environment.json mirrors the structure of app.json,
+        with concrete values where app.json had placeholders.
+        """
+        if value != ENV_VAR_PLACEHOLDER:
+            return value
+        if not self._env or not key_hint:
+            logger.warning(
+                f"Cannot resolve $env_var for {key_hint}: no environment "
+                f"file loaded."
+            )
+            return None
+        resolved = self._lookup_env(key_hint)
+        if resolved is None:
+            logger.warning(
+                f"$env_var for {key_hint} not present in {self.env_path}."
+            )
+        return resolved
+
+    def _lookup_env(self, dotted_key: str) -> Any:
+        # `app.json` may store keys at the root (`loggingSettings.*`) while
+        # `environment.json` wraps the same tree under `app.*`, or vice versa.
+        # Try the literal key first, then with/without an `app.` prefix.
+        candidates = [dotted_key]
+        if dotted_key.startswith("app."):
+            candidates.append(dotted_key[len("app.") :])
+        else:
+            candidates.append(f"app.{dotted_key}")
+        for key in candidates:
+            node: Any = self._env
+            ok = True
+            for part in key.split("."):
+                if not isinstance(node, dict) or part not in node:
+                    ok = False
+                    break
+                node = node[part]
+            if ok and node != ENV_VAR_PLACEHOLDER:
+                return node
+        return None
+
+    def _get(self, dotted_key: str) -> Any:
+        node: Any = self._app
+        for part in dotted_key.split("."):
+            if not isinstance(node, dict) or part not in node:
+                return None
+            node = node[part]
+        return self._resolve(node, key_hint=dotted_key)
+
+    def audio_bucket(self) -> str | None:
+        """Returns the GCS bucket configured for audio recording."""
+        # The Humana CFD app at humana_cfd_mvp1/.../app.json shows the path:
+        # app.loggingSettings.audioRecordingConfig.gcsBucket. Some apps wrap
+        # the whole app config under an "app" key; support both.
+        for prefix in ("app.", ""):
+            v = self._get(
+                f"{prefix}loggingSettings.audioRecordingConfig.gcsBucket"
+            )
+            if v:
+                return v
+        return None
+
+    def cloud_logging_enabled(self) -> bool:
+        for prefix in ("app.", ""):
+            v = self._get(
+                f"{prefix}loggingSettings.cloudLoggingSettings."
+                f"enableCloudLogging"
+            )
+            if v is not None:
+                return bool(v)
+        return False
+
+    def bigquery_export(self) -> dict[str, Any] | None:
+        for prefix in ("app.", ""):
+            project = self._get(
+                f"{prefix}loggingSettings.bigqueryExportSettings.project"
+            )
+            dataset = self._get(
+                f"{prefix}loggingSettings.bigqueryExportSettings.dataset"
+            )
+            enabled = self._get(
+                f"{prefix}loggingSettings.bigqueryExportSettings.enabled"
+            )
+            if project or dataset:
+                return {
+                    "project": project,
+                    "dataset": dataset,
+                    "enabled": bool(enabled) if enabled is not None else None,
+                }
+        return None
+
+    def model_version(self) -> str | None:
+        for prefix in ("app.", ""):
+            v = self._get(f"{prefix}modelSettings.model")
+            if v:
+                return v
+        return None
+
+    def display_name(self) -> str | None:
+        for prefix in ("app.", ""):
+            v = self._get(f"{prefix}displayName")
+            if v:
+                return v
+        return None
+
+    def root_agent(self) -> str | None:
+        for prefix in ("app.", ""):
+            v = self._get(f"{prefix}rootAgent")
+            if v:
+                return v
+        return None
+
+    def redaction_config(self) -> dict[str, Any]:
+        for prefix in ("app.", ""):
+            v = self._get(f"{prefix}loggingSettings.redactionConfig")
+            if v is not None:
+                return v if isinstance(v, dict) else {}
+        return {}

--- a/src/cxas_scrapi/utils/tracing/audio_analysis.py
+++ b/src/cxas_scrapi/utils/tracing/audio_analysis.py
@@ -1,0 +1,215 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Registry of audio analysis types for the `cxas trace audio analyze` command.
+
+Each analysis declares (a) a stable name, (b) a Gemini prompt, and (c) a
+file-filter that picks which audio files in a conversation it cares about
+(e.g. `agent-turn-*.wav` vs `full-session.wav`). Conversations are stored in
+GCS as a directory of files per conversation, so passing only the relevant
+files keeps the Gemini call focused and cheap.
+
+To add a new analysis: subclass `AudioAnalysis`, append an instance to
+`_ALL_ANALYSES`, and the `ANALYSIS_REGISTRY` will pick it up automatically.
+
+Prompt overrides can be supplied via `trace.yaml` under
+`gemini.audio_metrics.<analysis_name>.prompt` — the runtime resolves overrides
+in `Traces.analyze_audio` and falls back to the prompt defined here.
+"""
+
+import enum
+from abc import ABC, abstractmethod
+
+
+class AnalysisType(str, enum.Enum):
+    """String-valued enum (compatible with Python 3.10+; `enum.StrEnum`
+    is only available from 3.11)."""
+
+    AGENT_VOICE_CONSISTENCY = "agent_voice_consistency"
+    NO_LONG_PAUSES = "no_long_pauses"
+    AGENT_HAVING_TROUBLE = "agent_having_trouble"
+    AGENT_LOOPING = "agent_looping"
+    AGENT_CUTOFF = "agent_cutoff"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class AudioAnalysis(ABC):
+    """Base class for audio analyses."""
+
+    @property
+    @abstractmethod
+    def name(self) -> AnalysisType:
+        """Stable name; must match the AnalysisType enum value."""
+
+    @property
+    @abstractmethod
+    def prompt(self) -> str:
+        """The Gemini prompt to run on the filtered audio files."""
+
+    @abstractmethod
+    def filter_files(self, files_in_conversation: list[str]) -> list[str]:
+        """Picks the subset of conversation audio files this analysis needs."""
+
+
+class VoiceConsistencyAnalysis(AudioAnalysis):
+    """Analysis for voice consistency."""
+
+    @property
+    def name(self) -> AnalysisType:
+        return AnalysisType.AGENT_VOICE_CONSISTENCY
+
+    @property
+    def prompt(self) -> str:
+        return """
+# Setup
+- You are a voice analysis assistant that will analyze conversation audio/wav files.
+- You will be given a list of audio clips / files. Each clip contains the audio of one person speaking.
+
+# Task
+- Your task is to determine if all the audio files are from the same speaker.
+- You should analyze the voice profile (including pitch, timbre, and accent) to determine if the files are from the same speaker.
+- For finding outlier audio profiles, look for distinct differences (e.g. male vs female voice / pitch, different timbres) rather than minor fluctuations.
+
+# Output
+- Report PASS if all audio files are from the same speaker and provide a justification.
+- Report FAIL if any of the audio files are from a different speaker and provide a justification.
+"""
+
+    def filter_files(self, files_in_conversation: list[str]) -> list[str]:
+        return [f for f in files_in_conversation if "agent-turn" in f]
+
+
+class NoLongPausesAnalysis(AudioAnalysis):
+    """Analysis for long pauses."""
+
+    @property
+    def name(self) -> AnalysisType:
+        return AnalysisType.NO_LONG_PAUSES
+
+    @property
+    def prompt(self) -> str:
+        return """
+# Setup
+- You are a voice analysis assistant that will analyze conversation audio/wav files.
+- You will be given an audio clip of a conversation between two people.
+
+# Task
+- Your task is to determine if the conversation contains any pauses longer than 20 seconds.
+- For finding pauses, look for distinct differences (e.g. silence or non-speech sounds like music or ambient noise) rather than minor fluctuations.
+- If there is a pause between 0 and 19 seconds, that should not be considered a long pause.
+
+# Output
+- Report PASS if the audio clip does not contain long pauses and provide a justification.
+- Report FAIL if the audio clip contains a long pause and provide a justification.
+"""
+
+    def filter_files(self, files_in_conversation: list[str]) -> list[str]:
+        return [f for f in files_in_conversation if "full-session" in f]
+
+
+class AgentHavingTroubleAnalysis(AudioAnalysis):
+    """Analysis for agent having trouble."""
+
+    @property
+    def name(self) -> AnalysisType:
+        return AnalysisType.AGENT_HAVING_TROUBLE
+
+    @property
+    def prompt(self) -> str:
+        return """
+# Setup
+- You are a voice analysis assistant that will analyze conversation audio/wav files.
+- You will be given a list of audio clips / files. Each clip contains the audio of one person speaking.
+
+# Task
+- Your task is to determine if any of the audio clips contain a person saying they are having trouble.
+
+# Output
+- Report PASS if none of the audio files contain a person saying they are having trouble and provide a justification.
+- Report FAIL if any of the audio files contain a person saying they are having trouble and provide a justification.
+"""
+
+    def filter_files(self, files_in_conversation: list[str]) -> list[str]:
+        return [f for f in files_in_conversation if "agent-turn" in f]
+
+
+class AgentLoopingAnalysis(AudioAnalysis):
+    """Analysis for agent looping."""
+
+    @property
+    def name(self) -> AnalysisType:
+        return AnalysisType.AGENT_LOOPING
+
+    @property
+    def prompt(self) -> str:
+        return """
+# Setup
+- You are a voice analysis assistant that will analyze conversation audio/wav files.
+- You will be given a list of audio clips / files. All audio clips are of the virtual agent speaking in a conversation.
+- A common issue with virtual agents is to get stuck in a loop, repeating the same sentence or phrase multiple times.
+
+# Task
+- Your task is to determine if the speaker repeats the same sentence or phrase multiple times in the conversation.
+- The repetition could be exact or contain minor variations, but the sentiment should be the same. Questions and statements never have the same sentiment and should not be considered to repeat.
+- The repetition could occur in the same file or across multiple files.
+
+# Output
+- Report PASS if none of the audio files contain a person repeating the same sentence or phrase multiple times and provide a justification.
+- Report FAIL if any of the audio files contain a person repeating the same sentence or phrase multiple times and provide a justification.
+"""
+
+    def filter_files(self, files_in_conversation: list[str]) -> list[str]:
+        return [f for f in files_in_conversation if "agent-turn" in f]
+
+
+class AgentCutoffAnalysis(AudioAnalysis):
+    """Analysis for agent sentence cutoff."""
+
+    @property
+    def name(self) -> AnalysisType:
+        return AnalysisType.AGENT_CUTOFF
+
+    @property
+    def prompt(self) -> str:
+        return """
+# Setup
+- You are a voice analysis assistant that will analyze conversation audio/wav files.
+- You will be given a list of audio clips / files. All audio clips are of the virtual agent speaking in a conversation.
+
+# Task
+- Your task is to determine if any of the agent's sentences are cutoff or abruptly ended before the sentence is completed.
+- This could happen due to system issues or early termination of the turn.
+
+# Output
+- Report PASS if none of the audio files contain a sentence that is cutoff and provide a justification.
+- Report FAIL if any of the audio files contain a sentence that is cutoff and provide a justification.
+"""
+
+    def filter_files(self, files_in_conversation: list[str]) -> list[str]:
+        return [f for f in files_in_conversation if "agent-turn" in f]
+
+
+_ALL_ANALYSES: list[AudioAnalysis] = [
+    VoiceConsistencyAnalysis(),
+    NoLongPausesAnalysis(),
+    AgentHavingTroubleAnalysis(),
+    AgentLoopingAnalysis(),
+    AgentCutoffAnalysis(),
+]
+
+ANALYSIS_REGISTRY: dict[str, AudioAnalysis] = {
+    str(analysis.name): analysis for analysis in _ALL_ANALYSES
+}

--- a/src/cxas_scrapi/utils/tracing/cloud_logging.py
+++ b/src/cxas_scrapi/utils/tracing/cloud_logging.py
@@ -1,0 +1,195 @@
+"""Per-conversation Cloud Logging client.
+
+Builds a Cloud Logging filter from a template (in `trace.yaml`) populated with
+the conversation_id, time bounds, and severity threshold; merges entries
+chronologically and exposes a small structured row for downstream rendering.
+"""
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+import json
+import logging
+import re
+from typing import Any
+
+try:
+    from google.cloud import logging_v2
+except ImportError:
+    logging_v2 = None
+
+logger = logging.getLogger(__name__)
+
+
+class CloudLogsClient:
+    """Thin wrapper over `google.cloud.logging_v2` for conversation logs."""
+
+    def __init__(
+        self,
+        project_id: str,
+        filter_template: str,
+        time_padding_seconds: int = 30,
+        credentials: Any = None,
+    ):
+        if logging_v2 is None:
+            raise ImportError(
+                "google-cloud-logging is required for `cxas trace logs`. "
+                "Install with: pip install google-cloud-logging"
+            )
+        self.project_id = project_id
+        self.filter_template = filter_template
+        self.time_padding_seconds = time_padding_seconds
+        self._client = logging_v2.Client(
+            project=project_id, credentials=credentials
+        )
+
+    def fetch(
+        self,
+        conversation_id: str,
+        start_time: datetime.datetime | None,
+        end_time: datetime.datetime | None,
+        level: str = "WARNING",
+    ) -> list[dict[str, Any]]:
+        """Fetches log entries for a single conversation."""
+        return self.batch_fetch(
+            conversation_ids=[conversation_id],
+            start_time=start_time,
+            end_time=end_time,
+            level=level,
+        ).get(conversation_id, [])
+
+    def batch_fetch(
+        self,
+        conversation_ids: list[str],
+        start_time: datetime.datetime | None,
+        end_time: datetime.datetime | None,
+        level: str = "WARNING",
+    ) -> dict[str, list[dict[str, Any]]]:
+        """Fetches logs for many conversations in a single Cloud Logging
+        query and groups the rows by conversation_id.
+
+        Cuts down N round-trips to 1 when computing aggregate trace stats
+        across a time window.
+        """
+        if not conversation_ids:
+            return {}
+        if start_time is None:
+            start_time = datetime.datetime.utcnow() - datetime.timedelta(
+                hours=24
+            )
+        if end_time is None:
+            end_time = datetime.datetime.utcnow()
+
+        padded_start = start_time - datetime.timedelta(
+            seconds=self.time_padding_seconds
+        )
+        padded_end = end_time + datetime.timedelta(
+            seconds=self.time_padding_seconds
+        )
+
+        # Render one filter per conversation against the template, then OR
+        # them together so a single Cloud Logging query returns all rows.
+        per_conv_filters = [
+            "("
+            + self.filter_template.format(
+                level=level.upper(),
+                start_time=padded_start.isoformat(),
+                end_time=padded_end.isoformat(),
+                conversation_id=cid,
+            )
+            + ")"
+            for cid in conversation_ids
+        ]
+        combined = " OR ".join(per_conv_filters)
+
+        rows: list[dict[str, Any]] = []
+        try:
+            for entry in self._client.list_entries(
+                filter_=combined, order_by="timestamp asc"
+            ):
+                rows.append(_entry_to_row(entry))
+        except Exception as e:
+            logger.warning(f"Cloud Logging query failed: {e}")
+            return {cid: [] for cid in conversation_ids}
+
+        grouped: dict[str, list[dict[str, Any]]] = {
+            cid: [] for cid in conversation_ids
+        }
+        # Single-conversation queries don't need attribution — assign every
+        # returned row to that conversation. For multi-conversation batch
+        # queries, attribute by the conversation_id label (or, as a fallback,
+        # by scanning the message body).
+        if len(conversation_ids) == 1:
+            grouped[conversation_ids[0]] = rows
+        else:
+            for r in rows:
+                cid = _row_conversation_id(r)
+                if cid in grouped:
+                    grouped[cid].append(r)
+        for v in grouped.values():
+            v.sort(key=lambda r: r.get("timestamp") or "")
+        return grouped
+
+
+def _row_conversation_id(row: dict[str, Any]) -> str | None:
+    """Best-effort extraction of `conversation_id` from a log row's labels
+    or its message body, for grouping batch results back per conversation.
+    """
+    labels = row.get("labels") or {}
+    if isinstance(labels, dict) and labels.get("conversation_id"):
+        return labels["conversation_id"]
+    msg = row.get("message")
+    if isinstance(msg, str):
+        # Heuristic match for jsonPayload.conversation_id="..."; fall back to
+        # any UUID-like substring.
+        m = re.search(r"conversation_id[\"']?\s*[:=]\s*[\"']?([\w-]{8,})", msg)
+        if m:
+            return m.group(1)
+    return None
+
+
+def _entry_to_row(entry: Any) -> dict[str, Any]:
+    """Converts a Cloud Logging entry to a flat dict for rendering."""
+    payload = getattr(entry, "payload", None)
+    if isinstance(payload, dict):
+        message = payload.get("message") or payload
+    else:
+        message = payload
+
+    ts = getattr(entry, "timestamp", None)
+    return {
+        "timestamp": ts.isoformat() if ts else None,
+        "severity": getattr(entry, "severity", None),
+        "log_name": getattr(entry, "log_name", None),
+        "resource_type": (
+            getattr(entry.resource, "type", None)
+            if getattr(entry, "resource", None)
+            else None
+        ),
+        "message": _stringify(message),
+        "labels": dict(getattr(entry, "labels", {}) or {}),
+        "trace": getattr(entry, "trace", None),
+    }
+
+
+def _stringify(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, default=str)
+    except Exception:
+        return str(value)

--- a/src/cxas_scrapi/utils/tracing/trace_config.py
+++ b/src/cxas_scrapi/utils/tracing/trace_config.py
@@ -1,0 +1,158 @@
+"""Pydantic-validated config for the `cxas trace` command.
+
+Resolution order: explicit `--config FILE` -> `./.cxas/trace.yaml` ->
+`~/.cxas/trace.yaml` -> built-in defaults. Every section has defaults so the
+file is optional.
+"""
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+PROJECT_CONFIG_PATH = "./.cxas/trace.yaml"
+USER_CONFIG_PATH = os.path.expanduser("~/.cxas/trace.yaml")
+
+
+class AudioConfig(BaseModel):
+    bucket_override: str | None = None
+    uri_pattern: str = "{bucket}/{conversation_id}.wav"
+    download_dir: str = "./.cxas/audio"
+    mime_type: str = "audio/wav"
+    # If True (and the platform-managed bucket layout is used), search the
+    # configured bucket for objects whose path ends with
+    # `/{conversation_id}/{search_filename}` and use the first match.
+    search_bucket: bool = True
+    search_filename: str = "full-session.wav"
+
+
+class CloudLoggingConfig(BaseModel):
+    default_level: str = "WARNING"
+    time_padding_seconds: int = 30
+    filter_template: str = (
+        'severity >= "{level}"\n'
+        'AND timestamp >= "{start_time}" AND timestamp <= "{end_time}"\n'
+        'AND (jsonPayload.conversation_id="{conversation_id}"\n'
+        '     OR labels.conversation_id="{conversation_id}")\n'
+    )
+
+
+class GeminiMetric(BaseModel):
+    prompt: str
+
+
+class GeminiConfig(BaseModel):
+    # `gemini-3-flash-preview` supports both text and audio Parts and the
+    # ThinkingConfig API. Override per-project via `trace.yaml: gemini.model`.
+    model: str = "gemini-3-flash-preview"
+    # Vertex `ThinkingConfig` budget. Accepts "low" / "medium" / "high"
+    # (or None to disable). Audio metric and transcript triage prompts are
+    # classification-style, so "low" is a good default trade-off between
+    # quality and latency / cost.
+    thinking_level: str | None = "low"
+    # `audio_metrics` is an *override* layer; the catalog of analyses lives
+    # in `audio_analysis.ANALYSIS_REGISTRY`. Any key
+    # here whose name matches a registered analysis replaces that
+    # analysis's built-in prompt at runtime.
+    audio_metrics: dict[str, GeminiMetric] = Field(default_factory=dict)
+    triage_metrics: dict[str, GeminiMetric] = Field(
+        default_factory=lambda: {
+            "hallucination": GeminiMetric(
+                prompt=(
+                    "Identify turns where the agent made factually incorrect "
+                    "claims. Return the turn index, the claim, and why it "
+                    "is incorrect."
+                )
+            ),
+            "off_topic": GeminiMetric(
+                prompt=(
+                    "Flag turns where the agent's response was unrelated to "
+                    "the user's most recent question. Return the turn index "
+                    "and a brief reason."
+                )
+            ),
+            "failed_understanding": GeminiMetric(
+                prompt=(
+                    "Flag turns where the agent appears to have "
+                    "misunderstood the user. Return the turn index and a "
+                    "brief description of the misunderstanding."
+                )
+            ),
+        }
+    )
+
+
+class UIConfig(BaseModel):
+    ces_console_base: str = "https://ces.cloud.google.com"
+    ccai_insights_base: str = "https://ccai.cloud.google.com/insights"
+
+
+class BugReportConfig(BaseModel):
+    bucket: str | None = None
+    path_template: str = (
+        "{model_version}/{date}/{user}/{severity}/{conversation_id}/"
+    )
+    include: list[str] = Field(
+        default_factory=lambda: [
+            "transcript",
+            "logs",
+            "audio",
+            "gemini_analysis",
+            "environment",
+        ]
+    )
+
+
+class TraceConfig(BaseModel):
+    audio: AudioConfig = Field(default_factory=AudioConfig)
+    cloud_logging: CloudLoggingConfig = Field(
+        default_factory=CloudLoggingConfig
+    )
+    gemini: GeminiConfig = Field(default_factory=GeminiConfig)
+    ui: UIConfig = Field(default_factory=UIConfig)
+    bug_report: BugReportConfig = Field(default_factory=BugReportConfig)
+
+    @classmethod
+    def load(cls, explicit_path: str | None = None) -> "TraceConfig":
+        """Loads config from an explicit path or the standard search paths."""
+        path = cls._pick_path(explicit_path)
+        if path is None:
+            return cls()
+        with open(path) as f:
+            raw: dict[str, Any] = yaml.safe_load(f) or {}
+        try:
+            return cls.model_validate(raw)
+        except Exception as e:
+            raise ValueError(f"Invalid trace config at {path}: {e}") from e
+
+    @staticmethod
+    def _pick_path(explicit_path: str | None) -> str | None:
+        if explicit_path:
+            if not os.path.isfile(explicit_path):
+                raise FileNotFoundError(
+                    f"Trace config not found: {explicit_path}"
+                )
+            return explicit_path
+        if os.path.isfile(PROJECT_CONFIG_PATH):
+            return PROJECT_CONFIG_PATH
+        if os.path.isfile(USER_CONFIG_PATH):
+            return USER_CONFIG_PATH
+        return None

--- a/src/cxas_scrapi/utils/tracing/trace_report.py
+++ b/src/cxas_scrapi/utils/tracing/trace_report.py
@@ -1,0 +1,827 @@
+"""Normalizes a CES `Conversation` proto into a structured trace and renders it.
+
+Output formats: JSON, Markdown, plain text, HTML. The normalized
+representation is a list of `TraceEntry` dicts that the four formatters share,
+so adding a new format only means writing a new render function.
+"""
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+import html as _html
+import json
+from typing import Any
+
+from google.cloud.ces_v1beta import types as ces_types
+
+from cxas_scrapi.core.common import Common
+
+_SOURCE_NAMES = {s.value: s.name for s in ces_types.Conversation.Source}
+_INPUT_TYPE_NAMES = {s.value: s.name for s in ces_types.Conversation.InputType}
+
+
+def normalize(conversation: Any) -> dict[str, Any]:
+    """Converts a `types.Conversation` proto (or dict) to a normalized trace.
+
+    The normalized form is dict-of-primitives that can be JSON-serialized,
+    fed back into a Pydantic model, or rendered. Each entry has a `kind`
+    (`user`, `agent`, `tool_call`, `tool_response`, `agent_transfer`,
+    `custom_payload`, `system`) plus a small payload.
+    """
+    conv_dict = (
+        type(conversation).to_dict(conversation)
+        if not isinstance(conversation, dict)
+        else conversation
+    )
+
+    entries: list[dict[str, Any]] = []
+    turn_metrics: list[dict[str, Any]] = []
+    for turn_idx, turn in enumerate(conv_dict.get("turns", [])):
+        for msg in turn.get("messages", []):
+            role = msg.get("role", "")
+            for chunk in msg.get("chunks", []) or []:
+                entry = _chunk_to_entry(chunk, role, turn_idx)
+                if entry is not None:
+                    entries.append(entry)
+        turn_metrics.append(_turn_metrics(turn, turn_idx))
+
+    raw_source = conv_dict.get("source")
+    raw_input_types = conv_dict.get("input_types") or []
+    return {
+        "conversation_id": (conv_dict.get("name") or "").split("/")[-1],
+        "name": conv_dict.get("name"),
+        "display_name": conv_dict.get("display_name"),
+        "source": _source_name(raw_source),
+        "input_types": [_input_type_name(it) for it in raw_input_types],
+        "channel": _channel_label(raw_input_types),
+        "start_time": _to_iso(conv_dict.get("start_time")),
+        "end_time": _to_iso(conv_dict.get("end_time")),
+        "num_turns": len(conv_dict.get("turns", [])),
+        "entries": entries,
+        "turn_metrics": turn_metrics,
+        "totals": _conversation_totals(turn_metrics),
+        "raw": conv_dict,
+    }
+
+
+def _turn_metrics(turn: dict[str, Any], turn_idx: int) -> dict[str, Any]:
+    """Pulls per-turn timing, latency, tokens, and a flat span list."""
+    rs = turn.get("root_span") or {}
+    spans: list[dict[str, Any]] = []
+    _flatten_spans(rs.get("child_spans", []) or [], spans)
+    tokens = _sum_tokens(spans)
+    return {
+        "turn": turn_idx,
+        "start_time": _to_iso(rs.get("start_time")),
+        "end_time": _to_iso(rs.get("end_time")),
+        "duration_ms": _duration_ms(
+            rs.get("start_time"), rs.get("end_time"), rs.get("duration")
+        ),
+        "perceived_latency_ms": _attr(rs, "perceived latency (ms)"),
+        "tokens": tokens,
+        "spans": spans,
+    }
+
+
+def _flatten_spans(
+    children: list[dict[str, Any]],
+    out: list[dict[str, Any]],
+    depth: int = 0,
+) -> None:
+    """Walks `child_spans` recursively into a flat list with depth markers."""
+    for s in children:
+        attrs = s.get("attributes") or {}
+        out.append(
+            {
+                "name": s.get("name"),
+                "depth": depth,
+                "stage": attrs.get("stage"),
+                "agent": attrs.get("agent"),
+                "tool": attrs.get("name") if s.get("name") == "Tool" else None,
+                "model": attrs.get("model"),
+                "tool_args": Common.unwrap_struct(attrs.get("args"))
+                if s.get("name") == "Tool"
+                else None,
+                "tool_response": Common.unwrap_struct(attrs.get("response"))
+                if s.get("name") == "Tool"
+                else None,
+                "tool_id": attrs.get("tool call id"),
+                "tool_type": attrs.get("type"),
+                "tokens": (
+                    {
+                        "input": _to_int(attrs.get("input token count")),
+                        "output": _to_int(attrs.get("output token count")),
+                        "thought": _to_int(attrs.get("thought token count")),
+                        "ttfc_ms": _to_int(
+                            attrs.get("time to first chunk (ms)")
+                        ),
+                    }
+                    if s.get("name") == "LLM"
+                    else None
+                ),
+                "duration_ms": _duration_ms(
+                    s.get("start_time"), s.get("end_time"), s.get("duration")
+                ),
+                "start_time": _to_iso(s.get("start_time")),
+                "end_time": _to_iso(s.get("end_time")),
+            }
+        )
+        _flatten_spans(s.get("child_spans", []) or [], out, depth + 1)
+
+
+def _sum_tokens(spans: list[dict[str, Any]]) -> dict[str, int]:
+    totals = {"input": 0, "output": 0, "thought": 0}
+    for s in spans:
+        t = s.get("tokens")
+        if not t:
+            continue
+        for k in totals:
+            v = t.get(k)
+            if v is not None:
+                totals[k] += v
+    totals["total"] = totals["input"] + totals["output"] + totals["thought"]
+    return totals
+
+
+def _conversation_totals(
+    turn_metrics: list[dict[str, Any]],
+) -> dict[str, Any]:
+    total_ms = 0.0
+    perceived_ms = 0.0
+    tokens = {"input": 0, "output": 0, "thought": 0, "total": 0}
+    span_counts: dict[str, int] = {}
+    for tm in turn_metrics:
+        if tm.get("duration_ms") is not None:
+            total_ms += tm["duration_ms"]
+        if tm.get("perceived_latency_ms") is not None:
+            perceived_ms += tm["perceived_latency_ms"]
+        for k in tokens:
+            tokens[k] += tm.get("tokens", {}).get(k, 0) or 0
+        for s in tm.get("spans", []):
+            span_counts[s["name"]] = span_counts.get(s["name"], 0) + 1
+    return {
+        "duration_ms": total_ms,
+        "perceived_latency_ms": perceived_ms,
+        "tokens": tokens,
+        "span_counts": span_counts,
+    }
+
+
+def _attr(span: dict[str, Any], key: str) -> Any:
+    attrs = span.get("attributes") or {}
+    if isinstance(attrs, dict):
+        return _to_int_or_float(attrs.get(key))
+    return None
+
+
+def _duration_ms(start: Any, end: Any, duration: Any = None) -> float | None:
+    if duration:
+        # CES proto serializes as e.g. "0.131247s"
+        if isinstance(duration, str) and duration.endswith("s"):
+            try:
+                return float(duration[:-1]) * 1000.0
+            except ValueError:
+                pass
+    s = _to_dt(start)
+    e = _to_dt(end)
+    if s and e:
+        return (e - s).total_seconds() * 1000.0
+    return None
+
+
+def _to_dt(x: Any):
+    if x is None:
+        return None
+    if isinstance(x, datetime.datetime):
+        return x
+    if isinstance(x, str):
+        try:
+            return datetime.datetime.fromisoformat(x.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    return None
+
+
+def _to_int(x: Any) -> int | None:
+    if x is None:
+        return None
+    try:
+        return int(x)
+    except (TypeError, ValueError):
+        return None
+
+
+def _to_int_or_float(x: Any) -> Any:
+    if x is None:
+        return None
+    if isinstance(x, (int, float)):
+        return x
+    try:
+        return int(x)
+    except (TypeError, ValueError):
+        try:
+            return float(x)
+        except (TypeError, ValueError):
+            return None
+
+
+def _chunk_to_entry(
+    chunk: dict[str, Any],
+    role: str,
+    turn_idx: int,
+) -> dict[str, Any] | None:
+    if "text" in chunk and chunk["text"]:
+        kind = "user" if role.lower() == "user" else "agent"
+        return {
+            "kind": kind,
+            "turn": turn_idx,
+            "role": role,
+            "text": chunk["text"],
+        }
+    if "transcript" in chunk and chunk["transcript"]:
+        return {
+            "kind": "user" if role.lower() == "user" else "agent",
+            "turn": turn_idx,
+            "role": role,
+            "text": chunk["transcript"],
+        }
+    if "tool_call" in chunk:
+        tc = chunk["tool_call"]
+        return {
+            "kind": "tool_call",
+            "turn": turn_idx,
+            "agent": role,
+            "tool": tc.get("display_name") or tc.get("name") or tc.get("tool"),
+            "args": Common.unwrap_struct(tc.get("args", {})),
+        }
+    if "tool_response" in chunk:
+        tr = chunk["tool_response"]
+        return {
+            "kind": "tool_response",
+            "turn": turn_idx,
+            "agent": role,
+            "tool": tr.get("display_name") or tr.get("name") or tr.get("tool"),
+            "response": Common.unwrap_struct(tr.get("response", {})),
+        }
+    if "agent_transfer" in chunk:
+        at = chunk["agent_transfer"]
+        target = (
+            at.get("target_agent")
+            or at.get("agent")
+            or at.get("display_name")
+            or at
+        )
+        return {
+            "kind": "agent_transfer",
+            "turn": turn_idx,
+            "agent": role,
+            "target": target,
+        }
+    if "payload" in chunk:
+        return {
+            "kind": "custom_payload",
+            "turn": turn_idx,
+            "agent": role,
+            "payload": Common.unwrap_struct(chunk["payload"]),
+        }
+    if "default_variables" in chunk:
+        return {
+            "kind": "variable_default",
+            "turn": turn_idx,
+            "agent": role,
+            "variables": Common.unwrap_struct(chunk["default_variables"]),
+        }
+    if "updated_variables" in chunk:
+        return {
+            "kind": "variable_update",
+            "turn": turn_idx,
+            "agent": role,
+            "variables": Common.unwrap_struct(chunk["updated_variables"]),
+        }
+    return None
+
+
+def _channel_label(input_types: list[Any]) -> str:
+    """Maps `input_types` (list of enums or strings) to a friendly label."""
+    if not input_types:
+        return "UNKNOWN"
+    names = [_input_type_name(it) for it in input_types]
+    if "INPUT_TYPE_AUDIO" in names and "INPUT_TYPE_TEXT" in names:
+        return "MULTIMODAL"
+    if "INPUT_TYPE_AUDIO" in names:
+        return "AUDIO"
+    if "INPUT_TYPE_TEXT" in names:
+        return "TEXT"
+    return "OTHER"
+
+
+def _input_type_name(it: Any) -> str:
+    if hasattr(it, "name"):
+        return it.name
+    if isinstance(it, int):
+        return _INPUT_TYPE_NAMES.get(it, f"INPUT_TYPE_{it}")
+    return str(it).upper()
+
+
+def _source_name(s: Any) -> str | None:
+    if s is None:
+        return None
+    if hasattr(s, "name"):
+        return s.name
+    if isinstance(s, int):
+        return _SOURCE_NAMES.get(s, f"SOURCE_{s}")
+    return str(s)
+
+
+def _to_iso(ts: Any) -> str | None:
+    if ts is None:
+        return None
+    if isinstance(ts, str):
+        return ts
+    if hasattr(ts, "isoformat"):
+        return ts.isoformat()
+    return str(ts)
+
+
+def to_json(
+    trace: dict[str, Any],
+    include_raw: bool = False,
+    extras: dict[str, Any] | None = None,
+) -> str:
+    payload = {k: v for k, v in trace.items() if include_raw or k != "raw"}
+    if extras:
+        payload["extras"] = extras
+    return json.dumps(payload, indent=2, default=str, sort_keys=False)
+
+
+def to_text(trace: dict[str, Any], extras: dict[str, Any] | None = None) -> str:
+    lines: list[str] = []
+    lines.append(f"Conversation: {trace.get('conversation_id')}")
+    lines.append(
+        f"  source={trace.get('source')}  channel={trace.get('channel')}  "
+        f"turns={trace.get('num_turns')}"
+    )
+    lines.append(
+        f"  start={trace.get('start_time')}  end={trace.get('end_time')}"
+    )
+    totals = trace.get("totals") or {}
+    if totals:
+        t = totals.get("tokens", {})
+        lines.append(
+            f"  total_duration={_fmt_ms(totals.get('duration_ms'))}  "
+            f"perceived={_fmt_ms(totals.get('perceived_latency_ms'))}  "
+            f"tokens(in/out/think/total)="
+            f"{t.get('input', 0)}/{t.get('output', 0)}/"
+            f"{t.get('thought', 0)}/{t.get('total', 0)}"
+        )
+    lines.append("")
+    by_turn = _entries_by_turn(trace.get("entries", []))
+    metrics_by_turn = {m["turn"]: m for m in trace.get("turn_metrics", [])}
+    for turn_idx in sorted(set(by_turn) | set(metrics_by_turn)):
+        m = metrics_by_turn.get(turn_idx, {})
+        lines.append(_turn_header_text(turn_idx, m))
+        for e in by_turn.get(turn_idx, []):
+            lines.append(_entry_to_text(e))
+        for s in m.get("spans", []) or []:
+            lines.append(_span_to_text(s))
+    if extras:
+        lines.append("")
+        lines.append("--- Extras ---")
+        lines.append(json.dumps(extras, indent=2, default=str))
+    return "\n".join(lines)
+
+
+def _entries_by_turn(
+    entries: list[dict[str, Any]],
+) -> dict[int, list[dict[str, Any]]]:
+    out: dict[int, list[dict[str, Any]]] = {}
+    for e in entries:
+        out.setdefault(e.get("turn", 0), []).append(e)
+    return out
+
+
+def _turn_header_text(turn_idx: int, m: dict[str, Any]) -> str:
+    bits = [f"-- Turn {turn_idx} --"]
+    if m.get("duration_ms") is not None:
+        bits.append(f"duration={_fmt_ms(m['duration_ms'])}")
+    if m.get("perceived_latency_ms") is not None:
+        bits.append(f"perceived={_fmt_ms(m['perceived_latency_ms'])}")
+    tokens = m.get("tokens") or {}
+    if tokens.get("total"):
+        bits.append(
+            f"tokens={tokens.get('input', 0)}in/{tokens.get('output', 0)}out"
+        )
+    return "  ".join(bits)
+
+
+def _span_to_text(s: dict[str, Any]) -> str:
+    indent = "    " * (1 + s.get("depth", 0))
+    name = s.get("name") or "?"
+    dur = _fmt_ms(s.get("duration_ms"))
+    if name == "Callback":
+        return f"{indent}* Callback[{s.get('stage')}] {dur}"
+    if name == "LLM":
+        t = s.get("tokens") or {}
+        return (
+            f"{indent}* LLM {s.get('model')} {dur}  "
+            f"in={t.get('input')} out={t.get('output')} "
+            f"ttfc_ms={t.get('ttfc_ms')}"
+        )
+    if name == "Tool":
+        return (
+            f"{indent}* Tool {s.get('tool')} {dur}  "
+            f"args={json.dumps(s.get('tool_args'), default=str)[:80]}"
+        )
+    return f"{indent}* {name} {dur}"
+
+
+def _entry_to_text(e: dict[str, Any]) -> str:
+    kind = e["kind"]
+    turn = e.get("turn", 0)
+    if kind == "user":
+        return f"[{turn}] USER: {e['text']}"
+    if kind == "agent":
+        return f"[{turn}] AGENT ({e.get('role', '?')}): {e['text']}"
+    if kind == "tool_call":
+        return (
+            f"[{turn}]   tool_call {e.get('tool')} "
+            f"args={json.dumps(e.get('args'), default=str)}"
+        )
+    if kind == "tool_response":
+        resp = json.dumps(e.get("response"), default=str)
+        if len(resp) > 200:
+            resp = resp[:197] + "..."
+        return f"[{turn}]   tool_response {e.get('tool')} -> {resp}"
+    if kind == "agent_transfer":
+        return f"[{turn}]   transfer -> {e.get('target')}"
+    if kind == "custom_payload":
+        return (
+            f"[{turn}]   custom_payload "
+            f"{json.dumps(e.get('payload'), default=str)}"
+        )
+    if kind == "variable_default":
+        return (
+            f"[{turn}]   var_default "
+            f"{json.dumps(e.get('variables'), default=str)}"
+        )
+    if kind == "variable_update":
+        return (
+            f"[{turn}]   var_update "
+            f"{json.dumps(e.get('variables'), default=str)}"
+        )
+    return f"[{turn}]   {kind}"
+
+
+def _fmt_ms(v: Any) -> str:
+    if v is None:
+        return "?"
+    return f"{float(v):.1f}ms"
+
+
+def to_markdown(
+    trace: dict[str, Any],
+    console_url: str | None = None,
+    extras: dict[str, Any] | None = None,
+) -> str:
+    md: list[str] = []
+    md.append(f"# Conversation `{trace.get('conversation_id')}`\n")
+    md.append("| Field | Value |")
+    md.append("|---|---|")
+    md.append(f"| Source | {trace.get('source')} |")
+    md.append(f"| Channel | {trace.get('channel')} |")
+    md.append(f"| Turns | {trace.get('num_turns')} |")
+    md.append(f"| Start | {trace.get('start_time')} |")
+    md.append(f"| End | {trace.get('end_time')} |")
+    totals = trace.get("totals") or {}
+    if totals:
+        t = totals.get("tokens", {})
+        md.append(f"| Total span time | {_fmt_ms(totals.get('duration_ms'))} |")
+        md.append(
+            f"| Total perceived latency | "
+            f"{_fmt_ms(totals.get('perceived_latency_ms'))} |"
+        )
+        md.append(
+            f"| Tokens (in / out / think / total) | "
+            f"{t.get('input', 0)} / {t.get('output', 0)} / "
+            f"{t.get('thought', 0)} / {t.get('total', 0)} |"
+        )
+        sc = totals.get("span_counts") or {}
+        if sc:
+            md.append(
+                f"| Span counts | "
+                f"{', '.join(f'{k}={v}' for k, v in sorted(sc.items()))} |"
+            )
+    if console_url:
+        md.append(f"| Console | [Open in CES Console]({console_url}) |")
+    md.append("")
+    md.append("## Trace\n")
+
+    by_turn = _entries_by_turn(trace.get("entries", []))
+    metrics_by_turn = {m["turn"]: m for m in trace.get("turn_metrics", [])}
+    for turn_idx in sorted(set(by_turn) | set(metrics_by_turn)):
+        m = metrics_by_turn.get(turn_idx, {})
+        md.append(_turn_header_md(turn_idx, m))
+        for e in by_turn.get(turn_idx, []):
+            md.append(_entry_to_markdown(e))
+        spans = m.get("spans") or []
+        if spans:
+            md.append("")
+            md.append("  <details><summary>Execution spans</summary>")
+            md.append("")
+            md.append(
+                "  | depth | name | stage / tool / model | duration |"
+                " tokens (in/out/ttfc_ms) |"
+            )
+            md.append("  |---|---|---|---|---|")
+            for s in spans:
+                md.append(_span_to_markdown(s))
+            md.append("  </details>")
+        md.append("")
+
+    if extras:
+        for section, body in extras.items():
+            md.append(f"\n## {section}\n")
+            if isinstance(body, str):
+                md.append(body)
+            else:
+                md.append("```json")
+                md.append(json.dumps(body, indent=2, default=str))
+                md.append("```")
+    return "\n".join(md) + "\n"
+
+
+def _turn_header_md(turn_idx: int, m: dict[str, Any]) -> str:
+    bits = [f"### Turn {turn_idx}"]
+    extras = []
+    if m.get("duration_ms") is not None:
+        extras.append(f"duration **{_fmt_ms(m['duration_ms'])}**")
+    if m.get("perceived_latency_ms") is not None:
+        extras.append(f"perceived **{_fmt_ms(m['perceived_latency_ms'])}**")
+    tokens = m.get("tokens") or {}
+    if tokens.get("total"):
+        extras.append(
+            f"tokens **{tokens.get('input', 0)}** in / "
+            f"**{tokens.get('output', 0)}** out"
+        )
+    if extras:
+        bits.append("— " + " · ".join(extras))
+    return " ".join(bits)
+
+
+def _span_to_markdown(s: dict[str, Any]) -> str:
+    name = s.get("name") or "?"
+    dur = _fmt_ms(s.get("duration_ms"))
+    label = s.get("stage") or s.get("tool") or s.get("model") or ""
+    if name == "LLM":
+        t = s.get("tokens") or {}
+        token_str = (
+            f"{t.get('input', 0)} / {t.get('output', 0)} / "
+            f"{t.get('ttfc_ms', '?')}"
+        )
+    else:
+        token_str = ""
+    return (
+        f"  | {s.get('depth', 0)} | {name} | `{label}` | {dur} | {token_str} |"
+    )
+
+
+def _entry_to_markdown(e: dict[str, Any]) -> str:
+    kind = e["kind"]
+    turn = e.get("turn", 0)
+    if kind == "user":
+        return f"- **[{turn}] User:** {e['text']}"
+    if kind == "agent":
+        return f"- **[{turn}] Agent ({e.get('role', '?')}):** {e['text']}"
+    if kind == "tool_call":
+        args = json.dumps(e.get("args"), indent=2, default=str)
+        return (
+            f"- **[{turn}] Tool call** `{e.get('tool')}`\n"
+            f"  ```json\n  {args}\n  ```"
+        )
+    if kind == "tool_response":
+        resp = json.dumps(e.get("response"), indent=2, default=str)
+        return (
+            f"- **[{turn}] Tool response** `{e.get('tool')}`\n"
+            f"  ```json\n  {resp}\n  ```"
+        )
+    if kind == "agent_transfer":
+        return f"- **[{turn}] Transfer ->** `{e.get('target')}`"
+    if kind == "custom_payload":
+        body = json.dumps(e.get("payload"), indent=2, default=str)
+        return f"- **[{turn}] Custom payload**\n  ```json\n  {body}\n  ```"
+    if kind == "variable_default":
+        body = json.dumps(e.get("variables"), indent=2, default=str)
+        return f"- **[{turn}] Default variables**\n  ```json\n  {body}\n  ```"
+    if kind == "variable_update":
+        body = json.dumps(e.get("variables"), indent=2, default=str)
+        return f"- **[{turn}] Variable update**\n  ```json\n  {body}\n  ```"
+    return f"- [{turn}] {kind}"
+
+
+def to_html(
+    trace: dict[str, Any],
+    console_url: str | None = None,
+    extras: dict[str, Any] | None = None,
+    audio_path: str | None = None,
+) -> str:
+    body: list[str] = []
+    title = _html.escape(trace.get("conversation_id") or "conversation")
+    body.append(f"<h1>Conversation <code>{title}</code></h1>")
+    body.append("<table>")
+    for k in ("source", "channel", "num_turns", "start_time", "end_time"):
+        body.append(
+            f"<tr><th>{k}</th><td>{_html.escape(str(trace.get(k)))}</td></tr>"
+        )
+    totals = trace.get("totals") or {}
+    if totals:
+        t = totals.get("tokens", {})
+        body.append(
+            f"<tr><th>total span time</th><td>"
+            f"{_fmt_ms(totals.get('duration_ms'))}</td></tr>"
+        )
+        body.append(
+            f"<tr><th>total perceived latency</th><td>"
+            f"{_fmt_ms(totals.get('perceived_latency_ms'))}</td></tr>"
+        )
+        body.append(
+            f"<tr><th>tokens (in/out/think/total)</th><td>"
+            f"{t.get('input', 0)} / {t.get('output', 0)} / "
+            f"{t.get('thought', 0)} / {t.get('total', 0)}</td></tr>"
+        )
+        sc = totals.get("span_counts") or {}
+        if sc:
+            sc_str = ", ".join(f"{k}={v}" for k, v in sorted(sc.items()))
+            body.append(
+                f"<tr><th>span counts</th><td>{_html.escape(sc_str)}</td></tr>"
+            )
+    if console_url:
+        body.append(
+            f'<tr><th>Console</th><td><a href="{_html.escape(console_url)}" '
+            f'target="_blank">Open in CES Console</a></td></tr>'
+        )
+    body.append("</table>")
+    if audio_path:
+        body.append(
+            f'<audio controls src="{_html.escape(audio_path)}"></audio>'
+        )
+    body.append("<h2>Trace</h2>")
+    body.append('<div class="trace">')
+    by_turn = _entries_by_turn(trace.get("entries", []))
+    metrics_by_turn = {m["turn"]: m for m in trace.get("turn_metrics", [])}
+    for turn_idx in sorted(set(by_turn) | set(metrics_by_turn)):
+        m = metrics_by_turn.get(turn_idx, {})
+        body.append(_turn_header_html(turn_idx, m))
+        for e in by_turn.get(turn_idx, []):
+            body.append(_entry_to_html(e))
+        spans = m.get("spans") or []
+        if spans:
+            body.append(
+                "<details class='spans'><summary>Execution spans"
+                f" ({len(spans)})</summary><table>"
+                "<tr><th>depth</th><th>name</th><th>label</th>"
+                "<th>duration</th><th>tokens (in/out)</th>"
+                "<th>ttfc_ms</th></tr>"
+            )
+            for s in spans:
+                body.append(_span_to_html(s))
+            body.append("</table></details>")
+    body.append("</div>")
+    if extras:
+        for section, content in extras.items():
+            body.append(f"<h2>{_html.escape(section)}</h2>")
+            if isinstance(content, str):
+                body.append(f"<pre>{_html.escape(content)}</pre>")
+            else:
+                rendered = _html.escape(
+                    json.dumps(content, indent=2, default=str)
+                )
+                body.append(f"<pre>{rendered}</pre>")
+
+    css = (
+        "body{font-family:system-ui,sans-serif;max-width:1100px;"
+        "margin:2em auto;padding:0 1em;color:#222;}"
+        "table{border-collapse:collapse;margin-bottom:1em}"
+        "th,td{border:1px solid #ddd;padding:6px 12px;text-align:left;"
+        "vertical-align:top}"
+        ".trace .turn-header{margin-top:1.4em;padding:6px 8px;"
+        "background:#f0f0f5;border-left:4px solid #6b6b9a;"
+        "border-radius:4px;font-weight:600}"
+        ".trace .turn-header .meta{font-weight:400;color:#555;"
+        "margin-left:.6em;font-size:.92em}"
+        ".trace .user{background:#eef;padding:8px;"
+        "margin:4px 0;border-radius:6px}"
+        ".trace .agent{background:#efe;padding:8px;"
+        "margin:4px 0;border-radius:6px}"
+        ".trace .vars summary{color:#7a4d00}"
+        ".trace details{margin:4px 0}"
+        ".spans table{font-size:.9em}"
+        "pre{background:#f6f6f6;padding:8px;"
+        "border-radius:6px;overflow:auto}"
+    )
+    return (
+        '<!doctype html><html><head><meta charset="utf-8"/>'
+        f"<title>{title}</title><style>{css}</style></head>"
+        f"<body>{''.join(body)}</body></html>"
+    )
+
+
+def _turn_header_html(turn_idx: int, m: dict[str, Any]) -> str:
+    bits = []
+    if m.get("duration_ms") is not None:
+        bits.append(f"duration {_fmt_ms(m['duration_ms'])}")
+    if m.get("perceived_latency_ms") is not None:
+        bits.append(f"perceived {_fmt_ms(m['perceived_latency_ms'])}")
+    tokens = m.get("tokens") or {}
+    if tokens.get("total"):
+        bits.append(
+            f"{tokens.get('input', 0)} in / "
+            f"{tokens.get('output', 0)} out tokens"
+        )
+    sub = " · ".join(bits) if bits else ""
+    return (
+        f"<h3 class='turn-header'>Turn {turn_idx}"
+        f"<span class='meta'> {_html.escape(sub)}</span></h3>"
+    )
+
+
+def _span_to_html(s: dict[str, Any]) -> str:
+    esc = _html.escape
+    name = esc(str(s.get("name") or "?"))
+    label = esc(str(s.get("stage") or s.get("tool") or s.get("model") or ""))
+    dur = _fmt_ms(s.get("duration_ms"))
+    if s.get("name") == "LLM":
+        t = s.get("tokens") or {}
+        tok_in = t.get("input", 0)
+        tok_out = t.get("output", 0)
+        ttfc = t.get("ttfc_ms")
+    else:
+        tok_in = tok_out = ttfc = ""
+    return (
+        f"<tr><td>{s.get('depth', 0)}</td><td>{name}</td>"
+        f"<td>{label}</td><td>{dur}</td>"
+        f"<td>{tok_in}/{tok_out}</td><td>{ttfc}</td></tr>"
+    )
+
+
+def _entry_to_html(e: dict[str, Any]) -> str:
+    kind = e["kind"]
+    turn = e.get("turn", 0)
+    esc = _html.escape
+    if kind == "user":
+        return f'<div class="user"><b>[{turn}] User:</b> {esc(e["text"])}</div>'
+    if kind == "agent":
+        role = esc(e.get("role", "?"))
+        return (
+            f'<div class="agent"><b>[{turn}] Agent ({role}):</b> '
+            f"{esc(e['text'])}</div>"
+        )
+    if kind == "tool_call":
+        args = esc(json.dumps(e.get("args"), indent=2, default=str))
+        return (
+            f"<details><summary>&#128295; [{turn}] Tool call "
+            f"<code>{esc(str(e.get('tool')))}</code></summary>"
+            f"<pre>{args}</pre></details>"
+        )
+    if kind == "tool_response":
+        resp = esc(json.dumps(e.get("response"), indent=2, default=str))
+        return (
+            f"<details><summary>&#128228; [{turn}] Tool response "
+            f"<code>{esc(str(e.get('tool')))}</code></summary>"
+            f"<pre>{resp}</pre></details>"
+        )
+    if kind == "agent_transfer":
+        return (
+            f'<div class="system">&#128256; [{turn}] Transfer -> '
+            f"<code>{esc(str(e.get('target')))}</code></div>"
+        )
+    if kind == "custom_payload":
+        body = esc(json.dumps(e.get("payload"), indent=2, default=str))
+        return (
+            f"<details><summary>&#128230; [{turn}] Custom payload"
+            f"</summary><pre>{body}</pre></details>"
+        )
+    if kind == "variable_default":
+        body = esc(json.dumps(e.get("variables"), indent=2, default=str))
+        return (
+            f"<details class='vars'><summary>&#129529; [{turn}] "
+            f"Default variables</summary><pre>{body}</pre></details>"
+        )
+    if kind == "variable_update":
+        body = esc(json.dumps(e.get("variables"), indent=2, default=str))
+        return (
+            f"<details class='vars'><summary>&#9881;&#65039; [{turn}] "
+            f"Variable update</summary><pre>{body}</pre></details>"
+        )
+    return f'<div class="system">[{turn}] {esc(kind)}</div>'

--- a/tests/cxas_scrapi/cli/test_trace_cli.py
+++ b/tests/cxas_scrapi/cli/test_trace_cli.py
@@ -1,0 +1,493 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cxas_scrapi.cli import trace_cli
+
+APP = "projects/p/locations/l/apps/a"
+
+
+def _ns(**overrides):
+    base = dict(
+        app_name=APP,
+        app_dir=".",
+        env_file=None,
+        environment=None,
+        config=None,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+@pytest.fixture
+def fake_traces(monkeypatch):
+    fake = MagicMock()
+    monkeypatch.setattr(trace_cli, "Traces", MagicMock(return_value=fake))
+    return fake
+
+
+def test_register_smoke():
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    trace_cli.register(sub)
+    args = parser.parse_args(
+        ["trace", "list", "--app-name", APP, "--time-filter", "1d"]
+    )
+    assert args.func == trace_cli.trace_list
+    assert args.time_filter == "1d"
+
+
+def test_trace_list_table(fake_traces, capsys):
+    fake_traces.list.return_value = [
+        {
+            "id": "c1",
+            "source": "LIVE",
+            "channel": "TEXT",
+            "start_time": "s",
+            "end_time": "e",
+            "ces_url": "u",
+        }
+    ]
+    trace_cli.trace_list(
+        _ns(
+            time_filter="7d",
+            source=None,
+            channel=None,
+            limit=None,
+            format="table",
+        )
+    )
+    out = capsys.readouterr().out
+    assert "Conversations" in out
+    assert "c1" in out
+
+
+def test_trace_list_json(fake_traces, capsys):
+    fake_traces.list.return_value = [{"id": "c1"}]
+    trace_cli.trace_list(
+        _ns(
+            time_filter="7d",
+            source=None,
+            channel=None,
+            limit=None,
+            format="json",
+        )
+    )
+    out = capsys.readouterr().out
+    assert json.loads(out)[0]["id"] == "c1"
+
+
+def test_trace_list_csv(fake_traces, capsys):
+    fake_traces.list.return_value = [{"id": "c1", "ces_url": "u"}]
+    trace_cli.trace_list(
+        _ns(
+            time_filter="7d",
+            source=None,
+            channel=None,
+            limit=None,
+            format="csv",
+        )
+    )
+    out = capsys.readouterr().out
+    assert "id,ces_url" in out
+    assert "c1,u" in out
+
+
+def test_trace_list_csv_empty_no_output(fake_traces, capsys):
+    fake_traces.list.return_value = []
+    trace_cli.trace_list(
+        _ns(
+            time_filter="7d",
+            source=None,
+            channel=None,
+            limit=None,
+            format="csv",
+        )
+    )
+    assert capsys.readouterr().out == ""
+
+
+def test_trace_list_failure_exits(fake_traces, capsys):
+    fake_traces.list.side_effect = RuntimeError("boom")
+    with pytest.raises(SystemExit):
+        trace_cli.trace_list(
+            _ns(
+                time_filter="7d",
+                source=None,
+                channel=None,
+                limit=None,
+                format="json",
+            )
+        )
+
+
+def test_trace_get_stdout(fake_traces, capsys):
+    fake_traces.get_report.return_value = "MD report"
+    trace_cli.trace_get(
+        _ns(
+            conversation_id="c1",
+            format="md",
+            with_logs=False,
+            log_level=None,
+            with_audio=False,
+            with_analysis=False,
+            with_triage=False,
+            out=None,
+        )
+    )
+    assert "MD report" in capsys.readouterr().out
+
+
+def test_trace_get_writes_file(fake_traces, tmp_path, capsys):
+    fake_traces.get_report.return_value = "json body"
+    out_path = tmp_path / "out.json"
+    trace_cli.trace_get(
+        _ns(
+            conversation_id="c1",
+            format="json",
+            with_logs=True,
+            log_level="ERROR",
+            with_audio=True,
+            with_analysis=True,
+            with_triage=True,
+            out=str(out_path),
+        )
+    )
+    assert out_path.read_text() == "json body"
+    assert "Wrote" in capsys.readouterr().out
+
+
+def test_trace_get_failure(fake_traces):
+    fake_traces.get_report.side_effect = RuntimeError("boom")
+    with pytest.raises(SystemExit):
+        trace_cli.trace_get(
+            _ns(
+                conversation_id="c1",
+                format="md",
+                with_logs=False,
+                log_level=None,
+                with_audio=False,
+                with_analysis=False,
+                with_triage=False,
+                out=None,
+            )
+        )
+
+
+def test_trace_logs_text(fake_traces, capsys):
+    fake_traces.get_logs.return_value = [
+        {"timestamp": "t", "severity": "WARNING", "message": "hi"}
+    ]
+    trace_cli.trace_logs(
+        _ns(conversation_id="c1", level="WARNING", format="text")
+    )
+    out = capsys.readouterr().out
+    assert "WARNING" in out
+
+
+def test_trace_logs_json(fake_traces, capsys):
+    fake_traces.get_logs.return_value = [{"a": 1}]
+    trace_cli.trace_logs(
+        _ns(conversation_id="c1", level="ERROR", format="json")
+    )
+    assert json.loads(capsys.readouterr().out) == [{"a": 1}]
+
+
+def test_trace_logs_string_response(fake_traces, capsys):
+    fake_traces.get_logs.return_value = "Cloud logging not enabled"
+    trace_cli.trace_logs(
+        _ns(conversation_id="c1", level="WARNING", format="text")
+    )
+    assert "not enabled" in capsys.readouterr().out
+
+
+def test_trace_logs_failure(fake_traces):
+    fake_traces.get_logs.side_effect = RuntimeError("boom")
+    with pytest.raises(SystemExit):
+        trace_cli.trace_logs(
+            _ns(conversation_id="c1", level="WARNING", format="text")
+        )
+
+
+def test_trace_audio_download_success(fake_traces, capsys):
+    fake_traces.download_audio.return_value = "/tmp/a.wav"
+    trace_cli.trace_audio_download(_ns(conversation_id="c1", out=None))
+    assert "Downloaded to" in capsys.readouterr().out
+
+
+def test_trace_audio_download_no_audio(fake_traces, capsys):
+    fake_traces.download_audio.return_value = None
+    with pytest.raises(SystemExit) as exc:
+        trace_cli.trace_audio_download(_ns(conversation_id="c1", out=None))
+    assert exc.value.code == 2
+
+
+def test_trace_audio_download_failure(fake_traces):
+    fake_traces.download_audio.side_effect = RuntimeError("boom")
+    with pytest.raises(SystemExit):
+        trace_cli.trace_audio_download(_ns(conversation_id="c1", out=None))
+
+
+def test_trace_audio_analyze(fake_traces, capsys):
+    fake_traces.analyze_audio.return_value = {"audio_cutoff": "ok"}
+    trace_cli.trace_audio_analyze(
+        _ns(conversation_id="c1", metric="audio_cutoff,voice_drift")
+    )
+    out = capsys.readouterr().out
+    assert "audio_cutoff" in out
+
+
+def test_trace_audio_analyze_failure(fake_traces):
+    fake_traces.analyze_audio.side_effect = RuntimeError("boom")
+    with pytest.raises(SystemExit):
+        trace_cli.trace_audio_analyze(_ns(conversation_id="c1", metric=None))
+
+
+def test_trace_triage(fake_traces, capsys):
+    fake_traces.triage.return_value = {"hallucination": "none"}
+    trace_cli.trace_triage(_ns(conversation_id="c1", metric=None))
+    out = capsys.readouterr().out
+    assert "hallucination" in out
+
+
+def test_trace_triage_failure(fake_traces):
+    fake_traces.triage.side_effect = RuntimeError("boom")
+    with pytest.raises(SystemExit):
+        trace_cli.trace_triage(_ns(conversation_id="c1", metric=None))
+
+
+def test_trace_replay_md(fake_traces, capsys):
+    fake_traces.replay.return_value = {
+        "diff": "+changed",
+        "original": ["a"],
+        "replay": ["b"],
+    }
+    trace_cli.trace_replay(_ns(conversation_id="c1", diff=True, format="md"))
+    out = capsys.readouterr().out
+    assert "Replay diff" in out
+    assert "+changed" in out
+
+
+def test_trace_replay_md_no_diff(fake_traces, capsys):
+    fake_traces.replay.return_value = {"original": ["a"], "replay": ["a"]}
+    trace_cli.trace_replay(_ns(conversation_id="c1", diff=True, format="md"))
+    out = capsys.readouterr().out
+    assert "original" in out
+
+
+def test_trace_replay_json(fake_traces, capsys):
+    fake_traces.replay.return_value = {"diff": "+x"}
+    trace_cli.trace_replay(_ns(conversation_id="c1", diff=True, format="json"))
+    assert json.loads(capsys.readouterr().out) == {"diff": "+x"}
+
+
+def test_trace_replay_failure(fake_traces):
+    fake_traces.replay.side_effect = RuntimeError("boom")
+    with pytest.raises(SystemExit):
+        trace_cli.trace_replay(
+            _ns(conversation_id="c1", diff=True, format="md")
+        )
+
+
+def test_trace_stats_markdown(fake_traces, capsys):
+    fake_traces.aggregate_stats.return_value = {
+        "time_filter": "7d",
+        "total": 2,
+        "success_rate_no_transfer": 0.5,
+        "duration_seconds": {"p50": 1, "p95": 2, "median": 1.5},
+        "per_source": {"LIVE": 2},
+        "per_channel": {"TEXT": 2},
+        "top_tools": [("lookup", 5)],
+        "top_transfer_targets": [("agent_b", 1)],
+    }
+    trace_cli.trace_stats(
+        _ns(
+            time_filter="7d",
+            source=None,
+            channel=None,
+            limit=200,
+            format="md",
+            out=None,
+        )
+    )
+    out = capsys.readouterr().out
+    assert "Trace stats" in out
+    assert "lookup" in out
+    # ASCII bar uses solid blocks
+    assert "█" in out
+    # numerals + units appear
+    assert "5 calls" in out
+
+
+def test_trace_stats_markdown_no_transfers_branch(fake_traces, capsys):
+    fake_traces.aggregate_stats.return_value = {
+        "time_filter": "7d",
+        "total": 0,
+        "success_rate_no_transfer": None,
+        "duration_seconds": {"p50": None, "p95": None, "median": None},
+        "per_source": {},
+        "per_channel": {},
+        "top_tools": [],
+        "top_transfer_targets": [],
+    }
+    trace_cli.trace_stats(
+        _ns(
+            time_filter="7d",
+            source=None,
+            channel=None,
+            limit=200,
+            format="md",
+            out=None,
+        )
+    )
+    out = capsys.readouterr().out
+    assert "no transfers" in out
+    assert "_(no data)_" in out
+
+
+def test_trace_stats_json_to_file(fake_traces, tmp_path, capsys):
+    fake_traces.aggregate_stats.return_value = {"total": 0, "time_filter": "7d"}
+    p = tmp_path / "stats.json"
+    trace_cli.trace_stats(
+        _ns(
+            time_filter="7d",
+            source=None,
+            channel=None,
+            limit=200,
+            format="json",
+            out=str(p),
+        )
+    )
+    assert json.loads(p.read_text())["total"] == 0
+    assert "Wrote" in capsys.readouterr().out
+
+
+def test_trace_stats_failure(fake_traces):
+    fake_traces.aggregate_stats.side_effect = RuntimeError("boom")
+    with pytest.raises(SystemExit):
+        trace_cli.trace_stats(
+            _ns(
+                time_filter="7d",
+                source=None,
+                channel=None,
+                limit=200,
+                format="md",
+                out=None,
+            )
+        )
+
+
+def test_trace_bundle(fake_traces, tmp_path, capsys):
+    fake_traces.bundle.return_value = "/tmp/out.zip"
+    trace_cli.trace_bundle(
+        _ns(
+            conversation_id="c1",
+            out=str(tmp_path / "out.zip"),
+            no_logs=False,
+            no_audio=False,
+            with_analysis=False,
+            with_triage=False,
+        )
+    )
+    assert "out.zip" in capsys.readouterr().out
+
+
+def test_trace_bundle_failure(fake_traces):
+    fake_traces.bundle.side_effect = RuntimeError("boom")
+    with pytest.raises(SystemExit):
+        trace_cli.trace_bundle(
+            _ns(
+                conversation_id="c1",
+                out="x.zip",
+                no_logs=False,
+                no_audio=False,
+                with_analysis=False,
+                with_triage=False,
+            )
+        )
+
+
+def test_trace_bug_report(fake_traces, capsys):
+    fake_traces.report_bug.return_value = {"reason": "r"}
+    trace_cli.trace_bug_report(
+        _ns(conversation_id="c1", reason="r", severity="high")
+    )
+    out = capsys.readouterr().out
+    assert json.loads(out) == {"reason": "r"}
+
+
+def test_trace_bug_report_failure(fake_traces):
+    fake_traces.report_bug.side_effect = RuntimeError("boom")
+    with pytest.raises(SystemExit):
+        trace_cli.trace_bug_report(
+            _ns(conversation_id="c1", reason="r", severity="high")
+        )
+
+
+def test_trace_open_prints_and_runs_open(fake_traces, capsys, monkeypatch):
+    fake_traces.console_url.return_value = "https://x/y"
+    monkeypatch.setattr(trace_cli.platform, "system", lambda: "Darwin")
+    fake_run = MagicMock()
+    monkeypatch.setattr(trace_cli.subprocess, "run", fake_run)
+    trace_cli.trace_open(_ns(conversation_id="c1"))
+    assert "https://x/y" in capsys.readouterr().out
+    fake_run.assert_called_once()
+
+
+def test_trace_open_non_darwin(fake_traces, capsys, monkeypatch):
+    fake_traces.console_url.return_value = "https://x/y"
+    monkeypatch.setattr(trace_cli.platform, "system", lambda: "Linux")
+    fake_run = MagicMock()
+    monkeypatch.setattr(trace_cli.subprocess, "run", fake_run)
+    trace_cli.trace_open(_ns(conversation_id="c1"))
+    fake_run.assert_not_called()
+
+
+def test_trace_open_failure(fake_traces):
+    fake_traces.console_url.side_effect = RuntimeError("boom")
+    with pytest.raises(SystemExit):
+        trace_cli.trace_open(_ns(conversation_id="c1"))
+
+
+def test_trace_open_subprocess_failure_silent(fake_traces, monkeypatch, capsys):
+    fake_traces.console_url.return_value = "https://x/y"
+    monkeypatch.setattr(trace_cli.platform, "system", lambda: "Darwin")
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("nope")
+
+    monkeypatch.setattr(trace_cli.subprocess, "run", boom)
+    trace_cli.trace_open(_ns(conversation_id="c1"))
+    assert "https://x/y" in capsys.readouterr().out
+
+
+@patch("cxas_scrapi.cli.trace_cli.Traces")
+def test_build_traces_passes_through_args(mock_traces_cls):
+    args = _ns(
+        app_dir="/tmp/app",
+        env_file="/tmp/env.json",
+        environment="dev",
+        config="/tmp/trace.yaml",
+    )
+    trace_cli._build_traces(args)
+    _, kwargs = mock_traces_cls.call_args
+    assert kwargs["app_dir"] == "/tmp/app"
+    assert kwargs["env_file"] == "/tmp/env.json"
+    assert kwargs["environment"] == "dev"
+    assert kwargs["trace_config_path"] == "/tmp/trace.yaml"

--- a/tests/cxas_scrapi/core/test_traces.py
+++ b/tests/cxas_scrapi/core/test_traces.py
@@ -1,0 +1,881 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+import json
+import os
+import zipfile
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from cxas_scrapi.core import traces as traces_mod
+from cxas_scrapi.core.traces import Traces
+from cxas_scrapi.utils.tracing.audio_analysis import ANALYSIS_REGISTRY
+from cxas_scrapi.utils.tracing.trace_config import GeminiMetric
+
+APP = "projects/p/locations/l/apps/a"
+
+
+def _conv(
+    cid="c1",
+    source="LIVE",
+    input_types=("INPUT_TYPE_TEXT",),
+    start="2026-05-01T00:00:00",
+    end="2026-05-01T00:01:00",
+    turns=None,
+):
+    """Builds a fake CES Conversation-like object."""
+    return SimpleNamespace(
+        name=f"{APP}/conversations/{cid}",
+        source=SimpleNamespace(name=source),
+        input_types=list(input_types),
+        start_time=(datetime.datetime.fromisoformat(start) if start else None),
+        end_time=datetime.datetime.fromisoformat(end) if end else None,
+        turns=turns or [],
+    )
+
+
+def _conv_dict(
+    cid="c1",
+    source="LIVE",
+    input_types=("INPUT_TYPE_TEXT",),
+    start="2026-05-01T00:00:00",
+    end="2026-05-01T00:01:00",
+    turns=None,
+):
+    return {
+        "name": f"{APP}/conversations/{cid}",
+        "source": source,
+        "input_types": list(input_types),
+        "start_time": start,
+        "end_time": end,
+        "turns": turns
+        or [
+            {
+                "messages": [
+                    {"role": "user", "chunks": [{"text": "hi"}]},
+                    {
+                        "role": "agent_x",
+                        "chunks": [
+                            {"text": "hello"},
+                            {
+                                "tool_call": {
+                                    "display_name": "lookup",
+                                    "args": {"q": 1},
+                                }
+                            },
+                            {
+                                "tool_response": {
+                                    "display_name": "lookup",
+                                    "response": {"r": 2},
+                                }
+                            },
+                            {"agent_transfer": {"target_agent": "agent_b"}},
+                        ],
+                    },
+                ]
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def traces_obj(tmp_path, monkeypatch):
+    """Traces with no app dir; audio config from trace.yaml only."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(traces_mod.TraceConfig, "_pick_path", lambda *_: None)
+    return Traces(app_name=APP, app_dir=str(tmp_path / "missing"))
+
+
+def test_init_with_missing_app_dir_logs_and_continues(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    t = Traces(app_name=APP, app_dir=str(tmp_path / "no-app-dir"))
+    assert t.app_config is None
+
+
+def test_init_with_app_dir_loads_app_config(tmp_path, monkeypatch):
+    (tmp_path / "app.json").write_text(
+        json.dumps(
+            {
+                "loggingSettings": {
+                    "audioRecordingConfig": {"gcsBucket": "gs://from-app-json"}
+                }
+            }
+        )
+    )
+    monkeypatch.chdir(tmp_path)
+    t = Traces(app_name=APP, app_dir=str(tmp_path))
+    assert t.app_config is not None
+    assert t.app_config.audio_bucket() == "gs://from-app-json"
+
+
+def test_list_filters_by_channel(traces_obj):
+    text_conv = _conv("c-text", input_types=["INPUT_TYPE_TEXT"])
+    audio_conv = _conv("c-audio", input_types=["INPUT_TYPE_AUDIO"])
+    multi_conv = _conv(
+        "c-multi", input_types=["INPUT_TYPE_TEXT", "INPUT_TYPE_AUDIO"]
+    )
+    traces_obj.history = MagicMock()
+    traces_obj.history.list_conversations.return_value = [
+        text_conv,
+        audio_conv,
+        multi_conv,
+    ]
+
+    rows_audio = traces_obj.list(channel_filter="AUDIO")
+    assert [r["id"] for r in rows_audio] == ["c-audio"]
+
+    rows_text = traces_obj.list(channel_filter="TEXT")
+    assert [r["id"] for r in rows_text] == ["c-text"]
+
+    rows_multi = traces_obj.list(channel_filter="MULTIMODAL")
+    assert [r["id"] for r in rows_multi] == ["c-multi"]
+
+    rows_all = traces_obj.list()
+    assert len(rows_all) == 3
+
+
+def test_list_respects_limit(traces_obj):
+    traces_obj.history = MagicMock()
+    traces_obj.history.list_conversations.return_value = [
+        _conv("a"),
+        _conv("b"),
+        _conv("c"),
+    ]
+    rows = traces_obj.list(limit=2)
+    assert [r["id"] for r in rows] == ["a", "b"]
+
+
+def test_get_normalized(traces_obj):
+    traces_obj.history = MagicMock()
+    traces_obj.history.get_conversation.return_value = _conv_dict()
+    n = traces_obj.get_normalized("c1")
+    assert n["conversation_id"] == "c1"
+    assert n["num_turns"] == 1
+
+
+def test_get_report_all_formats(traces_obj):
+    traces_obj.history = MagicMock()
+    traces_obj.history.get_conversation.return_value = _conv_dict()
+
+    j = traces_obj.get_report("c1", fmt="json")
+    assert json.loads(j)["conversation_id"] == "c1"
+
+    md = traces_obj.get_report("c1", fmt="md")
+    assert "Conversation `c1`" in md
+
+    md2 = traces_obj.get_report("c1", fmt="markdown")
+    assert md == md2
+
+    text = traces_obj.get_report("c1", fmt="text")
+    assert "USER:" in text
+
+    html = traces_obj.get_report("c1", fmt="html")
+    assert "<html" in html
+
+
+def test_get_report_unknown_format_raises(traces_obj):
+    traces_obj.history = MagicMock()
+    traces_obj.history.get_conversation.return_value = _conv_dict()
+    with pytest.raises(ValueError, match="Unknown format"):
+        traces_obj.get_report("c1", fmt="xml")
+
+
+def test_get_report_with_logs_audio_analysis_triage(traces_obj):
+    traces_obj.history = MagicMock()
+    traces_obj.history.get_conversation.return_value = _conv_dict()
+    traces_obj.get_logs = MagicMock(return_value=[{"msg": "log"}])
+    traces_obj.download_audio = MagicMock(return_value="/tmp/audio.wav")
+    traces_obj.analyze_audio = MagicMock(
+        return_value={"agent_cutoff": {"result": "PASS"}}
+    )
+    traces_obj.triage = MagicMock(return_value={"hallucination": "none"})
+
+    out = traces_obj.get_report(
+        "c1",
+        fmt="json",
+        with_logs=True,
+        with_audio=True,
+        with_analysis=True,
+        with_triage=True,
+    )
+    payload = json.loads(out)
+    assert "Cloud Logs" in payload["extras"]
+    assert "Saved to" in payload["extras"]["Audio"]
+    assert "Audio Analysis" in payload["extras"]
+    assert "Transcript Triage" in payload["extras"]
+
+
+def test_get_report_audio_download_failure(traces_obj):
+    traces_obj.history = MagicMock()
+    traces_obj.history.get_conversation.return_value = _conv_dict()
+    traces_obj.download_audio = MagicMock(side_effect=RuntimeError("fail"))
+    out = traces_obj.get_report("c1", fmt="json", with_audio=True)
+    payload = json.loads(out)
+    assert "Download failed" in payload["extras"]["Audio"]
+
+
+def test_get_report_no_audio_returns_message(traces_obj):
+    traces_obj.history = MagicMock()
+    traces_obj.history.get_conversation.return_value = _conv_dict()
+    traces_obj.download_audio = MagicMock(return_value=None)
+    out = traces_obj.get_report("c1", fmt="json", with_audio=True)
+    payload = json.loads(out)
+    assert payload["extras"]["Audio"] == "No audio available."
+
+
+def test_get_logs_when_app_disables_cloud_logging(tmp_path, monkeypatch):
+    (tmp_path / "app.json").write_text(
+        json.dumps(
+            {
+                "loggingSettings": {
+                    "cloudLoggingSettings": {"enableCloudLogging": False}
+                }
+            }
+        )
+    )
+    monkeypatch.chdir(tmp_path)
+    t = Traces(app_name=APP, app_dir=str(tmp_path))
+    msg = t.get_logs("c1", normalized={"start_time": None, "end_time": None})
+    assert "not enabled" in msg
+
+
+def test_get_logs_no_project_id(traces_obj):
+    traces_obj.project_id = None
+    msg = traces_obj.get_logs(
+        "c1", normalized={"start_time": None, "end_time": None}
+    )
+    assert "project ID is unknown" in msg
+
+
+def test_get_logs_invokes_cloud_logs_client(traces_obj, monkeypatch):
+    fake_client = MagicMock()
+    fake_client.fetch.return_value = [{"timestamp": "t", "message": "m"}]
+    monkeypatch.setattr(
+        traces_mod, "CloudLogsClient", MagicMock(return_value=fake_client)
+    )
+    traces_obj.history = MagicMock()
+    traces_obj.history.get_conversation.return_value = _conv_dict()
+    rows = traces_obj.get_logs("c1")
+    assert rows == [{"timestamp": "t", "message": "m"}]
+    fake_client.fetch.assert_called_once()
+
+
+def test_resolve_audio_uri_uses_payload_audio_uri(traces_obj):
+    traces_obj.history = MagicMock()
+    d = _conv_dict(
+        turns=[
+            {
+                "messages": [
+                    {
+                        "role": "agent_x",
+                        "chunks": [
+                            {"payload": {"audioUri": "gs://from-payload/a.wav"}}
+                        ],
+                    }
+                ]
+            }
+        ]
+    )
+    traces_obj.history.get_conversation.return_value = d
+    assert traces_obj.resolve_audio_uri("c1") == "gs://from-payload/a.wav"
+
+
+def test_resolve_audio_uri_no_bucket_returns_none(traces_obj):
+    traces_obj.history = MagicMock()
+    traces_obj.history.get_conversation.return_value = _conv_dict()
+    assert traces_obj.resolve_audio_uri("c1") is None
+
+
+def test_resolve_audio_uri_uses_trace_config_override(traces_obj, monkeypatch):
+    traces_obj.history = MagicMock()
+    traces_obj.history.get_conversation.return_value = _conv_dict()
+    traces_obj.trace_config.audio.bucket_override = "gs://override"
+    traces_obj.trace_config.audio.search_bucket = False
+    uri = traces_obj.resolve_audio_uri("c1")
+    assert uri == "gs://override/c1.wav"
+
+
+def test_resolve_audio_uri_search_bucket_finds_via_listing(
+    traces_obj, monkeypatch
+):
+    traces_obj.history = MagicMock()
+    traces_obj.history.get_conversation.return_value = _conv_dict()
+    traces_obj.trace_config.audio.bucket_override = "gs://b"
+    traces_obj.trace_config.audio.search_bucket = True
+    fake_gcs = MagicMock()
+    fake_gcs.exists.return_value = False
+    fake_gcs.find_first.return_value = (
+        "gs://b/projnum/us/app-x/2026-05-01/c1/full-session.wav"
+    )
+    monkeypatch.setattr(
+        traces_mod, "GCSUtils", MagicMock(return_value=fake_gcs)
+    )
+    uri = traces_obj.resolve_audio_uri("c1")
+    assert uri.endswith("/c1/full-session.wav")
+    fake_gcs.find_first.assert_called_once()
+
+
+def test_resolve_audio_uri_search_bucket_returns_none_when_missing(
+    traces_obj, monkeypatch
+):
+    traces_obj.history = MagicMock()
+    traces_obj.history.get_conversation.return_value = _conv_dict()
+    traces_obj.trace_config.audio.bucket_override = "gs://b"
+    traces_obj.trace_config.audio.search_bucket = True
+    fake_gcs = MagicMock()
+    fake_gcs.exists.side_effect = RuntimeError("nope")
+    fake_gcs.find_first.return_value = None
+    monkeypatch.setattr(
+        traces_mod, "GCSUtils", MagicMock(return_value=fake_gcs)
+    )
+    assert traces_obj.resolve_audio_uri("c1") is None
+
+
+def test_resolve_audio_uri_uses_app_config_bucket(tmp_path, monkeypatch):
+    (tmp_path / "app.json").write_text(
+        json.dumps(
+            {
+                "loggingSettings": {
+                    "audioRecordingConfig": {"gcsBucket": "gs://from-app"}
+                }
+            }
+        )
+    )
+    monkeypatch.chdir(tmp_path)
+    t = Traces(app_name=APP, app_dir=str(tmp_path))
+    t.history = MagicMock()
+    t.history.get_conversation.return_value = _conv_dict()
+    t.trace_config.audio.search_bucket = False
+    assert t.resolve_audio_uri("c1") == "gs://from-app/c1.wav"
+
+
+def test_download_audio_success(traces_obj, tmp_path, monkeypatch):
+    traces_obj.history = MagicMock()
+    traces_obj.history.get_conversation.return_value = _conv_dict()
+    traces_obj.trace_config.audio.bucket_override = "gs://b"
+    traces_obj.trace_config.audio.search_bucket = False
+    traces_obj.trace_config.audio.download_dir = str(tmp_path / "audio")
+
+    fake_gcs = MagicMock()
+    fake_gcs.download_to_file.return_value = str(tmp_path / "audio" / "c1.wav")
+    monkeypatch.setattr(
+        traces_mod, "GCSUtils", MagicMock(return_value=fake_gcs)
+    )
+    out = traces_obj.download_audio("c1")
+    assert out.endswith("c1.wav")
+    fake_gcs.download_to_file.assert_called_once()
+
+
+def test_download_audio_no_uri_returns_none(traces_obj):
+    traces_obj.history = MagicMock()
+    traces_obj.history.get_conversation.return_value = _conv_dict()
+    assert traces_obj.download_audio("c1") is None
+
+
+_FAKE_FILES = [
+    "gs://b/p/conv-1/METADATA.json",
+    "gs://b/p/conv-1/full-session.wav",
+    "gs://b/p/conv-1/agent-turn-1.wav",
+    "gs://b/p/conv-1/agent-turn-2.wav",
+    "gs://b/p/conv-1/user-turn-1.wav",
+]
+
+
+def _patch_audio_files(traces_obj, monkeypatch, files=_FAKE_FILES):
+    traces_obj.list_audio_files = MagicMock(return_value=files)
+    monkeypatch.setattr(
+        traces_mod.genai.types.Part, "from_uri", lambda **kw: "audio_part"
+    )
+
+
+def test_analyze_audio_no_files(traces_obj, monkeypatch):
+    traces_obj.history = MagicMock()
+    traces_obj.history.get_conversation.return_value = _conv_dict()
+    traces_obj.list_audio_files = MagicMock(return_value=[])
+    assert traces_obj.analyze_audio("c1") == {
+        "error": "No audio files found for this conversation."
+    }
+
+
+def test_analyze_audio_runs_named_subset(traces_obj, monkeypatch):
+    _patch_audio_files(traces_obj, monkeypatch)
+    fake_gem = MagicMock()
+    fake_gem.generate_with_parts.side_effect = [
+        "PASS — voices match",
+        "FAIL — pause at 0:42",
+    ]
+    monkeypatch.setattr(
+        traces_mod, "GeminiGenerate", MagicMock(return_value=fake_gem)
+    )
+    out = traces_obj.analyze_audio(
+        "c1", metrics=["agent_voice_consistency", "no_long_pauses"]
+    )
+    assert set(out.keys()) == {"agent_voice_consistency", "no_long_pauses"}
+    assert out["agent_voice_consistency"]["result"] == "PASS"
+    assert out["no_long_pauses"]["result"] == "FAIL"
+    # Voice consistency only sees agent-turn files
+    assert all(
+        "agent-turn" in f
+        for f in out["agent_voice_consistency"]["files_analyzed"]
+    )
+    # No-long-pauses only sees full-session
+    assert out["no_long_pauses"]["files_analyzed"] == [
+        "gs://b/p/conv-1/full-session.wav"
+    ]
+
+
+def test_analyze_audio_runs_all_when_metrics_none(traces_obj, monkeypatch):
+    _patch_audio_files(traces_obj, monkeypatch)
+    fake_gem = MagicMock()
+    fake_gem.generate_with_parts.return_value = "PASS — looks fine"
+    monkeypatch.setattr(
+        traces_mod, "GeminiGenerate", MagicMock(return_value=fake_gem)
+    )
+    out = traces_obj.analyze_audio("c1")
+    assert set(out.keys()) == set(ANALYSIS_REGISTRY.keys())
+
+
+def test_analyze_audio_skips_unknown_metric(traces_obj, monkeypatch, caplog):
+    _patch_audio_files(traces_obj, monkeypatch)
+    fake_gem = MagicMock()
+    fake_gem.generate_with_parts.return_value = "PASS — ok"
+    monkeypatch.setattr(
+        traces_mod, "GeminiGenerate", MagicMock(return_value=fake_gem)
+    )
+    out = traces_obj.analyze_audio(
+        "c1", metrics=["agent_cutoff", "definitely_not_real"]
+    )
+    assert set(out.keys()) == {"agent_cutoff"}
+
+
+def test_analyze_audio_skip_when_filter_returns_empty(traces_obj, monkeypatch):
+    """If a registered analysis sees no matching files, it returns SKIP."""
+    _patch_audio_files(
+        traces_obj,
+        monkeypatch,
+        # No agent-turn-*.wav files — voice consistency must skip.
+        files=["gs://b/p/conv-1/full-session.wav"],
+    )
+    fake_gem = MagicMock()
+    monkeypatch.setattr(
+        traces_mod, "GeminiGenerate", MagicMock(return_value=fake_gem)
+    )
+    out = traces_obj.analyze_audio("c1", metrics=["agent_voice_consistency"])
+    assert out["agent_voice_consistency"]["result"] == "SKIP"
+    fake_gem.generate_with_parts.assert_not_called()
+
+
+def test_analyze_audio_uses_yaml_prompt_override(traces_obj, monkeypatch):
+    _patch_audio_files(traces_obj, monkeypatch)
+    traces_obj.trace_config.gemini.audio_metrics = {
+        "agent_cutoff": GeminiMetric(prompt="custom override prompt"),
+    }
+    fake_gem = MagicMock()
+    fake_gem.generate_with_parts.return_value = "PASS"
+    monkeypatch.setattr(
+        traces_mod, "GeminiGenerate", MagicMock(return_value=fake_gem)
+    )
+    traces_obj.analyze_audio("c1", metrics=["agent_cutoff"])
+    args, kwargs = fake_gem.generate_with_parts.call_args
+    parts = kwargs["parts"]
+    # Last part is the prompt string; preceding ones are audio Parts.
+    assert parts[-1] == "custom override prompt"
+
+
+def test_analyze_audio_handles_gemini_none(traces_obj, monkeypatch):
+    _patch_audio_files(traces_obj, monkeypatch)
+    fake_gem = MagicMock()
+    fake_gem.generate_with_parts.return_value = None
+    monkeypatch.setattr(
+        traces_mod, "GeminiGenerate", MagicMock(return_value=fake_gem)
+    )
+    out = traces_obj.analyze_audio("c1", metrics=["agent_cutoff"])
+    assert out["agent_cutoff"]["result"] == "ERROR"
+
+
+def test_analyze_audio_handles_unparseable_response(traces_obj, monkeypatch):
+    _patch_audio_files(traces_obj, monkeypatch)
+    fake_gem = MagicMock()
+    fake_gem.generate_with_parts.return_value = "no verdict here"
+    monkeypatch.setattr(
+        traces_mod, "GeminiGenerate", MagicMock(return_value=fake_gem)
+    )
+    out = traces_obj.analyze_audio("c1", metrics=["agent_cutoff"])
+    assert out["agent_cutoff"]["result"] == "UNKNOWN"
+    assert out["agent_cutoff"]["justification"] == "no verdict here"
+
+
+def test_list_audio_files_uses_gcs_listing(traces_obj, monkeypatch):
+    traces_obj.trace_config.audio.bucket_override = "gs://b"
+    fake_gcs = MagicMock()
+    fake_gcs.find_dir_for_conversation.return_value = "p/d/conv-1/"
+    fake_gcs.list_with_prefix.return_value = _FAKE_FILES
+    monkeypatch.setattr(
+        traces_mod, "GCSUtils", MagicMock(return_value=fake_gcs)
+    )
+    assert traces_obj.list_audio_files("conv-1") == _FAKE_FILES
+    fake_gcs.find_dir_for_conversation.assert_called_once_with(
+        "gs://b", conversation_id="conv-1"
+    )
+
+
+def test_list_audio_files_returns_empty_when_no_bucket(traces_obj):
+    assert traces_obj.list_audio_files("c1") == []
+
+
+def test_list_audio_files_returns_empty_when_dir_not_found(
+    traces_obj, monkeypatch
+):
+    traces_obj.trace_config.audio.bucket_override = "gs://b"
+    fake_gcs = MagicMock()
+    fake_gcs.find_dir_for_conversation.return_value = None
+    monkeypatch.setattr(
+        traces_mod, "GCSUtils", MagicMock(return_value=fake_gcs)
+    )
+    assert traces_obj.list_audio_files("c1") == []
+
+
+def test_parse_pass_fail_branches():
+    assert traces_mod._parse_pass_fail(None)["result"] == "ERROR"
+    assert traces_mod._parse_pass_fail("PASS — all good")["result"] == "PASS"
+    assert traces_mod._parse_pass_fail("FAIL — bad call")["result"] == "FAIL"
+    # Sentence with PASS/FAIL embedded as a separate token.
+    assert (
+        traces_mod._parse_pass_fail("Result is PASS overall")["result"]
+        == "PASS"
+    )
+    assert (
+        traces_mod._parse_pass_fail("Final verdict: FAIL — bad")["result"]
+        == "FAIL"
+    )
+    assert traces_mod._parse_pass_fail("nothing useful")["result"] == "UNKNOWN"
+
+
+def test_triage_runs_metrics(traces_obj, monkeypatch):
+    traces_obj.history = MagicMock()
+    traces_obj.history.get_conversation.return_value = _conv_dict()
+    fake_gem = MagicMock()
+    fake_gem.generate.side_effect = lambda prompt, **_: f"resp:{prompt[:20]}"
+    monkeypatch.setattr(
+        traces_mod, "GeminiGenerate", MagicMock(return_value=fake_gem)
+    )
+    out = traces_obj.triage("c1", metrics=["hallucination"])
+    assert list(out.keys()) == ["hallucination"]
+
+
+def test_triage_runs_all_metrics_when_none_specified(traces_obj, monkeypatch):
+    traces_obj.history = MagicMock()
+    traces_obj.history.get_conversation.return_value = _conv_dict()
+    fake_gem = MagicMock()
+    fake_gem.generate.return_value = "x"
+    monkeypatch.setattr(
+        traces_mod, "GeminiGenerate", MagicMock(return_value=fake_gem)
+    )
+    out = traces_obj.triage("c1")
+    assert set(out.keys()) == set(
+        traces_obj.trace_config.gemini.triage_metrics.keys()
+    )
+
+
+def test_replay_with_diff(traces_obj, monkeypatch):
+    traces_obj.history = MagicMock()
+    traces_obj.history.get_conversation.return_value = _conv_dict()
+
+    fake_sess = MagicMock()
+    fake_sess.create_session_id.return_value = "sid"
+    fake_sess.run.return_value = "raw"
+    fake_sess.get_structured_response.return_value = {
+        "agent_text": "different reply",
+    }
+    monkeypatch.setattr(
+        traces_mod, "Sessions", MagicMock(return_value=fake_sess)
+    )
+
+    out = traces_obj.replay("c1")
+    assert out["original"] == ["hello"]
+    assert out["replay"] == ["different reply"]
+    assert "+different reply" in out["diff"]
+
+
+def test_replay_handles_session_run_failure(traces_obj, monkeypatch):
+    traces_obj.history = MagicMock()
+    traces_obj.history.get_conversation.return_value = _conv_dict()
+    fake_sess = MagicMock()
+    fake_sess.create_session_id.return_value = "sid"
+    fake_sess.run.side_effect = RuntimeError("nope")
+    monkeypatch.setattr(
+        traces_mod, "Sessions", MagicMock(return_value=fake_sess)
+    )
+    out = traces_obj.replay("c1", diff=False)
+    assert out["replay"] == ["<replay error: nope>"]
+    assert "diff" not in out
+
+
+def test_aggregate_stats(traces_obj, monkeypatch):
+    convs = [
+        _conv("a", input_types=["INPUT_TYPE_TEXT"]),
+        _conv("b", input_types=["INPUT_TYPE_AUDIO"]),
+    ]
+    traces_obj.history = MagicMock()
+    traces_obj.history.list_conversations.return_value = convs
+
+    def fake_get_normalized(cid):
+        return {
+            "conversation_id": cid,
+            "source": "LIVE",
+            "channel": "AUDIO" if cid == "b" else "TEXT",
+            "start_time": "2026-05-01T00:00:00",
+            "end_time": "2026-05-01T00:00:30",
+            "entries": (
+                [
+                    {"kind": "tool_call", "tool": "lookup"},
+                    {"kind": "agent_transfer", "target": "agent_b"},
+                ]
+                if cid == "a"
+                else [{"kind": "tool_call", "tool": "calc"}]
+            ),
+        }
+
+    traces_obj.get_normalized = fake_get_normalized
+    stats = traces_obj.aggregate_stats(time_filter="7d")
+    assert stats["total"] == 2
+    assert stats["per_source"]["LIVE"] == 2
+    assert stats["per_channel"]["TEXT"] == 1
+    assert stats["per_channel"]["AUDIO"] == 1
+    assert stats["success_rate_no_transfer"] == 0.5
+    assert stats["duration_seconds"]["p50"] == 30.0
+    tools = dict(stats["top_tools"])
+    assert tools["lookup"] == 1 and tools["calc"] == 1
+
+
+def test_aggregate_stats_handles_fetch_error(traces_obj, monkeypatch):
+    traces_obj.history = MagicMock()
+    traces_obj.history.list_conversations.return_value = [_conv("a")]
+    traces_obj.get_normalized = MagicMock(side_effect=RuntimeError("err"))
+    stats = traces_obj.aggregate_stats(time_filter="7d")
+    assert stats["total"] == 0
+
+
+def test_bundle_creates_zip(traces_obj, tmp_path, monkeypatch):
+    traces_obj.history = MagicMock()
+    traces_obj.history.get_conversation.return_value = _conv_dict()
+    traces_obj.trace_config.audio.bucket_override = "gs://b"
+    traces_obj.trace_config.audio.search_bucket = False
+
+    audio_local = tmp_path / "c1.wav"
+    audio_local.write_bytes(b"audio")
+    fake_gcs = MagicMock()
+    fake_gcs.download_to_file.return_value = str(audio_local)
+    monkeypatch.setattr(
+        traces_mod, "GCSUtils", MagicMock(return_value=fake_gcs)
+    )
+
+    fake_logs_client = MagicMock()
+    fake_logs_client.fetch.return_value = [{"msg": "x"}]
+    monkeypatch.setattr(
+        traces_mod,
+        "CloudLogsClient",
+        MagicMock(return_value=fake_logs_client),
+    )
+
+    fake_gem = MagicMock()
+    fake_gem.generate_with_parts.return_value = "audio finding"
+    fake_gem.generate.return_value = "triage finding"
+    monkeypatch.setattr(
+        traces_mod, "GeminiGenerate", MagicMock(return_value=fake_gem)
+    )
+    monkeypatch.setattr(
+        traces_mod.genai.types.Part, "from_uri", lambda **kw: "audio_part"
+    )
+
+    out = tmp_path / "out.zip"
+    traces_obj.bundle(
+        "c1",
+        out_path=str(out),
+        with_analysis=True,
+        with_triage=True,
+    )
+    with zipfile.ZipFile(out) as z:
+        names = set(z.namelist())
+    assert "transcript.json" in names
+    assert "transcript.md" in names
+    assert "report.html" in names
+    assert "logs.json" in names
+    assert "metadata.json" in names
+    assert "gemini_analysis.json" in names
+    assert "triage.json" in names
+    assert "c1.wav" in names
+
+
+def test_bundle_skips_failing_audio_download(traces_obj, tmp_path, monkeypatch):
+    traces_obj.history = MagicMock()
+    traces_obj.history.get_conversation.return_value = _conv_dict()
+    traces_obj.download_audio = MagicMock(side_effect=RuntimeError("nope"))
+    out = tmp_path / "out.zip"
+    traces_obj.bundle("c1", out_path=str(out), with_logs=False, with_audio=True)
+    with zipfile.ZipFile(out) as z:
+        names = set(z.namelist())
+    assert "transcript.json" in names
+    assert "c1.wav" not in names
+
+
+def test_report_bug_requires_bucket(traces_obj):
+    with pytest.raises(ValueError, match="bug_report.bucket"):
+        traces_obj.report_bug("c1", reason="r")
+
+
+def test_report_bug_uploads_artifacts(traces_obj, monkeypatch):
+    traces_obj.history = MagicMock()
+    traces_obj.history.get_conversation.return_value = _conv_dict()
+    traces_obj.trace_config.bug_report.bucket = "gs://bugs"
+    traces_obj.trace_config.audio.bucket_override = "gs://b"
+    traces_obj.trace_config.audio.search_bucket = False
+
+    fake_gcs = MagicMock()
+    fake_gcs.upload_string.side_effect = lambda uri, *_args, **_kw: uri
+    fake_gcs.upload_file.side_effect = lambda uri, *_args, **_kw: uri
+    fake_gcs.download_to_file.return_value = "/tmp/c1.wav"
+    monkeypatch.setattr(
+        traces_mod, "GCSUtils", MagicMock(return_value=fake_gcs)
+    )
+
+    # Pretend the audio file exists locally so upload_file is reached.
+    monkeypatch.setattr(os.path, "exists", lambda p: p == "/tmp/c1.wav")
+
+    fake_logs = MagicMock()
+    fake_logs.fetch.return_value = [{"msg": "x"}]
+    monkeypatch.setattr(
+        traces_mod, "CloudLogsClient", MagicMock(return_value=fake_logs)
+    )
+    fake_gem = MagicMock()
+    fake_gem.generate_with_parts.return_value = "ok"
+    monkeypatch.setattr(
+        traces_mod, "GeminiGenerate", MagicMock(return_value=fake_gem)
+    )
+    monkeypatch.setattr(
+        traces_mod.genai.types.Part, "from_uri", lambda **kw: "p"
+    )
+    monkeypatch.setattr(traces_mod, "_gcloud_account", lambda: "u@x.com")
+
+    info = traces_obj.report_bug("c1", reason="bug", severity="high")
+    assert info["reason"] == "bug"
+    assert info["severity"] == "high"
+    assert "transcript.json" in info["uploaded"]
+    assert "audio" in info["uploaded"]
+    assert "logs.json" in info["uploaded"]
+    assert "gemini_analysis.json" in info["uploaded"]
+    assert "environment.json" in info["uploaded"]
+    assert "bug_report.json" in info["uploaded"]
+
+
+def test_report_bug_skips_failing_artifacts(traces_obj, monkeypatch):
+    traces_obj.history = MagicMock()
+    traces_obj.history.get_conversation.return_value = _conv_dict()
+    traces_obj.trace_config.bug_report.bucket = "gs://bugs"
+    traces_obj.trace_config.bug_report.include = [
+        "transcript",
+        "logs",
+        "audio",
+        "gemini_analysis",
+        "environment",
+    ]
+
+    fake_gcs = MagicMock()
+    fake_gcs.upload_string.side_effect = lambda uri, *_a, **_k: uri
+    monkeypatch.setattr(
+        traces_mod, "GCSUtils", MagicMock(return_value=fake_gcs)
+    )
+    traces_obj.get_logs = MagicMock(side_effect=RuntimeError("logs fail"))
+    traces_obj.download_audio = MagicMock(side_effect=RuntimeError("a fail"))
+    traces_obj.analyze_audio = MagicMock(side_effect=RuntimeError("g fail"))
+    info = traces_obj.report_bug("c1", reason="r")
+    assert "audio" not in info["uploaded"]
+    assert "gemini_analysis.json" not in info["uploaded"]
+
+
+def test_console_url_format(traces_obj):
+    url = traces_obj.console_url("conv-1")
+    assert url == (
+        "https://ces.cloud.google.com/projects/p/locations/l/apps/a/"
+        "conversations/conv-1"
+    )
+
+
+def test_metadata_collects_fields(traces_obj, monkeypatch):
+    monkeypatch.setattr(traces_mod, "_gcloud_account", lambda: "kr@x")
+    monkeypatch.setattr(traces_mod, "_git_sha", lambda: "abc123")
+    md = traces_obj._metadata()
+    assert md["app_name"] == APP
+    assert md["gcloud_account"] == "kr@x"
+    assert md["git_sha"] == "abc123"
+
+
+def test_helpers_pure_logic():
+    assert traces_mod._enum_name(None) is None
+    assert traces_mod._enum_name(SimpleNamespace(name="X")) == "X"
+    assert traces_mod._ts_iso(None) is None
+    assert traces_mod._ts_iso("s") == "s"
+    assert traces_mod._ts_iso(datetime.datetime(2026, 5, 1)).startswith(
+        "2026-05-01"
+    )
+    assert traces_mod._parse_iso(None) is None
+    assert traces_mod._parse_iso("not-a-date") is None
+    assert traces_mod._parse_iso("2026-05-01T00:00:00Z") == datetime.datetime(
+        2026, 5, 1, tzinfo=datetime.timezone.utc
+    )
+    assert traces_mod._duration_seconds(None, None) is None
+    assert (
+        traces_mod._duration_seconds(
+            "2026-05-01T00:00:00", "2026-05-01T00:00:30"
+        )
+        == 30.0
+    )
+    assert traces_mod._percentile([], 50) is None
+    assert traces_mod._percentile([1, 2, 3, 4], 50) == 3
+    assert traces_mod._top_n({"a": 1, "b": 5, "c": 2}, 2) == [
+        ("b", 5),
+        ("c", 2),
+    ]
+
+
+def test_git_sha_and_gcloud_account_failures(monkeypatch):
+    def boom(*_a, **_kw):
+        raise FileNotFoundError("nope")
+
+    monkeypatch.setattr(traces_mod.subprocess, "check_output", boom)
+    assert traces_mod._git_sha() is None
+    assert traces_mod._gcloud_account() is None
+
+
+def test_git_sha_and_gcloud_account_success(monkeypatch):
+    monkeypatch.setattr(
+        traces_mod.subprocess, "check_output", lambda *a, **k: b"abc\n"
+    )
+    assert traces_mod._git_sha() == "abc"
+    assert traces_mod._gcloud_account() == "abc"
+
+
+def test_agent_text_per_turn():
+    n = {
+        "entries": [
+            {"kind": "user", "turn": 0, "text": "hi"},
+            {"kind": "agent", "turn": 0, "text": "hello"},
+            {"kind": "agent", "turn": 1, "text": "second"},
+            {"kind": "agent", "turn": 0, "text": "world"},
+        ]
+    }
+    assert traces_mod._agent_text_per_turn(n) == ["hello world", "second"]

--- a/tests/cxas_scrapi/utils/test_gcs_utils.py
+++ b/tests/cxas_scrapi/utils/test_gcs_utils.py
@@ -53,3 +53,178 @@ def test_upload_string_no_path(mock_client_cls):
     gcs = GCSUtils()
     with pytest.raises(ValueError, match="Invalid GCS URI"):
         gcs.upload_string("gs://bucket", "content")
+
+
+@patch("cxas_scrapi.utils.gcs_utils.storage.Client")
+def test_upload_file_calls_upload_from_filename(mock_client_cls, tmp_path):
+    mock_client = mock_client_cls.return_value
+    mock_bucket = Mock()
+    mock_blob = Mock()
+    mock_client.get_bucket.return_value = mock_bucket
+    mock_bucket.blob.return_value = mock_blob
+
+    gcs = GCSUtils()
+    f = tmp_path / "x.bin"
+    f.write_bytes(b"abc")
+    url = gcs.upload_file(
+        "gs://bucket/path/x.bin", str(f), content_type="application/octet"
+    )
+    mock_blob.upload_from_filename.assert_called_once_with(
+        str(f), content_type="application/octet"
+    )
+    assert "bucket/path/x.bin" in url
+
+
+@patch("cxas_scrapi.utils.gcs_utils.storage.Client")
+def test_download_blob_returns_bytes(mock_client_cls):
+    mock_client = mock_client_cls.return_value
+    mock_bucket = Mock()
+    mock_blob = Mock()
+    mock_client.bucket.return_value = mock_bucket
+    mock_bucket.blob.return_value = mock_blob
+    mock_blob.download_as_bytes.return_value = b"hello"
+
+    gcs = GCSUtils()
+    assert gcs.download_blob("gs://b/p") == b"hello"
+
+
+@patch("cxas_scrapi.utils.gcs_utils.storage.Client")
+def test_download_string_decodes(mock_client_cls):
+    mock_client = mock_client_cls.return_value
+    mock_bucket = Mock()
+    mock_blob = Mock()
+    mock_client.bucket.return_value = mock_bucket
+    mock_bucket.blob.return_value = mock_blob
+    mock_blob.download_as_bytes.return_value = "héllo".encode("utf-8")
+
+    gcs = GCSUtils()
+    assert gcs.download_string("gs://b/p") == "héllo"
+
+
+@patch("cxas_scrapi.utils.gcs_utils.storage.Client")
+def test_download_to_file_creates_dirs(mock_client_cls, tmp_path):
+    mock_client = mock_client_cls.return_value
+    mock_bucket = Mock()
+    mock_blob = Mock()
+    mock_client.bucket.return_value = mock_bucket
+    mock_bucket.blob.return_value = mock_blob
+
+    gcs = GCSUtils()
+    dest = tmp_path / "nested" / "dir" / "audio.wav"
+    out = gcs.download_to_file("gs://b/audio.wav", str(dest))
+    mock_blob.download_to_filename.assert_called_once_with(str(dest))
+    assert out == str(dest.absolute())
+
+
+@patch("cxas_scrapi.utils.gcs_utils.storage.Client")
+def test_exists_returns_bool(mock_client_cls):
+    mock_client = mock_client_cls.return_value
+    mock_bucket = Mock()
+    mock_blob = Mock()
+    mock_client.bucket.return_value = mock_bucket
+    mock_bucket.blob.return_value = mock_blob
+    mock_blob.exists.return_value = True
+
+    gcs = GCSUtils()
+    assert gcs.exists("gs://b/p") is True
+    mock_blob.exists.assert_called_once_with(mock_client)
+
+
+@patch("cxas_scrapi.utils.gcs_utils.storage.Client")
+def test_parse_gcs_uri_validation_paths(mock_client_cls):
+    gcs = GCSUtils()
+    # Missing `gs://` prefix is always rejected.
+    with pytest.raises(ValueError):
+        gcs._parse_gcs_uri("not-a-gs-uri")
+    # Empty path is rejected by default (object operations need a path)...
+    with pytest.raises(ValueError):
+        gcs._parse_gcs_uri("gs://bucket/")
+    with pytest.raises(ValueError):
+        gcs._parse_gcs_uri("gs://bucket")
+    # ...but allowed when the caller explicitly opts in (bucket listings).
+    assert gcs._parse_gcs_uri("gs://bucket", require_path=False) == (
+        "bucket",
+        "",
+    )
+    assert gcs._parse_gcs_uri("gs://bucket/path/x", require_path=False) == (
+        "bucket",
+        "path/x",
+    )
+    # Empty input still raises.
+    with pytest.raises(ValueError):
+        gcs._parse_gcs_uri("")
+
+
+@patch("cxas_scrapi.utils.gcs_utils.storage.Client")
+def test_find_first_returns_match(mock_client_cls):
+    mock_client = mock_client_cls.return_value
+    blob_a = Mock(name="a")
+    blob_a.name = "x/y/conv-1/full-session.wav"
+    blob_b = Mock(name="b")
+    blob_b.name = "x/y/conv-1/agent-turn-1.wav"
+    mock_client.list_blobs.return_value = [blob_b, blob_a]
+
+    gcs = GCSUtils()
+    out = gcs.find_first("gs://my-bucket", suffix="/conv-1/full-session.wav")
+    assert out == "gs://my-bucket/x/y/conv-1/full-session.wav"
+
+
+@patch("cxas_scrapi.utils.gcs_utils.storage.Client")
+def test_find_first_returns_none(mock_client_cls):
+    mock_client = mock_client_cls.return_value
+    blob_a = Mock(name="a")
+    blob_a.name = "other/file.wav"
+    mock_client.list_blobs.return_value = [blob_a]
+
+    gcs = GCSUtils()
+    assert gcs.find_first("gs://my-bucket", suffix="/missing.wav") is None
+
+
+@patch("cxas_scrapi.utils.gcs_utils.storage.Client")
+def test_list_with_prefix_returns_sorted(mock_client_cls):
+    mock_client = mock_client_cls.return_value
+    a, b, c = Mock(), Mock(), Mock()
+    a.name = "p/c1/agent-turn-2.wav"
+    b.name = "p/c1/agent-turn-1.wav"
+    c.name = "p/c1/full-session.wav"
+    mock_client.list_blobs.return_value = [a, b, c]
+
+    gcs = GCSUtils()
+    out = gcs.list_with_prefix("gs://my-bucket", prefix="p/c1/")
+    assert out == [
+        "gs://my-bucket/p/c1/agent-turn-1.wav",
+        "gs://my-bucket/p/c1/agent-turn-2.wav",
+        "gs://my-bucket/p/c1/full-session.wav",
+    ]
+    mock_client.list_blobs.assert_called_once_with(
+        "my-bucket", prefix="p/c1/", max_results=5000
+    )
+
+
+@patch("cxas_scrapi.utils.gcs_utils.storage.Client")
+def test_find_dir_for_conversation(mock_client_cls):
+    mock_client = mock_client_cls.return_value
+    a, b = Mock(), Mock()
+    a.name = "x/y/wrong/METADATA.json"
+    b.name = "p/q/conv-42/METADATA.json"
+    mock_client.list_blobs.return_value = [a, b]
+
+    gcs = GCSUtils()
+    out = gcs.find_dir_for_conversation(
+        "gs://my-bucket", conversation_id="conv-42"
+    )
+    assert out == "p/q/conv-42/"
+
+
+@patch("cxas_scrapi.utils.gcs_utils.storage.Client")
+def test_find_dir_for_conversation_not_found(mock_client_cls):
+    mock_client = mock_client_cls.return_value
+    a = Mock()
+    a.name = "p/other/METADATA.json"
+    mock_client.list_blobs.return_value = [a]
+
+    gcs = GCSUtils()
+    assert (
+        gcs.find_dir_for_conversation("gs://b", conversation_id="missing")
+        is None
+    )

--- a/tests/cxas_scrapi/utils/test_gemini.py
+++ b/tests/cxas_scrapi/utils/test_gemini.py
@@ -1,0 +1,249 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from cxas_scrapi.utils.gemini import GeminiGenerate
+
+
+@patch("cxas_scrapi.utils.gemini.genai")
+def test_generate_with_parts_text_response(mock_genai):
+    mock_genai.types.Part.from_text = lambda text: f"text:{text}"
+    mock_genai.types.GenerateContentConfig = MagicMock()
+    fake_client = MagicMock()
+    mock_genai.Client.return_value = fake_client
+    fake_client.models.generate_content.return_value = SimpleNamespace(
+        text="reply"
+    )
+
+    gen = GeminiGenerate(project_id="p", credentials=None)
+    out = gen.generate_with_parts(
+        parts=["a prompt", SimpleNamespace(name="audio_part")],
+        system_prompt="sys",
+        temperature=0.5,
+    )
+    assert out == "reply"
+    args, kwargs = fake_client.models.generate_content.call_args
+    contents = kwargs["contents"]
+    assert contents[0] == "text:a prompt"
+    assert hasattr(contents[1], "name")
+
+
+@patch("cxas_scrapi.utils.gemini.genai")
+def test_generate_with_parts_returns_parsed_for_json_schema(mock_genai):
+    mock_genai.types.Part.from_text = lambda text: f"t:{text}"
+    fake_client = MagicMock()
+    mock_genai.Client.return_value = fake_client
+    fake_client.models.generate_content.return_value = SimpleNamespace(
+        parsed={"k": "v"}, text=None
+    )
+
+    gen = GeminiGenerate(project_id="p")
+    out = gen.generate_with_parts(
+        parts=["x"],
+        response_mime_type="application/json",
+        response_schema=object,
+        model_name="custom-model",
+    )
+    assert out == {"k": "v"}
+
+
+@patch("cxas_scrapi.utils.gemini.genai")
+def test_generate_with_parts_returns_none_on_failure(mock_genai):
+    mock_genai.types.Part.from_text = lambda text: text
+    fake_client = MagicMock()
+    mock_genai.Client.return_value = fake_client
+    fake_client.models.generate_content.side_effect = RuntimeError("boom")
+
+    gen = GeminiGenerate(project_id="p")
+    assert gen.generate_with_parts(parts=["x"]) is None
+
+
+@patch("cxas_scrapi.utils.gemini.genai")
+def test_generate_with_parts_no_config_when_no_args(mock_genai):
+    mock_genai.types.Part.from_text = lambda text: text
+    fake_client = MagicMock()
+    mock_genai.Client.return_value = fake_client
+    fake_client.models.generate_content.return_value = SimpleNamespace(
+        text="ok"
+    )
+    gen = GeminiGenerate(project_id="p")
+    out = gen.generate_with_parts(parts=["q"], temperature=None)
+    assert out == "ok"
+    _, kwargs = fake_client.models.generate_content.call_args
+    assert kwargs["config"] is None
+
+
+@patch("cxas_scrapi.utils.gemini.genai")
+def test_generate_text_response(mock_genai):
+    fake_client = MagicMock()
+    mock_genai.Client.return_value = fake_client
+    fake_client.models.generate_content.return_value = SimpleNamespace(
+        text="hi"
+    )
+    gen = GeminiGenerate(project_id="p")
+    assert gen.generate(prompt="p", system_prompt="s") == "hi"
+
+
+@patch("cxas_scrapi.utils.gemini.genai")
+def test_generate_returns_parsed_for_json_schema(mock_genai):
+    fake_client = MagicMock()
+    mock_genai.Client.return_value = fake_client
+    fake_client.models.generate_content.return_value = SimpleNamespace(
+        parsed={"k": "v"}, text=None
+    )
+    gen = GeminiGenerate(project_id="p")
+    out = gen.generate(
+        prompt="p",
+        response_mime_type="application/json",
+        response_schema=object,
+        model_name="custom",
+    )
+    assert out == {"k": "v"}
+
+
+@patch("cxas_scrapi.utils.gemini.genai")
+def test_generate_returns_none_on_failure(mock_genai):
+    fake_client = MagicMock()
+    mock_genai.Client.return_value = fake_client
+    fake_client.models.generate_content.side_effect = RuntimeError("boom")
+    gen = GeminiGenerate(project_id="p")
+    assert gen.generate(prompt="p") is None
+
+
+@patch("cxas_scrapi.utils.gemini.genai")
+def test_generate_no_config_when_no_args(mock_genai):
+    fake_client = MagicMock()
+    mock_genai.Client.return_value = fake_client
+    fake_client.models.generate_content.return_value = SimpleNamespace(
+        text="ok"
+    )
+    gen = GeminiGenerate(project_id="p")
+    assert gen.generate(prompt="p", temperature=None) == "ok"
+    _, kwargs = fake_client.models.generate_content.call_args
+    assert kwargs["config"] is None
+
+
+@patch("cxas_scrapi.utils.gemini.genai")
+def test_generate_passes_thinking_level(mock_genai):
+    """thinking_level='low' wraps a ThinkingConfig and forwards it."""
+    sentinel_thinking = MagicMock(name="ThinkingConfig")
+    mock_genai.types.ThinkingConfig.return_value = sentinel_thinking
+    fake_client = MagicMock()
+    mock_genai.Client.return_value = fake_client
+    fake_client.models.generate_content.return_value = SimpleNamespace(
+        text="ok"
+    )
+    gen = GeminiGenerate(project_id="p")
+    gen.generate(prompt="p", thinking_level="low")
+    mock_genai.types.ThinkingConfig.assert_called_once_with(
+        thinking_level="low"
+    )
+    _, kwargs = mock_genai.types.GenerateContentConfig.call_args
+    assert kwargs["thinking_config"] is sentinel_thinking
+
+
+@patch("cxas_scrapi.utils.gemini.genai")
+def test_generate_with_parts_passes_thinking_level(mock_genai):
+    sentinel_thinking = MagicMock(name="ThinkingConfig")
+    mock_genai.types.ThinkingConfig.return_value = sentinel_thinking
+    mock_genai.types.Part.from_text = lambda text: text
+    fake_client = MagicMock()
+    mock_genai.Client.return_value = fake_client
+    fake_client.models.generate_content.return_value = SimpleNamespace(
+        text="ok"
+    )
+    gen = GeminiGenerate(project_id="p")
+    gen.generate_with_parts(parts=["q"], thinking_level="medium")
+    mock_genai.types.ThinkingConfig.assert_called_once_with(
+        thinking_level="medium"
+    )
+    _, kwargs = mock_genai.types.GenerateContentConfig.call_args
+    assert kwargs["thinking_config"] is sentinel_thinking
+
+
+@patch("cxas_scrapi.utils.gemini.asyncio.sleep", new=AsyncMock())
+@patch("cxas_scrapi.utils.gemini.genai")
+def test_generate_async_success_with_schema(mock_genai):
+    fake_client = MagicMock()
+    mock_genai.Client.return_value = fake_client
+    fake_client.aio.models.generate_content = AsyncMock(
+        return_value=SimpleNamespace(parsed={"k": "v"}, text=None)
+    )
+    gen = GeminiGenerate(project_id="p", max_concurrent_requests=1)
+    res = asyncio.run(
+        gen.generate_async(
+            prompt="x",
+            system_prompt="s",
+            response_mime_type="application/json",
+            response_schema=object,
+        )
+    )
+    assert res == {"k": "v"}
+
+
+@patch("cxas_scrapi.utils.gemini.asyncio.sleep", new=AsyncMock())
+@patch("cxas_scrapi.utils.gemini.genai")
+def test_generate_async_returns_text(mock_genai):
+    fake_client = MagicMock()
+    mock_genai.Client.return_value = fake_client
+    fake_client.aio.models.generate_content = AsyncMock(
+        return_value=SimpleNamespace(text="resp")
+    )
+    gen = GeminiGenerate(project_id="p", max_concurrent_requests=1)
+    res = asyncio.run(gen.generate_async(prompt="x", temperature=None))
+    assert res == "resp"
+
+
+@patch("cxas_scrapi.utils.gemini.asyncio.sleep", new=AsyncMock())
+@patch("cxas_scrapi.utils.gemini.genai")
+def test_generate_async_quota_then_success(mock_genai):
+    fake_client = MagicMock()
+    mock_genai.Client.return_value = fake_client
+    quota = RuntimeError("RESOURCE_EXHAUSTED 429")
+    fake_client.aio.models.generate_content = AsyncMock(
+        side_effect=[quota, SimpleNamespace(text="ok")]
+    )
+    gen = GeminiGenerate(project_id="p", max_concurrent_requests=1)
+    res = asyncio.run(
+        gen.generate_async(prompt="x", max_retries=3, base_delay_seconds=0)
+    )
+    assert res == "ok"
+
+
+@patch("cxas_scrapi.utils.gemini.asyncio.sleep", new=AsyncMock())
+@patch("cxas_scrapi.utils.gemini.genai")
+def test_generate_async_all_retries_fail(mock_genai):
+    fake_client = MagicMock()
+    mock_genai.Client.return_value = fake_client
+    fake_client.aio.models.generate_content = AsyncMock(
+        side_effect=RuntimeError("boom")
+    )
+    gen = GeminiGenerate(project_id="p", max_concurrent_requests=1)
+    res = asyncio.run(
+        gen.generate_async(prompt="x", max_retries=2, base_delay_seconds=0)
+    )
+    assert res is None
+
+
+@patch("cxas_scrapi.utils.gemini.genai")
+def test_generate_async_zero_retries_returns_none(mock_genai):
+    """`max_retries=0` skips the loop entirely — falls through to None."""
+    fake_client = MagicMock()
+    mock_genai.Client.return_value = fake_client
+    gen = GeminiGenerate(project_id="p", max_concurrent_requests=1)
+    res = asyncio.run(gen.generate_async(prompt="x", max_retries=0))
+    assert res is None

--- a/tests/cxas_scrapi/utils/tracing/test_app_config.py
+++ b/tests/cxas_scrapi/utils/tracing/test_app_config.py
@@ -1,0 +1,322 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+
+import pytest
+
+from cxas_scrapi.utils.tracing.app_config import ENV_VAR_PLACEHOLDER, AppConfig
+
+
+def _write(path, payload):
+    with open(path, "w") as f:
+        json.dump(payload, f)
+
+
+def _make_app_dir(tmp_path, app, env=None, env_name=None):
+    _write(tmp_path / "app.json", app)
+    if env is not None:
+        env_filename = (
+            f"environment.{env_name}.json" if env_name else "environment.json"
+        )
+        _write(tmp_path / env_filename, env)
+    return str(tmp_path)
+
+
+def test_load_missing_app_json_raises(tmp_path):
+    with pytest.raises(FileNotFoundError, match="app.json not found"):
+        AppConfig.load(app_dir=str(tmp_path))
+
+
+def test_load_with_concrete_values(tmp_path):
+    app_dir = _make_app_dir(
+        tmp_path,
+        app={
+            "displayName": "My App",
+            "rootAgent": "main_agent",
+            "modelSettings": {"model": "gemini-3.1-flash-live"},
+            "loggingSettings": {
+                "audioRecordingConfig": {"gcsBucket": "gs://my-bucket"},
+                "cloudLoggingSettings": {"enableCloudLogging": True},
+                "bigqueryExportSettings": {
+                    "project": "p",
+                    "dataset": "d",
+                    "enabled": True,
+                },
+                "redactionConfig": {"foo": "bar"},
+            },
+        },
+    )
+    cfg = AppConfig.load(app_dir=app_dir)
+    assert cfg.audio_bucket() == "gs://my-bucket"
+    assert cfg.cloud_logging_enabled() is True
+    assert cfg.bigquery_export() == {
+        "project": "p",
+        "dataset": "d",
+        "enabled": True,
+    }
+    assert cfg.model_version() == "gemini-3.1-flash-live"
+    assert cfg.display_name() == "My App"
+    assert cfg.root_agent() == "main_agent"
+    assert cfg.redaction_config() == {"foo": "bar"}
+
+
+def test_app_wrapper_key_supported(tmp_path):
+    """app.json may wrap content under an `app` key — both must work."""
+    app_dir = _make_app_dir(
+        tmp_path,
+        app={
+            "app": {
+                "displayName": "Wrapped",
+                "loggingSettings": {
+                    "audioRecordingConfig": {"gcsBucket": "gs://wrapped"},
+                    "cloudLoggingSettings": {"enableCloudLogging": False},
+                    "bigqueryExportSettings": {
+                        "project": "wp",
+                        "dataset": "wd",
+                    },
+                },
+                "modelSettings": {"model": "gemini-2.5-flash"},
+                "rootAgent": "root_a",
+            }
+        },
+    )
+    cfg = AppConfig.load(app_dir=app_dir)
+    assert cfg.audio_bucket() == "gs://wrapped"
+    assert cfg.cloud_logging_enabled() is False
+    assert cfg.bigquery_export()["project"] == "wp"
+    assert cfg.model_version() == "gemini-2.5-flash"
+    assert cfg.display_name() == "Wrapped"
+    assert cfg.root_agent() == "root_a"
+
+
+def test_env_var_substitution(tmp_path):
+    app_dir = _make_app_dir(
+        tmp_path,
+        app={
+            "loggingSettings": {
+                "audioRecordingConfig": {"gcsBucket": ENV_VAR_PLACEHOLDER},
+                "bigqueryExportSettings": {
+                    "project": ENV_VAR_PLACEHOLDER,
+                    "dataset": ENV_VAR_PLACEHOLDER,
+                    "enabled": True,
+                },
+                "cloudLoggingSettings": {"enableCloudLogging": True},
+            }
+        },
+        env={
+            "loggingSettings": {
+                "audioRecordingConfig": {"gcsBucket": "gs://resolved"},
+                "bigqueryExportSettings": {
+                    "project": "envproj",
+                    "dataset": "envds",
+                },
+            }
+        },
+    )
+    cfg = AppConfig.load(app_dir=app_dir)
+    assert cfg.audio_bucket() == "gs://resolved"
+    assert cfg.bigquery_export() == {
+        "project": "envproj",
+        "dataset": "envds",
+        "enabled": True,
+    }
+
+
+def test_env_var_unresolved_when_no_env_file(tmp_path, caplog):
+    app_dir = _make_app_dir(
+        tmp_path,
+        app={
+            "loggingSettings": {
+                "audioRecordingConfig": {"gcsBucket": ENV_VAR_PLACEHOLDER}
+            }
+        },
+    )
+    cfg = AppConfig.load(app_dir=app_dir)
+    assert cfg.audio_bucket() is None
+
+
+def test_env_var_unresolved_when_key_missing_in_env(tmp_path):
+    app_dir = _make_app_dir(
+        tmp_path,
+        app={
+            "loggingSettings": {
+                "audioRecordingConfig": {"gcsBucket": ENV_VAR_PLACEHOLDER}
+            }
+        },
+        env={"unrelated": {"key": "value"}},
+    )
+    cfg = AppConfig.load(app_dir=app_dir)
+    assert cfg.audio_bucket() is None
+
+
+def test_env_var_when_env_value_is_also_placeholder(tmp_path):
+    app_dir = _make_app_dir(
+        tmp_path,
+        app={
+            "loggingSettings": {
+                "audioRecordingConfig": {"gcsBucket": ENV_VAR_PLACEHOLDER}
+            }
+        },
+        env={
+            "loggingSettings": {
+                "audioRecordingConfig": {"gcsBucket": ENV_VAR_PLACEHOLDER}
+            }
+        },
+    )
+    cfg = AppConfig.load(app_dir=app_dir)
+    assert cfg.audio_bucket() is None
+
+
+def test_explicit_env_file_path(tmp_path):
+    app_dir = _make_app_dir(
+        tmp_path,
+        app={
+            "loggingSettings": {
+                "audioRecordingConfig": {"gcsBucket": ENV_VAR_PLACEHOLDER}
+            }
+        },
+    )
+    custom_env = tmp_path / "envs" / "dev.json"
+    os.makedirs(custom_env.parent)
+    _write(
+        custom_env,
+        {
+            "loggingSettings": {
+                "audioRecordingConfig": {"gcsBucket": "gs://from-explicit"}
+            }
+        },
+    )
+    cfg = AppConfig.load(app_dir=app_dir, env_file=str(custom_env))
+    assert cfg.audio_bucket() == "gs://from-explicit"
+
+
+def test_named_environment(tmp_path):
+    app_dir = _make_app_dir(
+        tmp_path,
+        app={
+            "loggingSettings": {
+                "audioRecordingConfig": {"gcsBucket": ENV_VAR_PLACEHOLDER}
+            }
+        },
+        env={
+            "loggingSettings": {
+                "audioRecordingConfig": {"gcsBucket": "gs://staging-bucket"}
+            }
+        },
+        env_name="staging",
+    )
+    cfg = AppConfig.load(app_dir=app_dir, environment="staging")
+    assert cfg.audio_bucket() == "gs://staging-bucket"
+
+
+def test_named_environment_file_missing_warns(tmp_path):
+    app_dir = _make_app_dir(
+        tmp_path,
+        app={
+            "loggingSettings": {
+                "audioRecordingConfig": {"gcsBucket": ENV_VAR_PLACEHOLDER}
+            }
+        },
+    )
+    cfg = AppConfig.load(app_dir=app_dir, environment="prod")
+    assert cfg.audio_bucket() is None
+
+
+def test_missing_optional_fields_return_defaults(tmp_path):
+    app_dir = _make_app_dir(tmp_path, app={"displayName": "minimal"})
+    cfg = AppConfig.load(app_dir=app_dir)
+    assert cfg.audio_bucket() is None
+    assert cfg.cloud_logging_enabled() is False
+    assert cfg.bigquery_export() is None
+    assert cfg.model_version() is None
+    assert cfg.display_name() == "minimal"
+    assert cfg.root_agent() is None
+    assert cfg.redaction_config() == {}
+
+
+def test_redaction_config_non_dict(tmp_path):
+    app_dir = _make_app_dir(
+        tmp_path,
+        app={"loggingSettings": {"redactionConfig": "not-a-dict"}},
+    )
+    cfg = AppConfig.load(app_dir=app_dir)
+    assert cfg.redaction_config() == {}
+
+
+def test_env_lookup_handles_app_key_wrapping_mismatch(tmp_path):
+    """app.json may store keys at root while environment.json wraps them
+    under `app.*` (or vice versa). Lookup must try both shapes."""
+    app_dir = _make_app_dir(
+        tmp_path,
+        # app.json: root-level loggingSettings
+        app={
+            "loggingSettings": {
+                "audioRecordingConfig": {"gcsBucket": ENV_VAR_PLACEHOLDER}
+            }
+        },
+        # environment.json: wrapped under "app"
+        env={
+            "app": {
+                "loggingSettings": {
+                    "audioRecordingConfig": {"gcsBucket": "gs://wrapped"}
+                }
+            }
+        },
+    )
+    cfg = AppConfig.load(app_dir=app_dir)
+    assert cfg.audio_bucket() == "gs://wrapped"
+
+
+def test_env_lookup_app_to_root(tmp_path):
+    """Reverse direction: app.json wrapped in `app`, env.json at root."""
+    app_dir = _make_app_dir(
+        tmp_path,
+        app={
+            "app": {
+                "loggingSettings": {
+                    "audioRecordingConfig": {"gcsBucket": ENV_VAR_PLACEHOLDER}
+                }
+            }
+        },
+        env={
+            "loggingSettings": {
+                "audioRecordingConfig": {"gcsBucket": "gs://root"}
+            }
+        },
+    )
+    cfg = AppConfig.load(app_dir=app_dir)
+    assert cfg.audio_bucket() == "gs://root"
+
+
+def test_display_name_missing_returns_none(tmp_path):
+    app_dir = _make_app_dir(tmp_path, app={"rootAgent": "ra"})
+    cfg = AppConfig.load(app_dir=app_dir)
+    assert cfg.display_name() is None
+
+
+def test_no_environment_file_no_default_present(tmp_path):
+    app_dir = _make_app_dir(
+        tmp_path,
+        app={
+            "loggingSettings": {
+                "audioRecordingConfig": {"gcsBucket": "gs://concrete"}
+            }
+        },
+    )
+    cfg = AppConfig.load(app_dir=app_dir)
+    # No env file resolved at all.
+    assert cfg.env_path is None
+    assert cfg.audio_bucket() == "gs://concrete"

--- a/tests/cxas_scrapi/utils/tracing/test_audio_analysis.py
+++ b/tests/cxas_scrapi/utils/tracing/test_audio_analysis.py
@@ -1,0 +1,87 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cxas_scrapi.utils.tracing import audio_analysis as aa
+
+SAMPLE_FILES = [
+    "gs://b/p/conv-1/METADATA.json",
+    "gs://b/p/conv-1/full-session.wav",
+    "gs://b/p/conv-1/agent-turn-1.wav",
+    "gs://b/p/conv-1/agent-turn-2.wav",
+    "gs://b/p/conv-1/user-turn-1.wav",
+]
+
+
+def test_registry_contains_five_named_analyses():
+    expected = {
+        "agent_voice_consistency",
+        "no_long_pauses",
+        "agent_having_trouble",
+        "agent_looping",
+        "agent_cutoff",
+    }
+    assert set(aa.ANALYSIS_REGISTRY.keys()) == expected
+
+
+def test_analysis_type_enum_values_match_registry():
+    assert {t.value for t in aa.AnalysisType} == set(
+        aa.ANALYSIS_REGISTRY.keys()
+    )
+
+
+def test_voice_consistency_filters_to_agent_turns_only():
+    a = aa.ANALYSIS_REGISTRY["agent_voice_consistency"]
+    out = a.filter_files(SAMPLE_FILES)
+    assert all("agent-turn" in f for f in out)
+    assert len(out) == 2
+
+
+def test_no_long_pauses_filters_to_full_session_only():
+    a = aa.ANALYSIS_REGISTRY["no_long_pauses"]
+    out = a.filter_files(SAMPLE_FILES)
+    assert out == [f for f in SAMPLE_FILES if "full-session" in f]
+
+
+def test_agent_having_trouble_filters_to_agent_turns():
+    a = aa.ANALYSIS_REGISTRY["agent_having_trouble"]
+    assert all("agent-turn" in f for f in a.filter_files(SAMPLE_FILES))
+
+
+def test_agent_looping_filters_to_agent_turns():
+    a = aa.ANALYSIS_REGISTRY["agent_looping"]
+    assert all("agent-turn" in f for f in a.filter_files(SAMPLE_FILES))
+
+
+def test_agent_cutoff_filters_to_agent_turns():
+    a = aa.ANALYSIS_REGISTRY["agent_cutoff"]
+    assert all("agent-turn" in f for f in a.filter_files(SAMPLE_FILES))
+
+
+def test_each_analysis_has_pass_fail_in_prompt():
+    """Every prompt must direct Gemini to report PASS or FAIL."""
+    for name, analysis in aa.ANALYSIS_REGISTRY.items():
+        text = analysis.prompt.upper()
+        assert "PASS" in text, f"{name} missing PASS instruction"
+        assert "FAIL" in text, f"{name} missing FAIL instruction"
+
+
+def test_filter_files_handles_empty_list():
+    for analysis in aa.ANALYSIS_REGISTRY.values():
+        assert analysis.filter_files([]) == []
+
+
+def test_name_property_returns_enum_member():
+    for key, analysis in aa.ANALYSIS_REGISTRY.items():
+        assert isinstance(analysis.name, aa.AnalysisType)
+        assert str(analysis.name) == key

--- a/tests/cxas_scrapi/utils/tracing/test_cloud_logging.py
+++ b/tests/cxas_scrapi/utils/tracing/test_cloud_logging.py
@@ -1,0 +1,296 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cxas_scrapi.utils.tracing import cloud_logging as cl_mod
+
+
+def _entry(ts, severity="WARNING", payload="hi", labels=None):
+    return SimpleNamespace(
+        payload=payload,
+        timestamp=ts,
+        severity=severity,
+        log_name="projects/p/logs/req",
+        resource=SimpleNamespace(type="api"),
+        labels=labels or {},
+        trace="t",
+    )
+
+
+@patch.object(cl_mod, "logging_v2")
+def test_init_requires_dependency(mock_lv2):
+    with patch.object(cl_mod, "logging_v2", None):
+        with pytest.raises(ImportError, match="google-cloud-logging"):
+            cl_mod.CloudLogsClient(project_id="p", filter_template="severity")
+
+
+@patch.object(cl_mod, "logging_v2")
+def test_fetch_with_explicit_times(mock_lv2):
+    mock_client = MagicMock()
+    mock_lv2.Client.return_value = mock_client
+    e = _entry(datetime.datetime(2026, 5, 10, 12, 0, 0))
+    mock_client.list_entries.return_value = [e]
+
+    client = cl_mod.CloudLogsClient(
+        project_id="p",
+        filter_template=(
+            'severity >= "{level}" AND timestamp >= "{start_time}" '
+            'AND timestamp <= "{end_time}" AND id="{conversation_id}"'
+        ),
+        time_padding_seconds=10,
+    )
+    rows = client.fetch(
+        conversation_id="conv-1",
+        start_time=datetime.datetime(2026, 5, 10, 11, 59, 0),
+        end_time=datetime.datetime(2026, 5, 10, 12, 1, 0),
+        level="warning",
+    )
+    args, kwargs = mock_client.list_entries.call_args
+    assert kwargs["order_by"] == "timestamp asc"
+    assert "WARNING" in kwargs["filter_"]
+    assert "conv-1" in kwargs["filter_"]
+    assert len(rows) == 1
+    assert rows[0]["severity"] == "WARNING"
+    assert rows[0]["resource_type"] == "api"
+    assert rows[0]["message"] == "hi"
+
+
+@patch.object(cl_mod, "logging_v2")
+def test_fetch_defaults_when_no_times_given(mock_lv2):
+    mock_client = MagicMock()
+    mock_lv2.Client.return_value = mock_client
+    mock_client.list_entries.return_value = []
+
+    client = cl_mod.CloudLogsClient(
+        project_id="p",
+        filter_template=(
+            'severity >= "{level}" AND timestamp >= "{start_time}" '
+            'AND timestamp <= "{end_time}" AND id="{conversation_id}"'
+        ),
+    )
+    rows = client.fetch(conversation_id="x", start_time=None, end_time=None)
+    assert rows == []
+
+
+@patch.object(cl_mod, "logging_v2")
+def test_fetch_swallows_exception(mock_lv2):
+    mock_client = MagicMock()
+    mock_lv2.Client.return_value = mock_client
+    mock_client.list_entries.side_effect = RuntimeError("boom")
+    client = cl_mod.CloudLogsClient(
+        project_id="p",
+        filter_template=(
+            'severity >= "{level}" AND timestamp >= "{start_time}" '
+            'AND timestamp <= "{end_time}" AND id="{conversation_id}"'
+        ),
+    )
+    assert (
+        client.fetch(
+            conversation_id="x",
+            start_time=datetime.datetime(2026, 5, 1),
+            end_time=datetime.datetime(2026, 5, 2),
+        )
+        == []
+    )
+
+
+@patch.object(cl_mod, "logging_v2")
+def test_entry_to_row_with_dict_payload(mock_lv2):
+    mock_client = MagicMock()
+    mock_lv2.Client.return_value = mock_client
+    e = SimpleNamespace(
+        payload={"message": "hello", "extra": "data"},
+        timestamp=datetime.datetime(2026, 5, 1),
+        severity="ERROR",
+        log_name="ln",
+        resource=SimpleNamespace(type="cloud_function"),
+        labels={"k": "v"},
+        trace="trace-id",
+    )
+    mock_client.list_entries.return_value = [e]
+    client = cl_mod.CloudLogsClient(
+        project_id="p",
+        filter_template=(
+            'severity >= "{level}" AND timestamp >= "{start_time}" '
+            'AND timestamp <= "{end_time}" AND id="{conversation_id}"'
+        ),
+    )
+    rows = client.fetch(
+        conversation_id="c",
+        start_time=datetime.datetime(2026, 5, 1),
+        end_time=datetime.datetime(2026, 5, 2),
+    )
+    assert rows[0]["message"] == "hello"
+    assert rows[0]["labels"] == {"k": "v"}
+
+
+@patch.object(cl_mod, "logging_v2")
+def test_entry_to_row_no_resource_no_timestamp(mock_lv2):
+    mock_client = MagicMock()
+    mock_lv2.Client.return_value = mock_client
+    e = SimpleNamespace(
+        payload=None,
+        timestamp=None,
+        severity=None,
+        log_name=None,
+        resource=None,
+        labels=None,
+        trace=None,
+    )
+    mock_client.list_entries.return_value = [e]
+    client = cl_mod.CloudLogsClient(
+        project_id="p",
+        filter_template=(
+            'severity >= "{level}" AND timestamp >= "{start_time}" '
+            'AND timestamp <= "{end_time}" AND id="{conversation_id}"'
+        ),
+    )
+    rows = client.fetch(
+        conversation_id="c",
+        start_time=datetime.datetime(2026, 5, 1),
+        end_time=datetime.datetime(2026, 5, 2),
+    )
+    assert rows[0]["message"] == ""
+    assert rows[0]["labels"] == {}
+    assert rows[0]["resource_type"] is None
+
+
+@patch.object(cl_mod, "logging_v2")
+def test_batch_fetch_groups_by_conversation_id(mock_lv2):
+    mock_client = MagicMock()
+    mock_lv2.Client.return_value = mock_client
+    e1 = SimpleNamespace(
+        payload="hi",
+        timestamp=datetime.datetime(2026, 5, 1, 12, 0, 1),
+        severity="WARNING",
+        log_name="ln",
+        resource=None,
+        labels={"conversation_id": "c-1"},
+        trace=None,
+    )
+    e2 = SimpleNamespace(
+        payload="bye",
+        timestamp=datetime.datetime(2026, 5, 1, 12, 0, 2),
+        severity="ERROR",
+        log_name="ln",
+        resource=None,
+        labels={"conversation_id": "c-2"},
+        trace=None,
+    )
+    mock_client.list_entries.return_value = [e1, e2]
+
+    client = cl_mod.CloudLogsClient(
+        project_id="p",
+        filter_template=(
+            'severity >= "{level}" AND timestamp >= "{start_time}" '
+            'AND timestamp <= "{end_time}" '
+            'AND labels.conversation_id="{conversation_id}"'
+        ),
+    )
+    out = client.batch_fetch(
+        conversation_ids=["c-1", "c-2", "c-3"],
+        start_time=datetime.datetime(2026, 5, 1),
+        end_time=datetime.datetime(2026, 5, 2),
+    )
+    assert set(out.keys()) == {"c-1", "c-2", "c-3"}
+    assert len(out["c-1"]) == 1 and out["c-1"][0]["message"] == "hi"
+    assert len(out["c-2"]) == 1
+    assert out["c-3"] == []
+    # Verify the OR-combined filter went through
+    _, kwargs = mock_client.list_entries.call_args
+    assert " OR " in kwargs["filter_"]
+
+
+@patch.object(cl_mod, "logging_v2")
+def test_batch_fetch_empty_input(mock_lv2):
+    mock_client = MagicMock()
+    mock_lv2.Client.return_value = mock_client
+    client = cl_mod.CloudLogsClient(
+        project_id="p",
+        filter_template=(
+            'severity >= "{level}" AND timestamp >= "{start_time}" '
+            'AND timestamp <= "{end_time}" '
+            'AND labels.conversation_id="{conversation_id}"'
+        ),
+    )
+    assert (
+        client.batch_fetch(
+            conversation_ids=[],
+            start_time=datetime.datetime(2026, 5, 1),
+            end_time=datetime.datetime(2026, 5, 2),
+        )
+        == {}
+    )
+    mock_client.list_entries.assert_not_called()
+
+
+@patch.object(cl_mod, "logging_v2")
+def test_batch_fetch_handles_exception(mock_lv2):
+    mock_client = MagicMock()
+    mock_lv2.Client.return_value = mock_client
+    mock_client.list_entries.side_effect = RuntimeError("boom")
+    client = cl_mod.CloudLogsClient(
+        project_id="p",
+        filter_template=(
+            'severity >= "{level}" AND timestamp >= "{start_time}" '
+            'AND timestamp <= "{end_time}" '
+            'AND labels.conversation_id="{conversation_id}"'
+        ),
+    )
+    out = client.batch_fetch(
+        conversation_ids=["a", "b"],
+        start_time=datetime.datetime(2026, 5, 1),
+        end_time=datetime.datetime(2026, 5, 2),
+    )
+    assert out == {"a": [], "b": []}
+
+
+def test_row_conversation_id_from_labels():
+    assert (
+        cl_mod._row_conversation_id({"labels": {"conversation_id": "c-7"}})
+        == "c-7"
+    )
+
+
+def test_row_conversation_id_from_message_text():
+    msg = 'jsonPayload.conversation_id="abcd-1234-5678"'
+    assert cl_mod._row_conversation_id({"message": msg}) == "abcd-1234-5678"
+
+
+def test_row_conversation_id_returns_none_when_missing():
+    assert cl_mod._row_conversation_id({}) is None
+    assert cl_mod._row_conversation_id({"message": "no id here"}) is None
+    assert cl_mod._row_conversation_id({"labels": "not-a-dict"}) is None
+
+
+def test_stringify_paths():
+    assert cl_mod._stringify(None) == ""
+    assert cl_mod._stringify("hi") == "hi"
+    assert cl_mod._stringify({"a": 1}) == '{"a": 1}'
+
+    class NotJsonable:
+        def __repr__(self):
+            return "NotJsonable()"
+
+        def __str__(self):
+            return "stringified"
+
+    # Force json.dumps to fail by passing an object via patch.
+    with patch.object(cl_mod.json, "dumps", side_effect=ValueError):
+        assert cl_mod._stringify({"a": 1}) == "{'a': 1}"

--- a/tests/cxas_scrapi/utils/tracing/test_trace_config.py
+++ b/tests/cxas_scrapi/utils/tracing/test_trace_config.py
@@ -1,0 +1,108 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import yaml
+
+from cxas_scrapi.utils.tracing import trace_config as tc_mod
+from cxas_scrapi.utils.tracing.trace_config import TraceConfig
+
+
+def _write(path, payload):
+    with open(path, "w") as f:
+        yaml.safe_dump(payload, f)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_paths(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        tc_mod, "USER_CONFIG_PATH", str(tmp_path / "no_user.yaml")
+    )
+    yield
+
+
+def test_load_defaults_when_no_config_file_found():
+    cfg = TraceConfig.load()
+    assert cfg.audio.uri_pattern == "{bucket}/{conversation_id}.wav"
+    assert cfg.cloud_logging.default_level == "WARNING"
+    # Audio metrics now live in the registry; the YAML override map is empty
+    # by default.
+    assert cfg.gemini.audio_metrics == {}
+    assert "hallucination" in cfg.gemini.triage_metrics
+    assert (
+        cfg.bug_report.path_template
+        == "{model_version}/{date}/{user}/{severity}/{conversation_id}/"
+    )
+
+
+def test_load_explicit_path_missing_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        TraceConfig.load(explicit_path=str(tmp_path / "nope.yaml"))
+
+
+def test_explicit_path_overrides(tmp_path):
+    p = tmp_path / "trace.yaml"
+    _write(
+        p,
+        {
+            "audio": {"download_dir": "./customdir"},
+            "cloud_logging": {"default_level": "ERROR"},
+        },
+    )
+    cfg = TraceConfig.load(explicit_path=str(p))
+    assert cfg.audio.download_dir == "./customdir"
+    assert cfg.cloud_logging.default_level == "ERROR"
+    # Defaults still populate the rest.
+    assert cfg.gemini.model == "gemini-3-flash-preview"
+    assert cfg.gemini.thinking_level == "low"
+
+
+def test_project_config_takes_precedence_over_user(tmp_path, monkeypatch):
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    (project_dir / ".cxas").mkdir()
+    _write(
+        project_dir / ".cxas" / "trace.yaml",
+        {"audio": {"download_dir": "./project"}},
+    )
+    user_path = tmp_path / "user.yaml"
+    _write(user_path, {"audio": {"download_dir": "./user"}})
+    monkeypatch.chdir(project_dir)
+    monkeypatch.setattr(tc_mod, "USER_CONFIG_PATH", str(user_path))
+
+    cfg = TraceConfig.load()
+    assert cfg.audio.download_dir == "./project"
+
+
+def test_user_config_used_when_no_project(monkeypatch, tmp_path):
+    user_path = tmp_path / "user.yaml"
+    _write(user_path, {"audio": {"download_dir": "./user-only"}})
+    monkeypatch.setattr(tc_mod, "USER_CONFIG_PATH", str(user_path))
+    cfg = TraceConfig.load()
+    assert cfg.audio.download_dir == "./user-only"
+
+
+def test_invalid_yaml_payload_raises(tmp_path):
+    p = tmp_path / "trace.yaml"
+    _write(p, {"audio": {"uri_pattern": 123}})  # int where str expected
+    with pytest.raises(ValueError, match="Invalid trace config"):
+        TraceConfig.load(explicit_path=str(p))
+
+
+def test_empty_yaml_uses_defaults(tmp_path):
+    p = tmp_path / "trace.yaml"
+    p.write_text("")
+    cfg = TraceConfig.load(explicit_path=str(p))
+    assert cfg.audio.download_dir == "./.cxas/audio"

--- a/tests/cxas_scrapi/utils/tracing/test_trace_report.py
+++ b/tests/cxas_scrapi/utils/tracing/test_trace_report.py
@@ -1,0 +1,409 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+import json
+from types import SimpleNamespace
+
+from cxas_scrapi.utils.tracing import trace_report as tr
+
+SAMPLE_DICT = {
+    "name": "projects/p/locations/global/apps/a/conversations/c1",
+    "display_name": "test conv",
+    "source": "LIVE",
+    "input_types": ["INPUT_TYPE_TEXT", "INPUT_TYPE_AUDIO"],
+    "start_time": "2026-05-01T00:00:00",
+    "end_time": "2026-05-01T00:05:00",
+    "turns": [
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "chunks": [{"text": "hello"}],
+                },
+                {
+                    "role": "agent_a",
+                    "chunks": [
+                        {"text": "hi there"},
+                        {
+                            "tool_call": {
+                                "display_name": "lookup",
+                                "args": {"q": 1},
+                            }
+                        },
+                        {
+                            "tool_response": {
+                                "display_name": "lookup",
+                                "response": {"r": 2},
+                            }
+                        },
+                        {
+                            "agent_transfer": {"target_agent": "agent_b"},
+                        },
+                        {"payload": {"key": "v"}},
+                    ],
+                },
+            ]
+        },
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "chunks": [{"transcript": "audio said this"}],
+                },
+                {
+                    "role": "agent_b",
+                    "chunks": [{"transcript": "audio agent reply"}],
+                },
+            ]
+        },
+    ],
+}
+
+
+def test_normalize_from_dict():
+    n = tr.normalize(SAMPLE_DICT)
+    assert n["conversation_id"] == "c1"
+    assert n["channel"] == "MULTIMODAL"
+    assert n["num_turns"] == 2
+    kinds = [e["kind"] for e in n["entries"]]
+    assert kinds == [
+        "user",
+        "agent",
+        "tool_call",
+        "tool_response",
+        "agent_transfer",
+        "custom_payload",
+        "user",
+        "agent",
+    ]
+
+
+def test_normalize_from_proto_like_object():
+    class Proto:
+        @staticmethod
+        def to_dict(_):
+            return SAMPLE_DICT
+
+    n = tr.normalize(Proto())
+    assert n["conversation_id"] == "c1"
+
+
+def test_channel_label_paths():
+    assert tr._channel_label([]) == "UNKNOWN"
+    assert tr._channel_label(["INPUT_TYPE_TEXT"]) == "TEXT"
+    assert tr._channel_label(["INPUT_TYPE_AUDIO"]) == "AUDIO"
+    assert (
+        tr._channel_label(["INPUT_TYPE_TEXT", "INPUT_TYPE_AUDIO"])
+        == "MULTIMODAL"
+    )
+    assert tr._channel_label(["INPUT_TYPE_IMAGE"]) == "OTHER"
+
+
+def test_input_type_name_object():
+    obj = SimpleNamespace(name="INPUT_TYPE_TEXT")
+    assert tr._input_type_name(obj) == "INPUT_TYPE_TEXT"
+    assert tr._input_type_name("input_type_audio") == "INPUT_TYPE_AUDIO"
+
+
+def test_to_iso_paths():
+    assert tr._to_iso(None) is None
+    assert tr._to_iso("already") == "already"
+    assert tr._to_iso(datetime.datetime(2026, 5, 1)).startswith("2026-05-01")
+    assert tr._to_iso(123) == "123"
+
+
+def test_to_json_excludes_raw_by_default():
+    n = tr.normalize(SAMPLE_DICT)
+    out = json.loads(tr.to_json(n))
+    assert "raw" not in out
+    assert out["conversation_id"] == "c1"
+
+
+def test_to_json_with_raw_and_extras():
+    n = tr.normalize(SAMPLE_DICT)
+    out = json.loads(tr.to_json(n, include_raw=True, extras={"foo": "bar"}))
+    assert "raw" in out
+    assert out["extras"] == {"foo": "bar"}
+
+
+def test_to_text_includes_all_kinds():
+    n = tr.normalize(SAMPLE_DICT)
+    text = tr.to_text(n, extras={"x": 1})
+    assert "USER:" in text
+    assert "AGENT" in text
+    assert "tool_call" in text
+    assert "tool_response" in text
+    assert "transfer" in text
+    assert "custom_payload" in text
+    assert "Extras" in text
+
+
+def test_to_text_truncates_long_response():
+    big = {"big": "x" * 500}
+    n = tr.normalize(
+        {
+            "name": "n",
+            "turns": [
+                {
+                    "messages": [
+                        {
+                            "role": "agent",
+                            "chunks": [
+                                {
+                                    "tool_response": {
+                                        "display_name": "t",
+                                        "response": big,
+                                    }
+                                }
+                            ],
+                        }
+                    ]
+                }
+            ],
+        }
+    )
+    text = tr.to_text(n)
+    assert "..." in text
+
+
+def test_to_text_unknown_kind_branch():
+    # Hit the fall-through `_entry_to_text` branch.
+    assert tr._entry_to_text({"kind": "weird", "turn": 7}) == "[7]   weird"
+
+
+def test_to_markdown_with_console_url_and_extras():
+    n = tr.normalize(SAMPLE_DICT)
+    md = tr.to_markdown(n, console_url="https://x/y", extras={"S": "body"})
+    assert "Open in CES Console" in md
+    assert "## S" in md
+
+
+def test_to_markdown_with_dict_extras():
+    n = tr.normalize(SAMPLE_DICT)
+    md = tr.to_markdown(n, extras={"Stats": {"count": 5}})
+    assert "```json" in md
+    assert '"count": 5' in md
+
+
+def test_to_markdown_unknown_kind_branch():
+    assert tr._entry_to_markdown({"kind": "weird", "turn": 3}) == "- [3] weird"
+
+
+def test_to_html_with_audio_and_extras_string_and_dict():
+    n = tr.normalize(SAMPLE_DICT)
+    html = tr.to_html(
+        n,
+        console_url="https://x/y",
+        audio_path="audio.wav",
+        extras={"AString": "raw text", "ADict": {"k": "v"}},
+    )
+    assert "<audio" in html
+    assert "<title>" in html
+    assert "AString" in html
+    assert "ADict" in html
+    assert "raw text" in html
+
+
+def test_to_html_unknown_kind_branch():
+    assert "weird" in tr._entry_to_html({"kind": "weird", "turn": 1})
+
+
+def test_chunk_to_entry_returns_none_for_unknown_chunk():
+    assert tr._chunk_to_entry({}, "user", 0) is None
+
+
+def test_chunk_to_entry_user_via_text_role_lower():
+    e = tr._chunk_to_entry({"text": "hi"}, "USER", 0)
+    assert e["kind"] == "user"
+
+
+def test_chunk_to_entry_transcript_user_role():
+    e = tr._chunk_to_entry({"transcript": "spoken"}, "user", 0)
+    assert e["kind"] == "user"
+    assert e["text"] == "spoken"
+
+
+def test_chunk_to_entry_agent_transfer_dict_value():
+    e = tr._chunk_to_entry(
+        {"agent_transfer": {"display_name": "agent_x"}}, "agent", 0
+    )
+    assert e["target"] == "agent_x"
+
+
+def test_chunk_to_entry_variable_chunks():
+    a = tr._chunk_to_entry({"default_variables": {"foo": "bar"}}, "user", 0)
+    assert a["kind"] == "variable_default"
+    assert a["variables"] == {"foo": "bar"}
+    b = tr._chunk_to_entry({"updated_variables": {"x": 1}}, "agent_x", 1)
+    assert b["kind"] == "variable_update"
+    assert b["variables"] == {"x": 1}
+
+
+SPAN_TURN = {
+    "messages": [
+        {"role": "user", "chunks": [{"text": "hi"}]},
+        {
+            "role": "agent",
+            "chunks": [
+                {"updated_variables": {"step": "greet"}},
+                {"text": "hello"},
+            ],
+        },
+    ],
+    "root_span": {
+        "name": "root",
+        "start_time": "2026-05-01T00:00:00.000Z",
+        "end_time": "2026-05-01T00:00:01.500Z",
+        "duration": "1.500s",
+        "attributes": {"perceived latency (ms)": 1450.0},
+        "child_spans": [
+            {
+                "name": "Callback",
+                "start_time": "2026-05-01T00:00:00.100Z",
+                "end_time": "2026-05-01T00:00:00.200Z",
+                "duration": "0.1s",
+                "attributes": {"agent": "a", "stage": "BeforeAgent"},
+                "child_spans": [],
+            },
+            {
+                "name": "LLM",
+                "start_time": "2026-05-01T00:00:00.200Z",
+                "end_time": "2026-05-01T00:00:01.300Z",
+                "duration": "1.1s",
+                "attributes": {
+                    "agent": "a",
+                    "model": "gemini",
+                    "input token count": 100,
+                    "output token count": 25,
+                    "thought token count": 0,
+                    "time to first chunk (ms)": 500,
+                },
+                "child_spans": [],
+            },
+            {
+                "name": "Tool",
+                "start_time": "2026-05-01T00:00:01.300Z",
+                "end_time": "2026-05-01T00:00:01.400Z",
+                "duration": "0.1s",
+                "attributes": {
+                    "name": "lookup",
+                    "args": {"q": "test"},
+                    "response": {"r": 1},
+                },
+                "child_spans": [],
+            },
+        ],
+    },
+}
+
+
+def test_normalize_with_spans_and_metrics():
+    n = tr.normalize({"name": "p/c1", "turns": [SPAN_TURN]})
+    assert n["num_turns"] == 1
+    assert n["totals"]["tokens"]["input"] == 100
+    assert n["totals"]["tokens"]["output"] == 25
+    assert n["totals"]["tokens"]["total"] == 125
+    tm = n["turn_metrics"][0]
+    assert tm["perceived_latency_ms"] == 1450.0
+    assert tm["duration_ms"] == 1500.0
+    span_names = [s["name"] for s in tm["spans"]]
+    assert span_names == ["Callback", "LLM", "Tool"]
+    llm = tm["spans"][1]
+    assert llm["tokens"]["ttfc_ms"] == 500
+    tool = tm["spans"][2]
+    assert tool["tool"] == "lookup"
+    assert tool["tool_args"] == {"q": "test"}
+    assert tool["tool_response"] == {"r": 1}
+
+
+def test_to_text_includes_span_lines_and_variable_kinds():
+    n = tr.normalize({"name": "p/c1", "turns": [SPAN_TURN]})
+    out = tr.to_text(n)
+    assert "-- Turn 0 --" in out
+    assert "Callback[BeforeAgent]" in out
+    assert "LLM gemini" in out
+    assert "Tool lookup" in out
+    assert "var_update" in out
+    assert "tokens(in/out/think/total)=100/25/0/125" in out
+
+
+def test_to_markdown_with_spans_and_totals():
+    n = tr.normalize({"name": "p/c1", "turns": [SPAN_TURN]})
+    md = tr.to_markdown(n)
+    assert "Total span time" in md
+    assert "Tokens (in / out / think / total)" in md
+    assert "### Turn 0" in md
+    assert "Execution spans" in md
+    # Variable update entry rendered
+    assert "Variable update" in md
+
+
+def test_to_html_with_spans_and_totals():
+    n = tr.normalize({"name": "p/c1", "turns": [SPAN_TURN]})
+    html = tr.to_html(n)
+    assert "total span time" in html
+    assert "Execution spans" in html
+    assert "Variable update" in html
+
+
+def test_fmt_ms_paths():
+    assert tr._fmt_ms(None) == "?"
+    assert tr._fmt_ms(123.456) == "123.5ms"
+
+
+def test_to_int_paths():
+    assert tr._to_int(None) is None
+    assert tr._to_int(3) == 3
+    assert tr._to_int("4") == 4
+    assert tr._to_int("not-int") is None
+
+
+def test_to_int_or_float_paths():
+    assert tr._to_int_or_float(None) is None
+    assert tr._to_int_or_float(3) == 3
+    assert tr._to_int_or_float(3.5) == 3.5
+    assert tr._to_int_or_float("4") == 4
+    assert tr._to_int_or_float("4.5") == 4.5
+    assert tr._to_int_or_float("nope") is None
+
+
+def test_duration_ms_paths():
+    assert tr._duration_ms(None, None) is None
+    assert tr._duration_ms(None, None, "1.25s") == 1250.0
+    assert tr._duration_ms(None, None, "bad-s") is None
+    assert (
+        tr._duration_ms("2026-05-01T00:00:00", "2026-05-01T00:00:00.500")
+        == 500.0
+    )
+
+
+def test_to_dt_paths():
+    assert tr._to_dt(None) is None
+    assert tr._to_dt("invalid") is None
+    dt = datetime.datetime(2026, 5, 1)
+    assert tr._to_dt(dt) is dt
+    assert tr._to_dt(123) is None
+
+
+def test_attr_handles_non_dict_attributes():
+    assert tr._attr({"attributes": "not-a-dict"}, "k") is None
+    assert tr._attr({"attributes": {"k": 4}}, "k") == 4
+
+
+def test_span_renderers_unknown_name():
+    s = {"name": "Other", "depth": 0, "duration_ms": 10.0}
+    assert "Other" in tr._span_to_text(s)
+    md = tr._span_to_markdown(s)
+    assert "Other" in md


### PR DESCRIPTION
## Summary

Adds a new top-level `cxas trace` command that gives developers an end-to-end
observability and debugging surface for past CES conversations — list, fetch a
trace report (JSON / Markdown / text / HTML) with per-turn latency, tokens, and
callback / LLM / tool spans; merge Cloud Logging entries; download the GCS audio
recording and run Gemini audio analysis or text-only triage; replay original user
inputs against the current agent; aggregate stats over a time window with ASCII
bar charts; bundle the whole thing into a zip; and flag a conversation as a
platform bug uploaded to a configured GCS bucket.

Behavior is driven by `./.cxas/trace.yaml` (Pydantic-validated, fallback to
`~/.cxas/trace.yaml`); the audio bucket and Cloud Logging enablement are
auto-discovered from the pulled app's `loggingSettings` (with `$env_var`
substitution against `environment.json`). The audio resolver also supports
prefix-search of platform-managed bucket layouts.

Closes #120

## What's added

| Path | Notes |
|---|---|
| `src/cxas_scrapi/core/traces.py` | `Traces` orchestration class — public API |
| `src/cxas_scrapi/cli/trace_cli.py` | argparse subcommand handlers (10 subcommands) |
| `src/cxas_scrapi/utils/app_config.py` | reads `app.json` + `environment.json`; resolves `$env_var` placeholders |
| `src/cxas_scrapi/utils/trace_config.py` | Pydantic loader for `./.cxas/trace.yaml` |
| `src/cxas_scrapi/utils/cloud_logging.py` | per-conversation Cloud Logging client |
| `src/cxas_scrapi/utils/trace_report.py` | JSON / MD / text / HTML formatters |
| `src/cxas_scrapi/utils/gcs_utils.py` | added `download_blob`, `download_to_file`, `upload_file`, `exists`, `find_first` |
| `src/cxas_scrapi/utils/gemini.py` | added `generate_with_parts()` for audio multimodal |
| `src/cxas_scrapi/cli/main.py` | wires the `trace` subparser |
| `pyproject.toml` | adds `google-cloud-logging`; excludes `.agents/skills/cxas-cuj-report-generator/` from ruff |
| `docs/cli/trace.md`, `docs/cli/index.md` | usage guide + CLI index entry |
| `examples/test_trace.sh` | end-to-end smoke script that exercises every subcommand |

## Test plan

- [x] Unit tests added for every new module — 165 trace-related tests, **100% line coverage** on the new and modified modules
- [x] Full repo test suite green: **705 passed, 1 skipped, no regressions**
- [x] `ruff check` and `ruff format --check` clean across the repo
- [x] End-to-end manual smoke test against a real app via `examples/test_trace.sh`:
  - `trace list` (table / json / csv / `--source` / `--channel`)
  - `trace get` (json / md / text / html)
  - `trace logs` (warning + error)
  - `trace audio download` (downloaded `.wav` from configured GCS bucket)
  - `trace audio analyze` (4 metrics, real Gemini findings)
  - `trace triage` (text-only Gemini)
  - `trace replay --diff`
  - `trace stats` (ASCII bars with units + percentages)
  - `trace bundle` (transcript + logs + audio + report zip)
  - `trace bug-report` (uploaded artifacts to configured bug-report bucket)
