### PR TITLE
fix(cli): use app_name in app_create

### DIFF
--- a/src/cxas_scrapi/cli/app.py
+++ b/src/cxas_scrapi/cli/app.py
@@ -240,7 +240,7 @@ def app_create(args: argparse.Namespace) -> None:
     apps_client = Apps(project_id=args.project_id, location=args.location)
     try:
         app = apps_client.create_app(
-            app_id=getattr(args, "app_id", None),
+            app_id=getattr(args, "app_name", None),
             display_name=args.name,
             description=args.description,
         )

--- a/tests/cxas_scrapi/cli/test_app.py
+++ b/tests/cxas_scrapi/cli/test_app.py
@@ -76,6 +76,32 @@ def test_app_create(
     )
 
 
+def test_app_create_with_app_name(
+    mock_apps_client, mock_common_get_project_id, mock_common_get_location
+):
+    args = argparse.Namespace(
+        name="Test App",
+        description="A test app",
+        app_name="custom-app-name",
+        project_id="test-project",
+        location="us",
+    )
+
+    mock_app_response = mock.MagicMock()
+    mock_app_response.name = (
+        "projects/test-project/locations/us/apps/custom-app-name"
+    )
+    mock_apps_client.create_app.return_value = mock_app_response
+
+    cli_app.app_create(args)
+
+    mock_apps_client.create_app.assert_called_once_with(
+        app_id="custom-app-name",
+        display_name="Test App",
+        description="A test app",
+    )
+
+
 def test_apps_list(mock_apps_client, capsys):
     args = argparse.Namespace(project_id="test-project", location="us")
 


### PR DESCRIPTION
Fixes the app_name vs app_id mismatch in the app_create command.