### PR TITLE
fix: make various fixes to optimize sim runner

### DIFF
--- a/.agents/skills/cxas-agent-foundry/scripts/run-all-evals.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/run-all-evals.py
@@ -13,33 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Run all 4 eval types and generate a combined report in one command.
-
-Usage:
-  python run-all-evals.py                          # Run everything, default channel from gecx-config
-  python run-all-evals.py --channel audio          # Override channel
-  python run-all-evals.py --runs 5                 # Number of golden runs (default: 5)
-  python run-all-evals.py --skip-sims              # Skip sims
-  python run-all-evals.py --skip-goldens           # Skip goldens (just run local tests + sims)
-"""
+"""Run all 4 eval types and generate a combined report in one command (SCRAPI)."""
 
 import argparse
 import os
-import subprocess
 import sys
 import time
-from pathlib import Path
+from datetime import datetime
 
-from config import load_config as _load_shared_config, get_project_path, resolve_project_dir
-
+from config import load_config as _load_shared_config, get_project_path
 
 # --- Paths ---
-TOOL_TESTS_DIR = get_project_path("evals", "tool_tests")
-CALLBACK_TESTS_DIR = get_project_path("evals", "callback_tests")
 REPORTS_DIR = get_project_path("eval-reports")
-SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
-
-GOLDEN_TIMEOUT = 1200  # 20 minutes
 
 
 def load_config():
@@ -50,316 +35,61 @@ def load_config():
         "location": raw.get("location", "us"),
         "app_id": raw["deployed_app_id"],
         "app_name_short": raw.get("app_name", ""),
-        "default_channel": raw.get("default_channel", raw.get("modality", "text")),
+        "default_channel": raw.get(
+            "default_channel", raw.get("modality", "text")
+        ),
         "modality": raw.get("modality", "text"),
     }
     config["app_resource"] = (
         f"projects/{config['project']}/locations/{config['location']}/apps/{config['app_id']}"
     )
-    print(f"Config loaded from gecx-config.json (app: {config['app_name_short']})")
+    print(
+        f"Config loaded from gecx-config.json (app: {config['app_name_short']})"
+    )
     return config
-
-
-def run_callback_tests():
-    """Run callback tests using CallbackEvals and save results."""
-    print("\n" + "=" * 60)
-    print("PHASE 1: Callback Tests")
-    print("=" * 60)
-
-    if not os.path.isdir(CALLBACK_TESTS_DIR):
-        print(f"  Skipped: {CALLBACK_TESTS_DIR} not found")
-        return None
-
-    try:
-        from cxas_scrapi.evals.callback_evals import CallbackEvals
-
-        cb = CallbackEvals()
-        results_df = cb.test_all_callbacks_in_app_dir(app_dir=CALLBACK_TESTS_DIR)
-
-        os.makedirs(REPORTS_DIR, exist_ok=True)
-        output_path = os.path.join(REPORTS_DIR, "callback_test_results.json")
-        results_df.to_json(output_path, orient="records", indent=2)
-
-        total = len(results_df)
-        passed = len(results_df[results_df["status"].str.upper() == "PASSED"]) if "status" in results_df.columns else 0
-        print(f"  Callback tests: {passed}/{total} passed")
-        print(f"  Results saved to: {output_path}")
-        return output_path
-
-    except ImportError:
-        print("  Skipped: cxas_scrapi.evals.callback_evals not available")
-        return None
-    except Exception as e:
-        print(f"  ERROR: Callback tests failed: {e}")
-        return None
-
-
-def run_tool_tests(config):
-    """Run tool tests using ToolEvals and save results."""
-    print("\n" + "=" * 60)
-    print("PHASE 2: Tool Tests")
-    print("=" * 60)
-
-    yaml_files = list(Path(TOOL_TESTS_DIR).glob("*.yaml")) if os.path.isdir(TOOL_TESTS_DIR) else []
-    if not yaml_files:
-        print(f"  Skipped: No YAML files in {TOOL_TESTS_DIR}")
-        return None
-
-    try:
-        from cxas_scrapi.evals.tool_evals import ToolEvals
-
-        te = ToolEvals(app_name=config["app_resource"])
-        test_cases = te.load_tool_tests_from_dir(TOOL_TESTS_DIR)
-
-        if not test_cases:
-            print("  Skipped: No test cases loaded from YAML files")
-            return None
-
-        print(f"  Running {len(test_cases)} tool tests...")
-        results_df = te.run_tool_tests(test_cases)
-
-        os.makedirs(REPORTS_DIR, exist_ok=True)
-        output_path = os.path.join(REPORTS_DIR, "tool_test_results.json")
-        results_df.to_json(output_path, orient="records", indent=2)
-
-        total = len(results_df)
-        passed = len(results_df[results_df["status"].str.upper() == "PASSED"]) if "status" in results_df.columns else 0
-        print(f"  Tool tests: {passed}/{total} passed")
-        print(f"  Results saved to: {output_path}")
-        return output_path
-
-    except ImportError:
-        print("  Skipped: cxas_scrapi.evals.tool_evals not available")
-        return None
-    except Exception as e:
-        print(f"  ERROR: Tool tests failed: {e}")
-        return None
-
-
-def trigger_goldens(config, channel, runs):
-    """Trigger golden eval run and return the evaluationRun resource name.
-
-    Extracts the run name from the operation metadata — the platform
-    populates the evaluation_run field shortly after the operation starts.
-    """
-    print("\n" + "=" * 60)
-    print("PHASE 3: Platform Goldens (trigger)")
-    print("=" * 60)
-
-    from cxas_scrapi.core.evaluations import Evaluations
-    from google.cloud.ces_v1beta.types import RunEvaluationOperationMetadata
-    import time
-
-    app_name = config.get("app_resource")
-    if not app_name:
-        print("  ERROR: No app_resource in config")
-        return None
-
-    try:
-        client = Evaluations(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/run-all-evals")
-        response = client.run_evaluation(
-            eval_type="goldens",
-            app_name=app_name,
-            modality=channel,
-            run_count=runs,
-        )
-        print(f"  Golden eval run triggered ({channel}, {runs} runs)")
-
-        # Poll operation metadata for the evaluation_run field
-        for i in range(12):
-            time.sleep(10)
-            refreshed = response._refresh(None)
-            meta = RunEvaluationOperationMetadata()
-            meta._pb.ParseFromString(refreshed.metadata.value)
-            if meta.evaluation_run:
-                print(f"  Run: {meta.evaluation_run.split('/')[-1]}")
-                return meta.evaluation_run
-            print(f"  Waiting for run to appear... ({(i+1)*10}s)")
-
-        print("  WARNING: Could not extract run name from operation metadata")
-        return None
-    except Exception as e:
-        print(f"  ERROR: Failed to trigger golden run: {e}")
-        return None
-
-
-def _wait_for_run(app_name, run_name, timeout=GOLDEN_TIMEOUT):
-    """Poll until a specific evaluation run completes."""
-    import time
-    from cxas_scrapi.core.evaluations import Evaluations
-
-    client = Evaluations(app_name=app_name, user_agent_extension="skill/cxas-agent-foundry/run-all-evals")
-    start = time.time()
-    poll_interval = 15
-
-    while time.time() - start < timeout:
-        try:
-            run = client.client.get_evaluation_run(name=run_name)
-            state = run.state if isinstance(run.state, int) else run.state.value
-            if state in (2, 3):  # COMPLETED or ERROR
-                return run.name
-            print(f"  Waiting for run to complete... ({int(time.time() - start)}s)")
-        except Exception as e:
-            print(f"  Poll error: {e}")
-
-        time.sleep(poll_interval)
-
-    return None
-
-
-def poll_golden_results(config, run_name, timeout=GOLDEN_TIMEOUT):
-    """Wait for a specific golden run to complete and return run ID."""
-    print("\n" + "=" * 60)
-    print("PHASE 3: Platform Goldens (waiting for results)")
-    print("=" * 60)
-
-    if not run_name:
-        print("  WARNING: No run name to poll — skipping golden results")
-        return None
-
-    from cxas_scrapi.utils.eval_utils import EvalUtils
-
-    app_name = config.get("app_resource")
-
-    # Wait for the specific run to complete
-    completed_run = _wait_for_run(app_name, run_name, timeout=timeout)
-    if not completed_run:
-        print(f"  WARNING: Golden run timed out after {timeout}s")
-        return None
-
-    run_id_short = completed_run.split("/")[-1]
-    print(f"  Golden run completed: {run_id_short}")
-
-    # Fetch results
-    try:
-        utils = EvalUtils(app_name=app_name)
-        results = utils.wait_for_run_and_get_results(
-            run_name=completed_run,
-            timeout_seconds=60,
-        )
-        if results:
-            print(f"  Got {len(results)} golden results")
-    except Exception as e:
-        print(f"  WARNING: Failed to fetch results: {e}")
-
-    return run_id_short
-
-
-def run_sims(channel, runs, priority):
-    """Run local sims via scrapi-sim-runner.py.
-
-    Sims are LLM-driven so individual runs vary. Pass `runs > 1` (default
-    matches the suite's golden runs) so the sim runner repeats each sim N
-    times and aggregates pass rate — same stability signal as goldens.
-    Tool tests and callback tests are deterministic and always run once
-    regardless of `--runs`.
-    """
-    print("\n" + "=" * 60)
-    print(f"PHASE 4: Local Simulations ({runs} run{'s' if runs != 1 else ''} per sim, priority={priority})")
-    print("=" * 60)
-
-    runner_script = os.path.join(SCRIPTS_DIR, "scrapi-sim-runner.py")
-    cmd = [
-        sys.executable, runner_script, "run",
-        "--priority", priority,
-        "--parallel", "3",
-        "--channel", channel,
-        "--runs", str(runs),
-    ]
-
-    print(f"  Running: {' '.join(cmd)}")
-    result = subprocess.run(cmd, capture_output=False, text=True, cwd=resolve_project_dir())
-
-    if result.returncode != 0:
-        print(f"  ERROR: Sims exited with code {result.returncode}")
-        return None
-
-    # Find the most recent sim results JSON
-    if os.path.isdir(REPORTS_DIR):
-        sim_files = sorted(
-            Path(REPORTS_DIR).glob("sim_results_*.json"),
-            key=lambda p: p.stat().st_mtime,
-            reverse=True,
-        )
-        if sim_files:
-            print(f"  Sim results: {sim_files[0]}")
-            return str(sim_files[0])
-
-    print("  ERROR: No sim results file found")
-    return None
-
-
-def generate_combined_report(golden_run_id, sim_results_path, tool_results_path,
-                              callback_results_path, channel):
-    """Generate combined HTML report from all result sources."""
-    print("\n" + "=" * 60)
-    print("GENERATING COMBINED REPORT")
-    print("=" * 60)
-
-    report_script = os.path.join(SCRIPTS_DIR, "generate-combined-report.py")
-    cmd = [sys.executable, report_script]
-
-    if golden_run_id:
-        cmd.extend(["--golden-run", golden_run_id, "--golden-modality", channel])
-    if sim_results_path:
-        cmd.extend(["--sim-results", sim_results_path, "--sim-modality", channel])
-    if tool_results_path:
-        cmd.extend(["--tool-results", tool_results_path])
-    if callback_results_path:
-        cmd.extend(["--callback-results", callback_results_path])
-
-    if len(cmd) <= 2:
-        print("  Skipped: No results to combine")
-        return None
-
-    print(f"  Running: {' '.join(cmd)}")
-    result = subprocess.run(cmd, capture_output=False, text=True, cwd=resolve_project_dir())
-
-    if result.returncode != 0:
-        print(f"  WARNING: Report generation exited with code {result.returncode}")
-
-    # Find the most recent combined report
-    if os.path.isdir(REPORTS_DIR):
-        report_files = sorted(
-            Path(REPORTS_DIR).glob("combined_report_*.html"),
-            key=lambda p: p.stat().st_mtime,
-            reverse=True,
-        )
-        if report_files:
-            return str(report_files[0])
-
-    return None
 
 
 def main():
     try:
         import cxas_scrapi  # noqa: F401
     except ImportError:
-        print("Error: cxas-scrapi not installed. Activate venv (source .venv/bin/activate) and install cxas-scrapi first.")
+        print(
+            "Error: cxas-scrapi not installed. Activate venv (source .venv/bin/activate) and install cxas-scrapi first."
+        )
         sys.exit(1)
 
     parser = argparse.ArgumentParser(
         description="Run all 4 eval types and generate a combined report"
     )
     parser.add_argument(
-        "--channel", default=None,
-        help="Modality: text or audio (default: from gecx-config.json)"
+        "--channel",
+        default=None,
+        help="Modality: text or audio (default: from gecx-config.json)",
     )
     parser.add_argument(
-        "--runs", type=int, default=5,
-        help="Trials per golden AND per sim (default: 5). Tool tests and callback tests are deterministic and always run once."
+        "--runs",
+        type=int,
+        default=5,
+        help="Trials per golden AND per sim (default: 5). Tool tests and callback tests are deterministic and always run once.",
     )
     parser.add_argument(
-        "--skip-sims", action="store_true",
-        help="Skip simulation evals"
+        "--skip-sims", action="store_true", help="Skip simulation evals"
     )
     parser.add_argument(
-        "--skip-goldens", action="store_true",
-        help="Skip golden evals (just run local tests + sims)"
+        "--skip-goldens",
+        action="store_true",
+        help="Skip golden evals (just run local tests + sims)",
     )
     parser.add_argument(
-        "--priority", default="P0",
-        help="Sim priority filter forwarded to scrapi-sim-runner (e.g., P0, or P0,P1,P2). Default: P0."
+        "--priority",
+        default="P0",
+        help="Sim priority filter forwarded to scrapi-sim-runner (e.g., P0, or P0,P1,P2). Default: P0.",
+    )
+    parser.add_argument(
+        "--sim-parallel",
+        type=int,
+        default=5,
+        help="Number of parallel worker sessions for simulations. Defaults to 5.",
     )
     args = parser.parse_args()
 
@@ -367,8 +97,12 @@ def main():
     config = load_config()
 
     if args.channel and args.channel != config.get("modality", "text"):
-        print(f"ERROR: Cannot run evals in '{args.channel}' mode. gecx-config.json specifies modality '{config.get('modality', 'text')}'.")
-        print("To fix: Remove the --channel flag or ensure it matches the app's configured modality.")
+        print(
+            f"ERROR: Cannot run evals in '{args.channel}' mode. gecx-config.json specifies modality '{config.get('modality', 'text')}'."
+        )
+        print(
+            "To fix: Remove the --channel flag or ensure it matches the app's configured modality."
+        )
         sys.exit(1)
 
     channel = args.channel or config.get("default_channel", "text")
@@ -380,36 +114,46 @@ def main():
     print(f"Skip sims: {args.skip_sims}")
 
     overall_start = time.time()
-    golden_run_name = None
-    golden_run_id = None
 
-    # --- Step 1: Trigger goldens early (they run async on the platform) ---
-    if not args.skip_goldens:
-        golden_run_name = trigger_goldens(config, channel, args.runs)
-
-    # --- Step 2: While goldens are running, execute local tests ---
-    callback_results_path = run_callback_tests()
-    tool_results_path = run_tool_tests(config)
-
-    # --- Step 3: Wait for goldens to complete ---
-    if golden_run_name is not None:
-        golden_run_id = poll_golden_results(config, golden_run_name)
-
-    # --- Step 4: Run sims ---
-    sim_results_path = None
+    # Map skips to include list
+    include = ["tools", "callbacks"]
     if not args.skip_sims:
-        sim_results_path = run_sims(channel, args.runs, args.priority)
+        include.append("sims")
+    if not args.skip_goldens:
+        include.append("goldens")
 
-    # --- Step 5: Generate combined report ---
-    report_path = generate_combined_report(
-        golden_run_id=golden_run_id,
-        sim_results_path=sim_results_path,
-        tool_results_path=tool_results_path,
-        callback_results_path=callback_results_path,
-        channel=channel,
-    )
+    filter_tags = []
+    if args.priority:
+        filter_tags.extend(
+            [p.strip().upper() for p in args.priority.split(",")]
+        )
 
-    # --- Final summary ---
+    ts = datetime.now().strftime("%Y-%m-%d_%H%M")
+    report_path = os.path.join(REPORTS_DIR, f"combined_report_{ts}.html")
+
+    from cxas_scrapi.utils.reporting import generate_combined_report_from_dir
+
+    print("\nRunning all evaluations in-process...")
+    try:
+        generate_combined_report_from_dir(
+            output_dir=REPORTS_DIR,
+            app_name=config["app_resource"],
+            output_path=report_path,
+            run=True,
+            app_dir=get_project_path("evals", "callback_tests"),
+            tool_test_file=get_project_path("evals", "tool_tests"),
+            goldens_dir=get_project_path("evals", "goldens"),
+            simulation_dir=get_project_path("evals", "simulations"),
+            include=include,
+            modality=channel,
+            runs=args.runs,
+            filter_tags=filter_tags,
+            parallel=args.sim_parallel,
+        )
+    except Exception as e:
+        print(f"\n  ERROR: Evaluation run failed: {e}")
+        sys.exit(1)
+
     elapsed = time.time() - overall_start
     elapsed_str = f"{elapsed / 60:.1f}m" if elapsed >= 60 else f"{elapsed:.0f}s"
 
@@ -418,39 +162,8 @@ def main():
     print("=" * 60)
     print(f"  Total time: {elapsed_str}")
     print(f"  Channel:    {channel}")
+    print(f"  Combined report: {report_path}")
     print()
-
-    status_lines = [
-        ("Callback tests", callback_results_path),
-        ("Tool tests", tool_results_path),
-        ("Goldens", golden_run_id if golden_run_id else None),
-        ("Sims", sim_results_path),
-    ]
-    failed_phases = []
-    for label, result in status_lines:
-        if args.skip_goldens and label == "Goldens":
-            status = "SKIPPED"
-        elif args.skip_sims and label == "Sims":
-            status = "SKIPPED"
-        elif result:
-            status = f"DONE ({result})" if isinstance(result, str) else "DONE"
-        else:
-            status = "FAILED / NOT RUN"
-            failed_phases.append(label)
-        print(f"  {label:20s} {status}")
-
-    if report_path:
-        print(f"\n  Combined report: {report_path}")
-    else:
-        print("\n  No combined report generated.")
-        failed_phases.append("Combined report")
-
-    print()
-
-    if failed_phases:
-        print(f"FAILED: {len(failed_phases)} phase(s) did not complete: {', '.join(failed_phases)}")
-        print("Exit code 1 — downstream consumers (run-and-report.py, CI) should treat this run as failed.")
-        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/.agents/skills/cxas-agent-foundry/scripts/tests/test_runners.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/tests/test_runners.py
@@ -1,0 +1,227 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for scrapi-sim-runner.py and run-all-evals.py wrappers.
+
+Run from the project root:
+    python -m pytest .agents/skills/cxas-agent-foundry/scripts/tests/test_runners.py
+"""
+
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def config_mock():
+    """Fixture providing a dynamic config dictionary."""
+    return {
+        "gcp_project_id": "test-proj",
+        "deployed_app_id": "test-app",
+        "app_name": "test-app",
+        "default_channel": "text",
+        "modality": "text",
+        "app_resource": "projects/test-proj/locations/us/apps/test-app",
+    }
+
+
+@pytest.fixture(autouse=True)
+def setup_stubs(config_mock):
+    """Setup fake config module so script imports do not trigger project lookups."""
+    fake = types.ModuleType("config")
+    fake.load_app_name = lambda: "projects/test-proj/locations/us/apps/test-app"
+    fake.load_config = lambda: config_mock
+    fake.get_project_path = lambda *a: "/tmp/fakeproj/" + "/".join(a)
+    fake.resolve_project_dir = lambda: "/tmp/fakeproj"
+    sys.modules["config"] = fake
+
+    if _SCRIPTS_DIR not in sys.path:
+        sys.path.insert(0, _SCRIPTS_DIR)
+
+    yield
+
+    # Cleanup stub
+    sys.modules.pop("config", None)
+
+
+@pytest.fixture
+def sim_runner():
+    """Import the scrapi-sim-runner module."""
+    spec = importlib.util.spec_from_file_location(
+        "scrapi_sim_runner", os.path.join(_SCRIPTS_DIR, "scrapi-sim-runner.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def all_evals_runner():
+    """Import the run-all-evals module."""
+    spec = importlib.util.spec_from_file_location(
+        "run_all_evals", os.path.join(_SCRIPTS_DIR, "run-all-evals.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Test scrapi-sim-runner.py
+# ---------------------------------------------------------------------------
+
+
+def test_sim_runner_cmd_run_delegation(sim_runner):
+    """Verify scrapi-sim-runner.py run command delegates directly to SimulationEvals."""
+    mock_args = MagicMock()
+    mock_args.eval = ["test_case_1"]
+    mock_args.priority = "P0"
+    mock_args.tag = None
+    mock_args.model = "gemini-pro"
+    mock_args.channel = "audio"
+    mock_args.runs = 3
+    mock_args.parallel = 1
+    mock_args.verbose = True
+    mock_args.gcs_report_path = None
+
+    mock_templates = {
+        "test_case_1": {
+            "steps": [],
+            "expectations": [],
+            "session_parameters": {},
+        }
+    }
+
+    # Mock conversation object returned by simulate_conversation
+    mock_conv = MagicMock()
+    mock_conv.current_turn = 1
+    mock_conv.steps_progress = []
+    mock_conv.expectation_results = []
+    mock_conv.get_transcript.return_value = []
+    mock_conv._session_id = "fake_sess"
+    mock_conv._detailed_trace = []
+
+    with (
+        patch.object(sim_runner, "load_yaml", return_value={}),
+        patch.object(
+            sim_runner, "load_sim_templates", return_value=mock_templates
+        ),
+        patch.object(sim_runner, "EnhancedSimRunner") as MockEnhancedRunner,
+        patch(
+            "cxas_scrapi.utils.reporting.generate_combined_html_report"
+        ) as mock_gen_report,
+    ):
+        mock_sim_inst = MockEnhancedRunner.return_value
+        mock_sim_inst.simulate_conversation.return_value = mock_conv
+
+        sim_runner.cmd_run(mock_args)
+
+        # Assert that EnhancedSimRunner was initialized with correct parameters
+        assert MockEnhancedRunner.call_count == 3
+        MockEnhancedRunner.assert_any_call(
+            app_name="projects/test-proj/locations/us/apps/test-app",
+            user_agent_extension=sim_runner.USER_AGENT_EXTENSION,
+        )
+
+        # Assert simulate_conversation was called with correct parameters
+        mock_sim_inst.simulate_conversation.assert_any_call(
+            test_case={
+                "name": "test_case_1",
+                "steps": [],
+                "expectations": [],
+                "session_parameters": {},
+                "metadata": {},
+            },
+            model="gemini-pro",
+            console_logging=True,
+            modality="audio",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test run-all-evals.py
+# ---------------------------------------------------------------------------
+
+
+def test_run_all_evals_includes_all_by_default(all_evals_runner):
+    """Verify run-all-evals.py invokes combined report with goldens, sims, and scenarios by default."""
+    mock_args = MagicMock()
+    mock_args.channel = "text"
+    mock_args.runs = 5
+    mock_args.skip_sims = False
+    mock_args.skip_goldens = False
+    mock_args.priority = "P0"
+    mock_args.sim_parallel = 4
+
+    with (
+        patch("argparse.ArgumentParser.parse_args", return_value=mock_args),
+        patch(
+            "cxas_scrapi.utils.reporting.generate_combined_report_from_dir"
+        ) as mock_gen_report,
+    ):
+        all_evals_runner.main()
+
+        # Assert generate_combined_report_from_dir was called with goldens + sims + tools + callbacks
+        mock_gen_report.assert_called_once()
+        call_kwargs = mock_gen_report.call_args[1]
+
+        assert "goldens" in call_kwargs["include"]
+        assert "sims" in call_kwargs["include"]
+        assert "tools" in call_kwargs["include"]
+        assert "callbacks" in call_kwargs["include"]
+        assert call_kwargs["runs"] == 5
+        assert call_kwargs["modality"] == "text"
+        assert call_kwargs["filter_tags"] == ["P0"]
+        assert call_kwargs["parallel"] == 4
+
+
+def test_run_all_evals_excludes_goldens_and_sims(all_evals_runner, config_mock):
+    """Verify run-all-evals.py skips goldens and sims correctly based on CLI flags."""
+    # Set dynamic config mock modality to audio
+    config_mock["modality"] = "audio"
+    config_mock["default_channel"] = "audio"
+
+    mock_args = MagicMock()
+    mock_args.channel = "audio"
+    mock_args.runs = 2
+    mock_args.skip_sims = True
+    mock_args.skip_goldens = True
+    mock_args.priority = "P1,P2"
+    mock_args.sim_parallel = 8
+
+    with (
+        patch("argparse.ArgumentParser.parse_args", return_value=mock_args),
+        patch(
+            "cxas_scrapi.utils.reporting.generate_combined_report_from_dir"
+        ) as mock_gen_report,
+    ):
+        all_evals_runner.main()
+
+        mock_gen_report.assert_called_once()
+        call_kwargs = mock_gen_report.call_args[1]
+
+        assert "tools" in call_kwargs["include"]
+        assert "callbacks" in call_kwargs["include"]
+        assert "goldens" not in call_kwargs["include"]
+        assert "sims" not in call_kwargs["include"]
+        assert call_kwargs["runs"] == 2
+        assert call_kwargs["modality"] == "audio"
+        assert call_kwargs["filter_tags"] == ["P1", "P2"]
+        assert call_kwargs["parallel"] == 8

--- a/src/cxas_scrapi/cli/main.py
+++ b/src/cxas_scrapi/cli/main.py
@@ -484,6 +484,9 @@ def combined_evals_report_cmd(args: argparse.Namespace) -> None:
         if args.simulation_dir == "evals/simulations/":
             args.simulation_dir = os.path.join(args.input_dir, "simulations/")
 
+    sim_parallel = getattr(args, "sim_parallel", 5)
+    golden_timeout = getattr(args, "golden_timeout", 600)
+
     generate_combined_report_from_dir(
         output_dir=args.output_dir,
         golden_run=args.golden_run,
@@ -500,6 +503,8 @@ def combined_evals_report_cmd(args: argparse.Namespace) -> None:
         runs=args.runs,
         filter_files=filter_files_list,
         filter_tags=filter_tags_list,
+        parallel=sim_parallel,
+        golden_timeout=golden_timeout,
     )
     print(f"Combined report generated at {output_path}")
 
@@ -1020,6 +1025,14 @@ def get_parser() -> argparse.ArgumentParser:
         help="Number of runs per golden and simulation test case.",
     )
     parser_report.add_argument(
+        "--sim-parallel",
+        type=int,
+        default=5,
+        help=(
+            "Number of parallel worker sessions for simulations. Defaults to 5."
+        ),
+    )
+    parser_report.add_argument(
         "--modality",
         choices=["text", "audio"],
         default="text",
@@ -1027,10 +1040,10 @@ def get_parser() -> argparse.ArgumentParser:
     )
     parser_report.add_argument(
         "--include",
-        default="sims,goldens,scenarios",
+        default="sims,goldens,tools,callbacks",
         help=(
             "Categories to include (comma-separated, "
-            "default: sims,goldens,scenarios)."
+            "default: sims,goldens,tools,callbacks)."
         ),
     )
     parser_report.add_argument(
@@ -1040,6 +1053,12 @@ def get_parser() -> argparse.ArgumentParser:
     parser_report.add_argument(
         "--filter-tags",
         help="Optional: Comma-separated list of tags to include.",
+    )
+    parser_report.add_argument(
+        "--golden-timeout",
+        type=int,
+        default=600,
+        help="Timeout in seconds waiting for remote goldens. Defaults to 600.",
     )
     parser_report.set_defaults(func=combined_evals_report_cmd)
 

--- a/src/cxas_scrapi/core/audio_transformer.py
+++ b/src/cxas_scrapi/core/audio_transformer.py
@@ -14,6 +14,7 @@
 
 import io
 import logging
+import threading
 import wave
 
 from google.api_core import client_options
@@ -23,6 +24,9 @@ ClientOptions = client_options.ClientOptions
 
 
 class AudioTransformer:
+    _client = None
+    _lock = threading.Lock()
+
     def __init__(self):
         pass
 
@@ -32,10 +36,15 @@ class AudioTransformer:
         """Converts text to speech and returns a dictionary with text and
         audio bytes without saving to disk.
         """
-        client_options = ClientOptions(quota_project_id=project_id)
-        client = texttospeech.TextToSpeechClient(
-            credentials=credentials, client_options=client_options
-        )
+        if AudioTransformer._client is None:
+            with AudioTransformer._lock:
+                if AudioTransformer._client is None:
+                    client_options = ClientOptions(quota_project_id=project_id)
+                    AudioTransformer._client = texttospeech.TextToSpeechClient(
+                        credentials=credentials, client_options=client_options
+                    )
+
+        client = AudioTransformer._client
         synthesis_input = texttospeech.SynthesisInput(text=text)
         voice = texttospeech.VoiceSelectionParams(
             language_code="en-US", name="en-US-Standard-A"

--- a/src/cxas_scrapi/core/common.py
+++ b/src/cxas_scrapi/core/common.py
@@ -107,6 +107,20 @@ class Common:
 
         self.client_info = ClientInfo(user_agent=self.user_agent)
 
+    @property
+    def token(self) -> Optional[str]:
+        if (
+            hasattr(self, "creds")
+            and self.creds
+            and hasattr(self.creds, "token")
+        ):
+            return self.creds.token
+        return getattr(self, "_token", None)
+
+    @token.setter
+    def token(self, value: Optional[str]):
+        self._token = value
+
     @staticmethod
     def empty_to_dict(v: Any) -> Any:
         return v if v is not None else {}

--- a/src/cxas_scrapi/core/sessions.py
+++ b/src/cxas_scrapi/core/sessions.py
@@ -146,6 +146,22 @@ class BidiSessionHandler:
         self, audio_payload: Dict[str, Any], turn_index: int
     ):
         audio_bytes = audio_payload["audio"]
+        variables = audio_payload.get("variables")
+
+        if variables:
+            logging.debug(
+                "Sending variables before audio chunks: %s", variables
+            )
+            var_message = types.BidiSessionClientMessage(
+                realtime_input=types.SessionInput(variables=variables)
+            )
+            var_json = json_format.MessageToJson(
+                var_message._pb,
+                preserving_proto_field_name=False,
+                indent=None,
+            )
+            self.ws_app.send(var_json)
+            time.sleep(0.5)
 
         logging.debug("Sending leading silence before turn %d...", turn_index)
         self._send_silence(
@@ -154,16 +170,11 @@ class BidiSessionHandler:
 
         logging.debug("Sending audio chunks for turn %d...", turn_index)
 
-        variables = audio_payload.get("variables")
         for i in range(0, len(audio_bytes), AUDIO_CHUNK_SIZE):
             chunk = audio_bytes[i : i + AUDIO_CHUNK_SIZE]
 
-            input_args = {"audio": chunk}
-            if i == 0 and variables:
-                input_args["variables"] = variables
-
             query_message = types.BidiSessionClientMessage(
-                realtime_input=types.SessionInput(**input_args)
+                realtime_input=types.SessionInput(audio=chunk)
             )
             query_json = json_format.MessageToJson(
                 query_message._pb,
@@ -251,6 +262,11 @@ class BidiSessionHandler:
 
                         self.agent_turn_manager.reset()
                         time.sleep(1)
+                    elif "variables" in input_item:
+                        logging.debug(
+                            "Sent variables, pausing to allow state update..."
+                        )
+                        time.sleep(0.5)
 
                 except Exception as e:
                     logging.debug("Failed to send generic input: %s", e)
@@ -734,6 +750,14 @@ class Sessions(Common):
     def async_bidi_run_session(
         self, config: dict, inputs: list[dict[str, Any]]
     ):
+        try:
+            if hasattr(self.creds, "refresh"):
+                self.creds.refresh(Request())
+        except Exception as e:
+            logger.debug(
+                f"Failed to refresh credentials before Bidi session: {e}"
+            )
+
         handler = BidiSessionHandler(
             self.location,
             self.token,
@@ -899,8 +923,11 @@ class Sessions(Common):
                         )
             config["historical_contexts"] = parsed_contexts
 
-        if variables and modality == Modality.TEXT:
-            inputs.append({"variables": variables})
+        if variables:
+            if modality == Modality.TEXT:
+                inputs.append({"variables": variables})
+            elif modality == Modality.AUDIO and text is None and audio is None:
+                inputs.append({"variables": variables})
 
         if dtmf is not None:
             inputs.append({"dtmf": dtmf})

--- a/src/cxas_scrapi/utils/reporting.py
+++ b/src/cxas_scrapi/utils/reporting.py
@@ -1200,6 +1200,37 @@ def load_golden_results(
     return results
 
 
+def _load_sim_test_cases(yaml_path: str) -> list[dict]:
+    """Loads sim files and merges common params and expectations."""
+    with open(yaml_path) as f:
+        data = yaml.safe_load(f) or {}
+    if isinstance(data, list):
+        return data
+
+    common_params = data.get("common_session_parameters", {}) or {}
+    common_expectations = data.get("common_expectations", []) or []
+    cases = data.get("evals", [])
+    if not isinstance(cases, list):
+        return []
+
+    merged_cases = []
+    for c in cases:
+        if isinstance(c, dict):
+            case_copy = c.copy()
+            # Merge session parameters
+            case_params = case_copy.get("session_parameters", {}) or {}
+            merged = common_params.copy()
+            merged.update(case_params)
+            case_copy["session_parameters"] = merged
+
+            # Merge expectations
+            case_expectations = case_copy.get("expectations", []) or []
+            case_copy["expectations"] = common_expectations + case_expectations
+
+            merged_cases.append(case_copy)
+    return merged_cases
+
+
 def load_sim_results(json_path, sim_evals_yaml=None):
     """Load sim results from JSON file.
 
@@ -1220,10 +1251,12 @@ def load_sim_results(json_path, sim_evals_yaml=None):
     # Backfill session_parameters if missing
     if sim_evals_yaml:
         try:
-            with open(sim_evals_yaml) as f:
-                templates = {
-                    e["name"]: e for e in yaml.safe_load(f).get("evals", [])
-                }
+            eval_list = _load_sim_test_cases(sim_evals_yaml)
+            templates = {
+                e["name"]: e
+                for e in eval_list
+                if isinstance(e, dict) and "name" in e
+            }
             for r in results:
                 if "session_parameters" not in r and r.get("name") in templates:
                     r["session_parameters"] = templates[r["name"]].get(
@@ -1293,13 +1326,15 @@ def generate_combined_report_from_dir(
     runs=1,
     filter_files=None,
     filter_tags=None,
+    parallel=1,
+    golden_timeout=600,
 ):
     """Load results from directory and generate combined HTML report."""
     if not os.path.isdir(output_dir):
         raise ValueError(f"{output_dir} is not a directory.")
 
     if include is None or "all" in include:
-        include = ["sims", "goldens", "scenarios"]
+        include = ["sims", "goldens", "tools", "callbacks"]
 
     sim_results = []
     tool_results = []
@@ -1318,10 +1353,13 @@ def generate_combined_report_from_dir(
             runs=runs,
             filter_files=filter_files,
             filter_tags=filter_tags,
+            parallel=parallel,
+            golden_timeout=golden_timeout,
+            include=include,
         )
         sim_results = run_results["simulation"] if "sims" in include else []
         # Map tool results to expected format if needed
-        if "scenarios" in include:
+        if "tools" in include:
             for r in run_results["tool"]:
                 tool_results.append(
                     {
@@ -1334,7 +1372,8 @@ def generate_combined_report_from_dir(
                         "errors": r.get("errors", ""),
                     }
                 )
-            # Map callback results
+        # Map callback results
+        if "callbacks" in include:
             for r in run_results["callback"]:
                 callback_results.append(
                     {
@@ -1347,7 +1386,7 @@ def generate_combined_report_from_dir(
                         "error": r.get("error_message", ""),
                     }
                 )
-        golden_results = run_results["golden"]
+        golden_results = run_results["golden"] if "goldens" in include else []
     else:
         sim_files = []
         if "sims" in include:
@@ -1355,13 +1394,14 @@ def generate_combined_report_from_dir(
 
         tool_files = []
         callback_files = []
-        if "scenarios" in include:
+        if "tools" in include:
             tool_files = glob.glob(
                 os.path.join(output_dir, "tool_results*.csv")
             )
             tool_files.extend(
                 glob.glob(os.path.join(output_dir, "tool_results*.json"))
             )
+        if "callbacks" in include:
             callback_files = glob.glob(
                 os.path.join(output_dir, "callback_results*.csv")
             )
@@ -1455,147 +1495,159 @@ def run_all_evals(
     runs=1,
     filter_files=None,
     filter_tags=None,
+    parallel=1,
+    golden_timeout=600,
+    include=None,
 ):
-    """Runs all 4 types of evaluations and returns aggregated results."""
+    """Runs all 4 types of evaluations and returns aggregated results.
+
+    TODO(refactor): Move this high-level orchestration function into the core
+    `cxas_scrapi.evals.runner` module to decouple execution logic from pure HTML
+    report generation. During migration, refactor the goldens run trigger and
+    polling loops to directly reuse `cxas_scrapi.utils.eval_utils.EvalUtils`
+    (`create_and_run_evaluation_from_yaml` and `wait_for_run_and_get_results`).
+    """
     results = {"callback": [], "tool": [], "golden": [], "simulation": []}
+
+    include = include or ["sims", "goldens", "tools", "callbacks"]
 
     # 1. Platform goldens (Trigger async)
     evaluations_to_run = []
     run_name = None
-    if not goldens_dir:
-        goldens_dir = "evals/goldens/"
-    if app_name and os.path.exists(goldens_dir):
-        eval_client = Evaluations(app_name=app_name)
-        eval_utils = EvalUtils(app_name=app_name)
+    if "goldens" in include:
+        if not goldens_dir:
+            goldens_dir = "evals/goldens/"
+        if app_name and os.path.exists(goldens_dir):
+            eval_client = Evaluations(app_name=app_name)
+            eval_utils = EvalUtils(app_name=app_name)
 
-        if os.path.isdir(goldens_dir):
-            golden_files = glob.glob(os.path.join(goldens_dir, "*.yaml"))
-            print(f"Found {len(golden_files)} golden files in {goldens_dir}")
-        else:
-            golden_files = [goldens_dir]
-
-        if filter_files:
-            golden_files = [
-                f for f in golden_files if os.path.basename(f) in filter_files
-            ]
-
-        for gf in golden_files:
-            print(f"Pushing golden file {gf}")
-            evals = eval_utils.load_golden_evals_from_yaml(gf)
-            for eval_dict in evals:
-                if filter_tags:
-                    tags = eval_dict.get("tags", [])
-                    if not any(t in filter_tags for t in tags):
-                        continue
-                res = eval_client.update_evaluation(
-                    evaluation=eval_dict, app_name=app_name
+            if os.path.isdir(goldens_dir):
+                golden_files = glob.glob(os.path.join(goldens_dir, "*.yaml"))
+                print(
+                    f"Found {len(golden_files)} golden files in {goldens_dir}"
                 )
-                evaluations_to_run.append(res.name)
+            else:
+                golden_files = [goldens_dir]
 
-        if evaluations_to_run:
-            print(f"Running evaluations: {evaluations_to_run}")
-            operation = eval_client.run_evaluation(
-                evaluations=evaluations_to_run,
-                app_name=app_name,
-                modality=modality,
-                run_count=runs,
-            )
+            if filter_files:
+                golden_files = [
+                    f
+                    for f in golden_files
+                    if os.path.basename(f) in filter_files
+                ]
 
-            print(
-                "  Waiting for evaluation run name to appear in operation "
-                "metadata..."
-            )
-            for i in range(12):
-                time.sleep(10)
-                refreshed = operation._refresh(None)
-                meta = RunEvaluationOperationMetadata()
-                meta._pb.ParseFromString(refreshed.metadata.value)
-                if meta.evaluation_run:
-                    run_name = meta.evaluation_run
-                    print(f"  Run name resolved: {run_name}")
-                    break
-                print(f"  Waiting... ({(i + 1) * 10}s)")
+            for gf in golden_files:
+                print(f"Pushing golden file {gf}")
+                evals = eval_utils.load_golden_evals_from_yaml(gf)
+                for eval_dict in evals:
+                    if filter_tags:
+                        tags = eval_dict.get("tags", [])
+                        if not any(t in filter_tags for t in tags):
+                            continue
+                    res = eval_client.update_evaluation(
+                        evaluation=eval_dict, app_name=app_name
+                    )
+                    evaluations_to_run.append(res.name)
+
+            if evaluations_to_run:
+                print(f"Running evaluations: {evaluations_to_run}")
+                operation = eval_client.run_evaluation(
+                    evaluations=evaluations_to_run,
+                    app_name=app_name,
+                    modality=modality,
+                    run_count=runs,
+                )
+
+                print(
+                    "  Waiting for evaluation run name to appear in operation "
+                    "metadata..."
+                )
+                for i in range(12):
+                    time.sleep(10)
+                    refreshed = operation._refresh(None)
+                    meta = RunEvaluationOperationMetadata()
+                    meta._pb.ParseFromString(refreshed.metadata.value)
+                    if meta.evaluation_run:
+                        run_name = meta.evaluation_run
+                        print(f"  Run name resolved: {run_name}")
+                        break
+                    print(f"  Waiting... ({(i + 1) * 10}s)")
 
     # 2. Callback tests
-    if not app_dir and app_name:
-        app_dir = f"cxas_app/{app_name.split('/')[-1]}"
-    if app_dir and os.path.exists(app_dir):
-        print(f"Running callback tests in {app_dir}")
-        callback_evals = CallbackEvals()
-        df = callback_evals.test_all_callbacks_in_app_dir(app_dir=app_dir)
-        results["callback"] = df.to_dict(orient="records")
-        if output_dir:
-            df.to_csv(
-                os.path.join(output_dir, "callback_results.csv"), index=False
-            )
-
-    # 3. Tool tests
-    if not tool_test_file:
-        tool_test_file = "evals/tool_tests/"
-    if app_name and os.path.exists(tool_test_file):
-        tool_evals = ToolEvals(app_name=app_name)
-
-        if os.path.isdir(tool_test_file):
-            tool_files = glob.glob(os.path.join(tool_test_file, "*.yaml"))
-            print(
-                f"Found {len(tool_files)} tool test files in {tool_test_file}"
-            )
-        else:
-            tool_files = [tool_test_file]
-
-        if filter_files:
-            tool_files = [
-                f for f in tool_files if os.path.basename(f) in filter_files
-            ]
-
-        test_cases = []
-        for tf in tool_files:
-            print(f"Loading tool tests from {tf}")
-            cases = tool_evals.load_tool_test_cases_from_file(tf)
-            if filter_tags:
-                cases = [
-                    c
-                    for c in cases
-                    if any(t in filter_tags for t in c.get("tags", []))
-                ]
-            test_cases.extend(cases)
-
-        if test_cases:
-            print(f"Running {len(test_cases)} tool tests")
-            df = tool_evals.run_tool_tests(test_cases)
-            results["tool"] = df.to_dict(orient="records")
+    if "callbacks" in include:
+        if not app_dir and app_name:
+            app_dir = f"cxas_app/{app_name.split('/')[-1]}"
+        if app_dir and os.path.exists(app_dir):
+            print(f"Running callback tests in {app_dir}")
+            callback_evals = CallbackEvals()
+            df = callback_evals.test_all_callbacks_in_app_dir(app_dir=app_dir)
+            results["callback"] = df.to_dict(orient="records")
             if output_dir:
                 df.to_csv(
-                    os.path.join(output_dir, "tool_results.csv"), index=False
+                    os.path.join(output_dir, "callback_results.csv"),
+                    index=False,
                 )
 
-    # 4. Platform goldens (Wait for results)
-    if run_name:
-        print(f"Waiting for evaluation run {run_name} to complete...")
-        utils = EvalUtils(app_name=app_name)
-        utils.wait_for_run_and_get_results(
-            run_name=run_name, timeout_seconds=600
-        )
-        results["golden"] = load_golden_results(run_name, app_name)
+    # 3. Tool tests
+    if "tools" in include:
+        if not tool_test_file:
+            tool_test_file = "evals/tool_tests/"
+        if app_name and os.path.exists(tool_test_file):
+            tool_evals = ToolEvals(app_name=app_name)
 
-    # 5. Local simulations
-    if not simulation_dir:
-        simulation_dir = "evals/simulations/"
-    if app_name and os.path.exists(simulation_dir):
-        sim_files = glob.glob(os.path.join(simulation_dir, "*.yaml"))
-        if filter_files:
-            sim_files = [
-                f for f in sim_files if os.path.basename(f) in filter_files
-            ]
+            if os.path.isdir(tool_test_file):
+                tool_files = glob.glob(os.path.join(tool_test_file, "*.yaml"))
+                print(
+                    f"Found {len(tool_files)} tool test files "
+                    f"in {tool_test_file}"
+                )
+            else:
+                tool_files = [tool_test_file]
 
-        if sim_files:
-            print(f"Running {len(sim_files)} simulations")
-            sim_evals = SimulationEvals(app_name=app_name)
+            if filter_files:
+                tool_files = [
+                    f for f in tool_files if os.path.basename(f) in filter_files
+                ]
+
             test_cases = []
-            for sf in sim_files:
-                with open(sf) as f:
-                    cases = yaml.safe_load(f)
-                    if isinstance(cases, list):
+            for tf in tool_files:
+                print(f"Loading tool tests from {tf}")
+                cases = tool_evals.load_tool_test_cases_from_file(tf)
+                if filter_tags:
+                    cases = [
+                        c
+                        for c in cases
+                        if any(t in filter_tags for t in c.get("tags", []))
+                    ]
+                test_cases.extend(cases)
+
+            if test_cases:
+                print(f"Running {len(test_cases)} tool tests")
+                df = tool_evals.run_tool_tests(test_cases)
+                results["tool"] = df.to_dict(orient="records")
+                if output_dir:
+                    df.to_csv(
+                        os.path.join(output_dir, "tool_results.csv"),
+                        index=False,
+                    )
+
+    # 4. Local simulations
+    if "sims" in include:
+        if not simulation_dir:
+            simulation_dir = "evals/simulations/"
+        if app_name and os.path.exists(simulation_dir):
+            sim_files = glob.glob(os.path.join(simulation_dir, "*.yaml"))
+            if filter_files:
+                sim_files = [
+                    f for f in sim_files if os.path.basename(f) in filter_files
+                ]
+
+            if sim_files:
+                sim_evals = SimulationEvals(app_name=app_name)
+                test_cases = []
+                for sf in sim_files:
+                    cases = _load_sim_test_cases(sf)
+                    if cases:
                         if filter_tags:
                             cases = [
                                 c
@@ -1605,14 +1657,30 @@ def run_all_evals(
                                 )
                             ]
                         test_cases.extend(cases)
-            if test_cases:
-                sim_results = sim_evals.run_simulations(
-                    test_cases, runs=runs, modality=modality
-                )
-                results["simulation"] = sim_results
-                if output_dir:
-                    save_path = os.path.join(output_dir, "sim_results.json")
-                    with open(save_path, "w") as f:
-                        json.dump(sim_results, f, indent=2)
+                if test_cases:
+                    print(
+                        f"Running {len(test_cases)} simulations across "
+                        f"{len(sim_files)} files"
+                    )
+                    sim_results = sim_evals.run_simulations(
+                        test_cases,
+                        runs=runs,
+                        parallel=parallel,
+                        modality=modality,
+                    )
+                    results["simulation"] = sim_results
+                    if output_dir:
+                        save_path = os.path.join(output_dir, "sim_results.json")
+                        with open(save_path, "w") as f:
+                            json.dump(sim_results, f, indent=2)
+
+    # 5. Platform goldens (Wait for results)
+    if "goldens" in include and run_name:
+        print(f"Waiting for evaluation run {run_name} to complete...")
+        utils = EvalUtils(app_name=app_name)
+        utils.wait_for_run_and_get_results(
+            run_name=run_name, timeout_seconds=golden_timeout
+        )
+        results["golden"] = load_golden_results(run_name, app_name)
 
     return results

--- a/tests/cxas_scrapi/cli/test_cli_reporting.py
+++ b/tests/cxas_scrapi/cli/test_cli_reporting.py
@@ -83,6 +83,8 @@ def test_combined_evals_report_cmd(tmp_path):
             runs=1,
             filter_files=[],
             filter_tags=[],
+            parallel=5,
+            golden_timeout=600,
         )
 
 
@@ -131,4 +133,6 @@ def test_combined_evals_report_cmd_with_modality_and_runs(tmp_path):
             runs=5,
             filter_files=[],
             filter_tags=[],
+            parallel=5,
+            golden_timeout=600,
         )

--- a/tests/cxas_scrapi/core/test_audio_transformer.py
+++ b/tests/cxas_scrapi/core/test_audio_transformer.py
@@ -21,6 +21,7 @@ from cxas_scrapi.core.audio_transformer import AudioTransformer
 
 class TestAudioTransformer:
     def setup_method(self):
+        AudioTransformer._client = None
         self.transformer = AudioTransformer()
 
     @patch("cxas_scrapi.core.audio_transformer.texttospeech")

--- a/tests/cxas_scrapi/core/test_sessions.py
+++ b/tests/cxas_scrapi/core/test_sessions.py
@@ -446,6 +446,33 @@ def test_run_session_audio_modality_variables_all_turns(
         assert inputs[1]["audio"]["variables"] == {"v": "1"}
 
 
+@patch("cxas_scrapi.core.sessions.Sessions._check_audio_requirements")
+@patch("cxas_scrapi.core.sessions.SessionServiceClient")
+@patch("cxas_scrapi.core.sessions.Sessions.async_bidi_run_session")
+def test_run_session_audio_modality_variables_with_event(
+    mock_async_run, mock_client_cls, mock_check_reqs
+):
+    """Test Sessions.run attaches variables to inputs on event turns
+    in audio modality.
+    """
+    sessions = Sessions(app_name="projects/p/locations/l/apps/a")
+
+    sessions.run(
+        session_id="s1",
+        event="WELCOME",
+        modality=Modality.AUDIO,
+        variables={"disable_disclaimer": True},
+    )
+
+    mock_async_run.assert_called_once()
+    call_kwargs = mock_async_run.call_args[1]
+
+    inputs = call_kwargs["inputs"]
+    assert len(inputs) == 2  # noqa: PLR2004
+    assert inputs[0]["variables"] == {"disable_disclaimer": True}
+    assert inputs[1]["event"]["event"] == "WELCOME"
+
+
 @patch("cxas_scrapi.core.sessions.time.sleep")
 @patch("cxas_scrapi.core.sessions.json_format.MessageToJson")
 def test_bidi_session_handler_send_inputs_with_historical_contexts(

--- a/tests/cxas_scrapi/utils/test_reporting.py
+++ b/tests/cxas_scrapi/utils/test_reporting.py
@@ -22,6 +22,7 @@ from cxas_scrapi.utils.reporting import (
     _escape,
     _fmt_duration,
     _format_trace_line,
+    _load_sim_test_cases,
     _resolve_tool_name,
     _upload_to_gcs,
     generate_combined_html_report,
@@ -474,3 +475,246 @@ def test_run_all_evals_tag_filtering(
     mock_eval_client.update_evaluation.assert_called_once_with(
         evaluation={"name": "eval1", "tags": ["tag1"]}, app_name="projects/p"
     )
+
+
+@patch("cxas_scrapi.utils.reporting.Evaluations")
+@patch("cxas_scrapi.utils.reporting.ToolEvals")
+@patch("cxas_scrapi.utils.reporting.SimulationEvals")
+@patch("cxas_scrapi.utils.reporting.CallbackEvals")
+@patch("cxas_scrapi.utils.reporting.EvalUtils")
+@patch("glob.glob")
+@patch("os.path.exists")
+@patch("os.path.isdir")
+@patch("yaml.safe_load")
+@patch("builtins.open", new_callable=mock_open)
+def test_run_all_evals_include_filtering(
+    mock_open_file,
+    mock_yaml_load,
+    mock_isdir,
+    mock_exists,
+    mock_glob,
+    mock_eval_utils,
+    mock_callback_evals,
+    mock_sim_evals,
+    mock_tool_evals,
+    mock_evaluations,
+):
+    mock_exists.return_value = True
+    mock_isdir.return_value = True
+    mock_glob.side_effect = [
+        ["evals/simulations/sim1.yaml"],
+    ]
+    mock_yaml_load.return_value = [{"name": "sim1"}]
+
+    # Call with ONLY sims
+    run_all_evals(
+        app_name="projects/p",
+        include=["sims"],
+        goldens_dir="evals/goldens/",
+        tool_test_file="evals/tool_tests/",
+        simulation_dir="evals/simulations/",
+    )
+
+    # Assert SimulationEvals was instantiated and run
+    mock_sim_evals.assert_called_once_with(app_name="projects/p")
+    mock_sim_evals.return_value.run_simulations.assert_called_once()
+
+    # Assert others were NOT called/instantiated
+    mock_evaluations.assert_not_called()
+    mock_tool_evals.assert_not_called()
+    mock_callback_evals.assert_not_called()
+
+
+@patch("cxas_scrapi.utils.reporting.Evaluations")
+@patch("cxas_scrapi.utils.reporting.ToolEvals")
+@patch("cxas_scrapi.utils.reporting.SimulationEvals")
+@patch("cxas_scrapi.utils.reporting.CallbackEvals")
+@patch("cxas_scrapi.utils.reporting.EvalUtils")
+@patch("glob.glob")
+@patch("os.path.exists")
+@patch("os.path.isdir")
+def test_run_all_evals_include_tools(
+    mock_isdir,
+    mock_exists,
+    mock_glob,
+    mock_eval_utils,
+    mock_callback_evals,
+    mock_sim_evals,
+    mock_tool_evals,
+    mock_evaluations,
+):
+    mock_exists.return_value = True
+    mock_isdir.return_value = True
+    mock_glob.side_effect = [
+        ["evals/tool_tests/tool1.yaml"],
+    ]
+    mock_tool_evals.return_value.load_tool_test_cases_from_file.return_value = [
+        {"name": "case1"}
+    ]
+
+    # Call with ONLY tools
+    run_all_evals(
+        app_name="projects/p",
+        include=["tools"],
+        goldens_dir="evals/goldens/",
+        tool_test_file="evals/tool_tests/",
+        simulation_dir="evals/simulations/",
+    )
+
+    # Assert ToolEvals was instantiated and run
+    mock_tool_evals.assert_called_once_with(app_name="projects/p")
+    mock_tool_evals.return_value.run_tool_tests.assert_called_once()
+
+    # Assert others were NOT called/instantiated
+    mock_evaluations.assert_not_called()
+    mock_sim_evals.assert_not_called()
+    mock_callback_evals.assert_not_called()
+
+
+@patch("cxas_scrapi.utils.reporting.Evaluations")
+@patch("cxas_scrapi.utils.reporting.ToolEvals")
+@patch("cxas_scrapi.utils.reporting.SimulationEvals")
+@patch("cxas_scrapi.utils.reporting.CallbackEvals")
+@patch("cxas_scrapi.utils.reporting.EvalUtils")
+@patch("glob.glob")
+@patch("os.path.exists")
+@patch("os.path.isdir")
+def test_run_all_evals_include_callbacks(
+    mock_isdir,
+    mock_exists,
+    mock_glob,
+    mock_eval_utils,
+    mock_callback_evals,
+    mock_sim_evals,
+    mock_tool_evals,
+    mock_evaluations,
+):
+    mock_exists.return_value = True
+    mock_isdir.return_value = True
+
+    # Call with ONLY callbacks
+    run_all_evals(
+        app_name="projects/p",
+        include=["callbacks"],
+        goldens_dir="evals/goldens/",
+        tool_test_file="evals/tool_tests/",
+        simulation_dir="evals/simulations/",
+    )
+
+    # Assert CallbackEvals was instantiated and run
+    mock_callback_evals.assert_called_once()
+    mock_callback_evals.return_value.test_all_callbacks_in_app_dir.assert_called_once()
+
+    # Assert others were NOT called/instantiated
+    mock_evaluations.assert_not_called()
+    mock_sim_evals.assert_not_called()
+    mock_tool_evals.assert_not_called()
+
+
+@patch("cxas_scrapi.utils.reporting.Evaluations")
+@patch("cxas_scrapi.utils.reporting.ToolEvals")
+@patch("cxas_scrapi.utils.reporting.SimulationEvals")
+@patch("cxas_scrapi.utils.reporting.CallbackEvals")
+@patch("cxas_scrapi.utils.reporting.EvalUtils")
+@patch("glob.glob")
+@patch("os.path.exists")
+@patch("os.path.isdir")
+@patch(
+    "builtins.open",
+    new_callable=mock_open,
+    read_data="evals:\n  - name: sim1\n    tags: [P0]",
+)
+def test_run_all_evals_dict_based_simulations(
+    mock_file,
+    mock_isdir,
+    mock_exists,
+    mock_glob,
+    mock_eval_utils,
+    mock_callback_evals,
+    mock_sim_evals,
+    mock_tool_evals,
+    mock_evaluations,
+):
+    mock_exists.return_value = True
+    mock_isdir.return_value = True
+    mock_glob.side_effect = [
+        ["evals/simulations/sims.yaml"],
+    ]
+
+    run_all_evals(
+        app_name="projects/p",
+        include=["sims"],
+        simulation_dir="evals/simulations/",
+    )
+
+    # Verify SimulationEvals was instantiated and run
+    mock_sim_evals.assert_called_once_with(app_name="projects/p")
+    mock_sim_evals.return_value.run_simulations.assert_called_once_with(
+        [
+            {
+                "name": "sim1",
+                "tags": ["P0"],
+                "session_parameters": {},
+                "expectations": [],
+            }
+        ],
+        runs=1,
+        parallel=1,
+        modality="text",
+    )
+
+
+def test_load_sim_test_cases_merges_common_parameters():
+    yaml_data = """
+common_session_parameters:
+  disable_disclaimer: true
+  originationNumber: "1234567890"
+evals:
+  - name: sim1
+    session_parameters:
+      custom_param: "hello"
+  - name: sim2
+"""
+    with patch("builtins.open", mock_open(read_data=yaml_data)):
+        cases = _load_sim_test_cases("dummy.yaml")
+
+        assert len(cases) == 2
+        # Case 1 should have merged common params and its own params
+        assert cases[0]["session_parameters"] == {
+            "disable_disclaimer": True,
+            "originationNumber": "1234567890",
+            "custom_param": "hello",
+        }
+        # Case 2 should just have common params
+        assert cases[1]["session_parameters"] == {
+            "disable_disclaimer": True,
+            "originationNumber": "1234567890",
+        }
+
+
+def test_load_sim_test_cases_merges_common_expectations():
+    yaml_data = """
+common_expectations:
+  - "The agent welcomes the user"
+  - "The agent behaves politely"
+evals:
+  - name: sim1
+    expectations:
+      - "The agent offers options"
+  - name: sim2
+"""
+    with patch("builtins.open", mock_open(read_data=yaml_data)):
+        cases = _load_sim_test_cases("dummy.yaml")
+
+        assert len(cases) == 2
+        # Case 1 should have merged expectations
+        assert cases[0]["expectations"] == [
+            "The agent welcomes the user",
+            "The agent behaves politely",
+            "The agent offers options",
+        ]
+        # Case 2 should just have common expectations
+        assert cases[1]["expectations"] == [
+            "The agent welcomes the user",
+            "The agent behaves politely",
+        ]


### PR DESCRIPTION
- Implement thread-safe lazy static singleton caching for the GCloud TextToSpeechClient in audio_transformer.py to completely eliminate POSIX resolver and channels fork conflicts when spinning up multiple parallel execution threads.
- Add variables routing support for session-initiating events in the audio modality within sessions.py, ensuring "disable_disclaimer": true is transmitted inside the first sequential WebSocket frame before welcome audio starts playing.
- Propagate simulation parallelism parameters cleanly from the CLI args into reporting.py.
- Integrate comprehensive test coverage covering core variables injection on events, static text-to-speech instantiation safety, and integration tests for script wrappers in test_runners.py.