### PR TITLE
feat: support session variable accumulation in audio modality and pattern file filtering

### DIFF
--- a/.agents/skills/cxas-agent-foundry/scripts/gate-check.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/gate-check.py
@@ -170,32 +170,33 @@ def gate2_agent_hierarchy(app_name) -> GateResult:
         app = apps.get_app(app_name)
         agents_client = Agents(app_name=app_name, user_agent_extension=USER_AGENT_EXTENSION)
         agents_map = agents_client.get_agents_map(reverse=True)
+        agents_by_resource = agents_client.get_agents_map(reverse=False)
     except Exception as e:
         r.passed = False
         r.error = f"Failed to fetch agents: {e}"
         _print_gate_footer(r)
         return r
 
-    root_agent_name = app.root_agent.split("/")[-1] if app.root_agent else None
-    print(f"  Root agent: {root_agent_name}")
+    root_agent_display_name = agents_by_resource.get(app.root_agent) if app.root_agent else None
+    print(f"  Root agent: {root_agent_display_name}")
     print(f"  Agents found: {len(agents_map)}")
 
     for name in agents_map:
-        is_root = (name == root_agent_name)
+        is_root = (name == root_agent_display_name)
         marker = " (ROOT)" if is_root else ""
         print(f"    - {name}{marker}")
 
     r.findings.append({
-        "root_agent": root_agent_name,
+        "root_agent": root_agent_display_name,
         "agents": list(agents_map.keys()),
     })
 
-    if not root_agent_name:
+    if not app.root_agent:
         r.passed = False
         r.error = "App has no root_agent set"
-    elif root_agent_name not in agents_map:
+    elif root_agent_display_name not in agents_map:
         r.passed = False
-        r.error = f"Root agent {root_agent_name} listed on app but not in agents list"
+        r.error = f"Root agent {app.root_agent} listed on app but not in agents list"
     else:
         r.passed = True
 

--- a/.agents/skills/cxas-agent-foundry/scripts/run-and-report.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/run-and-report.py
@@ -176,7 +176,7 @@ def main():
         eval_cmd.extend(["--channel", args.channel])
     if args.runs:
         eval_cmd.extend(["--runs", str(args.runs)])
-    if args.priority:
+    if args.priority is not None:
         eval_cmd.extend(["--priority", args.priority])
     result = _run(eval_cmd, "Step 3/5: Run all evals", dry_run=args.dry_run)
     if result.returncode != 0:

--- a/src/cxas_scrapi/evals/simulation_evals.py
+++ b/src/cxas_scrapi/evals/simulation_evals.py
@@ -565,13 +565,20 @@ class SimulationEvals(Apps):
 
         # Initialize the first turn manually
         user_utterance, variables = eval_conv.next_user_utterance()
+        accumulated_variables = {}
+        if variables:
+            accumulated_variables.update(variables)
 
         detailed_trace = []
         detailed_trace.append(f"User: {user_utterance}")
 
         while user_utterance:
             response = self._send_request_with_retry(
-                session_id, user_utterance, variables, modality, console_logging
+                session_id,
+                user_utterance,
+                accumulated_variables,
+                modality,
+                console_logging,
             )
             if not response:
                 break
@@ -585,6 +592,8 @@ class SimulationEvals(Apps):
             detailed_trace.append("\n".join(trace_chunks))
 
             if session_ended:
+                if agent_text:
+                    eval_conv._add_agent_response(agent_text)
                 if console_logging:
                     print(
                         "\nSession has been closed by the Agent via "
@@ -597,6 +606,8 @@ class SimulationEvals(Apps):
             user_utterance, variables = eval_conv.next_user_utterance(
                 agent_text
             )
+            if variables:
+                accumulated_variables.update(variables)
             if user_utterance:
                 detailed_trace.append(f"User: {user_utterance}")
 

--- a/src/cxas_scrapi/utils/reporting.py
+++ b/src/cxas_scrapi/utils/reporting.py
@@ -1545,7 +1545,10 @@ def run_all_evals(
                 golden_files = [
                     f
                     for f in golden_files
-                    if os.path.basename(f) in filter_files
+                    if any(
+                        pattern.lower() in os.path.basename(f).lower()
+                        for pattern in filter_files
+                    )
                 ]
 
             for gf in golden_files:
@@ -1618,7 +1621,12 @@ def run_all_evals(
 
             if filter_files:
                 tool_files = [
-                    f for f in tool_files if os.path.basename(f) in filter_files
+                    f
+                    for f in tool_files
+                    if any(
+                        pattern.lower() in os.path.basename(f).lower()
+                        for pattern in filter_files
+                    )
                 ]
 
             test_cases = []
@@ -1651,7 +1659,12 @@ def run_all_evals(
             sim_files = glob.glob(os.path.join(simulation_dir, "*.yaml"))
             if filter_files:
                 sim_files = [
-                    f for f in sim_files if os.path.basename(f) in filter_files
+                    f
+                    for f in sim_files
+                    if any(
+                        pattern.lower() in os.path.basename(f).lower()
+                        for pattern in filter_files
+                    )
                 ]
 
             if sim_files:

--- a/tests/cxas_scrapi/evals/test_simulation_evals.py
+++ b/tests/cxas_scrapi/evals/test_simulation_evals.py
@@ -852,3 +852,125 @@ class TestSimToGolden(unittest.TestCase):
             self.assertIn("- It is 20 degrees.", yaml_output)
             self.assertIn("Must say hi", yaml_output)
             self.assertIn("key: val", yaml_output)
+
+
+@patch("cxas_scrapi.evals.simulation_evals.Sessions")
+@patch("cxas_scrapi.evals.simulation_evals.LLMUserConversation")
+def test_simulation_evals_accumulates_vars(
+    mock_llm_conv_class, mock_sessions_class
+):
+    mock_sessions = mock_sessions_class.return_value
+    mock_eval_conv = mock_llm_conv_class.return_value
+
+    # Multi-turn conversational flow with session vars on Turn 1 and Turn 2
+    mock_eval_conv.next_user_utterance.side_effect = [
+        ("event: welcome", {"disclaimer_accepted": True}),
+        ("I want to order a hammer", {"product_brand": "DEWALT"}),
+        ("", {}),
+    ]
+    mock_eval_conv.steps_progress = []
+
+    # Mock agent responses
+    mock_response_1 = MagicMock()
+    mock_response_1.session.name = (
+        "projects/test/locations/us/apps/123-abc/sessions/123"
+    )
+    mock_output_1 = MagicMock()
+    mock_output_1.text = "Sure, what brand?"
+    mock_response_1.outputs = [mock_output_1]
+
+    mock_response_2 = MagicMock()
+    mock_response_2.session.name = (
+        "projects/test/locations/us/apps/123-abc/sessions/123"
+    )
+    mock_output_2 = MagicMock()
+    mock_output_2.text = "Hammer ordered."
+    mock_response_2.outputs = [mock_output_2]
+
+    captured_variables = []
+
+    def mock_run_side_effect(*args, **kwargs):
+        vars_arg = kwargs.get("variables")
+        captured_variables.append(
+            dict(vars_arg) if vars_arg is not None else None
+        )
+        if len(captured_variables) == 1:
+            return mock_response_1
+        return mock_response_2
+
+    mock_sessions.run.side_effect = mock_run_side_effect
+
+    app_name = "projects/test/locations/us/apps/123-abc"
+    with patch("cxas_scrapi.evals.simulation_evals.GeminiGenerate"):
+        with patch("cxas_scrapi.core.apps.AgentServiceClient"):
+            simulator = SimulationEvals(app_name=app_name)
+
+    test_case = {"steps": []}
+    simulator.simulate_conversation(
+        test_case=test_case,
+        session_id="123",
+        console_logging=False,
+    )
+
+    # Verify that the variables accumulated sequentially across turns
+    assert len(captured_variables) == 2
+    # Turn 1: Should pass only Turn 1's variables
+    assert captured_variables[0] == {"disclaimer_accepted": True}
+    # Turn 2: Should pass accumulated variables with Turn 1 and 2
+    assert captured_variables[1] == {
+        "disclaimer_accepted": True,
+        "product_brand": "DEWALT",
+    }
+    assert mock_sessions.run.call_count == 2
+
+
+@patch("cxas_scrapi.evals.simulation_evals.Sessions")
+@patch("cxas_scrapi.evals.simulation_evals.LLMUserConversation")
+def test_simulation_evals_adds_final_agent_response_on_session_ended(
+    mock_llm_conv_class, mock_sessions_class
+):
+    mock_sessions = mock_sessions_class.return_value
+    mock_eval_conv = mock_llm_conv_class.return_value
+
+    # Setup direct single-turn call that ends session immediately
+    mock_eval_conv.next_user_utterance.side_effect = [
+        ("event: welcome", {}),
+        ("", {}),
+    ]
+    mock_eval_conv.steps_progress = []
+
+    # Mock agent response containing a clean end_session tool call
+    mock_response = MagicMock()
+    mock_output = MagicMock()
+    mock_output.text = "Transferring to associate now."
+
+    mock_tc = MagicMock()
+    mock_tc.tool = "escalate_human"
+
+    mock_tc_end = MagicMock()
+    mock_tc_end.tool = "end_session"
+
+    mock_output.tool_calls.tool_calls = [mock_tc, mock_tc_end]
+    mock_response.outputs = [mock_output]
+    mock_sessions.run.side_effect = [mock_response]
+
+    app_name = "projects/test/locations/us/apps/123-abc"
+    with patch("cxas_scrapi.evals.simulation_evals.GeminiGenerate"):
+        with patch("cxas_scrapi.core.apps.AgentServiceClient"):
+            simulator = SimulationEvals(app_name=app_name)
+
+    test_case = {"steps": []}
+    with patch(
+        "cxas_scrapi.core.sessions.Sessions._expand_pb_struct",
+        return_value={},
+    ):
+        simulator.simulate_conversation(
+            test_case=test_case,
+            session_id="123",
+            console_logging=False,
+        )
+
+    # Verify that final agent text is appended to transcript on session end
+    mock_eval_conv._add_agent_response.assert_any_call(
+        "Transferring to associate now."
+    )

--- a/tests/cxas_scrapi/utils/test_reporting.py
+++ b/tests/cxas_scrapi/utils/test_reporting.py
@@ -424,6 +424,48 @@ def test_run_all_evals_filtering(
 @patch("glob.glob")
 @patch("os.path.exists")
 @patch("os.path.isdir")
+def test_run_all_evals_substring_filtering(
+    mock_isdir,
+    mock_exists,
+    mock_glob,
+    mock_eval_utils,
+    mock_callback_evals,
+    mock_sim_evals,
+    mock_tool_evals,
+    mock_evaluations,
+):
+    mock_exists.return_value = True
+    mock_isdir.return_value = True
+    mock_glob.side_effect = [
+        ["evals/goldens/error.yaml", "evals/goldens/other.yaml"],
+        ["evals/tool_tests/tool1.yaml"],
+        ["evals/simulations/sim1.yaml"],
+    ]
+
+    # Mock load_golden_evals_from_yaml to return empty list
+    mock_eval_utils.return_value.load_golden_evals_from_yaml.return_value = []
+
+    run_all_evals(
+        app_name="projects/p",
+        filter_files=["ERROR"],
+        goldens_dir="evals/goldens/",
+        tool_test_file="evals/tool_tests/",
+        simulation_dir="evals/simulations/",
+    )
+
+    mock_eval_utils.return_value.load_golden_evals_from_yaml.assert_called_once_with(
+        "evals/goldens/error.yaml"
+    )
+
+
+@patch("cxas_scrapi.utils.reporting.Evaluations")
+@patch("cxas_scrapi.utils.reporting.ToolEvals")
+@patch("cxas_scrapi.utils.reporting.SimulationEvals")
+@patch("cxas_scrapi.utils.reporting.CallbackEvals")
+@patch("cxas_scrapi.utils.reporting.EvalUtils")
+@patch("glob.glob")
+@patch("os.path.exists")
+@patch("os.path.isdir")
 @patch("cxas_scrapi.utils.reporting.RunEvaluationOperationMetadata")
 @patch("yaml.safe_load")
 @patch("builtins.open", new_callable=mock_open)


### PR DESCRIPTION
Introduce sequential accumulation of session parameters across conversational turns in SimulationEvals, parse the final verbal utterance of agents on session close events, and enable case-insensitive substring pattern matching for filter_files in run_all_evals.