### PR TITLE
refactor: centralize base API endpoint to a single constant

### DIFF
--- a/src/cxas_scrapi/core/common.py
+++ b/src/cxas_scrapi/core/common.py
@@ -33,6 +33,8 @@ GLOBAL_SCOPES = [
     "https://www.googleapis.com/auth/generative-language.retriever",
 ]
 
+DEFAULT_API_ENDPOINT = "ces.googleapis.com"
+
 
 class Common:
     """Core Class for managing Auth and shared functions in CX Agent Studio."""
@@ -158,7 +160,7 @@ class Common:
             return {}
 
         # Using global endpoint mapping for CXAS v1beta
-        api_endpoint = "ces.googleapis.com"
+        api_endpoint = DEFAULT_API_ENDPOINT
         return {"api_endpoint": api_endpoint}
 
     @staticmethod
@@ -351,7 +353,7 @@ class Common:
         """Creates a customer gRPC transport for CXAS SCRAPI calls."""
         transport_class = client_class.get_transport_class("grpc")
 
-        host = "ces.googleapis.com"
+        host = DEFAULT_API_ENDPOINT
         client_opts = getattr(self, "client_options", None)
         if client_opts and "api_endpoint" in client_opts:
             host = self.client_options["api_endpoint"]

--- a/src/cxas_scrapi/core/sessions.py
+++ b/src/cxas_scrapi/core/sessions.py
@@ -39,7 +39,7 @@ except ImportError:
     HAS_IPYTHON = False
 
 from cxas_scrapi.core.audio_transformer import AudioTransformer
-from cxas_scrapi.core.common import Common
+from cxas_scrapi.core.common import DEFAULT_API_ENDPOINT, Common
 from cxas_scrapi.core.conversation_history import ConversationHistory
 
 logger = logging.getLogger(__name__)
@@ -51,7 +51,7 @@ class Modality(str, Enum):
 
 
 BIDI_SESSION_URI = (
-    "wss://ces.googleapis.com/ws/"
+    f"wss://{DEFAULT_API_ENDPOINT}/ws/"
     "google.cloud.ces.v1.SessionService/BidiRunSession/locations/"
 )
 AUDIO_CHUNK_SIZE = 3200

--- a/src/cxas_scrapi/core/tools.py
+++ b/src/cxas_scrapi/core/tools.py
@@ -27,6 +27,7 @@ from google.protobuf import field_mask_pb2
 from google.protobuf.json_format import MessageToDict
 
 from cxas_scrapi.core.apps import Apps
+from cxas_scrapi.core.common import DEFAULT_API_ENDPOINT
 from cxas_scrapi.core.variables import Variables
 
 
@@ -332,9 +333,7 @@ class Tools(Apps):
         Returns:
             The tool execution response (JSON or Object).
         """
-        # Use HTTP REST request instead of SDK because the current SDK version
-        # is missing the 'variables' field in ExecuteToolRequest proto
-        url = f"https://ces.googleapis.com/v1beta/{self.app_name}:executeTool"
+        url = f"https://{DEFAULT_API_ENDPOINT}/v1beta/{self.app_name}:executeTool"
 
         headers = {
             "Authorization": f"Bearer {self.creds.token}",

--- a/tests/cxas_scrapi/core/test_common.py
+++ b/tests/cxas_scrapi/core/test_common.py
@@ -21,7 +21,7 @@ sys.path.append(
     os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../src"))
 )
 
-from cxas_scrapi.core.common import Common  # noqa: E402
+from cxas_scrapi.core.common import DEFAULT_API_ENDPOINT, Common  # noqa: E402
 
 
 def test_common_init():
@@ -49,11 +49,11 @@ def test_common_auth(mock_auth):
 def test_client_options():
     us_id = "projects/my-project/locations/us/agents/my-agent"
     opts = Common._get_client_options(us_id)
-    assert opts["api_endpoint"] == "ces.googleapis.com"
+    assert opts["api_endpoint"] == DEFAULT_API_ENDPOINT
 
     eu_id = "projects/my-project/locations/eu/agents/my-agent"
     opts = Common._get_client_options(eu_id)
-    assert opts["api_endpoint"] == "ces.googleapis.com"
+    assert opts["api_endpoint"] == DEFAULT_API_ENDPOINT
 
 
 def test_project_id_extraction():

--- a/tests/cxas_scrapi/core/test_tools.py
+++ b/tests/cxas_scrapi/core/test_tools.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from cxas_scrapi.core.common import DEFAULT_API_ENDPOINT
 from cxas_scrapi.core.tools import Tools
 
 
@@ -274,7 +275,7 @@ def test_execute_tool(mock_client_cls, mock_post):
     args, kwargs = mock_post.call_args
     assert (
         args[0]
-        == "https://ces.googleapis.com/v1beta/projects/p/locations/l/apps/A:executeTool"
+        == f"https://{DEFAULT_API_ENDPOINT}/v1beta/projects/p/locations/l/apps/A:executeTool"
     )
     assert kwargs["json"]["tool"] == "projects/p/locations/l/apps/A/tools/t1"
     assert kwargs["json"]["args"] == {"query": "test"}
@@ -320,7 +321,7 @@ def test_execute_toolset(mock_client_cls, mock_post):
     args, kwargs = mock_post.call_args
     assert (
         args[0]
-        == "https://ces.googleapis.com/v1beta/projects/p/locations/l/apps/A:executeTool"
+        == f"https://{DEFAULT_API_ENDPOINT}/v1beta/projects/p/locations/l/apps/A:executeTool"
     )
     assert (
         kwargs["json"]["toolsetTool"]["toolset"]
@@ -390,7 +391,7 @@ def test_execute_tool_with_context(mock_client_cls, mock_post):
     args, kwargs = mock_post.call_args
     assert (
         args[0]
-        == "https://ces.googleapis.com/v1beta/projects/p/locations/l/apps/A:executeTool"
+        == f"https://{DEFAULT_API_ENDPOINT}/v1beta/projects/p/locations/l/apps/A:executeTool"
     )
     assert kwargs["json"]["tool"] == "projects/p/locations/l/apps/A/tools/t1"
     assert kwargs["json"]["args"] == {"query": "test"}


### PR DESCRIPTION
Declare a new centralized DEFAULT_API_ENDPOINT constant inside common.py (defaulting to ces.googleapis.com), refactor execute_tool URL endpoints, websocket BidiSession URIs, and GRPC hosts to use the constant, and update all client options and execution url unit tests.