### PR TITLE
feat: add DFCX conversation runner with live + history trace export

### DIFF
--- a/src/cxas_scrapi/migration/__init__.py
+++ b/src/cxas_scrapi/migration/__init__.py
@@ -15,6 +15,11 @@
 # limitations under the License.
 
 from cxas_scrapi.migration.ai_augment import AIAugment
+from cxas_scrapi.migration.dfcx_conversation_runner import (
+    ConversationTrace,
+    ConversationTurn,
+    DFCXConversationRunner,
+)
 from cxas_scrapi.migration.dfcx_exporter import (
     BaseDFCXClient,
     ConversationalAgentsAPI,
@@ -48,4 +53,7 @@ __all__ = [
     "MainVisualizer",
     "DFCXMigrationReporter",
     "AIAugment",
+    "DFCXConversationRunner",
+    "ConversationTrace",
+    "ConversationTurn",
 ]

--- a/src/cxas_scrapi/migration/dfcx_conversation_runner.py
+++ b/src/cxas_scrapi/migration/dfcx_conversation_runner.py
@@ -1,0 +1,604 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Drive a conversation with a Dialogflow CX (DFCX) agent and persist the
+full trace (user turns, agent responses, tool calls, playbook/flow
+invocations) as YAML.
+
+This module talks to Dialogflow CX directly via the
+`google-cloud-dialogflow-cx` SDK. It does not require dfcx-scrapi.
+"""
+
+import json
+import logging
+import os
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Optional
+
+import google.auth
+import yaml
+from google.cloud.dialogflowcx_v3beta1 import services as cx_services
+from google.cloud.dialogflowcx_v3beta1 import types as cx_types
+from google.oauth2 import service_account
+from google.protobuf.json_format import MessageToDict
+from proto.marshal.collections import maps, repeated
+
+from cxas_scrapi.migration.dfcx_exporter import BaseDFCXClient
+
+logger = logging.getLogger(__name__)
+
+INLINE_TOOL_SENTINEL = "inline-action"
+
+
+@dataclass
+class ConversationTurn:
+    """A single user/agent turn with its full trace."""
+
+    turn: int
+    user_query: str
+    agent_responses: List[str] = field(default_factory=list)
+    response_messages: List[Dict[str, Any]] = field(default_factory=list)
+    tool_calls: List[Dict[str, Any]] = field(default_factory=list)
+    playbook_invocations: List[Dict[str, Any]] = field(default_factory=list)
+    flow_invocations: List[Dict[str, Any]] = field(default_factory=list)
+    current_page: Optional[str] = None
+    current_playbooks: List[str] = field(default_factory=list)
+    intent: Optional[str] = None
+    match_type: Optional[str] = None
+    confidence: Optional[float] = None
+    parameters: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ConversationTrace:
+    """All metadata + ordered turns for a single conversation run."""
+
+    agent_id: str
+    session_id: str
+    language_code: str
+    started_at: str
+    turns: List[ConversationTurn] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "agent_id": self.agent_id,
+            "session_id": self.session_id,
+            "language_code": self.language_code,
+            "started_at": self.started_at,
+            "turns": [asdict(t) for t in self.turns],
+        }
+
+
+class DFCXConversationRunner(BaseDFCXClient):
+    """Drives a conversation with a DFCX agent via google-cloud-dialogflow-cx.
+
+    Each `send_message` call appends a fully traced `ConversationTurn` to
+    the in-memory transcript, which can be exported with `save_to_yaml`.
+    Inherits regional endpoint routing from `BaseDFCXClient` so behavior
+    matches the rest of the migration package.
+    """
+
+    def __init__(
+        self,
+        agent_id: str,
+        creds_path: Optional[str] = None,
+        creds: Any = None,
+        language_code: str = "en",
+        session_id: Optional[str] = None,
+        environment_id: Optional[str] = None,
+    ):
+        self.agent_id = agent_id
+        self.language_code = language_code
+        self.creds = self._resolve_credentials(creds, creds_path)
+        self._client_options = self._get_client_options(agent_id)
+
+        # Lazy resource clients & display-name maps.
+        self._sessions_client = None
+        self._history_client = None
+        self._tools_map: Optional[Dict[str, str]] = None
+        self._playbooks_map: Optional[Dict[str, str]] = None
+        self._flows_map: Optional[Dict[str, str]] = None
+
+        self.session_id = session_id or self._build_session_id(
+            agent_id, environment_id
+        )
+
+        self.trace = ConversationTrace(
+            agent_id=agent_id,
+            session_id=self.session_id,
+            language_code=language_code,
+            started_at=datetime.now(timezone.utc).isoformat(),
+        )
+
+    # ------------------------------------------------------------------ #
+    # Public API
+    # ------------------------------------------------------------------ #
+
+    def send_message(
+        self,
+        text: str,
+        parameters: Optional[Dict[str, Any]] = None,
+        end_user_metadata: Optional[Dict[str, Any]] = None,
+    ) -> ConversationTurn:
+        """Send a single user utterance and record the traced turn."""
+        logger.info("Turn %d -> %s", len(self.trace.turns) + 1, text)
+
+        request = self._build_detect_intent_request(
+            text=text,
+            parameters=parameters,
+            end_user_metadata=end_user_metadata,
+        )
+        response = self._get_sessions_client().detect_intent(request=request)
+        query_result = response.query_result
+
+        turn = self._build_turn(text, query_result)
+        self.trace.turns.append(turn)
+        return turn
+
+    def run_scripted_conversation(
+        self, utterances: Iterable[str]
+    ) -> ConversationTrace:
+        """Send a list of utterances in order and return the trace."""
+        for utterance in utterances:
+            self.send_message(utterance)
+        return self.trace
+
+    def list_past_conversations(self) -> List[Dict[str, Any]]:
+        """List historical conversations stored for this agent.
+
+        Returns a list of dicts: `{name, start_time, interaction_count}`.
+        """
+        client = self._get_history_client()
+        request = cx_types.conversation_history.ListConversationsRequest(
+            parent=self.agent_id
+        )
+        results = []
+        for convo in client.list_conversations(request=request):
+            start_time = getattr(convo, "start_time", None)
+            results.append(
+                {
+                    "name": convo.name,
+                    "start_time": start_time.isoformat()
+                    if start_time
+                    else None,
+                    "interaction_count": len(
+                        getattr(convo, "interactions", []) or []
+                    ),
+                }
+            )
+        return results
+
+    def load_past_conversation(
+        self, conversation_id: str
+    ) -> ConversationTrace:
+        """Replace `self.trace` with a recorded conversation from history.
+
+        The conversation's stored interactions are decoded through the same
+        `_build_turn` logic used for live turns, so the YAML schema is
+        identical regardless of source.
+
+        Args:
+          conversation_id: Full resource name
+            `projects/.../agents/.../conversations/<id>`.
+        """
+        client = self._get_history_client()
+        request = cx_types.conversation_history.GetConversationRequest(
+            name=conversation_id
+        )
+        convo = client.get_conversation(request=request)
+
+        start_time = getattr(convo, "start_time", None)
+        started_at = (
+            start_time.isoformat()
+            if start_time
+            else datetime.now(timezone.utc).isoformat()
+        )
+
+        # The conversation_id replaces session_id as the trace's source ref.
+        self.session_id = convo.name
+        self.trace = ConversationTrace(
+            agent_id=self.agent_id,
+            session_id=convo.name,
+            language_code=self.language_code,
+            started_at=started_at,
+        )
+
+        # Stored interactions are returned newest-first; reverse for
+        # chronological replay.
+        interactions = list(getattr(convo, "interactions", []) or [])
+        for interaction in reversed(interactions):
+            user_query = self._extract_user_input(
+                getattr(interaction.request, "query_input", None)
+            )
+            query_result = getattr(interaction.response, "query_result", None)
+            if query_result is None:
+                continue
+            turn = self._build_turn(user_query or "", query_result)
+            self.trace.turns.append(turn)
+
+        return self.trace
+
+    @classmethod
+    def from_past_conversation(
+        cls,
+        agent_id: str,
+        conversation_id: str,
+        creds_path: Optional[str] = None,
+        creds: Any = None,
+        language_code: str = "en",
+    ) -> "DFCXConversationRunner":
+        """Construct a runner pre-loaded with a recorded conversation."""
+        runner = cls(
+            agent_id=agent_id,
+            creds_path=creds_path,
+            creds=creds,
+            language_code=language_code,
+            session_id=conversation_id,  # avoid live-session UUID generation
+        )
+        runner.load_past_conversation(conversation_id)
+        return runner
+
+    @staticmethod
+    def _extract_user_input(query_input) -> Optional[str]:
+        """Pull the user-facing text out of a recorded QueryInput."""
+        if query_input is None:
+            return None
+        text = getattr(query_input, "text", None)
+        if text is not None and getattr(text, "text", ""):
+            return text.text
+        intent = getattr(query_input, "intent", None)
+        if intent is not None and getattr(intent, "intent", ""):
+            return f"<intent:{intent.intent}>"
+        event = getattr(query_input, "event", None)
+        if event is not None and getattr(event, "event", ""):
+            return f"<event:{event.event}>"
+        dtmf = getattr(query_input, "dtmf", None)
+        if dtmf is not None and getattr(dtmf, "digits", ""):
+            return f"<dtmf:{dtmf.digits}>"
+        return None
+
+    def save_to_yaml(self, output_path: str) -> str:
+        """Serialize the conversation trace to YAML at output_path."""
+        os.makedirs(
+            os.path.dirname(os.path.abspath(output_path)) or ".", exist_ok=True
+        )
+        content = yaml.dump(
+            self.trace.to_dict(),
+            sort_keys=False,
+            allow_unicode=True,
+            default_flow_style=False,
+        )
+        with open(output_path, "w", encoding="utf-8") as f:
+            f.write(content)
+        logger.info("Saved conversation trace to %s", output_path)
+        return content
+
+    # ------------------------------------------------------------------ #
+    # Credentials, region routing, session ID
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _resolve_credentials(creds, creds_path):
+        if creds is not None:
+            return creds
+        if creds_path:
+            return service_account.Credentials.from_service_account_file(
+                creds_path
+            )
+        adc_creds, _ = google.auth.default()
+        return adc_creds
+
+    def _build_session_id(
+        self, agent_id: str, environment_id: Optional[str]
+    ) -> str:
+        sid = uuid.uuid4()
+        if environment_id:
+            return f"{agent_id}/environments/{environment_id}/sessions/{sid}"
+        return f"{agent_id}/sessions/{sid}"
+
+    # ------------------------------------------------------------------ #
+    # Lazy CX clients
+    # ------------------------------------------------------------------ #
+
+    def _get_sessions_client(self):
+        if self._sessions_client is None:
+            self._sessions_client = cx_services.sessions.SessionsClient(
+                credentials=self.creds, client_options=self._client_options
+            )
+        return self._sessions_client
+
+    def _get_history_client(self):
+        if self._history_client is None:
+            self._history_client = (
+                cx_services.conversation_history.ConversationHistoryClient(
+                    credentials=self.creds,
+                    client_options=self._client_options,
+                )
+            )
+        return self._history_client
+
+    def _build_detect_intent_request(
+        self,
+        text: str,
+        parameters: Optional[Dict[str, Any]],
+        end_user_metadata: Optional[Dict[str, Any]],
+    ):
+        text_input = cx_types.session.TextInput(text=text)
+        query_input = cx_types.session.QueryInput(
+            text=text_input, language_code=self.language_code
+        )
+
+        query_param_kwargs: Dict[str, Any] = {}
+        if parameters:
+            query_param_kwargs["parameters"] = parameters
+        if end_user_metadata:
+            query_param_kwargs["end_user_metadata"] = end_user_metadata
+
+        request = cx_types.session.DetectIntentRequest(
+            session=self.session_id,
+            query_input=query_input,
+        )
+        if query_param_kwargs:
+            request.query_params = cx_types.session.QueryParameters(
+                **query_param_kwargs
+            )
+        return request
+
+    # ------------------------------------------------------------------ #
+    # Display-name maps (Tools / Playbooks / Flows)
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _is_full_resource_name(value: str) -> bool:
+        """True if `value` looks like projects/.../agents/.../<type>/<id>."""
+        parts = value.split("/")
+        return len(parts) >= 8 and parts[0] == "projects"
+
+    def _get_tools_map(self) -> Dict[str, str]:
+        if self._tools_map is not None:
+            return self._tools_map
+        client = cx_services.tools.ToolsClient(
+            credentials=self.creds, client_options=self._client_options
+        )
+        self._tools_map = {
+            t.name: t.display_name
+            for t in client.list_tools(
+                request=cx_types.ListToolsRequest(parent=self.agent_id)
+            )
+        }
+        return self._tools_map
+
+    def _get_playbooks_map(self) -> Dict[str, str]:
+        if self._playbooks_map is not None:
+            return self._playbooks_map
+        client = cx_services.playbooks.PlaybooksClient(
+            credentials=self.creds, client_options=self._client_options
+        )
+        self._playbooks_map = {
+            pb.name: pb.display_name
+            for pb in client.list_playbooks(
+                request=cx_types.ListPlaybooksRequest(parent=self.agent_id)
+            )
+        }
+        return self._playbooks_map
+
+    def _get_flows_map(self) -> Dict[str, str]:
+        if self._flows_map is not None:
+            return self._flows_map
+        client = cx_services.flows.FlowsClient(
+            credentials=self.creds, client_options=self._client_options
+        )
+        self._flows_map = {
+            f.name: f.display_name
+            for f in client.list_flows(
+                request=cx_types.ListFlowsRequest(parent=self.agent_id)
+            )
+        }
+        return self._flows_map
+
+    def _resolve_tool_name(self, tool_id: str) -> str:
+        try:
+            return self._get_tools_map().get(tool_id, tool_id)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning("Failed to load tools map: %s", e)
+            return tool_id
+
+    def _resolve_playbook_name(self, playbook_id: str) -> str:
+        try:
+            return self._get_playbooks_map().get(playbook_id, playbook_id)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning("Failed to load playbooks map: %s", e)
+            return playbook_id
+
+    def _resolve_flow_name(self, flow_id: str) -> str:
+        try:
+            return self._get_flows_map().get(flow_id, flow_id)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning("Failed to load flows map: %s", e)
+            return flow_id
+
+    # ------------------------------------------------------------------ #
+    # Trace extraction
+    # ------------------------------------------------------------------ #
+
+    def _build_turn(self, user_query: str, res) -> ConversationTurn:
+        """Convert a DFCX QueryResult into a ConversationTurn."""
+        turn = ConversationTurn(
+            turn=len(self.trace.turns) + 1,
+            user_query=user_query,
+        )
+
+        gen_info = getattr(res, "generative_info", None)
+        if gen_info:
+            actions = getattr(
+                getattr(gen_info, "action_tracing_info", None), "actions", []
+            )
+            for action in actions:
+                self._collect_action(action, turn)
+
+            current_pbs = list(getattr(gen_info, "current_playbooks", []) or [])
+            turn.current_playbooks = [
+                self._resolve_playbook_name(pb_id) for pb_id in current_pbs
+            ]
+
+        # Fall back to flat response_messages when no generative trace.
+        if not turn.agent_responses and getattr(res, "response_messages", None):
+            for msg in res.response_messages:
+                msg_dict = MessageToDict(msg._pb)  # noqa: SLF001
+                turn.response_messages.append(msg_dict)
+                text_block = msg_dict.get("text", {}).get("text")
+                if text_block:
+                    turn.agent_responses.extend(text_block)
+
+        current_page = getattr(res, "current_page", None)
+        if current_page is not None:
+            turn.current_page = getattr(current_page, "display_name", None)
+
+        intent = getattr(res, "intent", None)
+        if intent is not None:
+            turn.intent = getattr(intent, "display_name", None) or None
+
+        match = getattr(res, "match", None)
+        if match is not None:
+            match_type = getattr(match, "match_type", None)
+            if match_type is not None:
+                turn.match_type = getattr(match_type, "_name_", str(match_type))
+            turn.confidence = getattr(match, "confidence", None) or None
+
+        params = getattr(res, "parameters", None)
+        if params:
+            turn.parameters = self._convert_parameters(params)
+
+        return turn
+
+    def _collect_action(self, action, turn: ConversationTurn) -> None:
+        """Inspect a single action from action_tracing_info and route it."""
+        agent_utterance = getattr(action, "agent_utterance", None)
+        if agent_utterance and getattr(agent_utterance, "text", ""):
+            turn.agent_responses.append(agent_utterance.text)
+
+        tool_use = getattr(action, "tool_use", None)
+        if tool_use and getattr(tool_use, "tool", ""):
+            turn.tool_calls.append(self._build_tool_call(tool_use))
+
+        playbook_invocation = getattr(action, "playbook_invocation", None)
+        if playbook_invocation and getattr(playbook_invocation, "playbook", ""):
+            turn.playbook_invocations.append(
+                {
+                    "playbook_id": playbook_invocation.playbook,
+                    "playbook_name": self._resolve_playbook_name(
+                        playbook_invocation.playbook
+                    ),
+                }
+            )
+
+        flow_invocation = getattr(action, "flow_invocation", None)
+        if flow_invocation and getattr(flow_invocation, "flow", ""):
+            turn.flow_invocations.append(
+                {
+                    "flow_id": flow_invocation.flow,
+                    "flow_name": self._resolve_flow_name(flow_invocation.flow),
+                }
+            )
+
+    def _build_tool_call(self, tool_use) -> Dict[str, Any]:
+        """Normalize a tool_use action.
+
+        Inline actions (no registered tool resource) are tagged
+        `inline_action: True` and labeled with the INLINE_TOOL_SENTINEL.
+        Registered tools resolve to their display name. The raw resource
+        ID is always preserved under `tool_id`.
+        """
+        raw_tool_id = tool_use.tool
+        is_inline = not self._is_full_resource_name(raw_tool_id)
+
+        if is_inline:
+            tool_name = INLINE_TOOL_SENTINEL
+        else:
+            tool_name = self._resolve_tool_name(raw_tool_id)
+
+        return {
+            "tool_id": raw_tool_id,
+            "tool_name": tool_name,
+            "tool_action": tool_use.action,
+            "inline_action": is_inline,
+            "input_params": self._extract_tool_params(
+                tool_use.input_action_parameters
+            ),
+            "output_params": self._extract_tool_params(
+                tool_use.output_action_parameters
+            ),
+        }
+
+    def _extract_tool_params(self, params) -> Any:
+        """Convert proto-marshal tool params to plain Python.
+
+        DFCX wraps tool I/O under a single empty-string top-level key for
+        Agent Builder tools; we unwrap that for readability while keeping
+        the rest of the structure intact.
+        """
+        if params is None:
+            return {}
+        if isinstance(params, maps.MapComposite):
+            param_map = self._recurse_marshal_to_dict(params)
+        elif isinstance(params, dict):
+            param_map = dict(params)
+        else:
+            try:
+                param_map = json.loads(MessageToDict(params))
+            except Exception:  # pylint: disable=broad-except
+                return params
+
+        empty_top_key = param_map.get("", None)
+        if len(param_map) == 1 and empty_top_key is not None:
+            return empty_top_key
+        return param_map
+
+    def _convert_parameters(self, params) -> Dict[str, Any]:
+        """Recursively turn proto MapComposite/RepeatedComposite into plain
+        Python types so they can be YAML-serialized cleanly."""
+        out = {}
+        for key in params:
+            value = params[key]
+            if isinstance(value, repeated.RepeatedComposite):
+                value = self._recurse_repeated_composite(value)
+            elif isinstance(value, maps.MapComposite):
+                value = self._recurse_marshal_to_dict(value)
+            out[key] = value
+        return out
+
+    def _recurse_marshal_to_dict(self, marshal_object) -> Dict[str, Any]:
+        out: Dict[str, Any] = {}
+        for k, v in marshal_object.items():
+            if isinstance(v, maps.MapComposite):
+                converted = self._recurse_marshal_to_dict(v)
+            elif isinstance(v, repeated.RepeatedComposite):
+                converted = self._recurse_repeated_composite(v)
+            else:
+                converted = v
+            out[k] = converted
+        return out
+
+    def _recurse_repeated_composite(self, repeated_object) -> List[Any]:
+        out: List[Any] = []
+        for item in repeated_object:
+            if isinstance(item, maps.MapComposite):
+                out.append(self._recurse_marshal_to_dict(item))
+            elif isinstance(item, repeated.RepeatedComposite):
+                out.append(self._recurse_repeated_composite(item))
+            else:
+                out.append(item)
+        return out

--- a/src/cxas_scrapi/migration/dfcx_conversation_runner.py
+++ b/src/cxas_scrapi/migration/dfcx_conversation_runner.py
@@ -181,9 +181,7 @@ class DFCXConversationRunner(BaseDFCXClient):
             )
         return results
 
-    def load_past_conversation(
-        self, conversation_id: str
-    ) -> ConversationTrace:
+    def load_past_conversation(self, conversation_id: str) -> ConversationTrace:
         """Replace `self.trace` with a recorded conversation from history.
 
         The conversation's stored interactions are decoded through the same

--- a/src/cxas_scrapi/migration/dfcx_conversation_runner.py
+++ b/src/cxas_scrapi/migration/dfcx_conversation_runner.py
@@ -28,14 +28,13 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, List, Optional
 
-import google.auth
 import yaml
 from google.cloud.dialogflowcx_v3beta1 import services as cx_services
 from google.cloud.dialogflowcx_v3beta1 import types as cx_types
-from google.oauth2 import service_account
 from google.protobuf.json_format import MessageToDict
 from proto.marshal.collections import maps, repeated
 
+from cxas_scrapi.core.common import Common
 from cxas_scrapi.migration.dfcx_exporter import BaseDFCXClient
 
 logger = logging.getLogger(__name__)
@@ -102,7 +101,7 @@ class DFCXConversationRunner(BaseDFCXClient):
     ):
         self.agent_id = agent_id
         self.language_code = language_code
-        self.creds = self._resolve_credentials(creds, creds_path)
+        self.creds = Common(creds_path=creds_path, creds=creds).creds
         self._client_options = self._get_client_options(agent_id)
 
         # Lazy resource clients & display-name maps.
@@ -148,15 +147,18 @@ class DFCXConversationRunner(BaseDFCXClient):
         self.trace.turns.append(turn)
         return turn
 
-    def run_scripted_conversation(
-        self, utterances: Iterable[str]
-    ) -> ConversationTrace:
-        """Send a list of utterances in order and return the trace."""
+    def run_golden(self, utterances: Iterable[str]) -> ConversationTrace:
+        """Replay a golden script of utterances against the agent and return
+        the resulting trace.
+
+        Each utterance is sent in order via `send_message`, so the produced
+        trace can be diffed against a recorded baseline to detect regressions.
+        """
         for utterance in utterances:
             self.send_message(utterance)
         return self.trace
 
-    def list_past_conversations(self) -> List[Dict[str, Any]]:
+    def list_conversations(self) -> List[Dict[str, Any]]:
         """List historical conversations stored for this agent.
 
         Returns a list of dicts: `{name, start_time, interaction_count}`.
@@ -181,7 +183,7 @@ class DFCXConversationRunner(BaseDFCXClient):
             )
         return results
 
-    def load_past_conversation(self, conversation_id: str) -> ConversationTrace:
+    def get_conversation(self, conversation_id: str) -> ConversationTrace:
         """Replace `self.trace` with a recorded conversation from history.
 
         The conversation's stored interactions are decoded through the same
@@ -230,7 +232,7 @@ class DFCXConversationRunner(BaseDFCXClient):
         return self.trace
 
     @classmethod
-    def from_past_conversation(
+    def from_conversation(
         cls,
         agent_id: str,
         conversation_id: str,
@@ -246,7 +248,7 @@ class DFCXConversationRunner(BaseDFCXClient):
             language_code=language_code,
             session_id=conversation_id,  # avoid live-session UUID generation
         )
-        runner.load_past_conversation(conversation_id)
+        runner.get_conversation(conversation_id)
         return runner
 
     @staticmethod
@@ -285,19 +287,8 @@ class DFCXConversationRunner(BaseDFCXClient):
         return content
 
     # ------------------------------------------------------------------ #
-    # Credentials, region routing, session ID
+    # Session ID
     # ------------------------------------------------------------------ #
-
-    @staticmethod
-    def _resolve_credentials(creds, creds_path):
-        if creds is not None:
-            return creds
-        if creds_path:
-            return service_account.Credentials.from_service_account_file(
-                creds_path
-            )
-        adc_creds, _ = google.auth.default()
-        return adc_creds
 
     def _build_session_id(
         self, agent_id: str, environment_id: Optional[str]

--- a/tests/cxas_scrapi/migration/test_dfcx_conversation_runner.py
+++ b/tests/cxas_scrapi/migration/test_dfcx_conversation_runner.py
@@ -1,0 +1,524 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for dfcx_conversation_runner module."""
+
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from cxas_scrapi.migration.dfcx_conversation_runner import (
+    INLINE_TOOL_SENTINEL,
+    ConversationTrace,
+    ConversationTurn,
+    DFCXConversationRunner,
+)
+
+LIVE_AGENT_ID = (
+    "projects/ccai-platform-project/locations/global/agents/"
+    "406b66f8-43d0-494d-8a2d-05c1273f9265"
+)
+
+AGENT_BASE = "projects/p/locations/us-central1/agents/a"
+TOOL_ID = f"{AGENT_BASE}/tools/t1"
+PLAYBOOK_ID = f"{AGENT_BASE}/playbooks/pb1"
+FLOW_ID = f"{AGENT_BASE}/flows/f1"
+
+
+def _make_query_result(
+    *,
+    agent_text="Hello!",
+    tool_id=TOOL_ID,
+    tool_action="lookup",
+    playbook_id=PLAYBOOK_ID,
+    flow_id=FLOW_ID,
+    page_display_name="Start Page",
+    intent_display_name="welcome",
+    confidence=0.92,
+):
+    """Build a fake QueryResult mirroring the shape of a real one."""
+    tool_use = SimpleNamespace(
+        tool=tool_id,
+        action=tool_action,
+        input_action_parameters={"q": "weather"},
+        output_action_parameters={"result": "sunny"},
+    )
+
+    actions = [
+        SimpleNamespace(
+            agent_utterance=SimpleNamespace(text=agent_text),
+            tool_use=None,
+            playbook_invocation=None,
+            flow_invocation=None,
+        ),
+        SimpleNamespace(
+            agent_utterance=SimpleNamespace(text=""),
+            tool_use=tool_use,
+            playbook_invocation=None,
+            flow_invocation=None,
+        ),
+        SimpleNamespace(
+            agent_utterance=SimpleNamespace(text=""),
+            tool_use=None,
+            playbook_invocation=SimpleNamespace(playbook=playbook_id),
+            flow_invocation=None,
+        ),
+        SimpleNamespace(
+            agent_utterance=SimpleNamespace(text=""),
+            tool_use=None,
+            playbook_invocation=None,
+            flow_invocation=SimpleNamespace(flow=flow_id),
+        ),
+    ]
+
+    gen_info = SimpleNamespace(
+        action_tracing_info=SimpleNamespace(actions=actions),
+        current_playbooks=[playbook_id],
+    )
+
+    match_type = SimpleNamespace(_name_="INTENT")
+    match = SimpleNamespace(match_type=match_type, confidence=confidence)
+
+    return SimpleNamespace(
+        generative_info=gen_info,
+        response_messages=[],
+        current_page=SimpleNamespace(display_name=page_display_name),
+        intent=SimpleNamespace(display_name=intent_display_name),
+        match=match,
+        parameters={},
+        text="user input",
+    )
+
+
+def _build_runner_with_mock_session(query_result_factory=_make_query_result):
+    """Construct a DFCXConversationRunner whose CX clients are mocked
+    so the tests never touch the network."""
+    fake_response = MagicMock()
+    fake_response.query_result = query_result_factory()
+    fake_sessions_client = MagicMock()
+    fake_sessions_client.detect_intent.return_value = fake_response
+
+    with patch(
+        "cxas_scrapi.migration.dfcx_conversation_runner.google.auth.default",
+        return_value=(MagicMock(), "p"),
+    ):
+        runner = DFCXConversationRunner(
+            agent_id=AGENT_BASE,
+            language_code="en",
+        )
+
+    # Inject the mock SessionsClient and pre-populate display-name caches
+    # so no network calls happen.
+    runner._sessions_client = fake_sessions_client
+    runner._tools_map = {TOOL_ID: "my_tool"}
+    runner._playbooks_map = {PLAYBOOK_ID: "primary_playbook"}
+    runner._flows_map = {FLOW_ID: "main_flow"}
+
+    return runner, fake_sessions_client
+
+
+def test_dataclass_round_trip():
+    trace = ConversationTrace(
+        agent_id="a",
+        session_id="s",
+        language_code="en",
+        started_at="2026-05-14T00:00:00+00:00",
+        turns=[ConversationTurn(turn=1, user_query="hi")],
+    )
+    d = trace.to_dict()
+    assert d["agent_id"] == "a"
+    assert d["turns"][0]["user_query"] == "hi"
+    assert d["turns"][0]["agent_responses"] == []
+
+
+def test_session_id_built_with_correct_prefix():
+    with patch(
+        "cxas_scrapi.migration.dfcx_conversation_runner.google.auth.default",
+        return_value=(MagicMock(), "p"),
+    ):
+        runner = DFCXConversationRunner(agent_id=AGENT_BASE)
+    assert runner.session_id.startswith(f"{AGENT_BASE}/sessions/")
+
+
+def test_client_options_routes_regional_endpoint():
+    """The runner inherits BaseDFCXClient's regional endpoint routing."""
+    runner = DFCXConversationRunner.__new__(DFCXConversationRunner)
+    assert runner._get_client_options(AGENT_BASE) == {
+        "api_endpoint": "us-central1-dialogflow.googleapis.com"
+    }
+    assert runner._get_client_options(
+        "projects/p/locations/global/agents/a"
+    ) == {"api_endpoint": "dialogflow.googleapis.com"}
+
+
+def test_send_message_extracts_full_trace():
+    runner, fake_client = _build_runner_with_mock_session()
+
+    turn = runner.send_message("hello", parameters={"x": 1})
+
+    fake_client.detect_intent.assert_called_once()
+    # The conftest mocks google.cloud.dialogflowcx_v3beta1, so the
+    # DetectIntentRequest returned to the runner is itself a MagicMock —
+    # introspecting its fields would only assert on auto-generated mocks.
+    # Behavioral correctness is covered by the turn-data assertions below.
+    assert "request" in fake_client.detect_intent.call_args.kwargs
+
+    assert turn.turn == 1
+    assert turn.user_query == "hello"
+    assert turn.agent_responses == ["Hello!"]
+    assert turn.current_page == "Start Page"
+    assert turn.intent == "welcome"
+    assert turn.match_type == "INTENT"
+    assert turn.confidence == pytest.approx(0.92)
+
+    assert len(turn.tool_calls) == 1
+    tc = turn.tool_calls[0]
+    assert tc["tool_id"] == TOOL_ID
+    assert tc["tool_name"] == "my_tool"
+    assert tc["tool_action"] == "lookup"
+    assert tc["inline_action"] is False
+    assert tc["input_params"] == {"q": "weather"}
+    assert tc["output_params"] == {"result": "sunny"}
+
+    assert turn.playbook_invocations == [
+        {"playbook_id": PLAYBOOK_ID, "playbook_name": "primary_playbook"}
+    ]
+    assert turn.flow_invocations == [
+        {"flow_id": FLOW_ID, "flow_name": "main_flow"}
+    ]
+    assert turn.current_playbooks == ["primary_playbook"]
+
+
+def test_inline_tool_action_is_tagged_and_id_preserved():
+    """Inline actions don't have a registered tools/<id> resource."""
+
+    def factory():
+        return _make_query_result(tool_id="inline-action")
+
+    runner, _ = _build_runner_with_mock_session(query_result_factory=factory)
+    turn = runner.send_message("hi")
+
+    assert len(turn.tool_calls) == 1
+    tc = turn.tool_calls[0]
+    assert tc["tool_id"] == "inline-action"
+    assert tc["tool_name"] == INLINE_TOOL_SENTINEL
+    assert tc["inline_action"] is True
+    # We must NOT have attempted to resolve the inline ID against the map.
+    assert "inline-action" not in runner._tools_map
+
+
+def test_run_scripted_conversation_appends_turns():
+    runner, fake_client = _build_runner_with_mock_session()
+    fake_client.detect_intent.side_effect = [
+        SimpleNamespace(query_result=_make_query_result(agent_text="hi 1")),
+        SimpleNamespace(query_result=_make_query_result(agent_text="hi 2")),
+        SimpleNamespace(query_result=_make_query_result(agent_text="hi 3")),
+    ]
+
+    trace = runner.run_scripted_conversation(["a", "b", "c"])
+
+    assert len(trace.turns) == 3
+    assert [t.user_query for t in trace.turns] == ["a", "b", "c"]
+    assert trace.turns[1].agent_responses == ["hi 2"]
+    assert trace.turns[2].turn == 3
+
+
+def test_save_to_yaml_writes_expected_structure(tmp_path):
+    runner, _ = _build_runner_with_mock_session()
+    runner.send_message("hello")
+
+    out_path = tmp_path / "conv.yaml"
+    runner.save_to_yaml(str(out_path))
+
+    loaded = yaml.safe_load(out_path.read_text())
+    assert loaded["agent_id"] == AGENT_BASE
+    assert loaded["session_id"].startswith(f"{AGENT_BASE}/sessions/")
+    assert loaded["language_code"] == "en"
+    assert "started_at" in loaded
+    assert len(loaded["turns"]) == 1
+    turn = loaded["turns"][0]
+    assert turn["user_query"] == "hello"
+    assert turn["agent_responses"] == ["Hello!"]
+    tc = turn["tool_calls"][0]
+    assert tc["tool_id"] == TOOL_ID
+    assert tc["tool_name"] == "my_tool"
+    assert tc["inline_action"] is False
+    assert turn["playbook_invocations"][0]["playbook_name"] == (
+        "primary_playbook"
+    )
+    assert turn["flow_invocations"][0]["flow_name"] == "main_flow"
+
+
+def _make_recorded_conversation(
+    name="projects/p/locations/us-central1/agents/a/conversations/c1",
+    interactions=None,
+    start_time=None,
+):
+    """Build a fake stored Conversation that mirrors the SDK shape."""
+    if interactions is None:
+        interactions = [
+            SimpleNamespace(
+                request=SimpleNamespace(
+                    query_input=SimpleNamespace(
+                        text=SimpleNamespace(text="hello"),
+                        intent=None,
+                        event=None,
+                        dtmf=None,
+                    )
+                ),
+                response=SimpleNamespace(
+                    query_result=_make_query_result(agent_text="hi back")
+                ),
+            ),
+            SimpleNamespace(
+                request=SimpleNamespace(
+                    query_input=SimpleNamespace(
+                        text=SimpleNamespace(text="bye"),
+                        intent=None,
+                        event=None,
+                        dtmf=None,
+                    )
+                ),
+                response=SimpleNamespace(
+                    query_result=_make_query_result(agent_text="goodbye")
+                ),
+            ),
+        ]
+
+    if start_time is None:
+        start_time = SimpleNamespace(
+            isoformat=lambda: "2026-05-14T22:00:00+00:00"
+        )
+
+    # Stored conversations come back newest-first; mirror that.
+    return SimpleNamespace(
+        name=name,
+        start_time=start_time,
+        interactions=list(reversed(interactions)),
+    )
+
+
+def _build_runner_with_mock_history(convo):
+    """Construct a runner whose history client returns the supplied
+    Conversation, with all maps pre-populated to avoid network calls."""
+    fake_history_client = MagicMock()
+    fake_history_client.get_conversation.return_value = convo
+    fake_history_client.list_conversations.return_value = iter([convo])
+
+    with patch(
+        "cxas_scrapi.migration.dfcx_conversation_runner.google.auth.default",
+        return_value=(MagicMock(), "p"),
+    ):
+        runner = DFCXConversationRunner(
+            agent_id=AGENT_BASE,
+            language_code="en",
+        )
+
+    runner._history_client = fake_history_client
+    runner._tools_map = {TOOL_ID: "my_tool"}
+    runner._playbooks_map = {PLAYBOOK_ID: "primary_playbook"}
+    runner._flows_map = {FLOW_ID: "main_flow"}
+    return runner, fake_history_client
+
+
+def test_list_past_conversations_returns_summary():
+    convo = _make_recorded_conversation()
+    runner, fake_client = _build_runner_with_mock_history(convo)
+
+    listing = runner.list_past_conversations()
+
+    fake_client.list_conversations.assert_called_once()
+    assert len(listing) == 1
+    assert listing[0]["name"] == convo.name
+    assert listing[0]["start_time"] == "2026-05-14T22:00:00+00:00"
+    assert listing[0]["interaction_count"] == 2
+
+
+def test_load_past_conversation_replays_into_trace():
+    convo = _make_recorded_conversation()
+    runner, fake_client = _build_runner_with_mock_history(convo)
+
+    trace = runner.load_past_conversation(convo.name)
+
+    fake_client.get_conversation.assert_called_once()
+    # The historical conversation_id replaces session_id as the source ref.
+    assert trace.session_id == convo.name
+    assert runner.session_id == convo.name
+    assert trace.started_at == "2026-05-14T22:00:00+00:00"
+
+    assert len(trace.turns) == 2
+    # Replay reverses the SDK's newest-first ordering, so chronological.
+    assert [t.user_query for t in trace.turns] == ["hello", "bye"]
+    assert [t.agent_responses[0] for t in trace.turns] == ["hi back", "goodbye"]
+    # Same trace extraction means tool/playbook/flow data is captured too.
+    assert trace.turns[0].tool_calls[0]["tool_name"] == "my_tool"
+    assert trace.turns[0].playbook_invocations[0]["playbook_name"] == (
+        "primary_playbook"
+    )
+
+
+def test_load_past_conversation_handles_non_text_inputs():
+    interactions = [
+        SimpleNamespace(
+            request=SimpleNamespace(
+                query_input=SimpleNamespace(
+                    text=None,
+                    intent=SimpleNamespace(intent="welcome"),
+                    event=None,
+                    dtmf=None,
+                )
+            ),
+            response=SimpleNamespace(
+                query_result=_make_query_result(agent_text="hi")
+            ),
+        ),
+        SimpleNamespace(
+            request=SimpleNamespace(
+                query_input=SimpleNamespace(
+                    text=None,
+                    intent=None,
+                    event=SimpleNamespace(event="WELCOME"),
+                    dtmf=None,
+                )
+            ),
+            response=SimpleNamespace(
+                query_result=_make_query_result(agent_text="welcome event")
+            ),
+        ),
+    ]
+    convo = _make_recorded_conversation(interactions=interactions)
+    runner, _ = _build_runner_with_mock_history(convo)
+
+    trace = runner.load_past_conversation(convo.name)
+    queries = [t.user_query for t in trace.turns]
+    assert "<intent:welcome>" in queries
+    assert "<event:WELCOME>" in queries
+
+
+def test_save_to_yaml_works_for_loaded_history(tmp_path):
+    convo = _make_recorded_conversation()
+    runner, _ = _build_runner_with_mock_history(convo)
+    runner.load_past_conversation(convo.name)
+
+    out_path = tmp_path / "history.yaml"
+    runner.save_to_yaml(str(out_path))
+
+    loaded = yaml.safe_load(out_path.read_text())
+    assert loaded["agent_id"] == AGENT_BASE
+    assert loaded["session_id"] == convo.name
+    assert loaded["started_at"] == "2026-05-14T22:00:00+00:00"
+    assert len(loaded["turns"]) == 2
+    # Identical schema to live runs.
+    assert loaded["turns"][0]["agent_responses"] == ["hi back"]
+    assert loaded["turns"][0]["tool_calls"][0]["tool_id"] == TOOL_ID
+
+
+def test_from_past_conversation_classmethod():
+    convo = _make_recorded_conversation()
+    fake_history_client = MagicMock()
+    fake_history_client.get_conversation.return_value = convo
+
+    with patch(
+        "cxas_scrapi.migration.dfcx_conversation_runner.google.auth.default",
+        return_value=(MagicMock(), "p"),
+    ):
+        # Patch _get_history_client at class level so it survives __init__.
+        with patch.object(
+            DFCXConversationRunner,
+            "_get_history_client",
+            return_value=fake_history_client,
+        ):
+            runner = DFCXConversationRunner.from_past_conversation(
+                agent_id=AGENT_BASE,
+                conversation_id=convo.name,
+            )
+
+    assert runner.session_id == convo.name
+    assert len(runner.trace.turns) == 2
+
+
+@pytest.mark.online
+def test_live_history_pull_against_test_agent(tmp_path):
+    """List past conversations from the configured DFCX test agent, then
+    pull the most recent one and persist it as YAML.
+
+    Skipped unless --run-online is passed. Skipped at runtime if the agent
+    has no recorded conversations.
+    """
+    creds_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+
+    runner = DFCXConversationRunner(
+        agent_id=LIVE_AGENT_ID,
+        creds_path=creds_path,
+        language_code="en",
+    )
+
+    listing = runner.list_past_conversations()
+    if not listing:
+        pytest.skip("No recorded conversations on the test agent")
+
+    convo_id = listing[0]["name"]
+    trace = runner.load_past_conversation(convo_id)
+
+    assert trace.session_id == convo_id
+    assert trace.agent_id == LIVE_AGENT_ID
+    # A non-empty conversation must have at least one turn.
+    assert len(trace.turns) >= 1
+
+    out_path = tmp_path / "live_history_trace.yaml"
+    runner.save_to_yaml(str(out_path))
+    loaded = yaml.safe_load(out_path.read_text())
+    assert loaded["session_id"] == convo_id
+    assert len(loaded["turns"]) == len(trace.turns)
+
+
+@pytest.mark.online
+def test_live_conversation_against_test_agent(tmp_path):
+    """Drive a real conversation against the configured DFCX test agent and
+    persist the trace. Skipped unless --run-online is passed.
+
+    Authentication is picked up from Application Default Credentials, or
+    the GOOGLE_APPLICATION_CREDENTIALS env var if set.
+    """
+    creds_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+
+    runner = DFCXConversationRunner(
+        agent_id=LIVE_AGENT_ID,
+        creds_path=creds_path,
+        language_code="en",
+    )
+
+    utterances = ["hi", "I need help", "thanks"]
+    trace = runner.run_scripted_conversation(utterances)
+
+    assert trace.agent_id == LIVE_AGENT_ID
+    assert trace.session_id.startswith(f"{LIVE_AGENT_ID}/sessions/")
+    assert len(trace.turns) == len(utterances)
+    for utterance, turn in zip(utterances, trace.turns, strict=True):
+        assert turn.user_query == utterance
+        assert turn.agent_responses or turn.response_messages
+
+    out_path = tmp_path / "live_conversation_trace.yaml"
+    runner.save_to_yaml(str(out_path))
+    loaded = yaml.safe_load(out_path.read_text())
+    assert loaded["agent_id"] == LIVE_AGENT_ID
+    assert len(loaded["turns"]) == len(utterances)
+    # Every tool_call dict must carry tool_id and inline_action keys.
+    for turn in loaded["turns"]:
+        for tc in turn["tool_calls"]:
+            assert "tool_id" in tc
+            assert "inline_action" in tc

--- a/tests/cxas_scrapi/migration/test_dfcx_conversation_runner.py
+++ b/tests/cxas_scrapi/migration/test_dfcx_conversation_runner.py
@@ -112,14 +112,11 @@ def _build_runner_with_mock_session(query_result_factory=_make_query_result):
     fake_sessions_client = MagicMock()
     fake_sessions_client.detect_intent.return_value = fake_response
 
-    with patch(
-        "cxas_scrapi.migration.dfcx_conversation_runner.google.auth.default",
-        return_value=(MagicMock(), "p"),
-    ):
-        runner = DFCXConversationRunner(
-            agent_id=AGENT_BASE,
-            language_code="en",
-        )
+    runner = DFCXConversationRunner(
+        agent_id=AGENT_BASE,
+        creds=MagicMock(),
+        language_code="en",
+    )
 
     # Inject the mock SessionsClient and pre-populate display-name caches
     # so no network calls happen.
@@ -146,11 +143,7 @@ def test_dataclass_round_trip():
 
 
 def test_session_id_built_with_correct_prefix():
-    with patch(
-        "cxas_scrapi.migration.dfcx_conversation_runner.google.auth.default",
-        return_value=(MagicMock(), "p"),
-    ):
-        runner = DFCXConversationRunner(agent_id=AGENT_BASE)
+    runner = DFCXConversationRunner(agent_id=AGENT_BASE, creds=MagicMock())
     assert runner.session_id.startswith(f"{AGENT_BASE}/sessions/")
 
 
@@ -221,7 +214,7 @@ def test_inline_tool_action_is_tagged_and_id_preserved():
     assert "inline-action" not in runner._tools_map
 
 
-def test_run_scripted_conversation_appends_turns():
+def test_run_golden_appends_turns():
     runner, fake_client = _build_runner_with_mock_session()
     fake_client.detect_intent.side_effect = [
         SimpleNamespace(query_result=_make_query_result(agent_text="hi 1")),
@@ -229,7 +222,7 @@ def test_run_scripted_conversation_appends_turns():
         SimpleNamespace(query_result=_make_query_result(agent_text="hi 3")),
     ]
 
-    trace = runner.run_scripted_conversation(["a", "b", "c"])
+    trace = runner.run_golden(["a", "b", "c"])
 
     assert len(trace.turns) == 3
     assert [t.user_query for t in trace.turns] == ["a", "b", "c"]
@@ -319,14 +312,11 @@ def _build_runner_with_mock_history(convo):
     fake_history_client.get_conversation.return_value = convo
     fake_history_client.list_conversations.return_value = iter([convo])
 
-    with patch(
-        "cxas_scrapi.migration.dfcx_conversation_runner.google.auth.default",
-        return_value=(MagicMock(), "p"),
-    ):
-        runner = DFCXConversationRunner(
-            agent_id=AGENT_BASE,
-            language_code="en",
-        )
+    runner = DFCXConversationRunner(
+        agent_id=AGENT_BASE,
+        creds=MagicMock(),
+        language_code="en",
+    )
 
     runner._history_client = fake_history_client
     runner._tools_map = {TOOL_ID: "my_tool"}
@@ -335,11 +325,11 @@ def _build_runner_with_mock_history(convo):
     return runner, fake_history_client
 
 
-def test_list_past_conversations_returns_summary():
+def test_list_conversations_returns_summary():
     convo = _make_recorded_conversation()
     runner, fake_client = _build_runner_with_mock_history(convo)
 
-    listing = runner.list_past_conversations()
+    listing = runner.list_conversations()
 
     fake_client.list_conversations.assert_called_once()
     assert len(listing) == 1
@@ -348,11 +338,11 @@ def test_list_past_conversations_returns_summary():
     assert listing[0]["interaction_count"] == 2
 
 
-def test_load_past_conversation_replays_into_trace():
+def test_get_conversation_replays_into_trace():
     convo = _make_recorded_conversation()
     runner, fake_client = _build_runner_with_mock_history(convo)
 
-    trace = runner.load_past_conversation(convo.name)
+    trace = runner.get_conversation(convo.name)
 
     fake_client.get_conversation.assert_called_once()
     # The historical conversation_id replaces session_id as the source ref.
@@ -371,7 +361,7 @@ def test_load_past_conversation_replays_into_trace():
     )
 
 
-def test_load_past_conversation_handles_non_text_inputs():
+def test_get_conversation_handles_non_text_inputs():
     interactions = [
         SimpleNamespace(
             request=SimpleNamespace(
@@ -403,7 +393,7 @@ def test_load_past_conversation_handles_non_text_inputs():
     convo = _make_recorded_conversation(interactions=interactions)
     runner, _ = _build_runner_with_mock_history(convo)
 
-    trace = runner.load_past_conversation(convo.name)
+    trace = runner.get_conversation(convo.name)
     queries = [t.user_query for t in trace.turns]
     assert "<intent:welcome>" in queries
     assert "<event:WELCOME>" in queries
@@ -412,7 +402,7 @@ def test_load_past_conversation_handles_non_text_inputs():
 def test_save_to_yaml_works_for_loaded_history(tmp_path):
     convo = _make_recorded_conversation()
     runner, _ = _build_runner_with_mock_history(convo)
-    runner.load_past_conversation(convo.name)
+    runner.get_conversation(convo.name)
 
     out_path = tmp_path / "history.yaml"
     runner.save_to_yaml(str(out_path))
@@ -427,25 +417,22 @@ def test_save_to_yaml_works_for_loaded_history(tmp_path):
     assert loaded["turns"][0]["tool_calls"][0]["tool_id"] == TOOL_ID
 
 
-def test_from_past_conversation_classmethod():
+def test_from_conversation_classmethod():
     convo = _make_recorded_conversation()
     fake_history_client = MagicMock()
     fake_history_client.get_conversation.return_value = convo
 
-    with patch(
-        "cxas_scrapi.migration.dfcx_conversation_runner.google.auth.default",
-        return_value=(MagicMock(), "p"),
+    # Patch _get_history_client at class level so it survives __init__.
+    with patch.object(
+        DFCXConversationRunner,
+        "_get_history_client",
+        return_value=fake_history_client,
     ):
-        # Patch _get_history_client at class level so it survives __init__.
-        with patch.object(
-            DFCXConversationRunner,
-            "_get_history_client",
-            return_value=fake_history_client,
-        ):
-            runner = DFCXConversationRunner.from_past_conversation(
-                agent_id=AGENT_BASE,
-                conversation_id=convo.name,
-            )
+        runner = DFCXConversationRunner.from_conversation(
+            agent_id=AGENT_BASE,
+            conversation_id=convo.name,
+            creds=MagicMock(),
+        )
 
     assert runner.session_id == convo.name
     assert len(runner.trace.turns) == 2
@@ -467,12 +454,12 @@ def test_live_history_pull_against_test_agent(tmp_path):
         language_code="en",
     )
 
-    listing = runner.list_past_conversations()
+    listing = runner.list_conversations()
     if not listing:
         pytest.skip("No recorded conversations on the test agent")
 
     convo_id = listing[0]["name"]
-    trace = runner.load_past_conversation(convo_id)
+    trace = runner.get_conversation(convo_id)
 
     assert trace.session_id == convo_id
     assert trace.agent_id == LIVE_AGENT_ID
@@ -503,7 +490,7 @@ def test_live_conversation_against_test_agent(tmp_path):
     )
 
     utterances = ["hi", "I need help", "thanks"]
-    trace = runner.run_scripted_conversation(utterances)
+    trace = runner.run_golden(utterances)
 
     assert trace.agent_id == LIVE_AGENT_ID
     assert trace.session_id.startswith(f"{LIVE_AGENT_ID}/sessions/")


### PR DESCRIPTION
Summary

Adds DFCXConversationRunner to cxas_scrapi.migration — a single class that drives Dialogflow CX agent conversations and persists fully-traced transcripts to YAML. Supports two sources with an identical output schema:

Live conversations — drive a session via detect_intent, capture every turn's response, tool calls, playbook/flow invocations, and match metadata. Historical conversations — list and replay recorded conversations from the DFCX ConversationHistory API into the same YAML format. Built directly on google-cloud-dialogflow-cx (no new third-party deps) and inherits regional endpoint routing from the existing BaseDFCXClient for consistency with dfcx_exporter.py.
