### PR TITLE
feat(bella_notte): event preemption, response propagation

### DIFF
--- a/examples/bella_notte/agents/Bella_Notte_Host/before_agent_callbacks/before_agent_callbacks_01/python_code.py
+++ b/examples/bella_notte/agents/Bella_Notte_Host/before_agent_callbacks/before_agent_callbacks_01/python_code.py
@@ -92,19 +92,25 @@ You are operating in SLOT FILLING mode. Follow these rules strictly:
 
 _READBACK_BLOCK = """\
 <readback_protocol>
-After calling setter tools, values enter a "pending" state requiring user
-confirmation. Follow these rules:
+Some values require user confirmation before proceeding. When this happens,
+the system places them in a "pending" state. Follow these rules:
 
-1. READBACK: After calling setters, read back ONLY the new values in one
-   natural sentence and ask "Is that correct?" Use the tool response's
-   `value` field — always use digits for numbers, never spell them out.
-   Do NOT include previously confirmed values. Then STOP and WAIT.
+1. READBACK ONLY WHEN PENDING: After calling setters, check the system
+   directive. If the directive asks you to confirm/read back values, do so.
+   If the directive moves on to the next question (no mention of pending
+   values), skip readback and relay the directive directly. Do NOT invent
+   your own confirmation step — only read back when the system tells you to.
 
-2. CONFIRM / REJECT: On "yes" → call confirm_pending. On bare "no" with
+2. HOW TO READ BACK: Read back ONLY the new pending values in one natural
+   sentence and ask "Is that correct?" Use the tool response's `value`
+   field — always use digits for numbers, never spell them out. Do NOT
+   include previously confirmed values. Then STOP and WAIT.
+
+3. CONFIRM / REJECT: On "yes" → call confirm_pending. On bare "no" with
    no correction → call reject_pending. If the user corrects or provides
    new info (with or without "yes"/"no"), call the appropriate setter.
 
-3. CAPTURE EVERYTHING: Call setter tools for ANY information the user
+4. CAPTURE EVERYTHING: Call setter tools for ANY information the user
    provides, even alongside a confirmation. Never ignore new information.
 </readback_protocol>"""
 

--- a/examples/bella_notte/agents/Bella_Notte_Host/before_model_callbacks/before_model_callbacks_01/python_code.py
+++ b/examples/bella_notte/agents/Bella_Notte_Host/before_model_callbacks/before_model_callbacks_01/python_code.py
@@ -33,6 +33,7 @@ _EVENT_PREFILL_PATTERN = re.compile(
 _READBACK_PROTOCOL_PATTERN = re.compile(
     r"<readback_protocol>.*?</readback_protocol>", re.DOTALL,
 )
+_EVENT_TAG_PATTERN = re.compile(r"<event>(.*?)</event>")
 
 
 def _make_collection_block(
@@ -121,6 +122,13 @@ def before_model_callback(  # pylint: disable=undefined-variable
 
   # ── Call the engine ─────────────────────────────────────────
   event_data = callback_context.state.get("event_data", {})
+  ia_event = callback_context.state.get("ia_event_name")
+  if not ia_event and last_user_text:
+    m = _EVENT_TAG_PATTERN.search(last_user_text)
+    if m:
+      ia_event = m.group(1)
+  if ia_event:
+    event_data["ia_event_name"] = ia_event
   engine_result = tools.slot_filling_engine(  # pylint: disable=undefined-variable
       {"input_data": {
           "raw_config": _RAW_CONFIG,
@@ -198,6 +206,10 @@ def before_model_callback(  # pylint: disable=undefined-variable
       and llm_request.contents
       and (len(llm_request.contents) > 1 or result.get("force_preempt"))):
     parts = []
+    if result.get("message"):
+      parts.append(Part.from_text(  # pylint: disable=undefined-variable
+          text=result["message"],
+      ))
     response_parts = result.get("response")
     if response_parts:
       for rp in response_parts:
@@ -225,10 +237,6 @@ def before_model_callback(  # pylint: disable=undefined-variable
           parts.append(Part.from_agent_transfer(  # pylint: disable=undefined-variable
               agent=rp["agent"],
           ))
-    elif result.get("message"):
-      parts.append(Part.from_text(  # pylint: disable=undefined-variable
-          text=result["message"],
-      ))
     fc = result.get("function_call")
     if fc:
       fn_call = Part.from_function_call(  # pylint: disable=undefined-variable

--- a/examples/bella_notte/evals/tool_tests/engine_confirm.yaml
+++ b/examples/bella_notte/evals/tool_tests/engine_confirm.yaml
@@ -415,3 +415,69 @@ tests:
       value: false
     - path: "$.result.action.function_call"
       operator: is_null
+
+# ═══════════════════════════════════════════════════════════════════
+# INLINE CONFIRM — defers task fire
+# ═══════════════════════════════════════════════════════════════════
+
+- name: inline_confirm_defers_task_fire
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config: *config
+      sm:
+        _events_checked: true
+        filled:
+          welcome: true
+          party_size: 4
+        pending:
+          preferred_date: "2027-06-01"
+        _last_state:
+          filled:
+            welcome: true
+            party_size: 4
+          pending:
+            preferred_date: "2027-06-01"
+          deferred: {}
+      last_user_text: "Yea, also I was wondering if an evening time is available"
+  expectations:
+    response:
+    - path: "$.result.action.inline_confirmed"
+      operator: equals
+      value: true
+    - path: "$.result.action.function_call"
+      operator: is_null
+    - path: "$.result.sm.filled.preferred_date"
+      operator: equals
+      value: "2027-06-01"
+
+# ═══════════════════════════════════════════════════════════════════
+# AUTO CONFIRM — next turn doesn't re-readback confirmed values
+# ═══════════════════════════════════════════════════════════════════
+
+- name: auto_confirm_no_rereadback
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config: *config
+      sm:
+        _events_checked: true
+        filled:
+          welcome: true
+          party_size: 4
+        pending: {}
+        _last_state:
+          filled:
+            welcome: true
+          pending:
+            party_size: 4
+          deferred: {}
+        _readback_transition: true
+      last_user_text: ""
+  expectations:
+    response:
+    - path: "$.result.action.si_suffix"
+      operator: is_not_null
+    - path: "$.result.action.message"
+      operator: contains
+      value: "What date"

--- a/examples/bella_notte/evals/tool_tests/engine_core.yaml
+++ b/examples/bella_notte/evals/tool_tests/engine_core.yaml
@@ -456,3 +456,107 @@ tests:
     - path: "$.result.action.message"
       operator: contains
       value: "How many guests"
+
+# ═══════════════════════════════════════════════════════════════════
+# ADDITIONAL FORMATTERS
+# ═══════════════════════════════════════════════════════════════════
+
+- name: formatter_prefix
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config: *config
+      sm:
+        _events_checked: true
+        filled:
+          welcome: true
+          party_size: 5
+          preferred_date: "2027-06-01"
+          available_times: "7:00 PM"
+          selected_time: "19:00"
+          guest_name: "Maria"
+          special_requests: "none"
+        pending:
+          large_party_phone: "555-0100"
+        task_results:
+          FindAvailableTimes:
+            success: true
+            available_times: "7:00 PM"
+        _last_state:
+          filled:
+            welcome: true
+            party_size: 5
+            preferred_date: "2027-06-01"
+            available_times: "7:00 PM"
+            selected_time: "19:00"
+            guest_name: "Maria"
+            special_requests: "none"
+          pending: {}
+          deferred: {}
+      last_user_text: ""
+  expectations:
+    response:
+    - path: "$.result.action.si_suffix"
+      operator: contains
+      value: "contact phone 555-0100"
+
+- name: formatter_none_sub_passthrough
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config: *config
+      sm:
+        _events_checked: true
+        filled:
+          welcome: true
+          party_size: 2
+          preferred_date: "2027-06-01"
+          available_times: "6:00 PM"
+          selected_time: "18:00"
+          guest_name: "Maria"
+        pending:
+          special_requests: "Window seat please"
+        task_results:
+          FindAvailableTimes:
+            success: true
+            available_times: "6:00 PM"
+        _last_state:
+          filled:
+            welcome: true
+            party_size: 2
+            preferred_date: "2027-06-01"
+            available_times: "6:00 PM"
+            selected_time: "18:00"
+            guest_name: "Maria"
+          pending: {}
+          deferred: {}
+      last_user_text: ""
+  expectations:
+    response:
+    - path: "$.result.action.si_suffix"
+      operator: contains
+      value: "Window seat please"
+
+# ═══════════════════════════════════════════════════════════════════
+# FILL_SLOTS — event pre-fill writes directly to filled
+# ═══════════════════════════════════════════════════════════════════
+
+- name: fill_slots_via_event_to_filled
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config: *config
+      sm:
+        filled:
+          welcome: true
+        pending: {}
+      last_user_text: ""
+      event_data:
+        party_size: 4
+  expectations:
+    response:
+    - path: "$.result.sm.filled.party_size"
+      operator: equals
+      value: 4
+    - path: "$.result.sm.pending.party_size"
+      operator: is_null

--- a/examples/bella_notte/evals/tool_tests/engine_errors.yaml
+++ b/examples/bella_notte/evals/tool_tests/engine_errors.yaml
@@ -540,3 +540,67 @@ tests:
     response:
     - path: "$.result.action.hide_tools"
       operator: is_not_null
+
+# ═══════════════════════════════════════════════════════════════════
+# ERROR RETRY COUNTER — resets after successful fill
+# ═══════════════════════════════════════════════════════════════════
+
+- name: error_retry_counter_resets_on_fill
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config: *config
+      sm:
+        _events_checked: true
+        filled:
+          welcome: true
+          party_size: 4
+        pending: {}
+        _retries:
+          "slot:party_size": 2
+        _last_state:
+          filled:
+            welcome: true
+          pending: {}
+          deferred: {}
+      last_user_text: ""
+  expectations:
+    response:
+    - path: "$.result.sm._retries['slot:party_size']"
+      operator: is_null
+
+# ═══════════════════════════════════════════════════════════════════
+# READBACK STALL — non-exhaust clears pending and asks next
+# ═══════════════════════════════════════════════════════════════════
+
+- name: readback_stall_nonexhaust_asks_next
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config: *config
+      sm:
+        _events_checked: true
+        filled:
+          welcome: true
+        pending:
+          party_size: 4
+        _readback_stall: 2
+        _retries: {}
+        _last_state:
+          filled:
+            welcome: true
+          pending:
+            party_size: 4
+          deferred: {}
+      last_user_text: "I'm not sure"
+  expectations:
+    response:
+    - path: "$.result.action.preempt"
+      operator: equals
+      value: true
+    - path: "$.result.action.force_preempt"
+      operator: equals
+      value: true
+    - path: "$.result.sm.pending"
+      operator: equals
+      value: {}

--- a/examples/bella_notte/evals/tool_tests/engine_events.yaml
+++ b/examples/bella_notte/evals/tool_tests/engine_events.yaml
@@ -171,17 +171,18 @@ tests:
       operator: equals
       value: true
 
-- name: event_prefill_skips_when_checked
+- name: event_prefill_idempotent_already_filled
   tool: slot_filling_engine
   args:
     input_data:
       raw_config: *config
       sm:
-        _events_checked: true
-        filled: {}
+        filled:
+          party_size: 4
         pending: {}
         _last_state:
-          filled: {}
+          filled:
+            party_size: 4
           pending: {}
           deferred: {}
       last_user_text: ""
@@ -190,7 +191,8 @@ tests:
   expectations:
     response:
     - path: "$.result.sm.filled.party_size"
-      operator: is_null
+      operator: equals
+      value: 4
     - path: "$.result.action.event_prefilled"
       operator: equals
       value: false
@@ -213,3 +215,200 @@ tests:
     - path: "$.result.action.message"
       operator: contains
       value: "Welcome"
+
+# ═══════════════════════════════════════════════════════════════════
+# EVENT PREFILL — multiple slots at once
+# ═══════════════════════════════════════════════════════════════════
+
+- name: event_prefill_multiple_slots
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config:
+        slots:
+        - name: name
+          source: ["event", "user"]
+          event_key: name
+          setter: set_name
+          hint: "Name"
+          ask: "What name?"
+          requires_readback: true
+        - name: email
+          source: ["event", "user"]
+          event_key: email
+          setter: set_email
+          hint: "Email"
+          ask: "What email?"
+          requires_readback: true
+        - name: phone
+          source: user
+          setter: set_phone
+          hint: "Phone"
+          ask: "What phone?"
+          requires_readback: true
+        tasks: []
+        confirm_transition_prefix: ""
+        readback_retry:
+          max_retries: 2
+          on_exhaust:
+            say: "Error."
+            then: escalate
+        progress_stall:
+          max_turns: 4
+          on_exhaust:
+            say: "Error."
+            then: escalate
+      sm:
+        filled: {}
+        pending: {}
+      last_user_text: ""
+      event_data:
+        name: "Alice"
+        email: "alice@example.com"
+  expectations:
+    response:
+    - path: "$.result.sm.filled.name"
+      operator: equals
+      value: "Alice"
+    - path: "$.result.sm.filled.email"
+      operator: equals
+      value: "alice@example.com"
+    - path: "$.result.sm.filled.phone"
+      operator: is_null
+    - path: "$.result.action.event_prefilled"
+      operator: equals
+      value: true
+
+- name: event_prefill_skips_inactive_conditional
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config:
+        slots:
+        - name: party_size
+          source: ["event", "user"]
+          event_key: party_size
+          setter: set_party_size
+          hint: "Party size"
+          ask: "How many?"
+          requires_readback: true
+        - name: large_party_phone
+          source: ["event", "user"]
+          event_key: phone
+          setter: set_phone
+          hint: "Phone (large parties)"
+          condition: "lambda filled: int(filled.get('party_size', 0)) >= 5"
+          ask: "Phone number?"
+          requires_readback: true
+        tasks: []
+        confirm_transition_prefix: ""
+        readback_retry:
+          max_retries: 2
+          on_exhaust:
+            say: "Error."
+            then: escalate
+        progress_stall:
+          max_turns: 4
+          on_exhaust:
+            say: "Error."
+            then: escalate
+      sm:
+        filled: {}
+        pending: {}
+      last_user_text: ""
+      event_data:
+        party_size: 2
+        phone: "555-1234"
+  expectations:
+    response:
+    - path: "$.result.sm.filled.party_size"
+      operator: equals
+      value: 2
+    - path: "$.result.sm.filled.large_party_phone"
+      operator: is_null
+
+# ═══════════════════════════════════════════════════════════════════
+# EVENT MAPPINGS — CES event name maps to slot values via config
+# ═══════════════════════════════════════════════════════════════════
+
+- name: event_mapping_maps_event_to_slot
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config:
+        slots:
+        - name: alert_price_type
+          source: ["event", "user"]
+          setter: set_alert_price_type
+          hint: "Price type"
+          ask: "Bid, ask, or last?"
+          requires_readback: true
+        tasks: []
+        confirm_transition_prefix: ""
+        readback_retry:
+          max_retries: 2
+          on_exhaust:
+            say: "Error."
+            then: escalate
+        progress_stall:
+          max_turns: 4
+          on_exhaust:
+            say: "Error."
+            then: escalate
+        event_mappings:
+          alert_last_price:
+            alert_price_type: "last"
+          alert_bid_price:
+            alert_price_type: "bid"
+      sm:
+        filled: {}
+        pending: {}
+      last_user_text: ""
+      event_data:
+        ia_event_name: "alert_last_price"
+  expectations:
+    response:
+    - path: "$.result.sm.filled.alert_price_type"
+      operator: equals
+      value: "last"
+
+- name: event_mapping_no_match_ignored
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config:
+        slots:
+        - name: alert_price_type
+          source: ["event", "user"]
+          setter: set_alert_price_type
+          hint: "Price type"
+          ask: "Bid, ask, or last?"
+          requires_readback: true
+        tasks: []
+        confirm_transition_prefix: ""
+        readback_retry:
+          max_retries: 2
+          on_exhaust:
+            say: "Error."
+            then: escalate
+        progress_stall:
+          max_turns: 4
+          on_exhaust:
+            say: "Error."
+            then: escalate
+        event_mappings:
+          alert_last_price:
+            alert_price_type: "last"
+      sm:
+        filled: {}
+        pending: {}
+      last_user_text: ""
+      event_data:
+        ia_event_name: "some_other_event"
+  expectations:
+    response:
+    - path: "$.result.sm.filled.alert_price_type"
+      operator: is_null
+    - path: "$.result.action.message"
+      operator: contains
+      value: "Bid, ask, or last?"

--- a/examples/bella_notte/evals/tool_tests/engine_responses.yaml
+++ b/examples/bella_notte/evals/tool_tests/engine_responses.yaml
@@ -1,0 +1,750 @@
+# Slot filling engine: response/payload propagation through all output paths
+_config: &config
+  slots:
+  - name: welcome
+    source: announce
+    message: "Welcome!"
+    preempt: false
+    response:
+    - type: text
+      text: "Welcome!"
+    - type: payload
+      data:
+        richContent:
+        - - type: info
+            title: "Welcome Card"
+  - name: party_size
+    source: user
+    setter: set_party_size
+    hint: "Party size"
+    ask: "How many guests?"
+    response:
+    - type: payload
+      data:
+        richContent:
+        - - type: chips
+            options:
+            - text: "2"
+            - text: "4"
+    readback_fmt:
+      type: plural
+      one: guest
+      other: guests
+    requires_readback: true
+    validation:
+      max_retries: 2
+      errors:
+        out_of_range: "Parties of 1 to 8 only."
+      error_responses:
+        out_of_range:
+        - type: text
+          text: "Try 1-8."
+        - type: payload
+          data:
+            richContent:
+            - - type: chips
+                options:
+                - text: "2"
+                - text: "4"
+      on_exhaust:
+        say: "Please call us."
+        response:
+        - type: payload
+          data:
+            richContent:
+            - - type: info
+                title: "Call 555-0100"
+        then: escalate
+  - name: preferred_date
+    source: user
+    setter: set_preferred_date
+    hint: "Date"
+    ask: "What date?"
+    readback_fmt: date
+    requires_readback: true
+    validation:
+      max_retries: 3
+      errors:
+        invalid_format: "Use YYYY-MM-DD."
+      on_exhaust:
+        say: "Please call us."
+        then: escalate
+  - name: available_times
+    source: "task:FindAvailableTimes"
+  - name: selected_time
+    source: user
+    setter: set_selected_time
+    hint: "Time"
+    requires: ["available_times"]
+    ask: "Times: {available_times}. Pick one?"
+    response:
+    - type: payload
+      data:
+        richContent:
+        - - type: description
+            title: "Available for {preferred_date}"
+            text:
+            - "{available_times}"
+    readback_fmt: time
+    requires_readback: true
+    validation:
+      max_retries: 3
+      errors:
+        not_available: "Not available."
+      on_exhaust:
+        say: "Please call us."
+        then: escalate
+  - name: guest_name
+    source: user
+    setter: set_guest_name
+    hint: "Name"
+    ask: "Name for the reservation?"
+    readback_fmt:
+      type: prefix
+      text: "under the name"
+    requires_readback: true
+    validation:
+      max_retries: 3
+      errors:
+        empty_name: "Need a name."
+      on_exhaust:
+        say: "Please call us."
+        then: escalate
+  - name: confirmation_number
+    source: "task:BookReservation"
+  tasks:
+  - name: FindAvailableTimes
+    tool: find_available_times
+    inputs: ["party_size", "preferred_date"]
+    outputs:
+      available_times: available_times
+    success_check: success
+    then_say: "We have {available_times}."
+    then_response:
+    - type: payload
+      data:
+        richContent:
+        - - type: info
+            title: "Times Found"
+    on_failure:
+      retry_say: "No availability. Try another date?"
+      retry_response:
+      - type: payload
+        data:
+          richContent:
+          - - type: info
+              title: "Try Another Date"
+      max_retries: 2
+      clear_slots: ["preferred_date"]
+      on_exhaust:
+        say: "Please call us."
+        response:
+        - type: payload
+          data:
+            richContent:
+            - - type: info
+                title: "Call For Help"
+        then: escalate
+  - name: BookReservation
+    tool: book_reservation
+    inputs: ["party_size", "preferred_date", "selected_time", "guest_name"]
+    readback_inputs: true
+    outputs:
+      confirmation_number: confirmation_number
+    success_check: success
+    terminal: true
+    then_say: "Confirmed! #{confirmation_number}."
+    then_response:
+    - type: text
+      text: "Confirmed! #{confirmation_number}."
+    - type: payload
+      data:
+        richContent:
+        - - type: info
+            title: "Booking #{confirmation_number}"
+            text: "{party_size} guests on {preferred_date}"
+    on_failure:
+      retry_say: "Let me try again."
+      max_retries: 2
+      on_exhaust:
+        say: "Please call us."
+        then: escalate
+  confirm_transition_prefix: "Great!"
+  readback_retry:
+    max_retries: 2
+    on_exhaust:
+      say: "Please call us."
+      response:
+      - type: payload
+        data:
+          richContent:
+          - - type: info
+              title: "Readback Stall Help"
+      then: escalate
+  progress_stall:
+    max_turns: 4
+    on_exhaust:
+      say: "Please call us."
+      response:
+      - type: payload
+        data:
+          richContent:
+          - - type: info
+              title: "Progress Stall Help"
+      then: escalate
+  readback_response:
+  - type: payload
+    data:
+      richContent:
+      - - type: chips
+          options:
+          - text: "Confirm"
+          - text: "Change"
+
+# ── Config with channel overrides for channel response tests ───────
+_config_channel: &config_channel
+  slots:
+  - name: welcome
+    source: announce
+    message: "Welcome!"
+    preempt: false
+    response:
+    - type: payload
+      data:
+        richContent:
+        - - type: info
+            title: "Default Welcome"
+    channel_response:
+      voice:
+      - type: audio
+        uri: "gs://audio/welcome.wav"
+        cancellable: false
+  tasks: []
+  confirm_transition_prefix: "Great!"
+  readback_retry:
+    max_retries: 2
+    on_exhaust:
+      say: "Please call us."
+      then: escalate
+  progress_stall:
+    max_turns: 4
+    on_exhaust:
+      say: "Please call us."
+      then: escalate
+
+tests:
+# ═══════════════════════════════════════════════════════════════════
+# ANNOUNCE RESPONSE
+# ═══════════════════════════════════════════════════════════════════
+
+- name: announce_response_attached
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config: *config
+      sm:
+        _events_checked: true
+        filled: {}
+        pending: {}
+        _last_state:
+          filled: {}
+          pending: {}
+          deferred: {}
+      last_user_text: ""
+  expectations:
+    response:
+    - path: "$.result.sm._pending_payloads"
+      operator: is_not_null
+    - path: "$.result.sm._pending_payloads[1].type"
+      operator: equals
+      value: "payload"
+
+# ═══════════════════════════════════════════════════════════════════
+# QUESTION RESPONSE (stashed for after_model_callback)
+# ═══════════════════════════════════════════════════════════════════
+
+- name: question_response_stashed
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config: *config
+      sm:
+        _events_checked: true
+        filled:
+          welcome: true
+        pending: {}
+        _last_state:
+          filled:
+            welcome: true
+          pending: {}
+          deferred: {}
+      last_user_text: ""
+  expectations:
+    response:
+    - path: "$.result.sm._pending_question_payloads.slot"
+      operator: equals
+      value: "party_size"
+    - path: "$.result.sm._pending_question_payloads.parts[0].type"
+      operator: equals
+      value: "payload"
+
+# ═══════════════════════════════════════════════════════════════════
+# VALIDATION ERROR RESPONSE
+# ═══════════════════════════════════════════════════════════════════
+
+- name: error_response_attached
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config: *config
+      sm:
+        _events_checked: true
+        filled:
+          welcome: true
+        pending: {}
+        _slot_errors:
+        - slot: party_size
+          code: out_of_range
+        _last_state:
+          filled:
+            welcome: true
+          pending: {}
+          deferred: {}
+      last_user_text: ""
+  expectations:
+    response:
+    - path: "$.result.action.preempt"
+      operator: equals
+      value: true
+    - path: "$.result.action.response[0].type"
+      operator: equals
+      value: "text"
+    - path: "$.result.action.response[0].text"
+      operator: equals
+      value: "Try 1-8."
+    - path: "$.result.action.response[1].type"
+      operator: equals
+      value: "payload"
+
+# ═══════════════════════════════════════════════════════════════════
+# VALIDATION EXHAUST RESPONSE
+# ═══════════════════════════════════════════════════════════════════
+
+- name: error_exhaust_response_attached
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config: *config
+      sm:
+        _events_checked: true
+        filled:
+          welcome: true
+        pending: {}
+        _slot_errors:
+        - slot: party_size
+          code: out_of_range
+        _retries:
+          "slot:party_size": 2
+        _last_state:
+          filled:
+            welcome: true
+          pending: {}
+          deferred: {}
+      last_user_text: ""
+  expectations:
+    response:
+    - path: "$.result.action.preempt"
+      operator: equals
+      value: true
+    - path: "$.result.sm.status"
+      operator: equals
+      value: "escalated"
+    - path: "$.result.action.response[0].type"
+      operator: equals
+      value: "payload"
+    - path: "$.result.action.response[0].data.richContent[0][0].title"
+      operator: equals
+      value: "Call 555-0100"
+
+# ═══════════════════════════════════════════════════════════════════
+# TASK SUCCESS — TERMINAL (then_response)
+# ═══════════════════════════════════════════════════════════════════
+
+- name: task_terminal_response_attached
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config: *config
+      sm:
+        _events_checked: true
+        filled:
+          welcome: true
+          party_size: 2
+          preferred_date: "2027-06-01"
+          available_times: "6:00 PM"
+          selected_time: "18:00"
+          guest_name: "Maria"
+          confirmation_number: "BN-9999"
+        pending: {}
+        task_results:
+          FindAvailableTimes:
+            success: true
+            available_times: "6:00 PM"
+          BookReservation:
+            success: true
+            confirmation_number: "BN-9999"
+        _task_just_completed: "BookReservation"
+        _last_state:
+          filled:
+            welcome: true
+            party_size: 2
+            preferred_date: "2027-06-01"
+            available_times: "6:00 PM"
+            selected_time: "18:00"
+            guest_name: "Maria"
+            confirmation_number: "BN-9999"
+          pending: {}
+          deferred: {}
+      last_user_text: ""
+  expectations:
+    response:
+    - path: "$.result.action.preempt"
+      operator: equals
+      value: true
+    - path: "$.result.action.response[0].type"
+      operator: equals
+      value: "text"
+    - path: "$.result.action.response[0].text"
+      operator: contains
+      value: "BN-9999"
+    - path: "$.result.action.response[1].type"
+      operator: equals
+      value: "payload"
+    - path: "$.result.action.response[1].data.richContent[0][0].title"
+      operator: contains
+      value: "BN-9999"
+
+# ═══════════════════════════════════════════════════════════════════
+# TASK SUCCESS — NON-TERMINAL (then_response — NEW FEATURE)
+# ═══════════════════════════════════════════════════════════════════
+
+- name: task_nonterminal_response_combined
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config: *config
+      sm:
+        _events_checked: true
+        filled:
+          welcome: true
+          party_size: 4
+          preferred_date: "2027-06-01"
+          available_times: "6:00 PM, 7:30 PM"
+        pending: {}
+        task_results:
+          FindAvailableTimes:
+            success: true
+            available_times: "6:00 PM, 7:30 PM"
+        _task_just_completed: "FindAvailableTimes"
+        _last_state:
+          filled:
+            welcome: true
+            party_size: 4
+            preferred_date: "2027-06-01"
+            available_times: "6:00 PM, 7:30 PM"
+          pending: {}
+          deferred: {}
+      last_user_text: ""
+  expectations:
+    response:
+    - path: "$.result.action.preempt"
+      operator: equals
+      value: true
+    - path: "$.result.action.message"
+      operator: contains
+      value: "6:00 PM, 7:30 PM"
+    - path: "$.result.action.response[0].data.richContent[0][0].title"
+      operator: equals
+      value: "Times Found"
+
+# ═══════════════════════════════════════════════════════════════════
+# TASK FAILURE RETRY (retry_response)
+# ═══════════════════════════════════════════════════════════════════
+
+- name: task_retry_response_attached
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config: *config
+      sm:
+        _events_checked: true
+        filled:
+          welcome: true
+          party_size: 4
+          preferred_date: "2027-06-01"
+        pending: {}
+        task_results:
+          FindAvailableTimes:
+            success: false
+        _task_just_completed: "FindAvailableTimes"
+        _retries: {}
+        _last_state:
+          filled:
+            welcome: true
+            party_size: 4
+            preferred_date: "2027-06-01"
+          pending: {}
+          deferred: {}
+      last_user_text: ""
+  expectations:
+    response:
+    - path: "$.result.action.preempt"
+      operator: equals
+      value: true
+    - path: "$.result.action.message"
+      operator: contains
+      value: "No availability"
+    - path: "$.result.action.response[0].data.richContent[0][0].title"
+      operator: equals
+      value: "Try Another Date"
+
+# ═══════════════════════════════════════════════════════════════════
+# TASK FAILURE EXHAUST (on_exhaust.response)
+# ═══════════════════════════════════════════════════════════════════
+
+- name: task_exhaust_response_attached
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config: *config
+      sm:
+        _events_checked: true
+        filled:
+          welcome: true
+          party_size: 4
+          preferred_date: "2027-06-01"
+        pending: {}
+        task_results:
+          FindAvailableTimes:
+            success: false
+        _task_just_completed: "FindAvailableTimes"
+        _retries:
+          FindAvailableTimes: 1
+        _last_state:
+          filled:
+            welcome: true
+            party_size: 4
+            preferred_date: "2027-06-01"
+          pending: {}
+          deferred: {}
+      last_user_text: ""
+  expectations:
+    response:
+    - path: "$.result.sm.status"
+      operator: equals
+      value: "escalated"
+    - path: "$.result.action.preempt"
+      operator: equals
+      value: true
+    - path: "$.result.action.response[0].data.richContent[0][0].title"
+      operator: equals
+      value: "Call For Help"
+
+# ═══════════════════════════════════════════════════════════════════
+# READBACK STALL EXHAUST (on_exhaust.response)
+# ═══════════════════════════════════════════════════════════════════
+
+- name: readback_stall_exhaust_response
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config: *config
+      sm:
+        _events_checked: true
+        filled:
+          welcome: true
+        pending:
+          party_size: 4
+        _readback_stall: 2
+        _retries:
+          readback: 1
+        _last_state:
+          filled:
+            welcome: true
+          pending:
+            party_size: 4
+          deferred: {}
+      last_user_text: "I don't know"
+  expectations:
+    response:
+    - path: "$.result.sm.status"
+      operator: equals
+      value: "escalated"
+    - path: "$.result.action.preempt"
+      operator: equals
+      value: true
+    - path: "$.result.action.response[0].data.richContent[0][0].title"
+      operator: equals
+      value: "Readback Stall Help"
+
+# ═══════════════════════════════════════════════════════════════════
+# PROGRESS STALL EXHAUST (on_exhaust.response)
+# ═══════════════════════════════════════════════════════════════════
+
+- name: progress_stall_exhaust_response
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config: *config
+      sm:
+        _events_checked: true
+        filled:
+          welcome: true
+        pending: {}
+        _progress_turns: 3
+        _last_state:
+          filled:
+            welcome: true
+          pending: {}
+          deferred: {}
+      last_user_text: "tell me a joke"
+  expectations:
+    response:
+    - path: "$.result.action.preempt"
+      operator: equals
+      value: true
+    - path: "$.result.action.response[0].data.richContent[0][0].title"
+      operator: equals
+      value: "Progress Stall Help"
+
+# ═══════════════════════════════════════════════════════════════════
+# READBACK CONFIRMATION RESPONSE (NEW FEATURE — readback_response)
+# ═══════════════════════════════════════════════════════════════════
+
+- name: readback_response_stashed
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config: *config
+      sm:
+        _events_checked: true
+        filled:
+          welcome: true
+        pending:
+          party_size: 3
+        _last_state:
+          filled:
+            welcome: true
+          pending: {}
+          deferred: {}
+      last_user_text: ""
+  expectations:
+    response:
+    - path: "$.result.action.si_suffix"
+      operator: contains
+      value: "<readback_scope>"
+    - path: "$.result.sm._pending_payloads"
+      operator: is_not_null
+    - path: "$.result.sm._pending_payloads[0].data.richContent[0][0].options[0].text"
+      operator: equals
+      value: "Confirm"
+
+# ═══════════════════════════════════════════════════════════════════
+# RESPONSE SUBSTITUTION ({slot_name} placeholders resolved)
+# ═══════════════════════════════════════════════════════════════════
+
+- name: response_substitution
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config: *config
+      sm:
+        _events_checked: true
+        filled:
+          welcome: true
+          party_size: 2
+          preferred_date: "2027-06-01"
+          available_times: "6:00 PM"
+          selected_time: "18:00"
+          guest_name: "Maria"
+          confirmation_number: "BN-5555"
+        pending: {}
+        task_results:
+          FindAvailableTimes:
+            success: true
+            available_times: "6:00 PM"
+          BookReservation:
+            success: true
+            confirmation_number: "BN-5555"
+        _task_just_completed: "BookReservation"
+        _last_state:
+          filled:
+            welcome: true
+            party_size: 2
+            preferred_date: "2027-06-01"
+            available_times: "6:00 PM"
+            selected_time: "18:00"
+            guest_name: "Maria"
+            confirmation_number: "BN-5555"
+          pending: {}
+          deferred: {}
+      last_user_text: ""
+  expectations:
+    response:
+    - path: "$.result.action.response[1].data.richContent[0][0].text"
+      operator: contains
+      value: "2 guests"
+    - path: "$.result.action.response[1].data.richContent[0][0].text"
+      operator: contains
+      value: "2027-06-01"
+
+# ═══════════════════════════════════════════════════════════════════
+# CHANNEL OVERRIDE RESPONSE
+# ═══════════════════════════════════════════════════════════════════
+
+- name: channel_override_response
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config: *config_channel
+      sm:
+        _events_checked: true
+        filled: {}
+        pending: {}
+        channel: "voice"
+        _last_state:
+          filled: {}
+          pending: {}
+          deferred: {}
+      last_user_text: ""
+  expectations:
+    response:
+    - path: "$.result.sm._pending_payloads[0].type"
+      operator: equals
+      value: "audio"
+    - path: "$.result.sm._pending_payloads[0].uri"
+      operator: equals
+      value: "gs://audio/welcome.wav"
+
+- name: channel_default_no_override
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config: *config_channel
+      sm:
+        _events_checked: true
+        filled: {}
+        pending: {}
+        _last_state:
+          filled: {}
+          pending: {}
+          deferred: {}
+      last_user_text: ""
+  expectations:
+    response:
+    - path: "$.result.sm._pending_payloads[0].type"
+      operator: equals
+      value: "payload"
+    - path: "$.result.sm._pending_payloads[0].data.richContent[0][0].title"
+      operator: equals
+      value: "Default Welcome"

--- a/examples/bella_notte/evals/tool_tests/engine_tasks.yaml
+++ b/examples/bella_notte/evals/tool_tests/engine_tasks.yaml
@@ -570,3 +570,462 @@ tests:
     - path: "$.result.action.si_suffix"
       operator: contains
       value: "MUST confirm ALL"
+
+# ═══════════════════════════════════════════════════════════════════
+# CONDITIONAL SLOT LIFECYCLE — deactivation from pending/deferred
+# ═══════════════════════════════════════════════════════════════════
+
+- name: conditional_slot_deactivation_from_pending
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config: *config
+      sm:
+        _events_checked: true
+        filled:
+          welcome: true
+          party_size: 3
+        pending:
+          large_party_phone: "555-1234"
+        _last_state:
+          filled:
+            welcome: true
+            party_size: 5
+          pending:
+            large_party_phone: "555-1234"
+          deferred: {}
+      last_user_text: ""
+  expectations:
+    response:
+    - path: "$.result.sm.pending.large_party_phone"
+      operator: is_null
+
+- name: conditional_slot_deactivation_from_deferred
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config: *config
+      sm:
+        _events_checked: true
+        filled:
+          welcome: true
+          party_size: 3
+        pending: {}
+        deferred:
+          large_party_phone: "555-1234"
+        _last_state:
+          filled:
+            welcome: true
+            party_size: 5
+          pending: {}
+          deferred:
+            large_party_phone: "555-1234"
+      last_user_text: ""
+  expectations:
+    response:
+    - path: "$.result.sm.deferred.large_party_phone"
+      operator: is_null
+
+# ═══════════════════════════════════════════════════════════════════
+# ANNOUNCE SLOT — three-deep cascade
+# ═══════════════════════════════════════════════════════════════════
+
+- name: announce_cascade_three_deep
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config:
+        slots:
+        - name: greeting
+          source: announce
+          message: "Hello!"
+          preempt: false
+        - name: hours
+          source: announce
+          message: "Open 5-10pm."
+          preempt: false
+        - name: notice
+          source: announce
+          message: "No walk-ins today."
+          preempt: false
+        - name: party_size
+          source: user
+          setter: set_party_size
+          hint: "Party size"
+          ask: "How many guests?"
+          readback_fmt:
+            type: plural
+            one: guest
+            other: guests
+          requires_readback: true
+        tasks: []
+        confirm_transition_prefix: ""
+        readback_retry:
+          max_retries: 2
+          on_exhaust:
+            say: "Please call."
+            then: escalate
+        progress_stall:
+          max_turns: 4
+          on_exhaust:
+            say: "Please call."
+            then: escalate
+      sm:
+        _events_checked: true
+        filled: {}
+        pending: {}
+        _last_state:
+          filled: {}
+          pending: {}
+          deferred: {}
+      last_user_text: ""
+  expectations:
+    response:
+    - path: "$.result.sm.filled.greeting"
+      operator: equals
+      value: true
+    - path: "$.result.sm.filled.hours"
+      operator: equals
+      value: true
+    - path: "$.result.sm.filled.notice"
+      operator: equals
+      value: true
+    - path: "$.result.action.message"
+      operator: contains
+      value: "Hello!"
+    - path: "$.result.action.message"
+      operator: contains
+      value: "Open 5-10pm."
+    - path: "$.result.action.message"
+      operator: contains
+      value: "No walk-ins today."
+    - path: "$.result.action.message"
+      operator: contains
+      value: "How many guests?"
+
+# ═══════════════════════════════════════════════════════════════════
+# TASK WITH CONDITION — false prevents firing
+# ═══════════════════════════════════════════════════════════════════
+
+- name: task_with_condition_false
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config:
+        slots:
+        - name: party_size
+          source: user
+          setter: set_party_size
+          hint: "Party size"
+          ask: "How many guests?"
+          readback_fmt:
+            type: plural
+            one: guest
+            other: guests
+          requires_readback: true
+        - name: vip_code
+          source: user
+          setter: set_vip_code
+          hint: "VIP code"
+          ask: "Enter VIP code."
+          requires_readback: true
+        tasks:
+        - name: CheckVIP
+          tool: check_vip
+          condition: "lambda filled: int(filled.get('party_size', 0)) >= 10"
+          inputs: ["vip_code"]
+          outputs: {}
+          success_check: success
+          then_say: "VIP confirmed."
+        confirm_transition_prefix: ""
+        readback_retry:
+          max_retries: 2
+          on_exhaust:
+            say: "Please call."
+            then: escalate
+        progress_stall:
+          max_turns: 4
+          on_exhaust:
+            say: "Please call."
+            then: escalate
+      sm:
+        _events_checked: true
+        filled:
+          party_size: 3
+          vip_code: "GOLD"
+        pending: {}
+        task_results: {}
+        _last_state:
+          filled:
+            party_size: 3
+            vip_code: "GOLD"
+          pending: {}
+          deferred: {}
+      last_user_text: ""
+  expectations:
+    response:
+    - path: "$.result.action.function_call"
+      operator: is_null
+
+# ═══════════════════════════════════════════════════════════════════
+# TASK RESULT SUBSTITUTION — then_say references task result fields
+# ═══════════════════════════════════════════════════════════════════
+
+- name: task_result_substitution_then_say
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config:
+        slots:
+        - name: symbol
+          source: user
+          setter: set_symbol
+          hint: "Stock symbol"
+          ask: "Which symbol?"
+          requires_readback: false
+        - name: quote_result
+          source: "task:GetQuote"
+        tasks:
+        - name: GetQuote
+          tool: get_quote
+          inputs: ["symbol"]
+          outputs:
+            quote_result: quote_result
+          success_check: success
+          terminal: true
+          then_say: "As of {quoteDate}, {symbolName} ({symbol}) is trading at {lastTradeValue}."
+        confirm_transition_prefix: ""
+        readback_retry:
+          max_retries: 2
+          on_exhaust:
+            say: "Please call."
+            then: escalate
+        progress_stall:
+          max_turns: 4
+          on_exhaust:
+            say: "Please call."
+            then: escalate
+      sm:
+        _events_checked: true
+        filled:
+          symbol: "AAPL"
+          quote_result: "done"
+        pending: {}
+        task_results:
+          GetQuote:
+            success: true
+            quoteDate: "May 15, 2026"
+            symbolName: "Apple Inc."
+            lastTradeValue: "$195.50"
+            quote_result: "done"
+        _task_just_completed: "GetQuote"
+        _last_state:
+          filled:
+            symbol: "AAPL"
+            quote_result: "done"
+          pending: {}
+          deferred: {}
+      last_user_text: ""
+  expectations:
+    response:
+    - path: "$.result.action.message"
+      operator: contains
+      value: "Apple Inc."
+    - path: "$.result.action.message"
+      operator: contains
+      value: "$195.50"
+    - path: "$.result.action.message"
+      operator: contains
+      value: "AAPL"
+
+- name: task_result_substitution_then_response
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config:
+        slots:
+        - name: symbol
+          source: user
+          setter: set_symbol
+          hint: "Stock symbol"
+          ask: "Which symbol?"
+          requires_readback: false
+        - name: quote_result
+          source: "task:GetQuote"
+        tasks:
+        - name: GetQuote
+          tool: get_quote
+          inputs: ["symbol"]
+          outputs:
+            quote_result: quote_result
+          success_check: success
+          terminal: true
+          then_say: "Quote for {symbol}."
+          then_response:
+          - type: payload
+            data:
+              text: "{symbolName} is trading at {lastTradeValue}."
+        confirm_transition_prefix: ""
+        readback_retry:
+          max_retries: 2
+          on_exhaust:
+            say: "Please call."
+            then: escalate
+        progress_stall:
+          max_turns: 4
+          on_exhaust:
+            say: "Please call."
+            then: escalate
+      sm:
+        _events_checked: true
+        filled:
+          symbol: "MSFT"
+          quote_result: "done"
+        pending: {}
+        task_results:
+          GetQuote:
+            success: true
+            symbolName: "Microsoft Corp."
+            lastTradeValue: "$420.00"
+            quote_result: "done"
+        _task_just_completed: "GetQuote"
+        _last_state:
+          filled:
+            symbol: "MSFT"
+            quote_result: "done"
+          pending: {}
+          deferred: {}
+      last_user_text: ""
+  expectations:
+    response:
+    - path: "$.result.action.response[0].data.text"
+      operator: contains
+      value: "Microsoft Corp."
+    - path: "$.result.action.response[0].data.text"
+      operator: contains
+      value: "$420.00"
+
+# ═══════════════════════════════════════════════════════════════════
+# ON_COMPLETE — terminal task clears slots and resets status
+# ═══════════════════════════════════════════════════════════════════
+
+- name: on_complete_clears_slots_and_resets
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config:
+        slots:
+        - name: action
+          source: user
+          setter: set_action
+          hint: "Action"
+          ask: "Quote or Rating?"
+          requires_readback: false
+        - name: symbol
+          source: user
+          setter: set_symbol
+          hint: "Stock symbol"
+          ask: "Which symbol?"
+          requires_readback: false
+        - name: result
+          source: "task:FulfillAction"
+        tasks:
+        - name: FulfillAction
+          tool: fulfill_action
+          inputs: ["action", "symbol"]
+          outputs:
+            result: result
+          success_check: success
+          terminal: true
+          then_say: "Done for {symbol}."
+          on_complete:
+            clear_slots: ["action", "symbol"]
+        confirm_transition_prefix: ""
+        readback_retry:
+          max_retries: 2
+          on_exhaust:
+            say: "Please call."
+            then: escalate
+        progress_stall:
+          max_turns: 4
+          on_exhaust:
+            say: "Please call."
+            then: escalate
+      sm:
+        _events_checked: true
+        filled:
+          action: "Quote"
+          symbol: "AAPL"
+          result: "done"
+        pending: {}
+        task_results:
+          FulfillAction:
+            success: true
+            result: "done"
+        _task_just_completed: "FulfillAction"
+        _last_state:
+          filled:
+            action: "Quote"
+            symbol: "AAPL"
+            result: "done"
+          pending: {}
+          deferred: {}
+      last_user_text: ""
+  expectations:
+    response:
+    - path: "$.result.sm.status"
+      operator: equals
+      value: "in_progress"
+    - path: "$.result.sm.filled.action"
+      operator: is_null
+    - path: "$.result.sm.filled.symbol"
+      operator: is_null
+    - path: "$.result.sm.task_results.FulfillAction"
+      operator: is_null
+    - path: "$.result.action.message"
+      operator: contains
+      value: "Done for AAPL"
+
+- name: on_complete_absent_sets_complete
+  tool: slot_filling_engine
+  args:
+    input_data:
+      raw_config: *config
+      sm:
+        _events_checked: true
+        filled:
+          welcome: true
+          party_size: 2
+          preferred_date: "2027-06-01"
+          available_times: "6:00 PM"
+          selected_time: "18:00"
+          guest_name: "Maria"
+          special_requests: "none"
+          confirmation_number: "BN-1234"
+        pending: {}
+        task_results:
+          FindAvailableTimes:
+            success: true
+            available_times: "6:00 PM"
+          BookReservation:
+            success: true
+            confirmation_number: "BN-1234"
+        _task_just_completed: "BookReservation"
+        _last_state:
+          filled:
+            welcome: true
+            party_size: 2
+            preferred_date: "2027-06-01"
+            available_times: "6:00 PM"
+            selected_time: "18:00"
+            guest_name: "Maria"
+            special_requests: "none"
+            confirmation_number: "BN-1234"
+          pending: {}
+          deferred: {}
+      last_user_text: ""
+  expectations:
+    response:
+    - path: "$.result.sm.status"
+      operator: equals
+      value: "complete"

--- a/examples/bella_notte/slot_filling_dag_framework.md
+++ b/examples/bella_notte/slot_filling_dag_framework.md
@@ -118,8 +118,10 @@ Key properties:
 | `success_check` | Key in the result dict that must be truthy for the task to count as successful. |
 | `terminal` | If `True`, successful completion ends the conversation (sets `status = "complete"`). |
 | `readback_inputs` | Defer slot readback to grouped confirmation (7a). |
-| `then_say` | Message template shown on success. Supports `{slot_name}` placeholders. |
+| `then_say` | Message template shown on success. Supports `{slot_name}` placeholders from filled slots AND `{key}` placeholders from the task's result dict. For example, if the task tool returns `{"success": True, "symbolName": "Apple Inc.", "lastTradeValue": "$180.00"}`, you can write `"then_say": "{symbolName} is trading at {lastTradeValue}."`. See Section 12.5. |
+| `then_response` | Structured response list for channel-aware payloads. Same substitution rules as `then_say` — both filled slots and task result keys are available. See Section 12.5. |
 | `condition` | Optional lambda string compiled to a callable. When present, the task only fires if the condition returns `True`. Inactive tasks are skipped during DAG evaluation. Same compilation as slot conditions. |
+| `on_complete` | Optional dict with `clear_slots` (list of slot names). When present on a terminal task, after success the engine clears the specified slots, removes the task result, and resets `status` to `"in_progress"` — enabling conversation restart. See Section 12.6. |
 | `on_failure` | Retry and escalation configuration (see Section 5). |
 
 ### 2.3 The DAG
@@ -1376,12 +1378,43 @@ instruction directives and logging.
 |----------|-----------|----------------|
 | Announce slot | `message` | `response` |
 | User slot (ask) | `ask` | `response` |
-| Task success | `then_say` | `then_response` |
+| Readback confirmation | (generated) | `readback_response` (top-level) |
+| Task success (terminal) | `then_say` | `then_response` |
+| Task success (non-terminal) | `then_say` | `then_response` |
 | Task retry | `retry_say` | `retry_response` |
 | Task exhaust | `on_exhaust.say` | `on_exhaust.response` |
 | Validation error | `errors[code]` | `error_responses[code]` |
 | Readback exhaust | `on_exhaust.say` | `on_exhaust.response` |
 | Progress exhaust | `on_exhaust.say` | `on_exhaust.response` |
+
+### Readback Confirmation Response
+
+When the engine generates a readback prompt ("Just to confirm —
+3 guests, on June 15th. Is that correct?"), you can attach
+payloads via a top-level `readback_response` config field. This
+is useful for showing a summary card or confirm/reject chips
+during readback.
+
+```python
+{
+    "readback_response": [
+        {"type": "payload", "data": {
+            "richContent": [[
+                {"type": "chips", "options": [
+                    {"text": "Confirm"},
+                    {"text": "Change something"},
+                ]},
+            ]],
+        }},
+    ],
+}
+```
+
+The response supports `{slot_name}` substitution from both
+filled and pending values (since pending values are what the
+readback is confirming). Delivery uses the unconditional stash
+path (`sm["_pending_payloads"]`), so the after_model_callback
+injects the payload alongside the LLM's natural readback text.
 
 ### Channel-Aware Responses
 
@@ -1486,6 +1519,10 @@ This means payloads are delivered at these moments:
 
 On non-preempted turns, payloads are delivered via the
 **after_model_callback injection** path (see below).
+
+Non-terminal task `then_response` and readback `readback_response`
+payloads are always stashed to `sm["_pending_payloads"]` (since
+the LLM runs after both) and injected by the after_model_callback.
 
 **CES output format:** CES maps `Part.from_text()` to
 `output.text` and `Part.from_json()` to `output.payload`.
@@ -1764,28 +1801,36 @@ like `"user"` remain backward compatible.
 
 Event pre-fill runs inside `slot_filling_engine`, after
 config compilation but before DAG evaluation. It runs
-once per session (guarded by `sm["_events_checked"]`):
+on **every engine call** — no persistent guard is needed
+because `fill_slots()` is idempotent for already-filled
+slots (it returns `"skipped"` and moves on):
 
 ```python
-if not sm.get("_events_checked"):
-    event_data = callback_context.state.get("event_data", {})
-    if event_data:
-        event_values = {}
-        for slot_def in config["slots"]:
-            if "event" not in _normalize_sources(
-                slot_def.get("source", "user"),
-            ):
-                continue
-            key = slot_def.get("event_key", slot_def["name"])
-            value = event_data.get(key)
-            if value is not None:
-                event_values[slot_def["name"]] = value
-        if event_values:
-            result = fill_slots(sm, config, event_values)
-            if result["filled"]:
-                sm["_event_prefilled_this_turn"] = True
-    sm["_events_checked"] = True
+if event_data:
+    event_values = {}
+    for slot_def in config["slots"]:
+        if "event" not in _normalize_sources(
+            slot_def.get("source", "user"),
+        ):
+            continue
+        key = slot_def.get("event_key", slot_def["name"])
+        value = event_data.get(key)
+        if value is not None:
+            event_values[slot_def["name"]] = value
+    if event_values:
+        result = fill_slots(sm, config, event_values)
+        if result["filled"]:
+            sm["_event_prefilled_this_turn"] = True
 ```
+
+> **Why no guard?** An earlier version used an
+> `_events_checked` flag to run event processing only once.
+> This caused a bug: when new events arrived on later turns
+> (e.g., button presses injected as `ia_event_name`), the
+> flag was already `True` and the events were silently
+> ignored. Since `fill_slots()` skips already-filled slots,
+> re-processing the same event data is a no-op, making
+> the guard unnecessary.
 
 Event pre-fill uses `fill_slots()` (Section 12.2) with
 `skip_readback=True` (the default), writing trusted event
@@ -2045,6 +2090,174 @@ Without task `requires`, the only way to gate a task on
 a non-argument slot is via transitive slot `requires` —
 which doesn't work when the gate comes AFTER all input
 slots are collected but BEFORE the task fires.
+
+### 12.5 Task Result Substitution in `then_say` / `then_response`
+
+By default, `then_say` and `then_response` templates
+substitute from filled slots. Task result substitution
+extends this: the task tool's return dict is merged into
+the substitution context, so templates can reference
+**both** filled slots and task result keys.
+
+```python
+{
+    "name": "FulfillQuote",
+    "tool": "fulfill_quote",
+    "inputs": ["action", "symbol"],
+    "terminal": True,
+    "then_say": "As of {quoteDate}, {symbolName} ({symbol}) is trading at {lastTradeValue}.",
+}
+```
+
+Here `symbol` comes from filled slots, while `quoteDate`,
+`symbolName`, and `lastTradeValue` come from the
+`fulfill_quote` tool's return dict (e.g.,
+`{"success": True, "quoteDate": "2024-01-15",
+"symbolName": "Apple Inc.", "lastTradeValue": "$180.00"}`).
+
+The same substitution applies to `then_response` payloads:
+
+```python
+{
+    "name": "FulfillQuote",
+    "tool": "fulfill_quote",
+    "inputs": ["action", "symbol"],
+    "terminal": True,
+    "then_response": [
+        {"type": "payload", "data": {
+            "text": "{symbolName} ({symbol}) is {upDownPercent}, "
+                    "trading at {lastTradeValue}.",
+        }},
+    ],
+}
+```
+
+**Implementation:** In `_handle_post_executor()`, after
+a successful task, the engine builds
+`sub_context = {**filled, **result}` and uses it for
+both `then_say` format and `_resolve_response()` calls.
+If a key exists in both `filled` and `result`, the task
+result takes precedence (dict merge order).
+
+### 12.6 DAG Restart via `on_complete`
+
+By default, when a terminal task succeeds, the engine
+sets `status = "complete"` and the conversation ends.
+The `on_complete` field enables **conversation restart**
+— after a terminal task completes, specified slots are
+cleared and the DAG resets to `"in_progress"`, ready
+for the next query.
+
+```python
+{
+    "name": "FulfillQuote",
+    "tool": "fulfill_quote",
+    "inputs": ["action", "symbol"],
+    "condition": "lambda filled: filled.get('action') == 'Quote'",
+    "terminal": True,
+    "then_say": "{symbolName} is trading at {lastTradeValue}.",
+    "on_complete": {
+        "clear_slots": ["action", "symbol"],
+    },
+}
+```
+
+**Behavior:** After the task succeeds and `then_say` is
+delivered:
+
+1. Each slot in `clear_slots` is removed from `filled`.
+2. The task's result entry is removed from
+   `sm["_task_results"]`.
+3. `sm["status"]` is reset to `"in_progress"`.
+4. `sm["_events_checked"]` is reset to `False` (allowing
+   event re-processing if applicable).
+
+The DAG re-enters collection mode and asks for the next
+unfilled slot. If the user provides new values (e.g.,
+"what about MSFT?"), the same or a different conditional
+task can fire.
+
+**Use case:** Multi-action flows where the user can
+perform several operations in one session (e.g., get a
+stock quote, then a rating, then set a price alert).
+Each action is a conditional terminal task with
+`on_complete` clearing the action-specific slots.
+
+**Without `on_complete`:** The task sets
+`status = "complete"` and the conversation freezes. The
+user cannot start a new query without a new session.
+
+### 12.7 Event Mappings: CES Event Name → Slot Values
+
+CES UI elements (buttons, cards) can fire named events
+(e.g., `alert_last_price`, `alert_bid_price`). The
+`event_mappings` config maps these event names to slot
+values, keeping business logic out of callbacks.
+
+#### Config syntax
+
+Add `event_mappings` at the top level of your DAG config:
+
+```python
+{
+    "slots": [...],
+    "tasks": [...],
+    "event_mappings": {
+        "alert_last_price": {"alert_price_type": "last"},
+        "alert_bid_price": {"alert_price_type": "bid"},
+        "alert_ask_price": {"alert_price_type": "ask"},
+        "alert_rises_above": {"alert_price_direction": "rises above"},
+        "alert_drops_below": {"alert_price_direction": "drops below"},
+    },
+}
+```
+
+When the engine receives `event_data` with an
+`ia_event_name` key matching one of the mapping entries,
+the mapped slot values are injected into `event_data`
+before normal event pre-fill processing.
+
+#### Callback passthrough
+
+The standard `before_model_callback` passes
+`ia_event_name` through `event_data` so the engine can
+process it:
+
+```python
+event_data = callback_context.state.get("event_data", {})
+ia_event = callback_context.state.get("ia_event_name")
+if ia_event:
+    event_data["ia_event_name"] = ia_event
+```
+
+This is framework-level code (not agent-specific) and is
+already included in the standard `before_model_callback`.
+
+#### How it works
+
+In `slot_filling_engine()`, before event pre-fill:
+
+1. Read `event_mappings` from the compiled config.
+2. Check for `ia_event_name` in `event_data`.
+3. If a match is found, merge the mapped values into
+   `event_data`.
+4. Normal event pre-fill then processes the enriched
+   `event_data`, writing matched values to `filled`.
+
+Unmatched event names are ignored — the engine falls
+through to normal slot collection.
+
+#### Declaring `ia_event_name` in `app.json`
+
+CES only exposes declared variables. Add to
+`variableDeclarations`:
+
+```json
+{
+    "name": "ia_event_name",
+    "schema": {"type": "STRING", "default": ""}
+}
+```
 
 ---
 

--- a/examples/bella_notte/tools/slot_filling_engine/python_function/python_code.py
+++ b/examples/bella_notte/tools/slot_filling_engine/python_function/python_code.py
@@ -868,11 +868,11 @@ def _handle_post_executor(
     inv_n: int, phase: str, fresh_pending: bool,
     hide_tools: list[str],
     channel: str = "",
-) -> tuple[Optional[dict[str, Any]], str]:
+) -> tuple[Optional[dict[str, Any]], str, Optional[list[dict[str, Any]]]]:
   """Handle task executor results and retries."""
   task_just = sm.pop("_task_just_completed", None)
   if not task_just:
-    return None, ""
+    return None, "", None
 
   task_def = next(t for t in tasks if t["name"] == task_just)
   success_key = task_def.get("success_check", "success")
@@ -881,15 +881,25 @@ def _handle_post_executor(
   if result.get(success_key):
     _log("task", name=task_just, ok=True)
     retries.pop(task_just, None)
+    sub_context = {**filled, **result}
     task_msg = ""
     msg_template = task_def.get("then_say", "")
     if msg_template:
-      task_msg = msg_template.format(**filled)
+      task_msg = msg_template.format(**sub_context)
     deferred_transition = sm.pop("_deferred_transition", False)
     if deferred_transition and task_msg and confirm_transition_prefix:
       task_msg = f"{confirm_transition_prefix} {task_msg}"
     if task_def.get("terminal"):
-      sm["status"] = "complete"
+      on_complete = task_def.get("on_complete")
+      if on_complete:
+        for sn in on_complete.get("clear_slots", []):
+          filled.pop(sn, None)
+        task_results.pop(task_just, None)
+        sm["status"] = "in_progress"
+        _log("on_complete", task=task_just,
+             cleared=on_complete.get("clear_slots", []))
+      else:
+        sm["status"] = "complete"
       _log_invoke(inv_n, phase, filled, pending, fresh_pending,
                   hide_tools, fired=task_just, preempted=task_msg,
                   deferred=deferred)
@@ -897,12 +907,15 @@ def _handle_post_executor(
           "hide_tools": [], "preempt": True, "message": task_msg,
       }
       resp = _resolve_response(
-          task_def, "then_response", filled, channel,
+          task_def, "then_response", sub_context, channel,
       )
       if resp:
         preempt_result["response"] = resp
-      return preempt_result, task_msg
-    return None, task_msg
+      return preempt_result, task_msg, None
+    task_resp = _resolve_response(
+        task_def, "then_response", sub_context, channel,
+    )
+    return None, task_msg, task_resp
 
   _log("task", name=task_just, ok=False)
   on_failure = task_def.get("on_failure", {})
@@ -927,7 +940,7 @@ def _handle_post_executor(
     resp = _resolve_response(exhaust, "response", filled, channel)
     if resp:
       result["response"] = resp
-    return result, ""
+    return result, "", None
   retry_msg = on_failure.get("retry_say", "Let me try again.")
   _log_invoke(inv_n, phase, filled, pending, fresh_pending,
               hide_tools, preempted=retry_msg, deferred=deferred)
@@ -937,7 +950,7 @@ def _handle_post_executor(
   resp = _resolve_response(on_failure, "retry_response", filled, channel)
   if resp:
     retry_result["response"] = resp
-  return retry_result, ""
+  return retry_result, "", None
 
 
 def _build_readback_hint(
@@ -972,7 +985,7 @@ def _build_readback_hint(
 # ═════════════════════════════════════════════════════════════════════
 
 
-def _build_readback(slots, pending, filled):
+def _build_readback(slots, pending, filled, config=None, channel=""):
   """Build readback confirmation prompt."""
   fragments = []
   for slot_def in slots:
@@ -989,10 +1002,17 @@ def _build_readback(slots, pending, filled):
   if not fragments:
     return None
   summary = ", ".join(fragments)
-  return {
+  result = {
       "action": "awaiting_readback",
       "system_message": f"Just to confirm — {summary}. Is that correct?",
   }
+  if config:
+    resp = _resolve_response(
+        config, "readback_response", {**filled, **pending}, channel,
+    )
+    if resp:
+      result["response"] = resp
+  return result
 
 
 def _find_next_question(
@@ -1102,7 +1122,7 @@ def _find_next_slot_action(
 
 def _compute_dag_state(
     tasks, slots, filled, pending, task_results, slot_map,
-    deferred=None, channel="",
+    deferred=None, channel="", config=None,
 ):
   """Evaluate the DAG to determine the next action.
 
@@ -1119,6 +1139,7 @@ def _compute_dag_state(
     slot_map: Dict mapping slot name to slot definition.
     deferred: Currently deferred slot values.
     channel: Channel identifier for channel-aware responses.
+    config: Full compiled config (for readback_response).
 
   Returns:
     Action dict describing the next step (fire, next_question, etc.).
@@ -1154,7 +1175,7 @@ def _compute_dag_state(
     }
 
   if pending:
-    rb = _build_readback(slots, pending, filled)
+    rb = _build_readback(slots, pending, filled, config=config, channel=channel)
     if rb is not None:
       return rb
 
@@ -1521,7 +1542,7 @@ def _run_slot_filling(
   if result:
     return result
 
-  result, task_msg = _handle_post_executor(
+  result, task_msg, task_resp = _handle_post_executor(
       sm, tasks, task_results, filled, pending, deferred,
       retries, confirm_transition_prefix,
       inv_n, phase, fresh_pending, hide_tools,
@@ -1536,7 +1557,7 @@ def _run_slot_filling(
   any_announce_preempt = False
   dag_result = _compute_dag_state(
       tasks, slots, filled, pending, task_results, slot_map,
-      deferred=deferred, channel=channel,
+      deferred=deferred, channel=channel, config=config,
   )
   while dag_result["action"] == "announce":
     slot_def_a = dag_result["slot_def"]
@@ -1556,7 +1577,7 @@ def _run_slot_filling(
     _log("announce", slot=name_a)
     dag_result = _compute_dag_state(
         tasks, slots, filled, pending, task_results,
-        slot_map, deferred=deferred, channel=channel,
+        slot_map, deferred=deferred, channel=channel, config=config,
     )
 
   # Skip task fire on inline confirm — the LLM needs to run first
@@ -1604,7 +1625,11 @@ def _run_slot_filling(
       fire_result["response"] = announce_responses
     return fire_result
 
-  msg = task_msg or dag_result.get("system_message", "")
+  dag_msg = dag_result.get("system_message", "")
+  if task_msg and dag_msg:
+    msg = f"{task_msg} {dag_msg}"
+  else:
+    msg = task_msg or dag_msg
   if announce_msgs:
     announce_text = " ".join(announce_msgs)
     msg = (
@@ -1618,7 +1643,8 @@ def _run_slot_filling(
   if dag_result["action"] == "awaiting_readback" and not fresh_pending:
     msg = ""
 
-  preempt = bool(task_msg) or any_announce_preempt
+  event_prefilled = sm.get("_event_prefilled_this_turn", False)
+  preempt = bool(task_msg) or any_announce_preempt or event_prefilled
   if readback_transition and msg and confirm_transition_prefix:
     if not msg.lower().startswith(confirm_transition_prefix.lower()):
       msg = f"{confirm_transition_prefix} {msg}"
@@ -1662,6 +1688,8 @@ def _run_slot_filling(
   )
 
   combined_response = announce_responses or []
+  if task_resp:
+    combined_response = combined_response + task_resp
   dag_response = dag_result.get("response")
   if dag_response:
     combined_response = combined_response + dag_response
@@ -1679,11 +1707,16 @@ def _run_slot_filling(
     _log("payload_route", path="preempt_dispatch",
          n_parts=len(combined_response))
   else:
-    if announce_responses:
-      sm["_pending_payloads"] = announce_responses
-      _log("payload_route", path="stash_announce",
-           n_parts=len(announce_responses))
-    if dag_response:
+    unconditional = announce_responses or []
+    if task_resp:
+      unconditional = unconditional + task_resp
+    if dag_response and dag_result.get("action") == "awaiting_readback":
+      unconditional = unconditional + dag_response
+    if unconditional:
+      sm["_pending_payloads"] = unconditional
+      _log("payload_route", path="stash_unconditional",
+           n_parts=len(unconditional))
+    if dag_response and dag_result.get("action") != "awaiting_readback":
       sm["_pending_question_payloads"] = {
           "slot": dag_result.get("slot_name"),
           "parts": dag_response,
@@ -1691,7 +1724,7 @@ def _run_slot_filling(
       _log("payload_route", path="stash_question",
            slot=dag_result.get("slot_name"),
            n_parts=len(dag_response))
-    if not announce_responses and not dag_response:
+    if not unconditional and not dag_response:
       _log("payload_route", path="none")
   return final
 
@@ -1733,24 +1766,33 @@ def slot_filling_engine(input_data: dict[str, Any]) -> dict[str, Any]:
     _COMPILED_CONFIG = _compile_config(raw_config)
   config = _COMPILED_CONFIG
 
+  # ── Event mappings (CES event name → slot values) ───────────
+  event_mappings = config.get("event_mappings", {})
+  if event_mappings and event_data:
+    ia_event = event_data.get("ia_event_name", "")
+    if ia_event and ia_event in event_mappings:
+      for slot_name, value in event_mappings[ia_event].items():
+        event_data[slot_name] = value
+
   # ── Event pre-fill ──────────────────────────────────────────
-  if not sm.get("_events_checked"):
-    if event_data:
-      event_values = {}
-      for slot_def in config["slots"]:
-        if "event" not in _normalize_sources(
-            slot_def.get("source", "user")
-        ):
-          continue
-        key = slot_def.get("event_key", slot_def["name"])
-        value = event_data.get(key)
-        if value is not None:
-          event_values[slot_def["name"]] = value
-      if event_values:
-        result = fill_slots(sm, config, event_values)
-        if result["filled"]:
-          sm["_event_prefilled_this_turn"] = True
-    sm["_events_checked"] = True
+  # Process events on every engine call. fill_slots is idempotent
+  # for already-filled slots, so re-processing the same event is
+  # safe. No persistent guard needed.
+  if event_data:
+    event_values = {}
+    for slot_def in config["slots"]:
+      if "event" not in _normalize_sources(
+          slot_def.get("source", "user")
+      ):
+        continue
+      key = slot_def.get("event_key", slot_def["name"])
+      value = event_data.get(key)
+      if value is not None:
+        event_values[slot_def["name"]] = value
+    if event_values:
+      result = fill_slots(sm, config, event_values)
+      if result["filled"]:
+        sm["_event_prefilled_this_turn"] = True
 
   # ── Derive mappings for after_tool_callback ─────────────────
   if "_setter_slots" not in sm:


### PR DESCRIPTION
Engine:
- Event pre-fill now triggers preemption, bypassing the LLM when events
  are processed (fixes stale payload and confused LLM after event text)
- Task responses propagate through non-terminal tasks and readback
- on_complete handler allows terminal tasks to clear slots and continue
- Task then_say templates can reference task result fields

Callbacks:
- before_model: text-based <event> tag fallback when ia_event_name is not
  in state; message part always emitted before response parts on preempt
- before_agent: readback instructions clarified — only read back when
  system directive says to, not unconditionally after every setter

Tests:
- 124 tool tests across 5 files (engine_core, engine_confirm,
  engine_errors, engine_events, engine_tasks, engine_responses)
- New engine_responses.yaml covering response payload propagation

Docs:
- Framework guide updated with event pre-fill, response, and on_complete