### PR TITLE
[codex] Add poly launch readiness report

### DIFF
--- a/.agents/skills/cxas-agent-foundry/agents/polymorphic-adapter-author.md
+++ b/.agents/skills/cxas-agent-foundry/agents/polymorphic-adapter-author.md
@@ -1,0 +1,86 @@
+---
+name: polymorphic-adapter-author
+description: Author, review, validate, build, diff, and debug CXAS SCRAPI polymorphic channel adapter cards and compiled channel variants. Use for Gemini adapter-card work, chat/voice/API/web/telephony deltas, adapter validation failures, and compiled-output issues.
+---
+
+# Polymorphic Adapter Author Agent
+
+**Role:** Specialized Gemini-facing agent for CXAS SCRAPI polymorphic adapter
+work. Keep adapter work grounded in the current repo engine, validators,
+examples, and CLI. Do not invent unsupported adapter fields or runtime
+polymorphism.
+
+This file is exposed through `.gemini/agents`, which is a symlink to this
+directory.
+
+**Reasoning intensity: MEDIUM.** Adapter work is structural and schema-heavy,
+but the repo already defines the legal moves.
+
+## Inputs
+
+Expected inputs from the caller:
+
+- `app_dir`: path to the direct SCRAPI app root containing `app.json`
+- `task`: what the user wants changed, reviewed, built, or debugged
+- `channels`: target channel ids when known, such as `chat` or `voice`
+- `constraints`: channel-specific product or UX constraints
+- `output_dir`: optional build output directory
+
+If `app_dir` is missing, ask for it or infer it only from clear local context.
+
+## Canonical Instructions
+
+Read the canonical skill first:
+
+```text
+.agents/skills/cxas-polymorphic-adapters/SKILL.md
+```
+
+Then load only the reference that matches the task:
+
+```text
+.agents/skills/cxas-polymorphic-adapters/references/adapter-authoring.md
+.agents/skills/cxas-polymorphic-adapters/references/build-and-validate.md
+.agents/skills/cxas-polymorphic-adapters/references/debug-adapter.md
+```
+
+If those files cannot be read, stop and report the missing path. Do not proceed
+from memory on schema-heavy adapter work.
+
+## Process
+
+1. Confirm `app_dir` contains `app.json`, `agents/`, and, for existing adapter
+   work, `adapters/`.
+2. Inventory the base project: root agent, child agents, tools, callbacks,
+   evals, `gecx-config.json`, and existing adapter cards.
+3. Decide whether adapters are appropriate. If the channel delta is larger than
+   the base or replaces most behavior, recommend separate agents.
+4. For authoring tasks, edit only the base project and adapter sources that are
+   required. Keep channel-specific deltas in `adapters/`.
+5. For review and debug tasks, use `AD001`-`AD010` rule IDs and inspect the
+   compiled output rather than guessing from symptoms.
+6. Verify with the narrowest relevant commands:
+
+```bash
+uv run cxas poly validate --app-dir <app_dir>
+uv run cxas poly diff <channel> --app-dir <app_dir>
+uv run cxas poly build --app-dir <app_dir> --output-dir <output_dir>
+uv run cxas lint --app-dir <output_dir>/<channel>
+```
+
+## Output
+
+Return a concise report with:
+
+- Files changed or reviewed
+- Adapter-vs-separate-agent decision, if relevant
+- Commands run and their pass or fail result
+- Any unsupported request or remaining risk, with the exact repo source that
+  proves it
+
+## Constraints
+
+- Base instructions should stay channel-neutral; channel behavior belongs in
+  adapters.
+- Never hand-edit compiled output; rebuild from base plus adapters.
+- Do not use the `generalist` sub-agent.

--- a/.agents/skills/cxas-polymorphic-adapters/SKILL.md
+++ b/.agents/skills/cxas-polymorphic-adapters/SKILL.md
@@ -175,9 +175,15 @@ Load `references/debug-adapter.md` for cause and fix guidance.
    non-goals.
 4. Keep the base channel-neutral. Put channel-specific language, rich UI,
    telephony pacing, or API-specific behavior in adapters.
-5. Add or update `adapters/<channel>.adapter.yaml`.
-6. Validate first, then diff, then build, then lint the compiled output.
-7. Debug adapter rule IDs at the source adapter/base files, not by editing the
+5. Add or update `adapters/<channel>.adapter.yaml`. For a new channel, start
+   with `cxas poly init` so referenced eval/tool/callback paths are created
+   with the card.
+6. Validate first. Use `cxas poly doctor` or `validate --explain` when raw AD
+   rule output is not actionable enough.
+7. Diff before writing. Use `cxas poly diff <channel> --json` when CI or tools
+   need stable machine-readable deltas.
+8. Build, then lint the compiled output.
+9. Debug adapter rule IDs at the source adapter/base files, not by editing the
    compiled output.
 
 ## Required Commands
@@ -185,13 +191,18 @@ Load `references/debug-adapter.md` for cause and fix guidance.
 Use `uv run` from the repo root unless the environment has an activated venv.
 
 ```bash
+uv run cxas poly init --app-dir <app_dir> --channel <channel>
 uv run cxas poly validate --app-dir <app_dir>
+uv run cxas poly doctor --app-dir <app_dir>
 uv run cxas poly diff <channel> --app-dir <app_dir>
+uv run cxas poly diff <channel> --app-dir <app_dir> --json
 uv run cxas poly build --app-dir <app_dir> --output-dir <output_dir>
 uv run cxas lint --app-dir <output_dir>/<channel>
 ```
 
-When warnings must block, use `--strict` on `validate` and `build`.
+When warnings must block, use `--strict` on `validate`, `doctor`, and `build`.
+`init` writes only fields supported by the current `AdapterCard` schema and
+creates referenced starter eval/tool/callback files when requested.
 
 ## Python API Quick Reference
 

--- a/.agents/skills/cxas-polymorphic-adapters/SKILL.md
+++ b/.agents/skills/cxas-polymorphic-adapters/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: cxas-polymorphic-adapters
+description: Use when authoring, reviewing, validating, building, diffing, or debugging CXAS SCRAPI polymorphic channel adapters, adapter cards, channel-specific variants, or chat/voice/API/web/telephony adaptation work.
+---
+
+# CXAS Polymorphic Adapters
+
+Use this skill to help users keep one channel-neutral SCRAPI agent project at
+the center and compile channel-specific projects at the edges with `cxas poly`.
+
+## Contract
+
+- Polymorphism in this repo is build-time only. There is no polymorphic runtime.
+- The output of `cxas poly build` is an ordinary SCRAPI project that should
+  lint, eval, and deploy like a hand-authored project.
+- The adapter card schema is whatever `src/cxas_scrapi/poly/models.py`
+  supports today. Do not invent fields, channels, tool types, or deployment
+  values.
+- Adapter validation is the source of truth for buildability:
+  `src/cxas_scrapi/poly/validators.py` backs `cxas poly validate`, `cxas lint`,
+  and `PolymorphismEngine.compile()`.
+
+## When To Use This Skill
+
+Use this skill when the user mentions:
+
+- Polymorphism, polymorphic agents, channel adapters, or adapter cards
+- `cxas poly`, `cxas poly build`, `cxas poly validate`, or `cxas poly diff`
+- Making one base agent work across chat, voice, API, or telephony channels
+- Writing or editing `adapters/*.adapter.yaml` files
+- `AD001`-`AD010` validation errors
+- Comparing or inspecting compiled channel output
+
+Do not use this skill for:
+
+- Building a new agent from scratch from a PRD — use `cxas-agent-foundry`
+- Running or debugging the broader eval lifecycle after compilation — use
+  `cxas-agent-foundry` on the compiled project
+- Converting eval formats — use `cxas-sim-eval`
+
+## Load First
+
+For any real adapter task, skim these before editing:
+
+- `README.md`
+- `docs/guides/polymorphism.md`
+- `examples/polymorphic_pizza/README.md`
+- The target project's `app.json`, `agents/`, `tools/`, `evaluations/`,
+  `gecx-config.json`, and `adapters/`
+- Existing adapter examples under `examples/*/adapters/*.adapter.yaml`
+
+For schema or behavior questions, read the code instead of guessing:
+
+- `src/cxas_scrapi/poly/models.py`
+- `src/cxas_scrapi/poly/validators.py`
+- `src/cxas_scrapi/poly/engine.py`
+- `src/cxas_scrapi/cli/poly_cli.py`
+
+## Task Router
+
+- **Decide adapter vs separate agents**: use the decision framework below.
+- **Write or revise an adapter card**: read
+  `references/adapter-authoring.md`.
+- **Validate, diff, or build channels**: read
+  `references/build-and-validate.md`.
+- **Debug a validation or compilation problem**: read
+  `references/debug-adapter.md`.
+- **Need general agent build/eval/debug lifecycle after compilation**: also use
+  `.agents/skills/cxas-agent-foundry/SKILL.md` on the compiled project.
+
+## Adapters vs Separate Agents
+
+Use adapters when most of the work is shared:
+
+- Same root business flow, same source of truth, and mostly the same tools
+- Differences are channel presentation or tuning: response format, pacing,
+  rich cards, callbacks, model selection, extra evals, or deployment settings
+- The base can stay channel-neutral without hiding important channel behavior
+
+Prefer separate agents when the channels are really different products:
+
+- Conversation graphs, tools, state machines, or compliance requirements differ
+  more than they overlap
+- The adapter would replace most sections or remove or rebuild most tools
+- A future maintainer would need to read the compiled output to understand the
+  actual product
+
+Rule of thumb: if the adapter delta is larger than the base, or
+`replace_section` becomes the main authoring tool, stop and recommend separate
+agents or a smaller shared base.
+
+## The Three Primitives
+
+| Primitive | What it is | Where it lives |
+|---|---|---|
+| Base project | An ordinary SCRAPI project: `app.json`, `agents/`, `tools/`, `evaluations/`. Channel-neutral. | Project root |
+| Adapter card | A YAML or JSON file declaring per-channel deltas: instruction edits, tool add/remove, model overrides, callbacks, evals, deployment. | `adapters/<channel>.adapter.yaml` |
+| Poly engine | The compiler. Deep-copies the base, applies adapter deltas, writes one complete project per channel. | `cxas poly` CLI / `cxas_scrapi.poly` Python API |
+
+## Adapter Card Quick Reference
+
+Required header:
+
+```yaml
+apiVersion: poly.cxas.dev/v1
+kind: ChannelAdapter
+metadata:
+  channel: <string>
+  displayName: <string>
+  description: <optional string>
+```
+
+Optional delta sections, applied in this fixed order during compilation:
+
+| Section | Field | What it does |
+|---|---|---|
+| Instruction diffs | `instructionDiffs[]` | `mode: append` / `prepend` / `replace_section` on a named agent's instruction text |
+| Tool modifications | `tools[]` | `add` / `remove` tool names on a named agent's `tools` list |
+| Tool definitions | `toolDefinitions[]` | Bring a channel-only tool into `tools/` from a `sourceDir` |
+| Model overrides | `modelOverrides[]` | Set `modelSettings.model` for an agent |
+| Callbacks | `callbacks[]` | Append channel callbacks like `before_model` or `after_tool` |
+| Evaluations | `evaluations[]` | Merge channel eval directories into compiled `evaluations/` |
+| Expectations / datasets | `evaluationExpectations[]`, `evaluationDatasets[]` | Merge channel expectation and dataset dirs |
+| Deployment | `deployment` | Fold channel/modality/widget config into compiled `gecx-config.json` |
+
+Supported values to keep handy:
+
+- `toolType`: `python`, `openapi`
+- instruction diff `mode`: `append`, `prepend`, `replace_section`
+- callback `type`: `before_model`, `after_model`, `before_tool`,
+  `after_tool`, `before_agent`, `after_agent`
+- `deployment.channelType`: `WEB_UI`, `API`, `TWILIO`,
+  `GOOGLE_TELEPHONY_PLATFORM`, `CONTACT_CENTER_AS_A_SERVICE`, `FIVE9`,
+  `CONTACT_CENTER_INTEGRATION`
+- `deployment.modality` and `webWidgetConfig.modality`: `CHAT_AND_VOICE`,
+  `VOICE_ONLY`, `CHAT_ONLY`, `CHAT_VOICE_AND_VIDEO`
+- `webWidgetConfig.theme`: `LIGHT`, `DARK`
+
+Key conventions:
+
+- Agents can be referenced by display name or directory name.
+- `replace_section` requires `sectionTag` and a matching XML block in the base
+  instruction.
+- `tools.add` must resolve to a base tool, a same-card `toolDefinitions`
+  entry, or a supported platform tool.
+- All `sourceDir` and `pythonCode` paths are relative to the app root and must
+  not escape it.
+
+## Validation Rules
+
+These are the same rule IDs surfaced by `cxas poly validate`, `cxas lint`, and
+`compile()`:
+
+- `AD001`: malformed card or missing required schema fields
+- `AD002`: referenced agent does not exist
+- `AD003`: invalid `replace_section` usage
+- `AD004`: removing a tool the base agent does not have
+- `AD005`: missing tool definition, callback file, or source directory
+- `AD006`: adapter has no `evaluations` entries
+- `AD007`: duplicate `metadata.channel`
+- `AD008`: path escapes the app root
+- `AD009`: unsupported deployment enum value
+- `AD010`: unsupported `toolType`
+
+Load `references/debug-adapter.md` for cause and fix guidance.
+
+## Working Loop
+
+1. Identify the direct app root. It must contain `app.json`; nested foundry
+   workspaces are not the input shape for `cxas poly`.
+2. Inventory the base: root agent, child agents, tools, callbacks, evals,
+   `gecx-config.json`, and any existing adapters.
+3. Make a channel concern map before writing: instructions, tools, tool
+   definitions, callbacks, evals, model overrides, deployment settings, and
+   non-goals.
+4. Keep the base channel-neutral. Put channel-specific language, rich UI,
+   telephony pacing, or API-specific behavior in adapters.
+5. Add or update `adapters/<channel>.adapter.yaml`.
+6. Validate first, then diff, then build, then lint the compiled output.
+7. Debug adapter rule IDs at the source adapter/base files, not by editing the
+   compiled output.
+
+## Required Commands
+
+Use `uv run` from the repo root unless the environment has an activated venv.
+
+```bash
+uv run cxas poly validate --app-dir <app_dir>
+uv run cxas poly diff <channel> --app-dir <app_dir>
+uv run cxas poly build --app-dir <app_dir> --output-dir <output_dir>
+uv run cxas lint --app-dir <output_dir>/<channel>
+```
+
+When warnings must block, use `--strict` on `validate` and `build`.
+
+## Python API Quick Reference
+
+```python
+from cxas_scrapi.poly import PolymorphismEngine, CompilationError
+
+engine = PolymorphismEngine("<app_dir>")
+engine.load_base_project()
+engine.load_adapter_cards()
+
+try:
+    compiled = engine.compile_all()
+    for channel, config in compiled.items():
+        engine.write_output(config, f"./output/{channel}")
+except CompilationError as err:
+    for issue in err.issues:
+        print(issue["severity"], issue["rule_id"], issue["message"])
+```
+
+## Working Examples
+
+The repo ships two complete examples:
+
+- `examples/polymorphic_pizza/` — beginner chat + voice example
+- `examples/bella_notte/` — larger reservation example with richer channel
+  deltas
+
+Use those as templates when authoring new adapters.
+
+## Non-Negotiables
+
+- Do not fetch, push, or deploy unless the user explicitly asks.
+- Do not describe compiled output as the maintained source; the maintained
+  source is the base project plus adapter cards.
+- Do not document unsupported adapter fields. If a requested delta is not in
+  `AdapterCard`, call that out and suggest a supported alternative or source
+  change.
+- Do not use paths outside the app root in adapter cards; validators reject
+  path escapes.
+- Every behavior-changing adapter should have at least one channel-specific
+  eval entry unless the user intentionally accepts the `AD006` warning.
+- Never hand-edit compiled output directories; rebuild from the base plus
+  adapters instead.

--- a/.agents/skills/cxas-polymorphic-adapters/references/adapter-authoring.md
+++ b/.agents/skills/cxas-polymorphic-adapters/references/adapter-authoring.md
@@ -32,7 +32,26 @@ Get clear on:
 - Whether the channel delta is small enough for an adapter, instead of a fully
   separate agent
 
-### 2. Start from the required card skeleton
+### 2. Start from `cxas poly init` when possible
+
+For a new channel, let the CLI write the first valid card and referenced
+starter assets:
+
+```bash
+uv run cxas poly init \
+  --app-dir <app_dir> \
+  --channel chat \
+  --deployment-target WEB_UI \
+  --modality CHAT_ONLY \
+  --with-callback before_model \
+  --with-tool send_channel_card
+```
+
+Use `--dry-run` before writing and `--force` only when replacing known scaffold
+files. The generated adapter uses only currently supported fields; replace the
+starter instruction/eval/tool/callback content with real channel behavior.
+
+### 3. Or start from the required card skeleton
 
 ```yaml
 apiVersion: poly.cxas.dev/v1
@@ -58,7 +77,7 @@ named `*.adapter.yaml`, `*.adapter.yml`, or `*.adapter.json` under `adapters/`.
 `metadata.channel` becomes the output directory name and generated deployment
 id.
 
-### 3. Write instruction diffs
+### 4. Write instruction diffs
 
 Prefer `append` for channel behavior because it keeps the base readable and the
 delta small:
@@ -94,7 +113,7 @@ Channel-specific guidance:
 
 If most sections want `replace_section`, recommend separate agents.
 
-### 4. Add tool modifications and channel-only tools
+### 5. Add tool modifications and channel-only tools
 
 `tools.add` may reference:
 
@@ -124,7 +143,7 @@ and the referenced code. The compiler normalizes the code to
 For OpenAPI tools, use `toolType: openapi`; the engine copies the source
 folder verbatim.
 
-### 5. Add callbacks when the channel needs runtime hints
+### 6. Add callbacks when the channel needs runtime hints
 
 Supported callback types:
 
@@ -149,7 +168,7 @@ Callback paths are relative to the app root. The compiler appends the callback
 after existing callbacks of that type and writes it into the agent's standard
 callback directory in compiled output.
 
-### 6. Add channel evals
+### 7. Add channel evals
 
 Every behavior-changing adapter should usually add channel eval coverage:
 
@@ -162,7 +181,7 @@ The same source-dir structure also applies to `evaluationExpectations` and
 `evaluationDatasets`. If `evaluations` is missing, validation reports `AD006`
 warning.
 
-### 7. Set deployment values
+### 8. Set deployment values
 
 Chat example:
 
@@ -212,7 +231,9 @@ The compiler stores the resolved deployment block in compiled
 
 ```bash
 uv run cxas poly validate --app-dir <app_dir>
+uv run cxas poly doctor --app-dir <app_dir>
 uv run cxas poly diff <channel> --app-dir <app_dir>
+uv run cxas poly diff <channel> --app-dir <app_dir> --json
 uv run cxas poly build --app-dir <app_dir> --output-dir <output_dir>
 uv run cxas lint --app-dir <output_dir>/<channel>
 ```

--- a/.agents/skills/cxas-polymorphic-adapters/references/adapter-authoring.md
+++ b/.agents/skills/cxas-polymorphic-adapters/references/adapter-authoring.md
@@ -1,0 +1,225 @@
+# Adapter Authoring
+
+Use this reference when writing or revising `adapters/<channel>.adapter.yaml`
+for the current SCRAPI polymorphism engine.
+
+## Source Files To Read
+
+Before authoring an adapter, read the real project files:
+
+- `app.json`: app display name, root agent, app-level tool inventory
+- `agents/<agent>/<agent>.json`: agent display names, `tools`, callbacks,
+  `modelSettings`, child agents, and instruction path
+- `agents/<agent>/instruction.txt`: channel-neutral base behavior and any XML
+  sections available for `replace_section`
+- `tools/<tool>/<tool>.json` and tool code: which tools already exist
+- `evaluations/`, `evaluationExpectations/`, `evaluationDatasets/`: shared
+  baseline eval coverage
+- Existing `adapters/*.adapter.yaml`: current channel strategy and naming
+
+Use `examples/polymorphic_pizza/adapters/` for a smaller example and
+`examples/bella_notte/adapters/` for a larger slot-filling example.
+
+## Step-By-Step Workflow
+
+### 1. Identify the target channel and requirements
+
+Get clear on:
+
+- What channel is being added: `chat`, `voice`, or another channel id
+- Which changes are actually channel-specific: formatting, pacing, callbacks,
+  deployment target, widget settings, model tuning, or channel-only tools
+- Whether the channel delta is small enough for an adapter, instead of a fully
+  separate agent
+
+### 2. Start from the required card skeleton
+
+```yaml
+apiVersion: poly.cxas.dev/v1
+kind: ChannelAdapter
+metadata:
+  channel: chat
+  displayName: Example App - Chat
+  description: Web chat optimization for Example App.
+
+instructionDiffs: []
+tools: []
+toolDefinitions: []
+modelOverrides: []
+callbacks: []
+evaluations: []
+evaluationExpectations: []
+evaluationDatasets: []
+deployment: {}
+```
+
+Only include blocks that are needed. Adapter files are discovered only when
+named `*.adapter.yaml`, `*.adapter.yml`, or `*.adapter.json` under `adapters/`.
+`metadata.channel` becomes the output directory name and generated deployment
+id.
+
+### 3. Write instruction diffs
+
+Prefer `append` for channel behavior because it keeps the base readable and the
+delta small:
+
+```yaml
+instructionDiffs:
+  - agent: Order_Agent
+    mode: append
+    content: |
+      <channel_voice>
+      Keep each spoken turn to two or three short sentences.
+      Never use Markdown or symbols.
+      </channel_voice>
+```
+
+Use `replace_section` only when the base already has a stable XML section:
+
+```yaml
+instructionDiffs:
+  - agent: Reservation_Agent
+    mode: replace_section
+    sectionTag: channel_behavior
+    content: |
+      Offer at most three available times at once, spoken aloud.
+```
+
+Channel-specific guidance:
+
+- **chat**: Markdown, numbered lists, visual confirmations, richer UI helper
+  tools, short paragraphs
+- **voice**: short spoken turns, no Markdown or symbols, read numbers aloud,
+  pacing hints, tool-call filler phrases, tighter confirmations
+
+If most sections want `replace_section`, recommend separate agents.
+
+### 4. Add tool modifications and channel-only tools
+
+`tools.add` may reference:
+
+- A tool already present under `tools/`
+- A channel-only tool declared in the same card's `toolDefinitions`
+- Supported platform tools currently allowed by validators: `end_session`,
+  `customize_response`
+
+Example:
+
+```yaml
+tools:
+  - agent: Order_Agent
+    add:
+      - send_order_card
+
+toolDefinitions:
+  - displayName: send_order_card
+    toolType: python
+    sourceDir: adapters/chat_tools/send_order_card
+```
+
+For Python channel-only tools, the source directory must include the tool JSON
+and the referenced code. The compiler normalizes the code to
+`tools/<displayName>/python_function/python_code.py` in the compiled output.
+
+For OpenAPI tools, use `toolType: openapi`; the engine copies the source
+folder verbatim.
+
+### 5. Add callbacks when the channel needs runtime hints
+
+Supported callback types:
+
+- `before_model`
+- `after_model`
+- `before_tool`
+- `after_tool`
+- `before_agent`
+- `after_agent`
+
+Example:
+
+```yaml
+callbacks:
+  - agent: Bella_Notte_Host
+    type: before_model
+    pythonCode: adapters/voice_callbacks/voice_pacing.py
+    description: Inject voice pacing hints.
+```
+
+Callback paths are relative to the app root. The compiler appends the callback
+after existing callbacks of that type and writes it into the agent's standard
+callback directory in compiled output.
+
+### 6. Add channel evals
+
+Every behavior-changing adapter should usually add channel eval coverage:
+
+```yaml
+evaluations:
+  - sourceDir: adapters/voice_evals
+```
+
+The same source-dir structure also applies to `evaluationExpectations` and
+`evaluationDatasets`. If `evaluations` is missing, validation reports `AD006`
+warning.
+
+### 7. Set deployment values
+
+Chat example:
+
+```yaml
+deployment:
+  channelType: WEB_UI
+  modality: CHAT_ONLY
+  webWidgetConfig:
+    theme: LIGHT
+    webWidgetTitle: Polymorphic Pizza
+```
+
+Voice example:
+
+```yaml
+deployment:
+  channelType: GOOGLE_TELEPHONY_PLATFORM
+  modality: VOICE_ONLY
+  disableBargeInControl: false
+  disableDtmf: false
+```
+
+Supported values to keep handy:
+
+- `deployment.channelType`: `WEB_UI`, `API`, `TWILIO`,
+  `GOOGLE_TELEPHONY_PLATFORM`, `CONTACT_CENTER_AS_A_SERVICE`, `FIVE9`,
+  `CONTACT_CENTER_INTEGRATION`
+- `deployment.modality` and `webWidgetConfig.modality`: `CHAT_AND_VOICE`,
+  `VOICE_ONLY`, `CHAT_ONLY`, `CHAT_VOICE_AND_VIDEO`
+- `webWidgetConfig.theme`: `LIGHT`, `DARK`
+
+The compiler stores the resolved deployment block in compiled
+`gecx-config.json`; it does not write a separate deployment file.
+
+## Authoring Checklist
+
+- Base instructions describe the shared job, not a specific screen or phone
+  channel
+- Adapter deltas are small and organized by channel intent
+- Every referenced agent and tool matches an actual display name or directory
+- Channel-only tool source dirs and callback files exist under the app root
+- Each adapter has channel evals or an explicit reason to accept `AD006`
+- Deployment values come from the supported enum lists
+- Output directories for builds live outside the source app directory
+
+## Verify Before Hand-Off
+
+```bash
+uv run cxas poly validate --app-dir <app_dir>
+uv run cxas poly diff <channel> --app-dir <app_dir>
+uv run cxas poly build --app-dir <app_dir> --output-dir <output_dir>
+uv run cxas lint --app-dir <output_dir>/<channel>
+```
+
+Starter templates worth copying from:
+
+- `examples/polymorphic_pizza/adapters/chat.adapter.yaml`
+- `examples/polymorphic_pizza/adapters/voice.adapter.yaml`
+- `examples/bella_notte/adapters/chat.adapter.yaml`
+- `examples/bella_notte/adapters/voice.adapter.yaml`

--- a/.agents/skills/cxas-polymorphic-adapters/references/build-and-validate.md
+++ b/.agents/skills/cxas-polymorphic-adapters/references/build-and-validate.md
@@ -27,7 +27,15 @@ uv run cxas poly validate --app-dir <app_dir>
 Useful options:
 
 - `--format json` for structured output
+- `--explain` for guided what/why/path/fix output
 - `--strict` when warnings should block
+
+Use doctor when debugging:
+
+```bash
+uv run cxas poly doctor --app-dir <app_dir>
+uv run cxas poly doctor --app-dir <app_dir> --format json
+```
 
 `cxas lint` also discovers `adapters/*.adapter.{yaml,yml,json}` and delegates
 to the same rule IDs. In zero-warning workspaces, treat adapter warnings as
@@ -40,6 +48,7 @@ Preview what a channel changes before writing output:
 ```bash
 uv run cxas poly diff chat --app-dir <app_dir>
 uv run cxas poly diff voice --app-dir <app_dir>
+uv run cxas poly diff chat --app-dir <app_dir> --json
 ```
 
 Use the diff to verify:
@@ -148,7 +157,9 @@ For a fast example smoke:
 
 ```bash
 uv run cxas poly validate --app-dir examples/polymorphic_pizza
+uv run cxas poly doctor --app-dir examples/polymorphic_pizza
 uv run cxas poly diff chat --app-dir examples/polymorphic_pizza
+uv run cxas poly diff chat --app-dir examples/polymorphic_pizza --json
 uv run cxas poly build --app-dir examples/polymorphic_pizza --output-dir .tmp-poly-output
 uv run cxas lint --app-dir .tmp-poly-output/chat
 uv run cxas lint --app-dir .tmp-poly-output/voice
@@ -158,10 +169,15 @@ Clean temporary output after inspection if it is not part of the task.
 
 ## Typical Workflow
 
-1. `uv run cxas poly validate --app-dir <app_dir>`
-2. `uv run cxas poly diff <channel> --app-dir <app_dir>`
-3. `uv run cxas poly build --app-dir <app_dir> --output-dir <output_dir>`
-4. `uv run cxas lint --app-dir <output_dir>/<channel>`
-5. Inspect compiled instructions, tools, evals, and deployment config
-6. Hand the compiled project to `cxas-agent-foundry` if the user now wants
+1. `uv run cxas poly init --app-dir <app_dir> --channel <channel>` for a new
+   channel
+2. `uv run cxas poly validate --app-dir <app_dir>`
+3. `uv run cxas poly doctor --app-dir <app_dir>` if validation is not clear
+4. `uv run cxas poly diff <channel> --app-dir <app_dir>`
+5. `uv run cxas poly diff <channel> --app-dir <app_dir> --json` when CI/tooling
+   needs stable deltas
+6. `uv run cxas poly build --app-dir <app_dir> --output-dir <output_dir>`
+7. `uv run cxas lint --app-dir <output_dir>/<channel>`
+8. Inspect compiled instructions, tools, evals, and deployment config
+9. Hand the compiled project to `cxas-agent-foundry` if the user now wants
    eval, push, or broader lifecycle work

--- a/.agents/skills/cxas-polymorphic-adapters/references/build-and-validate.md
+++ b/.agents/skills/cxas-polymorphic-adapters/references/build-and-validate.md
@@ -1,0 +1,167 @@
+# Build, Validate, And Diff
+
+Use this reference after an adapter card exists, or when the user wants to
+review deltas, compile channels, or inspect compiled output.
+
+## Preflight
+
+From the repo root, confirm the app root is a direct SCRAPI project:
+
+```bash
+test -f <app_dir>/app.json
+test -d <app_dir>/agents
+test -d <app_dir>/adapters
+```
+
+If `app.json` is missing, polymorphism will fail with "No app.json found".
+Locate the direct project root before continuing.
+
+## Validation Loop
+
+Run validation before every build:
+
+```bash
+uv run cxas poly validate --app-dir <app_dir>
+```
+
+Useful options:
+
+- `--format json` for structured output
+- `--strict` when warnings should block
+
+`cxas lint` also discovers `adapters/*.adapter.{yaml,yml,json}` and delegates
+to the same rule IDs. In zero-warning workspaces, treat adapter warnings as
+blockers.
+
+## Preview The Delta
+
+Preview what a channel changes before writing output:
+
+```bash
+uv run cxas poly diff chat --app-dir <app_dir>
+uv run cxas poly diff voice --app-dir <app_dir>
+```
+
+Use the diff to verify:
+
+- Touched agents are expected
+- Instruction diffs are small and scoped
+- Added and removed tools are intentional
+- New callbacks, evals, and deployment settings appear where expected
+
+## Build
+
+Build into a directory outside the source app:
+
+```bash
+uv run cxas poly build --app-dir <app_dir> --output-dir <output_dir>
+```
+
+Build one channel when iterating:
+
+```bash
+uv run cxas poly build --app-dir <app_dir> --channel chat --output-dir <output_dir>
+```
+
+What build does:
+
+1. Validates adapter cards
+2. Deep-copies the base project per channel
+3. Applies deltas in fixed order: instruction diffs → tool modifications →
+   tool definitions → model overrides → callbacks → evals → deployment
+4. Writes one complete project directory per channel
+5. Places a `.poly_build.json` marker in each output directory
+
+The writer refuses to overwrite a non-empty directory unless it was produced by
+`cxas poly build` and contains `.poly_build.json`, or unless `--force` is
+used. Do not use an output directory inside the app root; the engine rejects
+overlap.
+
+## Lint And Inspect Compiled Output
+
+Compiled channels are ordinary projects:
+
+```bash
+uv run cxas lint --app-dir <output_dir>/chat
+uv run cxas lint --app-dir <output_dir>/voice
+```
+
+Then inspect the specific deltas you expected:
+
+```bash
+cat <output_dir>/<channel>/gecx-config.json
+cat <output_dir>/<channel>/agents/<Agent>/instruction.txt
+cat <output_dir>/<channel>/agents/<Agent>/<Agent>.json
+find <output_dir>/<channel>/tools -maxdepth 2 -type f | sort
+find <output_dir>/<channel>/evaluations -maxdepth 2 -type f | sort
+```
+
+If the compiled output looks wrong, fix the base project or adapter card and
+rebuild. Do not make the compiled directory the maintained source.
+
+## Python API
+
+For programmatic inspection or debugging without writing output:
+
+```python
+from cxas_scrapi.poly import PolymorphismEngine, CompilationError
+
+engine = PolymorphismEngine("<app_dir>")
+engine.load_base_project()
+engine.load_adapter_cards()
+
+card, path = engine.adapters["chat"]
+compiled = engine.compile(card, path)
+
+print(compiled.agent_instructions.keys())
+print(compiled.agents["Order_Agent"]["tools"])
+print(compiled.deployment)
+```
+
+To compile all channels programmatically:
+
+```python
+from cxas_scrapi.poly import PolymorphismEngine, CompilationError
+
+engine = PolymorphismEngine("<app_dir>")
+engine.load_base_project()
+engine.load_adapter_cards()
+
+try:
+    compiled = engine.compile_all()
+    for channel, config in compiled.items():
+        engine.write_output(config, f"./output/{channel}")
+except CompilationError as err:
+    for issue in err.issues:
+        print(issue["rule_id"], issue["message"])
+```
+
+## Relevant Verification
+
+For real engine, validator, CLI, and lint-rule coverage:
+
+```bash
+uv run pytest tests/cxas_scrapi/poly
+```
+
+For a fast example smoke:
+
+```bash
+uv run cxas poly validate --app-dir examples/polymorphic_pizza
+uv run cxas poly diff chat --app-dir examples/polymorphic_pizza
+uv run cxas poly build --app-dir examples/polymorphic_pizza --output-dir .tmp-poly-output
+uv run cxas lint --app-dir .tmp-poly-output/chat
+uv run cxas lint --app-dir .tmp-poly-output/voice
+```
+
+Clean temporary output after inspection if it is not part of the task.
+
+## Typical Workflow
+
+1. `uv run cxas poly validate --app-dir <app_dir>`
+2. `uv run cxas poly diff <channel> --app-dir <app_dir>`
+3. `uv run cxas poly build --app-dir <app_dir> --output-dir <output_dir>`
+4. `uv run cxas lint --app-dir <output_dir>/<channel>`
+5. Inspect compiled instructions, tools, evals, and deployment config
+6. Hand the compiled project to `cxas-agent-foundry` if the user now wants
+   eval, push, or broader lifecycle work

--- a/.agents/skills/cxas-polymorphic-adapters/references/debug-adapter.md
+++ b/.agents/skills/cxas-polymorphic-adapters/references/debug-adapter.md
@@ -1,0 +1,235 @@
+# Debug Adapter Validation And Compilation Errors
+
+Use this reference when `cxas poly validate`, `cxas poly build`, or the
+compiled output behaves unexpectedly.
+
+## Rule Reference
+
+### AD001 — Schema or required fields
+
+Cause:
+
+- Malformed YAML or JSON
+- Missing `apiVersion`, `kind`, or required `metadata` fields
+- Wrong types in required fields
+
+Required minimum header:
+
+```yaml
+apiVersion: poly.cxas.dev/v1
+kind: ChannelAdapter
+metadata:
+  channel: chat
+  displayName: Example App - Chat
+```
+
+Fixes:
+
+- Check YAML indentation and list syntax
+- Ensure `kind` is exactly `ChannelAdapter`
+- Ensure the file name is `*.adapter.yaml`, `*.adapter.yml`, or
+  `*.adapter.json`
+
+### AD002 — Referenced agent does not exist
+
+Cause:
+
+- An agent named in `instructionDiffs`, `tools`, `modelOverrides`, or
+  `callbacks` does not match a real agent
+
+Fixes:
+
+- Check directory names under `agents/`
+- Check agent `displayName` values in `agents/<agent>/<agent>.json`
+- Use either directory name or display name consistently
+
+### AD003 — Invalid `replace_section`
+
+Cause:
+
+- `mode: replace_section` is missing `sectionTag`, or
+- The base instruction does not contain the target XML section
+
+Fixes:
+
+- Add `sectionTag`
+- Verify the tag exists in `agents/<Agent>/instruction.txt`
+- If no stable base section exists, switch to `append`
+
+### AD004 — Remove targets a tool the base agent does not have
+
+Cause:
+
+- `tools[].remove` names a tool not present in the base agent's tool list
+
+Fixes:
+
+- Remove the no-op `remove`
+- Correct the tool name or target agent
+
+### AD005 — Missing definition or source path
+
+Cause:
+
+- `tools[].add` references a tool that is not in base tools, same-card
+  `toolDefinitions`, or supported platform tools
+- `toolDefinitions[].sourceDir` does not exist or lacks a valid tool file
+- `callbacks[].pythonCode` does not exist
+- An eval, expectation, or dataset source dir does not exist
+
+Fixes:
+
+- Add or correct the tool definition
+- Create the referenced callback or source directory under the app root
+- Re-check relative paths from the direct app root
+
+### AD006 — No evaluations entries
+
+Cause:
+
+- The adapter has no `evaluations` block
+
+Fix:
+
+- Add channel eval coverage, or explicitly accept the warning if the user
+  truly wants none
+
+### AD007 — Duplicate channel id
+
+Cause:
+
+- Two cards share the same `metadata.channel`
+
+Fix:
+
+- Rename one channel id so each adapter is unique
+
+### AD008 — Path escapes the app root
+
+Cause:
+
+- `sourceDir` or `pythonCode` resolves outside the app via `..` or absolute
+  paths
+
+Fix:
+
+- Keep all paths relative to the direct app root and inside it
+
+### AD009 — Invalid deployment enum value
+
+Cause:
+
+- Unsupported `channelType`, `modality`, or `theme`
+
+Fix:
+
+- Use only the enum values supported in `src/cxas_scrapi/poly/models.py`
+
+### AD010 — Unsupported tool type
+
+Cause:
+
+- `toolDefinitions[].toolType` is not `python` or `openapi`
+
+Fix:
+
+- Use `python` or `openapi`, or change source code before documenting a new
+  type
+
+## Common Failure Patterns
+
+### "No app.json found"
+
+The engine expects a direct project root. Nested foundry layouts are not valid
+base inputs for `cxas poly`.
+
+### "Refusing to write output — it overlaps the base project"
+
+The output directory cannot be inside or equal to the source app directory.
+Pick a sibling temp or output directory instead.
+
+### "Refusing to overwrite — not created by cxas poly build"
+
+The target directory exists and does not contain `.poly_build.json`. Use a new
+output directory or `--force` if overwriting is intentional.
+
+### Build succeeds but compiled output lints poorly
+
+Usually means:
+
+- A channel-only tool definition is incomplete
+- A callback has syntax or path problems
+- An instruction diff produced invalid or lint-hostile text
+
+Fix the source adapter or base project, then rebuild.
+
+### Voice output still uses Markdown
+
+Inspect the compiled voice instruction and strengthen the voice
+`instructionDiff`.
+
+### Chat output lacks rich UI tools
+
+Check `tools.add`, `toolDefinitions`, and callback paths. Missing definitions
+are often `AD005`.
+
+### Shared behavior drifted across channels
+
+The base project is not channel-neutral enough. Move shared business logic back
+into the base and keep adapters focused on channel deltas.
+
+## Debugging Workflow
+
+1. Run structured validation:
+
+```bash
+uv run cxas poly validate --app-dir <app_dir> --format json
+```
+
+2. Fix issues by rule ID.
+3. Re-run validation until clean.
+4. Preview the delta:
+
+```bash
+uv run cxas poly diff <channel> --app-dir <app_dir>
+```
+
+5. Build and lint compiled output.
+6. Compare compiled files to the intended behavior.
+
+## Compiled Output Inspection
+
+```bash
+cat <output_dir>/<channel>/gecx-config.json
+cat <output_dir>/<channel>/agents/<Agent>/instruction.txt
+cat <output_dir>/<channel>/agents/<Agent>/<Agent>.json
+find <output_dir>/<channel>/tools -maxdepth 2 -type f | sort
+find <output_dir>/<channel>/evaluations -maxdepth 2 -type f | sort
+```
+
+## Python Introspection
+
+```python
+from cxas_scrapi.poly.engine import PolymorphismEngine
+
+engine = PolymorphismEngine("<app_dir>")
+engine.load_base_project()
+engine.load_adapter_cards()
+card, path = engine.adapters["chat"]
+compiled = engine.compile(card, path)
+
+print(compiled.agent_instructions.keys())
+print(compiled.agents["Order_Agent"]["tools"])
+print(compiled.deployment)
+```
+
+This mirrors the CLI path and keeps debugging grounded in the same engine.
+
+## If The Requested Workflow Is Unsupported
+
+Point to the exact missing `AdapterCard` field, enum, or engine behavior in
+`src/cxas_scrapi/poly/models.py`, `src/cxas_scrapi/poly/validators.py`, or
+`src/cxas_scrapi/poly/engine.py`, then recommend either:
+
+- a supported adapter shape, or
+- a source-code change with tests

--- a/.agents/skills/cxas-polymorphic-adapters/references/debug-adapter.md
+++ b/.agents/skills/cxas-polymorphic-adapters/references/debug-adapter.md
@@ -180,22 +180,30 @@ into the base and keep adapters focused on channel deltas.
 
 ## Debugging Workflow
 
-1. Run structured validation:
+1. Run guided validation:
+
+```bash
+uv run cxas poly doctor --app-dir <app_dir>
+```
+
+2. Run structured validation when a script/tool needs JSON:
 
 ```bash
 uv run cxas poly validate --app-dir <app_dir> --format json
+uv run cxas poly validate --app-dir <app_dir> --explain --format json
 ```
 
-2. Fix issues by rule ID.
-3. Re-run validation until clean.
-4. Preview the delta:
+3. Fix issues by rule ID at the source adapter/base files.
+4. Re-run validation until clean.
+5. Preview the delta:
 
 ```bash
 uv run cxas poly diff <channel> --app-dir <app_dir>
+uv run cxas poly diff <channel> --app-dir <app_dir> --json
 ```
 
-5. Build and lint compiled output.
-6. Compare compiled files to the intended behavior.
+6. Build and lint compiled output.
+7. Compare compiled files to the intended behavior.
 
 ## Compiled Output Inspection
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "mkdir -p \"$CLAUDE_PROJECT_DIR/.git/hooks\" && cp \"$CLAUDE_PROJECT_DIR/.githooks/commit-msg\" \"$CLAUDE_PROJECT_DIR/.git/hooks/commit-msg\" && chmod +x \"$CLAUDE_PROJECT_DIR/.git/hooks/commit-msg\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",

--- a/.claude/skills/cxas-polymorphic-adapters/SKILL.md
+++ b/.claude/skills/cxas-polymorphic-adapters/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: cxas-polymorphic-adapters
+description: Use when authoring, reviewing, validating, building, diffing, or debugging CXAS SCRAPI polymorphic channel adapters, adapter cards, channel-specific variants, or chat/voice/API/web/telephony adaptation work.
+---
+
+# CXAS Polymorphic Adapters
+
+This is the Claude discovery wrapper for the repo's canonical polymorphic
+adapter skill.
+
+## Canonical Source
+
+Read this file first:
+
+```text
+.agents/skills/cxas-polymorphic-adapters/SKILL.md
+```
+
+Then load the matching reference:
+
+```text
+.agents/skills/cxas-polymorphic-adapters/references/adapter-authoring.md
+.agents/skills/cxas-polymorphic-adapters/references/build-and-validate.md
+.agents/skills/cxas-polymorphic-adapters/references/debug-adapter.md
+```
+
+## Quick Routing
+
+| User intent | Load |
+|---|---|
+| Should I use adapters or separate agents? | canonical `SKILL.md` decision framework |
+| Write or revise an adapter card | `references/adapter-authoring.md` |
+| Validate, diff, or build adapters | `references/build-and-validate.md` |
+| Fix AD00x or compilation issues | `references/debug-adapter.md` |
+
+## Key Commands
+
+```bash
+uv run cxas poly validate --app-dir <app_dir>
+uv run cxas poly diff <channel> --app-dir <app_dir>
+uv run cxas poly build --app-dir <app_dir> --output-dir <output_dir>
+uv run cxas lint --app-dir <output_dir>/<channel>
+```
+
+## Claude-Specific Rule
+
+Do not maintain a separate Claude-only version of the workflow. If this wrapper
+and the canonical `.agents` skill ever disagree, the canonical skill wins.

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Strip Claude Code session IDs / footers from commit messages.
+msg_file="$1"
+[ -f "$msg_file" ] || exit 0
+tmp="$(mktemp)"
+sed -E '/claude\.ai\/code\/session/d; /Generated (with|by).*Claude Code/d; /Co-[Aa]uthored-[Bb]y:.*[Cc]laude/d' "$msg_file" | git stripspace > "$tmp"
+mv "$tmp" "$msg_file"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ Requires Python 3.10+ and [astral-uv](https://docs.astral.sh/uv/getting-started/
 This workspace provides several specialized AI skills to assist with development. 
 
 - **`cxas-agent-foundry`**: The primary skill for the end-to-end GECX agent lifecycle. Use this for building agents from PRDs, generating and running evals, debugging failures, and syncing code.
+- **`cxas-polymorphic-adapters`**: A repo-native skill for deciding, authoring, validating, building, diffing, and debugging polymorphic channel adapter cards with `cxas poly`.
 - **`cxas-sim-eval`**: A utility skill for converting CXAS golden evaluations to SCRAPI SimulationEvals test cases.
 
 *Note: For detailed development workflows, linter policies, and GECX-specific conventions, refer to the documentation within the respective skills (e.g., `.agents/skills/cxas-agent-foundry/SKILL.md`).*

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -3,7 +3,7 @@
 ## Sub-Agent Delegation & Reasoning
 1. **Ban on Generalist Agent:** You MUST NEVER delegate ANY task to the `generalist` sub-agent. The `generalist` agent is explicitly forbidden in this workspace due to its tendency to take shortcuts and produce low-quality work.
 2. **Mandatory Plan Mode:** For complex tasks, cross-cutting architectural changes, or generating multiple files from a TDD, you MUST use the `enter_plan_mode` tool. Plan Mode is for architectural decisions and strategy; however, execution should leverage specialized sub-agents where appropriate.
-3. **Authorized Specialized Sub-Agents:** You are explicitly authorized and encouraged to use specialized sub-agents provided by the `cxas-agent-foundry` skill (such as `lint-fixer`, `eval-writer`, `coverage-analyst`, `tdd-writer`, and `triage-failure`) for their exact designated purposes to save main-thread context and execute repetitive tasks efficiently.
+3. **Authorized Specialized Sub-Agents:** You are explicitly authorized and encouraged to use specialized sub-agents provided by the `cxas-agent-foundry` skill (such as `lint-fixer`, `eval-writer`, `coverage-analyst`, `tdd-writer`, `triage-failure`, and `polymorphic-adapter-author`) for their exact designated purposes to save main-thread context and execute repetitive tasks efficiently.
 
 ## Code Generation Quality
 When translating specifications, requirements, or a TDD into code (especially `instruction.txt` files, Python scripts, or callbacks):

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,89 @@
+# PLAN.md
+
+## Goal
+Review and improve the polymorphic agent architecture so the Canonical Agent Card/root app, Channel Adapter Cards, Polymorphism Engine, and channel-specific runtime configs match the product proposal and the Polymorphic Pizza demo proves the end-to-end workflow.
+
+## Context
+- Product proposal: `/Users/andrew/Downloads/Polymorphic_Agent_Architecture_Product_Proposal.md`
+- Recent polymorphism commits inspected with local timestamps from May 21, 2026:
+  - `dad1236` / `a6e7d15` — initial Polymorphism Engine and Bella Notte adapters
+  - `bcd017d` — Polymorphic Pizza chat + voice demo
+  - `0264160` / `1d8252a` — production hardening pass
+- Core implementation:
+  - `src/cxas_scrapi/poly/models.py`
+  - `src/cxas_scrapi/poly/engine.py`
+  - `src/cxas_scrapi/poly/instructions.py`
+  - `src/cxas_scrapi/poly/validators.py`
+  - `src/cxas_scrapi/cli/poly_cli.py`
+  - `src/cxas_scrapi/utils/lint_rules/adapters.py`
+- Demo project:
+  - `examples/polymorphic_pizza/app.json`
+  - `examples/polymorphic_pizza/gecx-config.json`
+  - `examples/polymorphic_pizza/adapters/chat.adapter.yaml`
+  - `examples/polymorphic_pizza/adapters/voice.adapter.yaml`
+  - `examples/polymorphic_pizza/agents/**`
+  - `examples/polymorphic_pizza/tools/**`
+  - `examples/polymorphic_pizza/evaluations/**`
+- Existing tests:
+  - `tests/cxas_scrapi/poly/test_engine.py`
+  - `tests/cxas_scrapi/poly/test_models.py`
+  - `tests/cxas_scrapi/poly/test_validators.py`
+  - `tests/cxas_scrapi/poly/test_hardening.py`
+  - `tests/cxas_scrapi/poly/test_adapter_lint_rules.py`
+
+## Constraints
+- Preserve existing `cxas poly` CLI behavior unless a change is required to fulfill the product architecture.
+- Prefer small, additive, testable refactors.
+- Do not edit unrelated files.
+- Treat compiled channel output as a generated artifact, not a source of truth.
+- Channel adapters must express deltas from the canonical app, not duplicate full agent definitions.
+- Runtime configs must remain compatible with existing SCRAPI lint/build/deploy workflows.
+
+## Milestones
+
+### Milestone 1 — Understand and de-risk
+Review the proposal, recent commits, current poly module, linter rules, docs, and Polymorphic Pizza assets. Identify gaps between the product vision and implementation. Verify current behavior with targeted tests and `cxas poly` commands.
+
+### Milestone 2 — Implement architecture fixes
+Make focused changes where the implementation currently falls short. Expected areas include deterministic runtime config merge behavior, adapter validation, root agent/app-card treatment, compiled output cleanliness, and demo adapters that visibly demonstrate channel-specific depth.
+
+### Milestone 3 — Harden and verify
+Add or update tests for every behavior change. Build and lint the Polymorphic Pizza chat and voice outputs. Update docs or demo instructions only when needed to match the verified workflow.
+
+## Verification Commands
+Run these from the repo root unless noted otherwise.
+
+```bash
+uv run pytest tests/cxas_scrapi/poly -q
+uv run cxas poly validate --app-dir examples/polymorphic_pizza
+uv run cxas poly diff chat --app-dir examples/polymorphic_pizza
+uv run cxas poly diff voice --app-dir examples/polymorphic_pizza
+uv run cxas poly build --app-dir examples/polymorphic_pizza --output-dir /tmp/polymorphic_pizza_build
+uv run cxas lint --app-dir /tmp/polymorphic_pizza_build/chat
+uv run cxas lint --app-dir /tmp/polymorphic_pizza_build/voice
+```
+
+## Acceptance Criteria
+- The code review identifies concrete architecture/product-fit risks with file and line references.
+- The final implementation keeps the canonical project as the source of truth and applies channel adapters as auditable deltas.
+- Chat output contains chat-specific runtime config, tools, callbacks, instructions, and evals.
+- Voice output contains voice-specific runtime config, callbacks, instructions, and evals without chat-only tools or formatting.
+- The Polymorphic Pizza demo validates, builds, and produces lint-clean channel outputs.
+- Targeted polymorphism tests pass.
+
+## Progress
+- [x] Milestone 1 started: proposal, recent commits, and demo README inspected.
+- [x] Milestone 1 complete: identified duplicate-channel validation loss, unknown-field drift risk, and missing channel runtime config overlay.
+- [x] Milestone 2 complete: implemented strict adapter models, preserved all adapter cards for cross-card validation, added `gecxConfig` deep merge, and updated the Pizza demo adapters.
+- [x] Milestone 3 complete: added regression tests, updated docs, built the Pizza chat/voice outputs, and linted both compiled projects.
+
+## Decision Log
+- 2026-05-22 00:00 — Treat May 21 local commit timestamps as the polymorphism work "committed today" because the repo log shows all relevant polymorphism commits in that local evening window while the session date is May 22, 2026.
+- 2026-05-22 00:00 — Use the Polymorphic Pizza example as the primary product validation target because the proposal says the example should be the main mechanism for communicating and validating the architecture.
+- 2026-05-22 00:00 — Reject unknown adapter fields with Pydantic `extra="forbid"` so adapter deltas stay auditable and typo-safe.
+- 2026-05-22 00:00 — Preserve the full ordered adapter-card list separately from the channel lookup map so duplicate channel adapters are validated instead of overwritten.
+- 2026-05-22 00:00 — Add `gecxConfig` as a deep-merged adapter delta for channel-specific runtime defaults while keeping compiler-owned `default_channel`, `app_dir`, and deployment-derived modality deterministic.
+
+## Notes / Blockers
+- Verification used `/tmp/polymorphic_pizza_build_codex` as the generated output directory.
+- No blockers.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,89 +1,138 @@
 # PLAN.md
 
 ## Goal
-Review and improve the polymorphic agent architecture so the Canonical Agent Card/root app, Channel Adapter Cards, Polymorphism Engine, and channel-specific runtime configs match the product proposal and the Polymorphic Pizza demo proves the end-to-end workflow.
+Implement the first wave of polymorphic-agent developer experience improvements:
+`cxas poly init` scaffolding, guided validation diagnostics via `doctor` and
+`validate --explain`, and stable `cxas poly diff --json` output with clearer
+human review output.
 
 ## Context
-- Product proposal: `/Users/andrew/Downloads/Polymorphic_Agent_Architecture_Product_Proposal.md`
-- Recent polymorphism commits inspected with local timestamps from May 21, 2026:
-  - `dad1236` / `a6e7d15` — initial Polymorphism Engine and Bella Notte adapters
-  - `bcd017d` — Polymorphic Pizza chat + voice demo
-  - `0264160` / `1d8252a` — production hardening pass
+- Current branch/worktree: `feat/poly-first-wave-codex` in
+  `/Users/andrew/Desktop/cxas-scrapi-polymorphic-codex-first-wave`.
+- Base behavior is build-time polymorphism only: base project plus
+  `adapters/*.adapter.yaml` compiles to ordinary SCRAPI projects.
 - Core implementation:
+  - `src/cxas_scrapi/cli/poly_cli.py`
   - `src/cxas_scrapi/poly/models.py`
   - `src/cxas_scrapi/poly/engine.py`
-  - `src/cxas_scrapi/poly/instructions.py`
   - `src/cxas_scrapi/poly/validators.py`
-  - `src/cxas_scrapi/cli/poly_cli.py`
   - `src/cxas_scrapi/utils/lint_rules/adapters.py`
-- Demo project:
-  - `examples/polymorphic_pizza/app.json`
-  - `examples/polymorphic_pizza/gecx-config.json`
-  - `examples/polymorphic_pizza/adapters/chat.adapter.yaml`
-  - `examples/polymorphic_pizza/adapters/voice.adapter.yaml`
-  - `examples/polymorphic_pizza/agents/**`
-  - `examples/polymorphic_pizza/tools/**`
-  - `examples/polymorphic_pizza/evaluations/**`
+- Existing docs and examples:
+  - `README.md`
+  - `docs/cli/poly.md`
+  - `docs/guides/polymorphism.md`
+  - `docs/patterns/polymorphism.md`
+  - `examples/polymorphic_pizza/**`
+  - `examples/bella_notte/**`
 - Existing tests:
-  - `tests/cxas_scrapi/poly/test_engine.py`
   - `tests/cxas_scrapi/poly/test_models.py`
   - `tests/cxas_scrapi/poly/test_validators.py`
+  - `tests/cxas_scrapi/poly/test_engine.py`
   - `tests/cxas_scrapi/poly/test_hardening.py`
   - `tests/cxas_scrapi/poly/test_adapter_lint_rules.py`
 
 ## Constraints
-- Preserve existing `cxas poly` CLI behavior unless a change is required to fulfill the product architecture.
-- Prefer small, additive, testable refactors.
-- Do not edit unrelated files.
-- Treat compiled channel output as a generated artifact, not a source of truth.
-- Channel adapters must express deltas from the canonical app, not duplicate full agent definitions.
-- Runtime configs must remain compatible with existing SCRAPI lint/build/deploy workflows.
+- Do not fetch, pull, or push.
+- Preserve existing `cxas poly build`, `validate`, `diff`, and adapter-rule
+  behavior unless extending it intentionally.
+- Do not invent runtime polymorphism or unsupported adapter-card fields.
+- Keep emitted scaffolded paths valid under current validators and compiler.
+- Prefer shared helpers and explicit data shapes over CLI-only string handling.
+- Avoid unrelated churn and generated output in the repo.
 
 ## Milestones
 
-### Milestone 1 — Understand and de-risk
-Review the proposal, recent commits, current poly module, linter rules, docs, and Polymorphic Pizza assets. Identify gaps between the product vision and implementation. Verify current behavior with targeted tests and `cxas poly` commands.
+### Milestone 1 - Understand And Plan
+Read the requested docs/examples/source, refresh prior polymorphism memory, and
+replace this plan with the first-wave implementation checklist.
 
-### Milestone 2 — Implement architecture fixes
-Make focused changes where the implementation currently falls short. Expected areas include deterministic runtime config merge behavior, adapter validation, root agent/app-card treatment, compiled output cleanliness, and demo adapters that visibly demonstrate channel-specific depth.
+### Milestone 2 - Shared DX Helpers
+Add reusable helper modules for scaffold planning/writing, validation
+explanations, and diff report generation. Keep business validation in
+`validators.py` and compilation in `engine.py`.
 
-### Milestone 3 — Harden and verify
-Add or update tests for every behavior change. Build and lint the Polymorphic Pizza chat and voice outputs. Update docs or demo instructions only when needed to match the verified workflow.
+### Milestone 3 - CLI Surface
+Wire helpers into:
+- `cxas poly init` with non-interactive flags and prompt fallback.
+- `cxas poly doctor` and `cxas poly validate --explain`.
+- `cxas poly diff --json` plus improved text rendering.
+
+### Milestone 4 - Tests, Docs, Examples
+Add targeted tests for scaffold output, doctor/explain output, and diff JSON.
+Update CLI docs, guide/pattern docs, README, and example walkthroughs where the
+new commands materially improve the workflow.
+
+### Milestone 5 - Verification And Cleanup
+Run targeted tests and real example commands, check formatting/diff cleanliness,
+and optionally commit the intended changes with a conventional commit.
 
 ## Verification Commands
-Run these from the repo root unless noted otherwise.
+Run from the repo root.
 
 ```bash
-uv run pytest tests/cxas_scrapi/poly -q
-uv run cxas poly validate --app-dir examples/polymorphic_pizza
-uv run cxas poly diff chat --app-dir examples/polymorphic_pizza
-uv run cxas poly diff voice --app-dir examples/polymorphic_pizza
-uv run cxas poly build --app-dir examples/polymorphic_pizza --output-dir /tmp/polymorphic_pizza_build
-uv run cxas lint --app-dir /tmp/polymorphic_pizza_build/chat
-uv run cxas lint --app-dir /tmp/polymorphic_pizza_build/voice
+git diff --check
+uv run --with-editable . --with alive-progress pytest tests/cxas_scrapi/poly -q
+uv run --with-editable . --with alive-progress cxas poly init --app-dir /tmp/poly-init-smoke --channel chat --deployment-target WEB_UI --modality CHAT_ONLY --with-tool send_channel_card --with-callback before_model --force
+uv run --with-editable . --with alive-progress cxas poly validate --app-dir examples/bella_notte
+uv run --with-editable . --with alive-progress cxas poly doctor --app-dir examples/bella_notte
+uv run --with-editable . --with alive-progress cxas poly diff chat --app-dir examples/bella_notte --json
+uv run --with-editable . --with alive-progress cxas poly build --app-dir examples/bella_notte --output-dir /tmp/poly_first_wave_build
+uv run --with-editable . --with alive-progress cxas lint --app-dir /tmp/poly_first_wave_build/chat
+uv run --with-editable . --with alive-progress cxas lint --app-dir /tmp/poly_first_wave_build/voice
 ```
 
+For the `init` smoke, first create `/tmp/poly-init-smoke` from the committed
+test fixture or another direct app project before running the command.
+
 ## Acceptance Criteria
-- The code review identifies concrete architecture/product-fit risks with file and line references.
-- The final implementation keeps the canonical project as the source of truth and applies channel adapters as auditable deltas.
-- Chat output contains chat-specific runtime config, tools, callbacks, instructions, and evals.
-- Voice output contains voice-specific runtime config, callbacks, instructions, and evals without chat-only tools or formatting.
-- The Polymorphic Pizza demo validates, builds, and produces lint-clean channel outputs.
-- Targeted polymorphism tests pass.
+- A developer can scaffold one or more adapter cards plus referenced starter
+  eval/tool/callback files from an existing direct SCRAPI app.
+- Scaffolded adapter cards use only fields supported by current
+  `AdapterCard` models and validate under current rules.
+- Validation diagnostics explain what failed, why, where to look, and a likely
+  fix shape without forking validator business logic.
+- `cxas poly diff --json` emits a stable, machine-readable v1 report for CI and
+  tools, while text diff remains readable for humans.
+- Docs and examples describe the new first-wave workflow accurately.
+- The full `tests/cxas_scrapi/poly` suite and real example validation/build/lint
+  checks pass.
 
 ## Progress
-- [x] Milestone 1 started: proposal, recent commits, and demo README inspected.
-- [x] Milestone 1 complete: identified duplicate-channel validation loss, unknown-field drift risk, and missing channel runtime config overlay.
-- [x] Milestone 2 complete: implemented strict adapter models, preserved all adapter cards for cross-card validation, added `gecxConfig` deep merge, and updated the Pizza demo adapters.
-- [x] Milestone 3 complete: added regression tests, updated docs, built the Pizza chat/voice outputs, and linted both compiled projects.
+- [x] Milestone 1 complete
+- [x] Milestone 2 complete
+- [x] Milestone 3 complete
+- [x] Milestone 4 complete
+- [x] Milestone 5 complete
 
 ## Decision Log
-- 2026-05-22 00:00 — Treat May 21 local commit timestamps as the polymorphism work "committed today" because the repo log shows all relevant polymorphism commits in that local evening window while the session date is May 22, 2026.
-- 2026-05-22 00:00 — Use the Polymorphic Pizza example as the primary product validation target because the proposal says the example should be the main mechanism for communicating and validating the architecture.
-- 2026-05-22 00:00 — Reject unknown adapter fields with Pydantic `extra="forbid"` so adapter deltas stay auditable and typo-safe.
-- 2026-05-22 00:00 — Preserve the full ordered adapter-card list separately from the channel lookup map so duplicate channel adapters are validated instead of overwritten.
-- 2026-05-22 00:00 — Add `gecxConfig` as a deep-merged adapter delta for channel-specific runtime defaults while keeping compiler-owned `default_channel`, `app_dir`, and deployment-derived modality deterministic.
+- 2026-05-22 00:23 - Keep polymorphism strictly build-time and expose new DX
+  through local CLI/helper modules only; no runtime behavior or deploy behavior
+  changes are in scope.
+- 2026-05-22 00:23 - Add `doctor` as the clearer guided-debug command while
+  also supporting `validate --explain` for users who naturally start from
+  validation.
+- 2026-05-22 00:23 - Put stable diff data behind a shared report builder, then
+  render both text and JSON from that report so CI and humans see the same
+  underlying deltas.
+- 2026-05-22 01:05 - Keep `cxas poly init` scaffold defaults conservative:
+  known chat/web/voice/telephony/api channels get deployment defaults, unknown
+  channel ids stay valid but do not invent deployment fields.
+- 2026-05-22 01:05 - Reverted unrelated `uv.lock` churn from `uv run`; the
+  first-wave implementation does not need dependency changes.
 
 ## Notes / Blockers
-- Verification used `/tmp/polymorphic_pizza_build_codex` as the generated output directory.
+- Verification completed:
+  - `git diff --check`
+  - `uv run --with-editable . --with alive-progress ruff check src/cxas_scrapi/poly src/cxas_scrapi/cli/poly_cli.py tests/cxas_scrapi/poly`
+  - `uv run --with-editable . --with alive-progress pytest tests/cxas_scrapi/poly -q` (85 passed, 1 existing pytest config warning)
+  - `uv run --with-editable . --with alive-progress cxas poly init --app-dir /tmp/cxas_poly_init_smoke_codex --channel sms --deployment-target TWILIO --modality VOICE_ONLY --with-tool send_sms_card --with-callback before_model`
+  - `uv run --with-editable . --with alive-progress cxas poly validate --app-dir /tmp/cxas_poly_init_smoke_codex` (0 errors, 1 pre-existing fixture warning from the original voice adapter)
+  - `uv run --with-editable . --with alive-progress cxas poly validate --app-dir examples/bella_notte`
+  - `uv run --with-editable . --with alive-progress cxas poly doctor --app-dir examples/bella_notte`
+  - `uv run --with-editable . --with alive-progress cxas poly validate --app-dir examples/bella_notte --explain`
+  - `uv run --with-editable . --with alive-progress cxas poly diff chat --app-dir examples/bella_notte`
+  - `uv run --with-editable . --with alive-progress cxas poly diff chat --app-dir examples/bella_notte --json`
+  - `uv run --with-editable . --with alive-progress cxas poly build --app-dir examples/bella_notte --output-dir /tmp/poly_first_wave_build`
+  - `uv run --with-editable . --with alive-progress cxas lint --app-dir /tmp/poly_first_wave_build/chat`
+  - `uv run --with-editable . --with alive-progress cxas lint --app-dir /tmp/poly_first_wave_build/voice`
 - No blockers.

--- a/PLAN.md
+++ b/PLAN.md
@@ -103,7 +103,7 @@ uv run --with-editable . --with alive-progress cxas lint --app-dir /tmp/poly_prd
 - [x] Milestone 2 complete
 - [x] Milestone 3 complete
 - [x] Milestone 4 complete
-- [ ] Milestone 5 complete
+- [x] Milestone 5 complete
 
 ## Decision Log
 - 2026-05-22 01:55 - Treat the PRD as the primary source of truth for launch
@@ -128,3 +128,4 @@ uv run --with-editable . --with alive-progress cxas lint --app-dir /tmp/poly_prd
   - `uv run --with-editable . --with alive-progress cxas lint --app-dir /tmp/poly_prd_alignment_build_c72c_readiness_20260522/chat`
   - `uv run --with-editable . --with alive-progress cxas lint --app-dir /tmp/poly_prd_alignment_build_c72c_readiness_20260522/voice`
 - No blockers.
+- Draft PR: https://github.com/GoogleCloudPlatform/cxas-scrapi/pull/172

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,138 +1,130 @@
 # PLAN.md
 
 ## Goal
-Implement the first wave of polymorphic-agent developer experience improvements:
-`cxas poly init` scaffolding, guided validation diagnostics via `doctor` and
-`validate --explain`, and stable `cxas poly diff --json` output with clearer
-human review output.
+Review the current SCRAPI polymorphic-agent implementation against
+`/Users/andrew/Downloads/Polymorphic_Agent_Architecture_Product_Proposal.md`,
+identify gaps between the implementation and the PRD promises, select a narrow
+set of high-leverage improvements, implement and verify them, and prepare a PR
+with meaningful product progress.
 
 ## Context
-- Current branch/worktree: `feat/poly-first-wave-codex` in
-  `/Users/andrew/Desktop/cxas-scrapi-polymorphic-codex-first-wave`.
-- Base behavior is build-time polymorphism only: base project plus
-  `adapters/*.adapter.yaml` compiles to ordinary SCRAPI projects.
-- Core implementation:
-  - `src/cxas_scrapi/cli/poly_cli.py`
+- Repo root: `/Users/andrew/.codex/worktrees/c72c/cxas-scrapi-polymorphic`
+- Current git state: detached `HEAD`, clean at start.
+- PRD: `/Users/andrew/Downloads/Polymorphic_Agent_Architecture_Product_Proposal.md`
+- Relevant implementation:
   - `src/cxas_scrapi/poly/models.py`
-  - `src/cxas_scrapi/poly/engine.py`
   - `src/cxas_scrapi/poly/validators.py`
+  - `src/cxas_scrapi/poly/engine.py`
+  - `src/cxas_scrapi/poly/diffing.py`
+  - `src/cxas_scrapi/poly/diagnostics.py`
+  - `src/cxas_scrapi/poly/scaffold.py`
+  - `src/cxas_scrapi/cli/poly_cli.py`
   - `src/cxas_scrapi/utils/lint_rules/adapters.py`
-- Existing docs and examples:
+- Relevant docs and examples:
   - `README.md`
   - `docs/cli/poly.md`
   - `docs/guides/polymorphism.md`
   - `docs/patterns/polymorphism.md`
-  - `examples/polymorphic_pizza/**`
   - `examples/bella_notte/**`
-- Existing tests:
-  - `tests/cxas_scrapi/poly/test_models.py`
-  - `tests/cxas_scrapi/poly/test_validators.py`
-  - `tests/cxas_scrapi/poly/test_engine.py`
-  - `tests/cxas_scrapi/poly/test_hardening.py`
-  - `tests/cxas_scrapi/poly/test_adapter_lint_rules.py`
+  - `examples/polymorphic_pizza/**`
+- Relevant tests:
+  - `tests/cxas_scrapi/poly/**`
 
 ## Constraints
-- Do not fetch, pull, or push.
-- Preserve existing `cxas poly build`, `validate`, `diff`, and adapter-rule
-  behavior unless extending it intentionally.
-- Do not invent runtime polymorphism or unsupported adapter-card fields.
-- Keep emitted scaffolded paths valid under current validators and compiler.
-- Prefer shared helpers and explicit data shapes over CLI-only string handling.
-- Avoid unrelated churn and generated output in the repo.
+- Preserve the repo's existing contract: polymorphism is build-time only, and
+  compiled output must remain an ordinary SCRAPI project.
+- Do not invent unsupported adapter card fields unless intentionally extending
+  the schema with tests, validation, engine behavior, and docs.
+- Do not hand-edit compiled output directories; rebuild from base projects plus
+  adapter cards.
+- Do not fetch, push, or deploy until the implementation is ready and the PR
+  publishing step requires it.
+- Use small, additive, testable changes. Avoid unrelated refactors and metadata
+  churn.
+- Every behavior change needs focused tests.
 
 ## Milestones
 
-### Milestone 1 - Understand And Plan
-Read the requested docs/examples/source, refresh prior polymorphism memory, and
-replace this plan with the first-wave implementation checklist.
+### Milestone 1 - PRD Gap Review
+Extract the PRD's concrete promises, map them to current code/docs/examples,
+and record gaps by severity and launch value in `findings.md`.
 
-### Milestone 2 - Shared DX Helpers
-Add reusable helper modules for scaffold planning/writing, validation
-explanations, and diff report generation. Keep business validation in
-`validators.py` and compilation in `engine.py`.
+### Milestone 2 - Improvement Selection And Design
+Choose a bounded improvement set that materially advances V1 launch readiness,
+state the reasoning and trade-offs, and update this plan with exact files and
+verification commands.
 
-### Milestone 3 - CLI Surface
-Wire helpers into:
-- `cxas poly init` with non-interactive flags and prompt fallback.
-- `cxas poly doctor` and `cxas poly validate --explain`.
-- `cxas poly diff --json` plus improved text rendering.
+Selected slice: add `cxas poly readiness`, a pre-launch design-partner report
+that composes current validation, adapter diff summaries, eval coverage,
+duplicate eval-name detection, and compileability into one human/JSON surface.
+This fills the PRD gap around launch evidence and workflow ergonomics without
+changing the build-time-only adapter contract.
 
-### Milestone 4 - Tests, Docs, Examples
-Add targeted tests for scaffold output, doctor/explain output, and diff JSON.
-Update CLI docs, guide/pattern docs, README, and example walkthroughs where the
-new commands materially improve the workflow.
+### Milestone 3 - Implementation
+Implement the selected improvements in the smallest coherent slice, including
+tests and docs/examples where behavior or workflow changes.
 
-### Milestone 5 - Verification And Cleanup
-Run targeted tests and real example commands, check formatting/diff cleanliness,
-and optionally commit the intended changes with a conventional commit.
+### Milestone 4 - Verification
+Run targeted unit tests, CLI smoke checks against the examples, and diff
+cleanliness checks. Record all results in `progress.md`.
+
+### Milestone 5 - Branch, Commit, And PR
+Create/switch to a `codex/` branch, commit one logical change using Conventional
+Commits, push, and open a PR with the gap analysis and verification summary.
 
 ## Verification Commands
-Run from the repo root.
+Initial expected commands from the repo root; update after Milestone 2 if the
+selected improvement changes the surface area.
 
 ```bash
 git diff --check
+uv run --with-editable . --with alive-progress ruff check src/cxas_scrapi/poly src/cxas_scrapi/cli/poly_cli.py tests/cxas_scrapi/poly
 uv run --with-editable . --with alive-progress pytest tests/cxas_scrapi/poly -q
-uv run --with-editable . --with alive-progress cxas poly init --app-dir /tmp/poly-init-smoke --channel chat --deployment-target WEB_UI --modality CHAT_ONLY --with-tool send_channel_card --with-callback before_model --force
 uv run --with-editable . --with alive-progress cxas poly validate --app-dir examples/bella_notte
 uv run --with-editable . --with alive-progress cxas poly doctor --app-dir examples/bella_notte
 uv run --with-editable . --with alive-progress cxas poly diff chat --app-dir examples/bella_notte --json
-uv run --with-editable . --with alive-progress cxas poly build --app-dir examples/bella_notte --output-dir /tmp/poly_first_wave_build
-uv run --with-editable . --with alive-progress cxas lint --app-dir /tmp/poly_first_wave_build/chat
-uv run --with-editable . --with alive-progress cxas lint --app-dir /tmp/poly_first_wave_build/voice
+uv run --with-editable . --with alive-progress cxas poly build --app-dir examples/bella_notte --output-dir /tmp/poly_prd_alignment_build
+uv run --with-editable . --with alive-progress cxas lint --app-dir /tmp/poly_prd_alignment_build/chat
+uv run --with-editable . --with alive-progress cxas lint --app-dir /tmp/poly_prd_alignment_build/voice
 ```
 
-For the `init` smoke, first create `/tmp/poly-init-smoke` from the committed
-test fixture or another direct app project before running the command.
-
 ## Acceptance Criteria
-- A developer can scaffold one or more adapter cards plus referenced starter
-  eval/tool/callback files from an existing direct SCRAPI app.
-- Scaffolded adapter cards use only fields supported by current
-  `AdapterCard` models and validate under current rules.
-- Validation diagnostics explain what failed, why, where to look, and a likely
-  fix shape without forking validator business logic.
-- `cxas poly diff --json` emits a stable, machine-readable v1 report for CI and
-  tools, while text diff remains readable for humans.
-- Docs and examples describe the new first-wave workflow accurately.
-- The full `tests/cxas_scrapi/poly` suite and real example validation/build/lint
-  checks pass.
+- `findings.md` contains a concrete PRD-to-implementation gap matrix.
+- The implemented slice addresses one or more high-value V1 launch gaps rather
+  than cosmetic cleanup.
+- Tests cover the changed behavior and describe user-visible outcomes.
+- Docs/examples explain the improved workflow accurately.
+- Targeted verification commands pass or any remaining failures are documented
+  with a clear reason.
+- A PR exists with a concise summary, gap rationale, and verification evidence.
 
 ## Progress
 - [x] Milestone 1 complete
 - [x] Milestone 2 complete
 - [x] Milestone 3 complete
 - [x] Milestone 4 complete
-- [x] Milestone 5 complete
+- [ ] Milestone 5 complete
 
 ## Decision Log
-- 2026-05-22 00:23 - Keep polymorphism strictly build-time and expose new DX
-  through local CLI/helper modules only; no runtime behavior or deploy behavior
-  changes are in scope.
-- 2026-05-22 00:23 - Add `doctor` as the clearer guided-debug command while
-  also supporting `validate --explain` for users who naturally start from
-  validation.
-- 2026-05-22 00:23 - Put stable diff data behind a shared report builder, then
-  render both text and JSON from that report so CI and humans see the same
-  underlying deltas.
-- 2026-05-22 01:05 - Keep `cxas poly init` scaffold defaults conservative:
-  known chat/web/voice/telephony/api channels get deployment defaults, unknown
-  channel ids stay valid but do not invent deployment fields.
-- 2026-05-22 01:05 - Reverted unrelated `uv.lock` churn from `uv run`; the
-  first-wave implementation does not need dependency changes.
+- 2026-05-22 01:55 - Treat the PRD as the primary source of truth for launch
+  promises and select an implementation slice only after mapping those promises
+  to current code, docs, examples, and tests.
+- 2026-05-22 02:03 - Select a readiness report over deeper schema expansion:
+  the schema/compiler already cover V1 primitives, while the PRD's design
+  partner launch plan lacks a single artifact that proves validation, coverage,
+  auditability, and compileability before build/deploy.
 
 ## Notes / Blockers
 - Verification completed:
   - `git diff --check`
   - `uv run --with-editable . --with alive-progress ruff check src/cxas_scrapi/poly src/cxas_scrapi/cli/poly_cli.py tests/cxas_scrapi/poly`
-  - `uv run --with-editable . --with alive-progress pytest tests/cxas_scrapi/poly -q` (85 passed, 1 existing pytest config warning)
-  - `uv run --with-editable . --with alive-progress cxas poly init --app-dir /tmp/cxas_poly_init_smoke_codex --channel sms --deployment-target TWILIO --modality VOICE_ONLY --with-tool send_sms_card --with-callback before_model`
-  - `uv run --with-editable . --with alive-progress cxas poly validate --app-dir /tmp/cxas_poly_init_smoke_codex` (0 errors, 1 pre-existing fixture warning from the original voice adapter)
+  - `uv run --with-editable . --with alive-progress pytest tests/cxas_scrapi/poly -q` (89 passed, 1 existing pytest config warning)
+  - `uv run --with-editable . --with alive-progress cxas poly readiness --app-dir examples/bella_notte`
+  - `uv run --with-editable . --with alive-progress cxas poly readiness --app-dir examples/bella_notte --format json`
   - `uv run --with-editable . --with alive-progress cxas poly validate --app-dir examples/bella_notte`
   - `uv run --with-editable . --with alive-progress cxas poly doctor --app-dir examples/bella_notte`
-  - `uv run --with-editable . --with alive-progress cxas poly validate --app-dir examples/bella_notte --explain`
-  - `uv run --with-editable . --with alive-progress cxas poly diff chat --app-dir examples/bella_notte`
   - `uv run --with-editable . --with alive-progress cxas poly diff chat --app-dir examples/bella_notte --json`
-  - `uv run --with-editable . --with alive-progress cxas poly build --app-dir examples/bella_notte --output-dir /tmp/poly_first_wave_build`
-  - `uv run --with-editable . --with alive-progress cxas lint --app-dir /tmp/poly_first_wave_build/chat`
-  - `uv run --with-editable . --with alive-progress cxas lint --app-dir /tmp/poly_first_wave_build/voice`
+  - `uv run --with-editable . --with alive-progress cxas poly build --app-dir examples/bella_notte --output-dir /tmp/poly_prd_alignment_build_c72c_readiness_20260522`
+  - `uv run --with-editable . --with alive-progress cxas lint --app-dir /tmp/poly_prd_alignment_build_c72c_readiness_20260522/chat`
+  - `uv run --with-editable . --with alive-progress cxas lint --app-dir /tmp/poly_prd_alignment_build_c72c_readiness_20260522/voice`
 - No blockers.

--- a/README.md
+++ b/README.md
@@ -100,10 +100,14 @@ uv sync --extra dev
 # 2. Validate the demo's two channel adapters:
 uv run cxas poly validate --app-dir examples/polymorphic_pizza
 
-# 3. Compile the base project into a chat agent and a voice agent:
+# 3. Preview a channel delta in either human or JSON form:
+uv run cxas poly diff chat --app-dir examples/polymorphic_pizza
+uv run cxas poly diff chat --app-dir examples/polymorphic_pizza --json
+
+# 4. Compile the base project into a chat agent and a voice agent:
 uv run cxas poly build --app-dir examples/polymorphic_pizza --output-dir ./output
 
-# 4. The output is just a normal project — lint it like any other:
+# 5. The output is just a normal project — lint it like any other:
 uv run cxas lint --app-dir ./output/chat
 uv run cxas lint --app-dir ./output/voice
 ```
@@ -113,6 +117,8 @@ visual order card, deployed to a web widget) and `voice/` (short spoken turns,
 deployed to telephony) — both generated from the **same** `agents/`, `tools/`,
 and `evaluations/`. Want to preview the per-channel changes before building? Run
 `uv run cxas poly diff chat --app-dir examples/polymorphic_pizza` (or `voice`).
+If validation fails, `uv run cxas poly doctor --app-dir examples/polymorphic_pizza`
+prints the same AD rule IDs with field paths and likely fixes.
 
 Full file-by-file walkthrough, a chat-vs-voice comparison, and what to try next:
 **[examples/polymorphic_pizza/README.md](examples/polymorphic_pizza/README.md)**.
@@ -132,7 +138,7 @@ The library is organized by responsibility. Each top-level package under
 |---|---|
 | [`core/`](src/cxas_scrapi/core) | High-level building blocks mapped to CXAS resource types — `Apps`, `Agents`, `Tools`, `Guardrails`, `Deployments`, `Sessions`, etc. The main public SDK surface. |
 | [`poly/`](src/cxas_scrapi/poly) | **The polymorphism engine** — adapter-card models, validators, and the compiler. Pure local file I/O; intentionally **GCP-free** (no `google.cloud.*` imports, no network). |
-| [`cli/`](src/cxas_scrapi/cli) | The `cxas` command line. `cli/poly_cli.py` wires up `cxas poly build / validate / diff`. |
+| [`cli/`](src/cxas_scrapi/cli) | The `cxas` command line. `cli/poly_cli.py` wires up `cxas poly init / build / validate / doctor / diff`. |
 | [`evals/`](src/cxas_scrapi/evals) | Executing and analyzing agent evaluations — goldens, simulations, latency. |
 | [`utils/`](src/cxas_scrapi/utils) | Pagination, proto/response flattening, linting, Sheets/GCS integrations. |
 | [`migration/`](src/cxas_scrapi/migration) | Tools for migrating legacy Dialogflow CX agents into CXAS. |
@@ -236,7 +242,27 @@ examples/bella_notte/
 Write the base instructions to be **channel-neutral**: describe *what* the agent
 does, not *how* it should look on a screen or sound on a call.
 
-### 2. Write a channel adapter card
+### 2. Scaffold a starter adapter when adding a new channel
+
+If you are starting from an existing base app, `init` creates a valid starter
+card and any referenced eval/tool/callback files:
+
+```bash
+cxas poly init \
+  --app-dir examples/bella_notte \
+  --channel sms \
+  --deployment-target TWILIO \
+  --modality VOICE_ONLY \
+  --with-callback before_model
+```
+
+By default, `init` includes a starter eval so validation does not immediately
+warn about missing channel coverage. Use `--dry-run` to inspect planned files or
+`--no-eval` for a non-behavioral adapter. The generated content is intentionally
+plain: replace it with real channel-specific instructions, evals, and runtime
+hooks before shipping.
+
+### 3. Write a channel adapter card
 
 An adapter card is a short declaration of deltas. Here is the voice adapter,
 annotated:
@@ -281,7 +307,7 @@ numbered lists, and an extra `send_rich_card` tool. See
 [`chat.adapter.yaml`](examples/bella_notte/adapters/chat.adapter.yaml) for the
 full version, which also demonstrates `tools` + `toolDefinitions`.
 
-### 3. Validate before you build
+### 4. Validate before you build
 
 ```bash
 cxas poly validate --app-dir examples/bella_notte
@@ -295,12 +321,26 @@ Validation checks that every referenced agent/tool/section actually exists, that
 no two cards claim the same channel, and more — see
 [Validation rules](#validation-rules).
 
-### 4. Preview the changes with `diff`
+When a card is not valid yet, use the guided form:
 
-`diff` shows exactly what an adapter will change, **without writing anything**:
+```bash
+cxas poly doctor --app-dir examples/bella_notte
+# or
+cxas poly validate --app-dir examples/bella_notte --explain
+```
+
+Doctor reuses the same validators, then adds what failed, why it matters, which
+adapter field or referenced path to inspect, and a likely fix shape.
+
+### 5. Preview the changes with `diff`
+
+`diff` shows exactly what an adapter will change, **without writing anything**.
+The human output is for review, and `--json` emits a stable `poly-diff/v1`
+report for CI/tooling:
 
 ```bash
 cxas poly diff chat --app-dir examples/bella_notte
+cxas poly diff chat --app-dir examples/bella_notte --json
 ```
 
 ```
@@ -335,7 +375,7 @@ gecx-config.json (deployment)
   + web_widget_title: Bella Notte Reservations
 ```
 
-### 5. Build the channels
+### 6. Build the channels
 
 ```bash
 cxas poly build --app-dir examples/bella_notte --output-dir ./output
@@ -348,7 +388,7 @@ Compiled channel 'voice' -> ./output/voice
 Done. 2 channel(s) written to ./output
 ```
 
-### 6. Lint, evaluate, and deploy — the output is "just a project"
+### 7. Lint, evaluate, and deploy — the output is "just a project"
 
 The single most important property of the engine: **the compiled output is
 indistinguishable from a hand-authored project.** Every existing command works on

--- a/README.md
+++ b/README.md
@@ -6,202 +6,482 @@
 
 <html>
     <h2 align="center">
-      <!-- Replace with actual image path once uploaded -->
       <img src="assets/cxas-scrapi-logo.png" width="256" alt="CXAS SCRAPI Logo"/>
     </h2>
     <h3 align="center">
-      A powerful Python API, CLI, and set of Agent Skills for CX Agent Studio to automate, evaluate, and scale your agents with ease.
+      Author one agent at the center. Compile channel-optimized variants at the edges.
     </h3>
     <h3 align="center">
       Important Links:
       <a href="https://googlecloudplatform.github.io/cxas-scrapi/stable/">Docs</a>,
       <a href="examples/">Examples</a>,
-      <a href="https://googlecloudplatform.github.io/cxas-scrapi/stable/guides/skills/">Agent Skills</a>,
-      <a href="https://googlecloudplatform.github.io/cxas-scrapi/stable/api/">Core SDK</a>
+      <a href="docs/guides/polymorphism.md">Polymorphism Guide</a>,
+      <a href="docs/cli/poly.md"><code>cxas poly</code> CLI</a>
     </h3>
 </html>
 
-CX Agent Studio Scripting API (CXAS SCRAPI) is an open-source Python scripting
-API, CLI, and set of Agent Skills for CX Agent Studio. It is designed to
-simplify building, deploying, and orchestrating agent workflows, from simple
-tasks to complex systems. It integrates seamlessly with Agentic IDEs like
-Gemini CLI, Claude Code, and Antigravity, exposing advanced tooling for deep
-evaluations, real-time latency metrics, offline linting, and conversation
-history.
+CXAS SCRAPI is a Python API, CLI, and set of Agent Skills for CX Agent Studio.
+This README focuses on its **architecture** and on the feature this repository is
+built around: **polymorphism** — authoring an agent project once and compiling a
+complete, channel-optimized project (chat, voice, …) for each target.
+
+> New to the project's auth, install, and core SDK? See the
+> [official docs](https://googlecloudplatform.github.io/cxas-scrapi/stable/).
+> This document assumes you just want to understand how the pieces fit together
+> and how to use polymorphism.
 
 ---
 
-## Built With
-* Python 3.10+
+## Table of contents
 
-
-<!-- AUTHENTICATION -->
-# Authentication
-Authentication can vary depending on how and where you are interacting with SCRAPI.
-
-## Google Colab
-If you're using CXAS SCRAPI with a [Google Colab](https://colab.research.google.com/) notebook, you can add the following to the top of your notebook for easy authentication:
-
-```py
-pip install cxas-scrapi
-```
-
-```py
-project_id = '<YOUR_GCP_PROJECT_ID>'
-
-# this will launch an interactive prompt that allows you to auth with GCP in a browser
-!gcloud auth application-default login --no-launch-browser
-
-# this will set your active project to the `project_id` above
-!gcloud auth application-default set-quota-project $project_id
-```
-
-After running the above, Colab will pick up your credentials from the environment and pass them to CXAS SCRAPI directly. No need to use Service Account keys!
-You can then use CXAS SCRAPI simply like this:
-```py
-from cxas_scrapi import Apps
-
-project_id = '<YOUR_GCP_PROJECT_ID>'
-location = 'us'
-
-app_client = Apps(project_id=project_id, location=location) # <-- Creds will be automatically picked up from the environment
-apps_map = app_client.get_apps_map()
-```
----
-## Cloud Functions / Cloud Run
-If you're using CXAS SCRAPI with [Cloud Functions](https://cloud.google.com/functions) or [Cloud Run](https://cloud.google.com/run), CXAS SCRAPI can pick up on the default environment creds used by these services without any additional configuration!
-
-1. Add `cxas-scrapi` to your `requirements.txt` file
-2. Ensure the Cloud Function / Cloud Run service account has the appropriate Custom Agent / Conversational Agents IAM Role
-
-Once you are setup with the above, your function code can be used easily like this:
-```py
-from cxas_scrapi import Agents
-
-app_name = '<YOUR_APP_NAME>'
-a = Agents(project_id='<YOUR_GCP_PROJECT_ID>', location='global')
-agents_map = a.get_agents_map(app_name)
-```
+1. [The core idea](#the-core-idea)
+2. [Architecture at a glance](#architecture-at-a-glance)
+3. [Inside the polymorphism engine](#inside-the-polymorphism-engine)
+4. [Using polymorphism, step by step](#using-polymorphism-step-by-step)
+5. [Adapter card reference](#adapter-card-reference)
+6. [The compilation pipeline](#the-compilation-pipeline)
+7. [Driving the engine from Python](#driving-the-engine-from-python)
+8. [Validation rules](#validation-rules)
+9. [When to use adapters vs. separate agents](#when-to-use-adapters-vs-separate-agents)
+10. [Where to go next](#where-to-go-next)
 
 ---
-## Local Python Environment
-Similar to Cloud Functions / Cloud Run, CXAS SCRAPI can pick up on your local authentication creds _if you are using the gcloud CLI._
 
-1. Install [gcloud CLI](https://cloud.google.com/sdk/docs/install).
-2. Run `gcloud init`.
-3. Run `gcloud auth login`
-4. Run `gcloud auth application-default login`
-5. Run `gcloud auth list` to ensure your principal account is active.
+## The core idea
 
-This will authenticate your principal GCP account with the gcloud CLI, and SCRAPI can pick up the creds from here.
+A reservation agent that works beautifully in a web chat widget rarely works
+well on a phone call. Chat wants Markdown, numbered lists, and rich confirmation
+cards. Voice wants two-sentence turns, spelled-out numbers, and filler phrases so
+the line is never silent. The behavior is *mostly* the same — same tools, same
+flow, same business rules — but the surface differs.
+
+The naive answer is to **fork**: maintain `bella_notte_chat/` and
+`bella_notte_voice/` as two full projects. They immediately drift. A bug fixed in
+one isn't fixed in the other; a tool added to one is forgotten in the other.
+
+**Polymorphism** is the alternative:
+
+> **Author the agent once at the center, describe the per-channel _deltas_
+> declaratively, and _compile_ a complete, channel-optimized project for each
+> target.**
+
+The polymorphism happens entirely at **build time**. There is no special
+"polymorphic runtime" — what you deploy is an ordinary SCRAPI project.
+
+```
+              base project                      cxas poly build           one project per channel
+  ┌───────────────────────────────┐                                  ┌──────────────────────────┐
+  │ app.json · agents/ · tools/    │                                  │ output/chat/   (Markdown, │
+  │ evaluations/ (channel-neutral) │  ──────────────────────────►    │   rich cards, WEB_UI)     │
+  │                                │        compile + validate        ├──────────────────────────┤
+  │ adapters/                      │                                  │ output/voice/  (terse,    │
+  │   chat.adapter.yaml   (deltas) │                                  │   spoken, TELEPHONY)      │
+  │   voice.adapter.yaml  (deltas) │                                  └──────────────────────────┘
+  └───────────────────────────────┘
+```
+
+### The three primitives
+
+| Primitive | What it is | Where it lives |
+|---|---|---|
+| **Canonical Agent Card** | Your ordinary, channel-neutral agent project — `app.json`, `agents/`, `tools/`, `evaluations/`. Nothing new to learn. | The project root |
+| **Channel Adapter Card** | A small YAML/JSON file describing what changes for one channel: instruction edits, tool add/remove, model overrides, extra callbacks, channel evals, and deployment settings. | `adapters/<channel>.adapter.yaml` |
+| **Polymorphism Engine** | The compiler. Reads the base project + adapter cards and writes one complete project directory per channel. | `cxas poly` / `cxas_scrapi.poly` |
 
 ---
-## Exceptions and Misc.
-If you prefer to explicitly assign Service Account credentials programmatically instead of relying on the environmental `application-default`, you can pass the path to your JSON key using `creds_path`.
 
-```py
-from cxas_scrapi import Tools
+## Architecture at a glance
 
-creds_path = '<PATH_TO_YOUR_SERVICE_ACCOUNT_JSON_FILE>'
+The library is organized by responsibility. Each top-level package under
+`src/cxas_scrapi/` owns one concern:
 
-t = Tools(project_id='<YOUR_GCP_PROJECT_ID>', location='global', creds_path=creds_path)
-tools_map = t.get_tools_map('<YOUR_APP_NAME>')
+| Package | Responsibility |
+|---|---|
+| [`core/`](src/cxas_scrapi/core) | High-level building blocks mapped to CXAS resource types — `Apps`, `Agents`, `Tools`, `Guardrails`, `Deployments`, `Sessions`, etc. The main public SDK surface. |
+| [`poly/`](src/cxas_scrapi/poly) | **The polymorphism engine** — adapter-card models, validators, and the compiler. Pure local file I/O; intentionally **GCP-free** (no `google.cloud.*` imports, no network). |
+| [`cli/`](src/cxas_scrapi/cli) | The `cxas` command line. `cli/poly_cli.py` wires up `cxas poly build / validate / diff`. |
+| [`evals/`](src/cxas_scrapi/evals) | Executing and analyzing agent evaluations — goldens, simulations, latency. |
+| [`utils/`](src/cxas_scrapi/utils) | Pagination, proto/response flattening, linting, Sheets/GCS integrations. |
+| [`migration/`](src/cxas_scrapi/migration) | Tools for migrating legacy Dialogflow CX agents into CXAS. |
+
+The dependency arrow points one way: **`poly/` depends on nothing in the rest of
+the SDK** (and pulls in no GCP libraries), so the compiler runs anywhere — CI, a
+laptop, a sandbox — without credentials. The CLI and the rest of the SDK depend
+on `poly/`, never the reverse.
+
+```
+cli/poly_cli.py ──► poly/engine.py ──► poly/models.py
+                          │                  ▲
+                          └──► poly/validators.py
+                          (no google.cloud.*, no network)
 ```
 
-<!-- GETTING STARTED -->
-# Getting Started
-## Environment Setup
-Set up Google Cloud Platform credentials and install dependencies.
-```sh
-gcloud auth login
-gcloud auth application-default login
-gcloud config set project <project name>
+---
+
+## Inside the polymorphism engine
+
+The `poly/` package is three small files. Reading them top to bottom is the
+fastest way to understand the whole feature:
+
+### `poly/models.py` — the schema
+
+Pydantic models that define the **shape of an adapter card**. The top-level
+[`AdapterCard`](src/cxas_scrapi/poly/models.py) holds:
+
+- `metadata` ([`AdapterMetadata`](src/cxas_scrapi/poly/models.py)) — `channel`,
+  `displayName`, `description`.
+- `instruction_diffs` (`List[InstructionDiff]`) — edits to instruction text.
+- `tools` (`List[ToolModification]`) — add/remove tools on an agent.
+- `tool_definitions` (`List[ToolDefinition]`) — bring channel-only tools in.
+- `model_overrides` (`List[ModelOverride]`) — per-agent model swap.
+- `callbacks` (`List[CallbackDefinition]`) — channel-specific callbacks.
+- `evaluations` (`List[EvalReference]`) — extra eval directories to merge.
+- `deployment` (`Optional[DeploymentOverride]`) — channel/modality/widget config.
+
+Every model uses `populate_by_name=True`, so cards can be written in friendly
+**camelCase** (`displayName`, `sectionTag`, `pythonCode`) while the Python code
+reads them as snake_case. The result of a compile is a
+[`CompiledAgentConfig`](src/cxas_scrapi/poly/models.py): a pure-data snapshot of
+everything the engine will write to disk, so callers can introspect or transform
+it before anything touches the filesystem.
+
+### `poly/validators.py` — the safety net
+
+Pure, local checks (`AD001`–`AD007`) that run **before** compilation. Each
+returns a list of issue dicts shaped exactly like the linter's results
+(`{rule_id, severity, message, path}`), and the same checks back the `adapters`
+category of `cxas lint`. See [Validation rules](#validation-rules).
+
+### `poly/engine.py` — the compiler
+
+[`PolymorphismEngine`](src/cxas_scrapi/poly/engine.py) does the work in three
+phases:
+
+1. **Load** — `load_base_project()` reads `app.json`, every agent (config +
+   instruction + callback code), and every tool into memory as
+   `BaseProject`. `load_adapter_cards()` globs `adapters/*.adapter.{yaml,yml,json}`.
+2. **Compile** — `compile(card)` deep-copies the base and applies the card's
+   deltas in a fixed order (see [pipeline](#the-compilation-pipeline)), returning
+   a `CompiledAgentConfig`. `compile_all()` validates and compiles every card.
+3. **Write** — `write_output(compiled, dir)` materializes one complete project
+   directory: untouched base files are copied verbatim; agents, `app.json`, and
+   `gecx-config.json` are reconstructed; channel-only tools/evals/deployment are
+   added.
+
+---
+
+## Using polymorphism, step by step
+
+The repository ships a complete, runnable example — the **Bella Notte**
+restaurant agent — under [`examples/bella_notte/`](examples/bella_notte). All
+commands below operate on it.
+
+### 1. Start from an ordinary project
+
+The base project is a normal SCRAPI project — nothing about it is
+polymorphism-specific. The only addition is an `adapters/` directory:
+
 ```
-```sh
-uv sync
-source .venv/bin/activate
+examples/bella_notte/
+├── app.json
+├── gecx-config.json
+├── agents/
+│   ├── Bella_Notte_Host/        # root agent: routes reservation vs. takeout
+│   ├── Reservation_Agent/       # slot-filling specialist
+│   └── Takeout_Agent/
+├── tools/                       # set_active_flow, book_reservation, …
+├── evaluations/                 # shared, channel-neutral goldens
+└── adapters/                    # ← the per-channel deltas live here
+    ├── chat.adapter.yaml
+    └── voice.adapter.yaml
 ```
 
-## Usage
-To run a simple bit of code you can do the following:
-- Import a Class from `cxas_scrapi`
-- Define your GCP Project and Location
+Write the base instructions to be **channel-neutral**: describe *what* the agent
+does, not *how* it should look on a screen or sound on a call.
+
+### 2. Write a channel adapter card
+
+An adapter card is a short declaration of deltas. Here is the voice adapter,
+annotated:
+
+```yaml
+apiVersion: poly.cxas.dev/v1
+kind: ChannelAdapter
+metadata:
+  channel: voice                       # the channel name (becomes output/voice/)
+  displayName: Bella Notte — Voice
+
+# Layer voice behavior on top of the base instructions.
+instructionDiffs:
+  - agent: Bella_Notte_Host
+    mode: append                       # append | prepend | replace_section
+    content: |
+      <channel_voice>
+      You are speaking on a phone call. There is no screen.
+      - Keep every response to two or three short sentences.
+      - Spell out numbers and times ("six thirty in the evening").
+      </channel_voice>
+
+# Inject pacing hints right before the model call.
+callbacks:
+  - agent: Bella_Notte_Host
+    type: before_model
+    pythonCode: adapters/voice_callbacks/voice_pacing.py
+    description: Inject voice pacing and filler-phrase hints.
+
+# Fold channel-specific evaluations into the compiled evaluations/.
+evaluations:
+  - sourceDir: adapters/voice_evals
+
+# Emit a deployment.json for telephony, voice-only.
+deployment:
+  channelType: GOOGLE_TELEPHONY_PLATFORM
+  modality: VOICE_ONLY
+```
+
+The chat adapter pulls the *same* base in the opposite direction — Markdown,
+numbered lists, and an extra `send_rich_card` tool. See
+[`chat.adapter.yaml`](examples/bella_notte/adapters/chat.adapter.yaml) for the
+full version, which also demonstrates `tools` + `toolDefinitions`.
+
+### 3. Validate before you build
+
+```bash
+cxas poly validate --app-dir examples/bella_notte
+```
+
+```
+All 2 adapter card(s) valid.
+```
+
+Validation checks that every referenced agent/tool/section actually exists, that
+no two cards claim the same channel, and more — see
+[Validation rules](#validation-rules).
+
+### 4. Preview the changes with `diff`
+
+`diff` shows exactly what an adapter will change, **without writing anything**:
+
+```bash
+cxas poly diff chat --app-dir examples/bella_notte
+```
+
+```
+Channel: chat   (adapter: adapters/chat.adapter.yaml)
+
+agents/Bella_Notte_Host
+  instruction: + 7 line(s) append
+    + <channel_chat>
+    + You are responding in a web chat widget that renders Markdown.
+    + - Use **bold** for emphasis and short numbered lists for options.
+    + ...
+  tools (2 -> 3):
+    + send_rich_card
+  callbacks: + before_model (Inject rich card formatting hints for chat confirmations.)
+agents/Reservation_Agent
+  instruction: + 8 line(s) append
+    + <channel_chat>
+    + Present available time slots as a numbered, selectable list, e.g.:
+    +   1. 6:00 PM
+    + ...
+
+tools/
+  + send_rich_card
+
+evaluations/
+  + 1 eval(s): Rich_Card_Confirmation
+
+deployment.json
+  + channelType: WEB_UI
+  + modality: CHAT_ONLY
+  + theme: LIGHT
+  + webWidgetTitle: Bella Notte Reservations
+```
+
+### 5. Build the channels
+
+```bash
+cxas poly build --app-dir examples/bella_notte --output-dir ./output
+```
+
+```
+Compiled channel 'chat' -> ./output/chat
+Compiled channel 'voice' -> ./output/voice
+
+Done. 2 channel(s) written to ./output
+```
+
+### 6. Lint, evaluate, and deploy — the output is "just a project"
+
+The single most important property of the engine: **the compiled output is
+indistinguishable from a hand-authored project.** Every existing command works on
+it with zero changes:
+
+```bash
+cxas lint --app-dir ./output/chat     # ✓ passes
+cxas lint --app-dir ./output/voice    # ✓ passes
+# run evals, deploy, etc. on ./output/<channel> exactly as usual
+```
+
+There is no half-compiled state and no special runtime to install. That is the
+payoff of *author once at the center*: you maintain a single agent, and the
+channel-specific surfaces fall out of two short adapter files.
+
+---
+
+## Adapter card reference
+
+An adapter card declares deltas in seven optional sections. Each is applied to
+the deep-copied base during compilation.
+
+| Section | Field | What it does |
+|---|---|---|
+| **Instruction diffs** | `instructionDiffs[]` | Edit an agent's instruction text. `mode: append` / `prepend` add text; `mode: replace_section` swaps the contents of an XML-style `<sectionTag>…</sectionTag>` block. |
+| **Tool modifications** | `tools[]` | `add`/`remove` tool names on a named agent's `tools` list. |
+| **Tool definitions** | `toolDefinitions[]` | Bring a channel-only tool into `tools/` from a `sourceDir` (its `<name>.json` + `python_code.py`). Required when a `tools.add` references a tool not in the base. |
+| **Model overrides** | `modelOverrides[]` | Set `modelSettings.model` for an agent in this channel. |
+| **Callbacks** | `callbacks[]` | Append a channel-specific callback (`before_model`, `after_model`, `before_tool`, `after_tool`, `before_agent`, `after_agent`). Auto-numbered after any existing ones. |
+| **Evaluations** | `evaluations[]` | Merge a `sourceDir` of channel-specific evaluations into `evaluations/`. |
+| **Deployment** | `deployment` | Emit a `deployment.json` (channel type, modality, web-widget config) and update `gecx-config.json`. |
+
+Two conveniences worth knowing:
+
+- **Agents may be referenced by display name or directory name** — the engine
+  resolves either form.
+- **`replace_section` is surgical.** It only replaces the matched `<tag>…</tag>`
+  block, so the rest of the instruction stays byte-for-byte intact. If most of
+  your sections need `replace_section`, that's a signal the channels may want to
+  be [separate agents](#when-to-use-adapters-vs-separate-agents).
+
+---
+
+## The compilation pipeline
+
+`PolymorphismEngine.compile()` applies an adapter in a fixed, deterministic
+order. Understanding the order explains the output:
+
+1. **Deep-copy the base.** Agent configs, instructions, and existing callback
+   code are copied so the base is never mutated.
+2. **Instruction diffs.** `append` / `prepend` / `replace_section` on each named
+   agent.
+3. **Tool add / remove.** Update each agent's `tools` list (adds are
+   de-duplicated; removes are filtered out).
+4. **Tool definitions.** Read each channel-only tool's directory; normalize its
+   code path to the canonical `tools/<name>/python_function/python_code.py`.
+5. **Model overrides.** Set `modelSettings.model` per agent.
+6. **Callbacks.** Append channel callbacks, auto-numbering after existing ones
+   (e.g. a second `before_model` callback becomes `before_model_callbacks_02`).
+7. **Evaluations.** Merge each channel eval directory.
+8. **Deployment + gecx config.** Build `deployment.json`; set `default_channel`,
+   `app_dir`, and (for voice) `modality` in `gecx-config.json`.
+
+Errors are **accumulated, not fail-fast**: a missing agent or section is recorded
+as an issue and compilation continues, so a single run surfaces *every* problem
+at once via a `CompilationError` carrying the full issue list.
+
+---
+
+## Driving the engine from Python
+
+Everything the CLI does is available programmatically. The engine is GCP-free, so
+this snippet runs anywhere:
 
 ```python
-from cxas_scrapi import Apps
+from cxas_scrapi.poly import PolymorphismEngine, CompilationError
 
-# Instantiate your class object and pass in your credentials
-app_client = Apps(project_id='<YOUR_GCP_PROJECT_ID>', location='global')
+engine = PolymorphismEngine("examples/bella_notte")
+engine.load_base_project()
+engine.load_adapter_cards()          # populates engine.adapters {channel: (card, path)}
 
-# Retrieve all Apps existing in your project
-apps = app_client.list_apps()
-for app in apps:
-    print(app.display_name, app.name)
+try:
+    # Compile and write every channel.
+    compiled = engine.compile_all()  # {channel: CompiledAgentConfig}, validated first
+    for channel, config in compiled.items():
+        out_dir = engine.write_output(config, f"./output/{channel}")
+        print(f"wrote {channel} -> {out_dir}")
+except CompilationError as err:
+    for issue in err.issues:
+        print(issue["severity"], issue["rule_id"], issue["message"])
 ```
 
-# Library Composition
-Here is a brief overview of the CXAS SCRAPI library's structure and the motivation behind that structure.
+Because `compile()` returns a `CompiledAgentConfig` *before* anything is written,
+you can inspect or post-process the compiled state — agents, instructions, merged
+tools/evals, deployment — and only call `write_output()` when you're ready.
 
-## [Core](src/cxas_scrapi/core)
-The `src/cxas_scrapi/core` directory contains the high level building blocks of CXAS SCRAPI, mapped to core resource types in the CXAS environment (Apps, Agents, Tools, Guardrails, Deployments, Sessions, etc.)
+The public exports live in
+[`cxas_scrapi.poly`](src/cxas_scrapi/poly/__init__.py): `PolymorphismEngine`,
+`CompilationError`, `AdapterCard`, `CompiledAgentConfig`, and the individual
+delta models.
 
-## [Utils](src/cxas_scrapi/utils)
-The `src/cxas_scrapi/utils` directory contains helper functions and background logic for pagination, response flattening, proto conversions, and external integrations like Google Sheets.
+---
 
-## [Evals](src/cxas_scrapi/evals)
-The `src/cxas_scrapi/evals` directory provides tools for executing and analyzing agent performance evaluations, including Golden tests and simulation runs, and extracting metrics like latency.
+## Validation rules
 
-## [CLI](src/cxas_scrapi/cli)
-The `src/cxas_scrapi/cli` directory implements the command line interface for SCRAPI, offering tools like `cxas lint` to automate development and validation workflows.
+Run via `cxas poly validate` (or as the `adapters` category of `cxas lint`). The
+`AD` prefix avoids collision with the `config` lint category, which owns
+`A001`–`A006`.
 
-## [Migration](src/cxas_scrapi/migration)
-The `src/cxas_scrapi/migration` directory contains tools to facilitate transitioning legacy Dialogflow CX agents to CXAS, including agent generation from flows and artifact building.
+| ID | Severity | Check |
+|----|----------|-------|
+| `AD001` | error | Adapter card has required fields (`apiVersion`, `kind`, `metadata.channel`) and valid types. |
+| `AD002` | error | Every agent referenced in `instructionDiffs`, `tools`, `modelOverrides`, `callbacks` exists in `agents/`. |
+| `AD003` | error | `replace_section` diffs set `sectionTag`, and that `<sectionTag>` exists in the target instruction. |
+| `AD004` | warning | A tool `remove` references a tool not in the base agent's tool list. |
+| `AD005` | error | A tool `add` references a tool defined neither in `tools/` nor in the adapter's `toolDefinitions`. |
+| `AD006` | warning | The adapter declares no `evaluations` entries. |
+| `AD007` | error | Two adapter cards target the same `metadata.channel`. |
 
-<!-- DOCUMENTATION -->
-# Documentation
+`cxas poly build --channel all` runs this validation first and writes **nothing**
+if any error-severity issue is found.
 
-The official documentation is hosted online at [https://googlecloudplatform.github.io/cxas-scrapi/stable/](https://googlecloudplatform.github.io/cxas-scrapi/stable/).
+---
 
-The documentation site is built with [MkDocs Material](https://squidfunk.github.io/mkdocs-material/). To run it locally:
+## When to use adapters vs. separate agents
 
-```sh
-# Install dependencies including docs extras
-uv sync --extra docs
+Reach for **adapters** when:
 
-# Start the local dev server
-uv run mkdocs serve
-```
+- The channels share the same core flow, tools, and business logic.
+- The differences are presentational or tuning — formatting, verbosity, pacing,
+  a handful of channel-only tools.
+- You want a single source of truth and one place to fix bugs.
 
-Open [http://127.0.0.1:8000](http://127.0.0.1:8000) in your browser. Changes to files in `docs/` will reload automatically.
+Build **separate agents** when:
 
-To build the static site without serving:
+- The channels have genuinely different conversation graphs or tool sets with
+  little overlap.
+- The "delta" would be larger than the base — at that point an adapter hides more
+  than it reveals.
 
-```sh
-mkdocs build          # output goes to site/
-mkdocs build --strict # also fails on warnings (used in CI)
-```
+A good rule of thumb: if you find yourself using `replace_section` on most
+sections, the channels probably want to be separate agents.
 
-<!-- CONTRIBUTING -->
-# Contributing
-We welcome any contributions or feature requests you would like to submit!
+---
 
-1. Fork the Project
-2. Create your Feature Branch (git checkout -b feature/AmazingFeature)
-3. Commit your Changes (git commit -m 'Add some AmazingFeature')
-4. Push to the Branch (git push origin feature/AmazingFeature)
-5. Open a Pull Request
+## Where to go next
 
-<!-- LICENSE -->
-# License
-Distributed under the Apache 2.0 License. See [LICENSE](LICENSE.txt) for more information.
+- **[Polymorphism guide](docs/guides/polymorphism.md)** — concepts and the
+  compilation model in depth.
+- **[Polymorphism pattern](docs/patterns/polymorphism.md)** — a full Bella Notte
+  chat-vs-voice walkthrough.
+- **[`cxas poly` CLI reference](docs/cli/poly.md)** — every flag for `build`,
+  `validate`, and `diff`.
+- **[Examples](examples/)** — the runnable Bella Notte project and its adapters.
+- **[Official docs](https://googlecloudplatform.github.io/cxas-scrapi/stable/)**
+  — install, authentication, and the full core SDK.
 
-<!-- CONTACT -->
-# Contact
-Patrick Marlow - [pmarlow@google.com](mailto:pmarlow@google.com) - [@kmaphoenix](https://github.com/kmaphoenix)
+---
 
-Project Link: [https://github.com/GoogleCloudPlatform/cxas-scrapi](https://github.com/GoogleCloudPlatform/cxas-scrapi)
+## Contributing
 
-<!-- REFERENCES -->
-# References
-* [CX Agent Studio Documentation](https://docs.cloud.google.com/customer-engagement-ai/conversational-agents/ps)
-* [CX Agent Studio Console](https://ces.cloud.google.com/)
+We welcome contributions and feature requests! Fork the project, create a feature
+branch, commit your changes, and open a pull request. See
+[CONTRIBUTING.md](CONTRIBUTING.md) for details.
+
+## License
+
+Distributed under the Apache 2.0 License. See [LICENSE.txt](LICENSE.txt).
+
+## References
+
+- [CX Agent Studio Documentation](https://docs.cloud.google.com/customer-engagement-ai/conversational-agents/ps)
+- [CX Agent Studio Console](https://ces.cloud.google.com/)

--- a/README.md
+++ b/README.md
@@ -28,15 +28,16 @@ complete, channel-optimized project (chat, voice, …) for each target.
 ## Table of contents
 
 1. [The core idea](#the-core-idea)
-2. [Architecture at a glance](#architecture-at-a-glance)
-3. [Inside the polymorphism engine](#inside-the-polymorphism-engine)
-4. [Using polymorphism, step by step](#using-polymorphism-step-by-step)
-5. [Adapter card reference](#adapter-card-reference)
-6. [The compilation pipeline](#the-compilation-pipeline)
-7. [Driving the engine from Python](#driving-the-engine-from-python)
-8. [Validation rules](#validation-rules)
-9. [When to use adapters vs. separate agents](#when-to-use-adapters-vs-separate-agents)
-10. [Where to go next](#where-to-go-next)
+2. [Quickstart: the Polymorphic Pizza demo](#quickstart-the-polymorphic-pizza-demo)
+3. [Architecture at a glance](#architecture-at-a-glance)
+4. [Inside the polymorphism engine](#inside-the-polymorphism-engine)
+5. [Using polymorphism, step by step](#using-polymorphism-step-by-step)
+6. [Adapter card reference](#adapter-card-reference)
+7. [The compilation pipeline](#the-compilation-pipeline)
+8. [Driving the engine from Python](#driving-the-engine-from-python)
+9. [Validation rules](#validation-rules)
+10. [When to use adapters vs. separate agents](#when-to-use-adapters-vs-separate-agents)
+11. [Where to go next](#where-to-go-next)
 
 ---
 
@@ -80,6 +81,45 @@ The polymorphism happens entirely at **build time**. There is no special
 | **Canonical Agent Card** | Your ordinary, channel-neutral agent project — `app.json`, `agents/`, `tools/`, `evaluations/`. Nothing new to learn. | The project root |
 | **Channel Adapter Card** | A small YAML/JSON file describing what changes for one channel: instruction edits, tool add/remove, model overrides, extra callbacks, channel evals, and deployment settings. | `adapters/<channel>.adapter.yaml` |
 | **Polymorphism Engine** | The compiler. Reads the base project + adapter cards and writes one complete project directory per channel. | `cxas poly` / `cxas_scrapi.poly` |
+
+---
+
+## Quickstart: the Polymorphic Pizza demo
+
+Want to see it work right now? The repository ships a small, beginner-friendly
+demo — **Polymorphic Pizza** — that compiles **one** agent project into a
+**chat agent** and a **voice agent**. You do **not** need a Google Cloud account
+to build and inspect them.
+
+**Prerequisites:** Python 3.10+ and [uv](https://docs.astral.sh/uv/).
+
+```bash
+# 1. Install the cxas CLI (once), from the repo root:
+uv sync --extra dev
+
+# 2. Validate the demo's two channel adapters:
+uv run cxas poly validate --app-dir examples/polymorphic_pizza
+
+# 3. Compile the base project into a chat agent and a voice agent:
+uv run cxas poly build --app-dir examples/polymorphic_pizza --output-dir ./output
+
+# 4. The output is just a normal project — lint it like any other:
+uv run cxas lint --app-dir ./output/chat
+uv run cxas lint --app-dir ./output/voice
+```
+
+You'll get two finished projects under `./output/`: `chat/` (Markdown plus a
+visual order card, deployed to a web widget) and `voice/` (short spoken turns,
+deployed to telephony) — both generated from the **same** `agents/`, `tools/`,
+and `evaluations/`. Want to preview the per-channel changes before building? Run
+`uv run cxas poly diff chat --app-dir examples/polymorphic_pizza` (or `voice`).
+
+Full file-by-file walkthrough, a chat-vs-voice comparison, and what to try next:
+**[examples/polymorphic_pizza/README.md](examples/polymorphic_pizza/README.md)**.
+
+> Prefer a more advanced example with a slot-filling framework? The
+> [step-by-step section below](#using-polymorphism-step-by-step) uses the larger
+> Bella Notte project.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,11 @@
 # CX Agent Studio Scripting API (CXAS SCRAPI)
 
-[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE.txt)
-[![PyPI](https://img.shields.io/pypi/v/cxas-scrapi)](https://pypi.org/project/cxas-scrapi/)
-[![Python Unit Tests](https://github.com/GoogleCloudPlatform/cxas-scrapi/actions/workflows/ci.yml/badge.svg)](https://github.com/GoogleCloudPlatform/cxas-scrapi/actions/workflows/ci.yml)
+
 
 <html>
     <h2 align="center">
-      <img src="assets/cxas-scrapi-logo.png" width="256" alt="CXAS SCRAPI Logo"/>
+      Polymorphic Agents Experiment - Author one agent at the center. Compile channel-optimized variants at the edges.
     </h2>
-    <h3 align="center">
-      Author one agent at the center. Compile channel-optimized variants at the edges.
-    </h3>
     <h3 align="center">
       Important Links:
       <a href="https://googlecloudplatform.github.io/cxas-scrapi/stable/">Docs</a>,

--- a/README.md
+++ b/README.md
@@ -104,10 +104,13 @@ uv run cxas poly validate --app-dir examples/polymorphic_pizza
 uv run cxas poly diff chat --app-dir examples/polymorphic_pizza
 uv run cxas poly diff chat --app-dir examples/polymorphic_pizza --json
 
-# 4. Compile the base project into a chat agent and a voice agent:
+# 4. Check pre-build launch readiness:
+uv run cxas poly readiness --app-dir examples/polymorphic_pizza
+
+# 5. Compile the base project into a chat agent and a voice agent:
 uv run cxas poly build --app-dir examples/polymorphic_pizza --output-dir ./output
 
-# 5. The output is just a normal project — lint it like any other:
+# 6. The output is just a normal project — lint it like any other:
 uv run cxas lint --app-dir ./output/chat
 uv run cxas lint --app-dir ./output/voice
 ```
@@ -137,8 +140,8 @@ The library is organized by responsibility. Each top-level package under
 | Package | Responsibility |
 |---|---|
 | [`core/`](src/cxas_scrapi/core) | High-level building blocks mapped to CXAS resource types — `Apps`, `Agents`, `Tools`, `Guardrails`, `Deployments`, `Sessions`, etc. The main public SDK surface. |
-| [`poly/`](src/cxas_scrapi/poly) | **The polymorphism engine** — adapter-card models, validators, and the compiler. Pure local file I/O; intentionally **GCP-free** (no `google.cloud.*` imports, no network). |
-| [`cli/`](src/cxas_scrapi/cli) | The `cxas` command line. `cli/poly_cli.py` wires up `cxas poly init / build / validate / doctor / diff`. |
+| [`poly/`](src/cxas_scrapi/poly) | **The polymorphism engine** — adapter-card models, validators, compiler, diffing, diagnostics, scaffolding, and readiness reports. Pure local file I/O; intentionally **GCP-free** (no `google.cloud.*` imports, no network). |
+| [`cli/`](src/cxas_scrapi/cli) | The `cxas` command line. `cli/poly_cli.py` wires up `cxas poly init / build / validate / doctor / readiness / diff`. |
 | [`evals/`](src/cxas_scrapi/evals) | Executing and analyzing agent evaluations — goldens, simulations, latency. |
 | [`utils/`](src/cxas_scrapi/utils) | Pagination, proto/response flattening, linting, Sheets/GCS integrations. |
 | [`migration/`](src/cxas_scrapi/migration) | Tools for migrating legacy Dialogflow CX agents into CXAS. |
@@ -159,8 +162,9 @@ cli/poly_cli.py ──► poly/engine.py ──► poly/models.py
 
 ## Inside the polymorphism engine
 
-The `poly/` package is three small files. Reading them top to bottom is the
-fastest way to understand the whole feature:
+The `poly/` package is organized around small, local modules. Reading the
+schema, validators, compiler, and readiness report top to bottom is the fastest
+way to understand the whole feature:
 
 ### `poly/models.py` — the schema
 
@@ -210,6 +214,14 @@ phases:
    directory: untouched base files are copied verbatim; agents, `app.json`, and
    `gecx-config.json` are reconstructed; channel-only tools/evals/deployment are
    added.
+
+### `poly/readiness.py` — the launch review
+
+`build_readiness_report()` composes validation, compileability, diff summaries,
+and eval coverage into a `poly-readiness/v1` report. It is the design-partner
+review surface: run `cxas poly readiness` before `build` when you want to know
+which channels are ready, which need attention, and whether channel eval names
+would shadow base evals in compiled output.
 
 ---
 
@@ -375,7 +387,21 @@ gecx-config.json (deployment)
   + web_widget_title: Bella Notte Reservations
 ```
 
-### 6. Build the channels
+### 6. Check launch readiness
+
+Before writing compiled output, run the pre-build readiness report:
+
+```bash
+cxas poly readiness --app-dir examples/bella_notte
+cxas poly readiness --app-dir examples/bella_notte --format json
+```
+
+`readiness` gives you one launch-review artifact: validation issues,
+compileability, the diff summary, base/channel eval counts, duplicate eval names
+that would shadow base evals in compiled output, and concrete next steps. Use
+`--strict` in CI when warning-level gaps should block launch.
+
+### 7. Build the channels
 
 ```bash
 cxas poly build --app-dir examples/bella_notte --output-dir ./output
@@ -388,7 +414,7 @@ Compiled channel 'voice' -> ./output/voice
 Done. 2 channel(s) written to ./output
 ```
 
-### 7. Lint, evaluate, and deploy — the output is "just a project"
+### 8. Lint, evaluate, and deploy — the output is "just a project"
 
 The single most important property of the engine: **the compiled output is
 indistinguishable from a hand-authored project.** Every existing command works on
@@ -553,7 +579,7 @@ sections, the channels probably want to be separate agents.
 - **[Polymorphism pattern](docs/patterns/polymorphism.md)** — a full Bella Notte
   chat-vs-voice walkthrough.
 - **[`cxas poly` CLI reference](docs/cli/poly.md)** — every flag for `build`,
-  `validate`, and `diff`.
+  `validate`, `doctor`, `readiness`, and `diff`.
 - **[Examples](examples/)** — the runnable Bella Notte project and its adapters.
 - **[Official docs](https://googlecloudplatform.github.io/cxas-scrapi/stable/)**
   — install, authentication, and the full core SDK.

--- a/README.md
+++ b/README.md
@@ -140,10 +140,11 @@ it before anything touches the filesystem.
 
 ### `poly/validators.py` — the safety net
 
-Pure, local checks (`AD001`–`AD007`) that run **before** compilation. Each
-returns a list of issue dicts shaped exactly like the linter's results
-(`{rule_id, severity, message, path}`), and the same checks back the `adapters`
-category of `cxas lint`. See [Validation rules](#validation-rules).
+Pure, local checks (`AD001`–`AD010`) that are the single source of truth — they
+run inside `cxas poly validate`, back the `adapters` category of `cxas lint`, and
+are invoked by `compile()` itself **before** any deltas are applied. Each returns
+a list of issue dicts shaped exactly like the linter's results (`{rule_id,
+severity, message, path}`). See [Validation rules](#validation-rules).
 
 ### `poly/engine.py` — the compiler
 
@@ -226,7 +227,7 @@ callbacks:
 evaluations:
   - sourceDir: adapters/voice_evals
 
-# Emit a deployment.json for telephony, voice-only.
+# Channel/modality settings, folded into the compiled gecx-config.json.
 deployment:
   channelType: GOOGLE_TELEPHONY_PLATFORM
   modality: VOICE_ONLY
@@ -284,11 +285,11 @@ tools/
 evaluations/
   + 1 eval(s): Rich_Card_Confirmation
 
-deployment.json
-  + channelType: WEB_UI
+gecx-config.json (deployment)
+  + channel_type: WEB_UI
   + modality: CHAT_ONLY
   + theme: LIGHT
-  + webWidgetTitle: Bella Notte Reservations
+  + web_widget_title: Bella Notte Reservations
 ```
 
 ### 5. Build the channels
@@ -331,11 +332,11 @@ the deep-copied base during compilation.
 |---|---|---|
 | **Instruction diffs** | `instructionDiffs[]` | Edit an agent's instruction text. `mode: append` / `prepend` add text; `mode: replace_section` swaps the contents of an XML-style `<sectionTag>…</sectionTag>` block. |
 | **Tool modifications** | `tools[]` | `add`/`remove` tool names on a named agent's `tools` list. |
-| **Tool definitions** | `toolDefinitions[]` | Bring a channel-only tool into `tools/` from a `sourceDir` (its `<name>.json` + `python_code.py`). Required when a `tools.add` references a tool not in the base. |
+| **Tool definitions** | `toolDefinitions[]` | Bring a channel-only tool into `tools/` from a `sourceDir`. `toolType: python` brings its `<name>.json` + normalized `python_code.py`; `toolType: openapi` copies the source directory verbatim. Required when a `tools.add` references a tool not in the base. |
 | **Model overrides** | `modelOverrides[]` | Set `modelSettings.model` for an agent in this channel. |
 | **Callbacks** | `callbacks[]` | Append a channel-specific callback (`before_model`, `after_model`, `before_tool`, `after_tool`, `before_agent`, `after_agent`). Auto-numbered after any existing ones. |
-| **Evaluations** | `evaluations[]` | Merge a `sourceDir` of channel-specific evaluations into `evaluations/`. |
-| **Deployment** | `deployment` | Emit a `deployment.json` (channel type, modality, web-widget config) and update `gecx-config.json`. |
+| **Evaluations** | `evaluations[]`, `evaluationExpectations[]`, `evaluationDatasets[]` | Merge a `sourceDir` of channel-specific evaluations, expectations, and datasets into the matching output directories. |
+| **Deployment** | `deployment` | Fold a `deployment` block (channel type, modality, web-widget config) into `gecx-config.json` — the file deploy tooling reads — and set `default_channel`/`modality`. |
 
 Two conveniences worth knowing:
 
@@ -350,27 +351,34 @@ Two conveniences worth knowing:
 
 ## The compilation pipeline
 
-`PolymorphismEngine.compile()` applies an adapter in a fixed, deterministic
-order. Understanding the order explains the output:
+`PolymorphismEngine.compile()` first **validates** the card (the same checks as
+`cxas poly validate` — the single source of truth), then applies it in a fixed,
+deterministic order. Understanding the order explains the output:
 
-1. **Deep-copy the base.** Agent configs, instructions, and existing callback
+1. **Validate.** Run the adapter validators; if any error-severity issue is
+   found, raise a `CompilationError` carrying the *full* list — nothing is
+   applied. A validated card always compiles.
+2. **Deep-copy the base.** Agent configs, instructions, and existing callback
    code are copied so the base is never mutated.
-2. **Instruction diffs.** `append` / `prepend` / `replace_section` on each named
-   agent.
-3. **Tool add / remove.** Update each agent's `tools` list (adds are
+3. **Instruction diffs.** `append` / `prepend` / `replace_section` on each named
+   agent (`replace_section` matches `<tag …>…</tag>`, attributes allowed).
+4. **Tool add / remove.** Update each agent's `tools` list (adds are
    de-duplicated; removes are filtered out).
-4. **Tool definitions.** Read each channel-only tool's directory; normalize its
-   code path to the canonical `tools/<name>/python_function/python_code.py`.
-5. **Model overrides.** Set `modelSettings.model` per agent.
-6. **Callbacks.** Append channel callbacks, auto-numbering after existing ones
+5. **Tool definitions.** Read each channel-only tool's directory; `python` tools
+   normalize to `tools/<name>/python_function/python_code.py`, `openapi` tools
+   are copied verbatim.
+6. **Model overrides.** Set `modelSettings.model` per agent.
+7. **Callbacks.** Append channel callbacks, auto-numbering after existing ones
    (e.g. a second `before_model` callback becomes `before_model_callbacks_02`).
-7. **Evaluations.** Merge each channel eval directory.
-8. **Deployment + gecx config.** Build `deployment.json`; set `default_channel`,
-   `app_dir`, and (for voice) `modality` in `gecx-config.json`.
+8. **Evaluations.** Merge each channel eval / expectation / dataset directory.
+9. **Deployment + gecx config.** Fold the `deployment` block into
+   `gecx-config.json`; set `default_channel`, `app_dir`, and (for voice)
+   `modality`.
 
-Errors are **accumulated, not fail-fast**: a missing agent or section is recorded
-as an issue and compilation continues, so a single run surfaces *every* problem
-at once via a `CompilationError` carrying the full issue list.
+Validation surfaces *every* problem at once: all issues are accumulated and, if
+any are errors, raised together as a single `CompilationError` — the engine never
+applies a partial or invalid card. Malformed adapter files are reported as
+`AD001` issues (with the file name), never as a Python traceback.
 
 ---
 
@@ -416,13 +424,16 @@ Run via `cxas poly validate` (or as the `adapters` category of `cxas lint`). The
 
 | ID | Severity | Check |
 |----|----------|-------|
-| `AD001` | error | Adapter card has required fields (`apiVersion`, `kind`, `metadata.channel`) and valid types. |
+| `AD001` | error | Adapter card has required fields (`apiVersion`, `kind`, `metadata.channel`) and valid types (malformed cards report here, not as a traceback). |
 | `AD002` | error | Every agent referenced in `instructionDiffs`, `tools`, `modelOverrides`, `callbacks` exists in `agents/`. |
-| `AD003` | error | `replace_section` diffs set `sectionTag`, and that `<sectionTag>` exists in the target instruction. |
+| `AD003` | error | `replace_section` diffs set `sectionTag`, and a matching `<sectionTag …>…</sectionTag>` block (attributes allowed) exists in the target instruction. |
 | `AD004` | warning | A tool `remove` references a tool not in the base agent's tool list. |
-| `AD005` | error | A tool `add` references a tool defined neither in `tools/` nor in the adapter's `toolDefinitions`. |
+| `AD005` | error | A tool `add` references a tool defined neither in `tools/`, the adapter's `toolDefinitions`, nor a platform tool; or a referenced `pythonCode`/`sourceDir` is missing. |
 | `AD006` | warning | The adapter declares no `evaluations` entries. |
 | `AD007` | error | Two adapter cards target the same `metadata.channel`. |
+| `AD008` | error | A referenced `sourceDir`/`pythonCode` path escapes the project root. |
+| `AD009` | error | `deployment` `channelType`/`modality`/`theme` use known, supported values. |
+| `AD010` | error | `toolDefinitions` declare a supported `toolType` (`python`, `openapi`). |
 
 `cxas poly build --channel all` runs this validation first and writes **nothing**
 if any error-severity issue is found.

--- a/README.md
+++ b/README.md
@@ -169,11 +169,14 @@ Pydantic models that define the **shape of an adapter card**. The top-level
 - `model_overrides` (`List[ModelOverride]`) — per-agent model swap.
 - `callbacks` (`List[CallbackDefinition]`) — channel-specific callbacks.
 - `evaluations` (`List[EvalReference]`) — extra eval directories to merge.
+- `gecx_config` (`Dict[str, Any]`) — channel-specific `gecx-config.json`
+  overlay.
 - `deployment` (`Optional[DeploymentOverride]`) — channel/modality/widget config.
 
 Every model uses `populate_by_name=True`, so cards can be written in friendly
 **camelCase** (`displayName`, `sectionTag`, `pythonCode`) while the Python code
-reads them as snake_case. The result of a compile is a
+reads them as snake_case. Unknown fields are rejected instead of ignored, so a
+typo in an adapter cannot silently disappear. The result of a compile is a
 [`CompiledAgentConfig`](src/cxas_scrapi/poly/models.py): a pure-data snapshot of
 everything the engine will write to disk, so callers can introspect or transform
 it before anything touches the filesystem.
@@ -365,7 +368,7 @@ channel-specific surfaces fall out of two short adapter files.
 
 ## Adapter card reference
 
-An adapter card declares deltas in seven optional sections. Each is applied to
+An adapter card declares deltas in optional sections. Each is applied to
 the deep-copied base during compilation.
 
 | Section | Field | What it does |
@@ -376,6 +379,7 @@ the deep-copied base during compilation.
 | **Model overrides** | `modelOverrides[]` | Set `modelSettings.model` for an agent in this channel. |
 | **Callbacks** | `callbacks[]` | Append a channel-specific callback (`before_model`, `after_model`, `before_tool`, `after_tool`, `before_agent`, `after_agent`). Auto-numbered after any existing ones. |
 | **Evaluations** | `evaluations[]`, `evaluationExpectations[]`, `evaluationDatasets[]` | Merge a `sourceDir` of channel-specific evaluations, expectations, and datasets into the matching output directories. |
+| **Runtime config** | `gecxConfig` | Deep-merge channel-specific `gecx-config.json` defaults such as model or modality before compiler-owned fields are finalized. |
 | **Deployment** | `deployment` | Fold a `deployment` block (channel type, modality, web-widget config) into `gecx-config.json` — the file deploy tooling reads — and set `default_channel`/`modality`. |
 
 Two conveniences worth knowing:
@@ -411,9 +415,10 @@ deterministic order. Understanding the order explains the output:
 7. **Callbacks.** Append channel callbacks, auto-numbering after existing ones
    (e.g. a second `before_model` callback becomes `before_model_callbacks_02`).
 8. **Evaluations.** Merge each channel eval / expectation / dataset directory.
-9. **Deployment + gecx config.** Fold the `deployment` block into
-   `gecx-config.json`; set `default_channel`, `app_dir`, and (for voice)
-   `modality`.
+9. **Runtime config.** Deep-merge `gecxConfig` into `gecx-config.json`.
+10. **Deployment + gecx config.** Fold the `deployment` block into
+    `gecx-config.json`; set `default_channel`, `app_dir`, and (for voice)
+    `modality`.
 
 Validation surfaces *every* problem at once: all issues are accumulated and, if
 any are errors, raised together as a single `CompilationError` — the engine never
@@ -464,7 +469,7 @@ Run via `cxas poly validate` (or as the `adapters` category of `cxas lint`). The
 
 | ID | Severity | Check |
 |----|----------|-------|
-| `AD001` | error | Adapter card has required fields (`apiVersion`, `kind`, `metadata.channel`) and valid types (malformed cards report here, not as a traceback). |
+| `AD001` | error | Adapter card has required fields (`apiVersion`, `kind`, `metadata.channel`), valid types, and no unknown fields (malformed cards report here, not as a traceback). |
 | `AD002` | error | Every agent referenced in `instructionDiffs`, `tools`, `modelOverrides`, `callbacks` exists in `agents/`. |
 | `AD003` | error | `replace_section` diffs set `sectionTag`, and a matching `<sectionTag …>…</sectionTag>` block (attributes allowed) exists in the target instruction. |
 | `AD004` | warning | A tool `remove` references a tool not in the base agent's tool list. |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# CX Agent Studio Scripting API (CXAS SCRAPI)
-
-
+# Polymorphism Proof of Concept with SCRAPI
 
 <html>
     <h2 align="center">

--- a/docs/cli/poly.md
+++ b/docs/cli/poly.md
@@ -4,15 +4,100 @@
 
 See the **[Polymorphism guide](../guides/polymorphism.md)** for concepts and the **[Polymorphism pattern](../patterns/polymorphism.md)** for a full walkthrough.
 
-The command has three subcommands:
+The command has five subcommands:
 
 | Subcommand | Purpose |
 |---|---|
+| [`cxas poly init`](#cxas-poly-init) | Scaffold starter adapter cards and referenced assets. |
 | [`cxas poly build`](#cxas-poly-build) | Compile channel-optimized projects. |
 | [`cxas poly validate`](#cxas-poly-validate) | Validate adapter cards against the base project. |
+| [`cxas poly doctor`](#cxas-poly-doctor) | Explain validation failures with guided fixes. |
 | [`cxas poly diff`](#cxas-poly-diff) | Show what an adapter changes for a channel. |
 
 Adapter cards live in `<app-dir>/adapters/` and are named `*.adapter.yaml`, `*.adapter.yml`, or `*.adapter.json`.
+
+---
+
+## cxas poly init
+
+Scaffold one or more starter channel adapters from an existing direct SCRAPI app
+directory. The command writes only fields supported by the current adapter-card
+schema, then creates the minimum referenced filesystem around the card: optional
+channel evals, optional channel-only tool definitions, and optional callbacks.
+
+### Usage
+
+```
+cxas poly init [--app-dir DIR]
+               [--channel NAME[,NAME] ...]
+               [--agent AGENT]
+               [--deployment-target auto|none|CHANNEL_TYPE]
+               [--modality auto|none|MODALITY]
+               [--with-tool TOOL_NAME]
+               [--with-callback CALLBACK_TYPE]
+               [--no-eval]
+               [--dry-run]
+               [--force]
+```
+
+If `--channel` is omitted in an interactive terminal, the command prompts for a
+comma-separated channel list. In automation, pass `--channel` explicitly.
+
+### Options
+
+| Option | Required | Default | Description |
+|--------|----------|---------|-------------|
+| `--app-dir DIR` | No | `.` | Path to the existing base app. Must directly contain `app.json`. |
+| `--channel NAME` | No in TTY, yes in automation | prompt | Channel id to scaffold. Repeat or comma-separate for multiple channels. |
+| `--agent AGENT` | No | app `rootAgent` | Agent directory or displayName to receive starter instruction/tool/callback deltas. |
+| `--display-name NAME` | No | generated | Adapter display name for a single channel. |
+| `--display-name-template TEMPLATE` | No | `{app} - {channel_title}` | Template for multiple adapters. Supports `{app}`, `{channel}`, `{channel_title}`, and `{channel_slug}`. |
+| `--deployment-target VALUE` | No | `auto` | `auto`, `none`, or a supported `deployment.channelType` enum such as `WEB_UI`, `API`, `TWILIO`, or `GOOGLE_TELEPHONY_PLATFORM`. |
+| `--modality VALUE` | No | `auto` | `auto`, `none`, or a supported modality enum such as `CHAT_ONLY` or `VOICE_ONLY`. |
+| `--with-tool TOOL_NAME` | No | none | Create a channel-only Python tool under `adapters/<channel>_tools/` and reference it via `toolDefinitions`. May be repeated. |
+| `--with-callback TYPE` | No | none | Create and reference a starter callback. Supported types match the adapter schema: `before_model`, `after_model`, `before_tool`, `after_tool`, `before_agent`, `after_agent`. |
+| `--no-eval` | No | off | Skip the starter `adapters/<channel>_evals/` directory. |
+| `--dry-run` | No | off | Print planned files without writing. |
+| `--force` | No | off | Overwrite existing scaffold files. Without it, init refuses to clobber files. |
+
+### Auto defaults
+
+`auto` deployment defaults are intentionally small and explicit:
+
+| Channel id | `channelType` | `modality` |
+|------------|---------------|------------|
+| `chat`, `web` | `WEB_UI` | `CHAT_ONLY` |
+| `voice`, `phone`, `telephony` | `GOOGLE_TELEPHONY_PLATFORM` | `VOICE_ONLY` |
+| `api` | `API` | `CHAT_ONLY` |
+
+Unknown channel ids are allowed, but `auto` does not invent a deployment block
+for them. Pass `--deployment-target` and `--modality` when you want one.
+
+### Example
+
+```bash
+cxas poly init \
+  --app-dir examples/polymorphic_pizza \
+  --channel sms \
+  --deployment-target TWILIO \
+  --modality VOICE_ONLY \
+  --with-tool send_sms_card \
+  --with-callback before_model
+```
+
+This creates:
+
+```
+adapters/sms.adapter.yaml
+adapters/sms_evals/Sms_Smoke/Sms_Smoke.yaml
+adapters/sms_tools/send_sms_card/send_sms_card.json
+adapters/sms_tools/send_sms_card/python_code.py
+adapters/sms_callbacks/before_model.py
+```
+
+Run `cxas poly validate --app-dir examples/polymorphic_pizza --explain` next,
+then replace the starter instruction/eval/tool/callback content with real
+channel behavior.
 
 ---
 
@@ -73,7 +158,7 @@ Validate every adapter card against the base project structure. Prints results i
 ### Usage
 
 ```
-cxas poly validate [--app-dir DIR] [--format text|json] [--strict]
+cxas poly validate [--app-dir DIR] [--format text|json] [--strict] [--explain]
 ```
 
 ### Options
@@ -83,6 +168,7 @@ cxas poly validate [--app-dir DIR] [--format text|json] [--strict]
 | `--app-dir DIR` | No | `.` (current directory) | Path to the base agent project root. |
 | `--format` | No | `text` | Output format. `json` emits a machine-readable report (`errors`, `warnings`, `issues[]`) for CI. |
 | `--strict` | No | off | Exit non-zero if any warnings are present (not just errors). |
+| `--explain` | No | off | Add guided issue explanations: what failed, why, where to look, and a likely fix shape. With `--format json`, emits the doctor report shape. |
 
 ### Rules
 
@@ -120,14 +206,53 @@ All 2 adapter card(s) valid.
 
 ---
 
-## cxas poly diff
+## cxas poly doctor
 
-Show a human-readable, per-agent summary of what a channel's adapter changes — without writing any files.
+Explain adapter validation findings in a guided debugging format. `doctor` uses
+the same validators as `validate`; it only enriches their issues with context.
 
 ### Usage
 
 ```
-cxas poly diff CHANNEL [--app-dir DIR]
+cxas poly doctor [--app-dir DIR] [--format text|json] [--strict]
+```
+
+### Output
+
+For each issue, doctor answers:
+
+- what failed
+- why the rule exists
+- the adapter file and field path that need attention
+- related referenced files or directories when the message includes them
+- a likely fix shape
+
+Example:
+
+```
+ERROR [AD005] adapters/chat.adapter.yaml
+  field: tools[0]
+  look at: adapters/chat_tools/send_rich_card
+  what failed: tools[0] adds 'send_rich_card' which has no definition...
+  why: The compiler only copies files that exist under the direct app root...
+  likely fix: Create the referenced sourceDir/pythonCode path...
+```
+
+`cxas poly validate --explain` is equivalent for developers who start from the
+validation command. Use `cxas poly doctor --format json` for structured tooling.
+
+---
+
+## cxas poly diff
+
+Show what a channel's adapter changes without writing any files. By default the
+command renders a reviewer-friendly text diff. Use `--json` for a stable
+machine-readable report.
+
+### Usage
+
+```
+cxas poly diff CHANNEL [--app-dir DIR] [--json]
 ```
 
 ### Arguments & options
@@ -136,10 +261,26 @@ cxas poly diff CHANNEL [--app-dir DIR]
 |-------------------|----------|---------|-------------|
 | `CHANNEL` | Yes | — | The channel to diff (matched against an adapter's `metadata.channel`). |
 | `--app-dir DIR` | No | `.` (current directory) | Path to the base agent project root. |
+| `--json` | No | off | Emit a `poly-diff/v1` JSON report for CI and tooling. |
 
 ### Output
 
-For each touched agent, the diff shows instruction additions/replacements, tool changes (`+`/`-`), model overrides (`old -> new`), and added callbacks, followed by new tools, merged evaluations, `gecxConfig` overlays, and deployment overrides.
+For each touched agent, the text diff shows instruction additions/replacements,
+tool changes (`+`/`-`), model overrides (`old -> new`), and added callbacks,
+followed by new tools, merged evaluations, `gecxConfig` overlays, and deployment
+overrides.
+
+The JSON report includes:
+
+- `schema_version: "poly-diff/v1"`
+- `channel`, `adapter_path`, and `app_dir`
+- `summary` counts
+- grouped `agents[]` deltas
+- `tool_definitions_added[]`
+- `evaluation_merges`
+- `gecx_config_overlay`
+- `deployment`
+- a flattened `deltas[]` list for simple CI checks
 
 ### Exit codes
 
@@ -156,6 +297,7 @@ cxas poly diff voice --app-dir examples/bella_notte
 
 ```
 Channel: voice   (adapter: adapters/voice.adapter.yaml)
+Summary: 2 agent(s), 2 instruction diff(s), 0 tool add(s), 0 tool remove(s), 1 callback(s), 1 eval merge(s)
 
 agents/Bella_Notte_Host
   instruction: + N line(s) append
@@ -164,6 +306,26 @@ agents/Bella_Notte_Host
 gecx-config.json (deployment)
   + channel_type: GOOGLE_TELEPHONY_PLATFORM
   + modality: VOICE_ONLY
+```
+
+JSON example:
+
+```bash
+cxas poly diff chat --app-dir examples/bella_notte --json
+```
+
+```json
+{
+  "schema_version": "poly-diff/v1",
+  "channel": "chat",
+  "adapter_path": "adapters/chat.adapter.yaml",
+  "summary": {
+    "agents_touched": 2,
+    "tools_added": 1,
+    "callbacks_added": 1,
+    "deployment_changed": true
+  }
+}
 ```
 
 ---

--- a/docs/cli/poly.md
+++ b/docs/cli/poly.md
@@ -34,13 +34,15 @@ cxas poly build [--app-dir DIR]
 |--------|----------|---------|-------------|
 | `--app-dir DIR` | No | `.` (current directory) | Path to the base agent project root (the directory containing `app.json`, `agents/`, `tools/`, `adapters/`). |
 | `--channel NAME` | No | `all` | A specific channel to compile (matched against an adapter's `metadata.channel`), or `all` to compile every adapter. |
-| `--output-dir DIR` | No | `./output` | Directory to write compiled projects into. Each channel is written to `<output-dir>/<channel>/`. |
+| `--output-dir DIR` | No | `./output` | Directory to write compiled projects into. Each channel is written to `<output-dir>/<channel>/`. Must not overlap the base project. |
+| `--force` | No | off | Overwrite a `<output-dir>/<channel>/` that is non-empty and was **not** created by `cxas poly build`. Without it, such a directory is left untouched. |
+| `--strict` | No | off | Treat warnings as errors and abort the build. |
 
 ### Behavior
 
-- With `--channel all`, all adapters are validated first; if any **error**-severity issue is found, nothing is written.
+- With `--channel all`, all adapters are validated first; if any **error**-severity issue is found (including a malformed card), nothing is written.
 - With a specific `--channel`, only that adapter is validated and compiled.
-- Each existing `<output-dir>/<channel>/` directory is replaced on every build.
+- A `<output-dir>/<channel>/` directory is replaced only when it is empty or was previously produced by `cxas poly build` (it carries a `.poly_build.json` marker); otherwise the build refuses unless `--force` is given. The output directory may never overlap the base project.
 
 ### Exit codes
 
@@ -71,7 +73,7 @@ Validate every adapter card against the base project structure. Prints results i
 ### Usage
 
 ```
-cxas poly validate [--app-dir DIR]
+cxas poly validate [--app-dir DIR] [--format text|json] [--strict]
 ```
 
 ### Options
@@ -79,18 +81,23 @@ cxas poly validate [--app-dir DIR]
 | Option | Required | Default | Description |
 |--------|----------|---------|-------------|
 | `--app-dir DIR` | No | `.` (current directory) | Path to the base agent project root. |
+| `--format` | No | `text` | Output format. `json` emits a machine-readable report (`errors`, `warnings`, `issues[]`) for CI. |
+| `--strict` | No | off | Exit non-zero if any warnings are present (not just errors). |
 
 ### Rules
 
 | ID | Severity | Check |
 |----|----------|-------|
-| `AD001` | error | Adapter card has required fields (`apiVersion`, `kind`, `metadata.channel`) and valid types. |
+| `AD001` | error | Adapter card has required fields (`apiVersion`, `kind`, `metadata.channel`) and valid types (malformed cards are reported here, not as a traceback). |
 | `AD002` | error | Every agent referenced in `instructionDiffs`, `tools`, `modelOverrides`, `callbacks` exists in `agents/`. |
-| `AD003` | error | `replace_section` diffs set `sectionTag`, and the `<sectionTag>` exists in the target instruction. |
+| `AD003` | error | `replace_section` diffs set `sectionTag`, and a matching `<sectionTag …>…</sectionTag>` block (attributes allowed) exists in the target instruction. |
 | `AD004` | warning | A tool `remove` references a tool not in the base agent's tool list. |
-| `AD005` | error | A tool `add` references a tool defined neither in `tools/` nor in the adapter's `toolDefinitions`. |
+| `AD005` | error | A tool `add` references a tool defined neither in `tools/`, the adapter's `toolDefinitions`, nor a platform tool; or a referenced `pythonCode`/`sourceDir` is missing. |
 | `AD006` | warning | The adapter declares no `evaluations` entries. |
 | `AD007` | error | Two adapter cards target the same `metadata.channel`. |
+| `AD008` | error | A referenced `sourceDir`/`pythonCode` path escapes the project root. |
+| `AD009` | error | `deployment` `channelType`/`modality`/`theme` use known, supported values. |
+| `AD010` | error | `toolDefinitions` declare a supported `toolType` (`python`, `openapi`). |
 
 > **Note on rule IDs:** the `AD` prefix is used (not `A`) because the `config` lint category already owns `A001`–`A006`. The same rules run inside `cxas lint --only adapters`.
 
@@ -98,8 +105,8 @@ cxas poly validate [--app-dir DIR]
 
 | Code | Meaning |
 |------|---------|
-| `0` | No errors (warnings may be present), or no adapter cards found. |
-| `1` | One or more **error**-severity issues, or a missing base project. |
+| `0` | No errors (warnings may be present, unless `--strict`), or no adapter cards found. |
+| `1` | One or more **error**-severity issues (or any warnings with `--strict`), or a missing base project. |
 
 ### Example
 
@@ -154,8 +161,8 @@ agents/Bella_Notte_Host
   instruction: + N line(s) append
   callbacks: + before_model (Inject voice pacing and filler-phrase hints.)
 
-deployment.json
-  + channelType: GOOGLE_TELEPHONY_PLATFORM
+gecx-config.json (deployment)
+  + channel_type: GOOGLE_TELEPHONY_PLATFORM
   + modality: VOICE_ONLY
 ```
 
@@ -165,4 +172,4 @@ deployment.json
 
 - **[Polymorphism guide](../guides/polymorphism.md)**
 - **[Polymorphism pattern](../patterns/polymorphism.md)**
-- **[`cxas lint`](lint.md)** — the `adapters` category runs `AD001`–`AD007` as part of a normal lint.
+- **[`cxas lint`](lint.md)** — the `adapters` category runs `AD001`–`AD010` as part of a normal lint.

--- a/docs/cli/poly.md
+++ b/docs/cli/poly.md
@@ -1,0 +1,168 @@
+# cxas poly
+
+`cxas poly` is the **Polymorphism Engine**: it compiles a single base agent project plus per-channel **adapter cards** into channel-optimized agent project directories. The compiled output is a complete, ordinary SCRAPI project — lintable, evaluable, and deployable with no special handling.
+
+See the **[Polymorphism guide](../guides/polymorphism.md)** for concepts and the **[Polymorphism pattern](../patterns/polymorphism.md)** for a full walkthrough.
+
+The command has three subcommands:
+
+| Subcommand | Purpose |
+|---|---|
+| [`cxas poly build`](#cxas-poly-build) | Compile channel-optimized projects. |
+| [`cxas poly validate`](#cxas-poly-validate) | Validate adapter cards against the base project. |
+| [`cxas poly diff`](#cxas-poly-diff) | Show what an adapter changes for a channel. |
+
+Adapter cards live in `<app-dir>/adapters/` and are named `*.adapter.yaml`, `*.adapter.yml`, or `*.adapter.json`.
+
+---
+
+## cxas poly build
+
+Compile one or all channels into output project directories.
+
+### Usage
+
+```
+cxas poly build [--app-dir DIR]
+                [--channel NAME|all]
+                [--output-dir DIR]
+```
+
+### Options
+
+| Option | Required | Default | Description |
+|--------|----------|---------|-------------|
+| `--app-dir DIR` | No | `.` (current directory) | Path to the base agent project root (the directory containing `app.json`, `agents/`, `tools/`, `adapters/`). |
+| `--channel NAME` | No | `all` | A specific channel to compile (matched against an adapter's `metadata.channel`), or `all` to compile every adapter. |
+| `--output-dir DIR` | No | `./output` | Directory to write compiled projects into. Each channel is written to `<output-dir>/<channel>/`. |
+
+### Behavior
+
+- With `--channel all`, all adapters are validated first; if any **error**-severity issue is found, nothing is written.
+- With a specific `--channel`, only that adapter is validated and compiled.
+- Each existing `<output-dir>/<channel>/` directory is replaced on every build.
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | All requested channels compiled and written successfully. |
+| `1` | No adapters found, unknown `--channel`, validation errors, or a missing base project. |
+
+### Example
+
+```bash
+cxas poly build --app-dir examples/bella_notte --output-dir ./output
+```
+
+```
+Compiled channel 'chat'  -> ./output/chat
+Compiled channel 'voice' -> ./output/voice
+
+Done. 2 channel(s) written to ./output
+```
+
+---
+
+## cxas poly validate
+
+Validate every adapter card against the base project structure. Prints results in the same severity/rule-ID format as `cxas lint`.
+
+### Usage
+
+```
+cxas poly validate [--app-dir DIR]
+```
+
+### Options
+
+| Option | Required | Default | Description |
+|--------|----------|---------|-------------|
+| `--app-dir DIR` | No | `.` (current directory) | Path to the base agent project root. |
+
+### Rules
+
+| ID | Severity | Check |
+|----|----------|-------|
+| `AD001` | error | Adapter card has required fields (`apiVersion`, `kind`, `metadata.channel`) and valid types. |
+| `AD002` | error | Every agent referenced in `instructionDiffs`, `tools`, `modelOverrides`, `callbacks` exists in `agents/`. |
+| `AD003` | error | `replace_section` diffs set `sectionTag`, and the `<sectionTag>` exists in the target instruction. |
+| `AD004` | warning | A tool `remove` references a tool not in the base agent's tool list. |
+| `AD005` | error | A tool `add` references a tool defined neither in `tools/` nor in the adapter's `toolDefinitions`. |
+| `AD006` | warning | The adapter declares no `evaluations` entries. |
+| `AD007` | error | Two adapter cards target the same `metadata.channel`. |
+
+> **Note on rule IDs:** the `AD` prefix is used (not `A`) because the `config` lint category already owns `A001`–`A006`. The same rules run inside `cxas lint --only adapters`.
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | No errors (warnings may be present), or no adapter cards found. |
+| `1` | One or more **error**-severity issues, or a missing base project. |
+
+### Example
+
+```bash
+cxas poly validate --app-dir examples/bella_notte
+```
+
+```
+All 2 adapter card(s) valid.
+```
+
+---
+
+## cxas poly diff
+
+Show a human-readable, per-agent summary of what a channel's adapter changes — without writing any files.
+
+### Usage
+
+```
+cxas poly diff CHANNEL [--app-dir DIR]
+```
+
+### Arguments & options
+
+| Argument / Option | Required | Default | Description |
+|-------------------|----------|---------|-------------|
+| `CHANNEL` | Yes | — | The channel to diff (matched against an adapter's `metadata.channel`). |
+| `--app-dir DIR` | No | `.` (current directory) | Path to the base agent project root. |
+
+### Output
+
+For each touched agent, the diff shows instruction additions/replacements, tool changes (`+`/`-`), model overrides (`old -> new`), and added callbacks, followed by new tools, merged evaluations, and the deployment overrides.
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Diff rendered successfully. |
+| `1` | Unknown channel, compilation error, or a missing base project. |
+
+### Example
+
+```bash
+cxas poly diff voice --app-dir examples/bella_notte
+```
+
+```
+Channel: voice   (adapter: adapters/voice.adapter.yaml)
+
+agents/Bella_Notte_Host
+  instruction: + N line(s) append
+  callbacks: + before_model (Inject voice pacing and filler-phrase hints.)
+
+deployment.json
+  + channelType: GOOGLE_TELEPHONY_PLATFORM
+  + modality: VOICE_ONLY
+```
+
+---
+
+## See also
+
+- **[Polymorphism guide](../guides/polymorphism.md)**
+- **[Polymorphism pattern](../patterns/polymorphism.md)**
+- **[`cxas lint`](lint.md)** — the `adapters` category runs `AD001`–`AD007` as part of a normal lint.

--- a/docs/cli/poly.md
+++ b/docs/cli/poly.md
@@ -4,7 +4,7 @@
 
 See the **[Polymorphism guide](../guides/polymorphism.md)** for concepts and the **[Polymorphism pattern](../patterns/polymorphism.md)** for a full walkthrough.
 
-The command has five subcommands:
+The command has six subcommands:
 
 | Subcommand | Purpose |
 |---|---|
@@ -12,6 +12,7 @@ The command has five subcommands:
 | [`cxas poly build`](#cxas-poly-build) | Compile channel-optimized projects. |
 | [`cxas poly validate`](#cxas-poly-validate) | Validate adapter cards against the base project. |
 | [`cxas poly doctor`](#cxas-poly-doctor) | Explain validation failures with guided fixes. |
+| [`cxas poly readiness`](#cxas-poly-readiness) | Summarize validation, diff, eval coverage, and build readiness before launch review. |
 | [`cxas poly diff`](#cxas-poly-diff) | Show what an adapter changes for a channel. |
 
 Adapter cards live in `<app-dir>/adapters/` and are named `*.adapter.yaml`, `*.adapter.yml`, or `*.adapter.json`.
@@ -240,6 +241,76 @@ ERROR [AD005] adapters/chat.adapter.yaml
 
 `cxas poly validate --explain` is equivalent for developers who start from the
 validation command. Use `cxas poly doctor --format json` for structured tooling.
+
+---
+
+## cxas poly readiness
+
+Summarize whether a polymorphic project is ready for design-partner or launch
+review. `readiness` does not write output; it composes the existing validators,
+compiler, and diff report into one pre-build report.
+
+Use it after `validate`/`diff` and before `build` when you want a single answer
+to: Which channels are ready? Which need attention? Are channel evals present?
+Will any channel eval names shadow base eval names in the compiled project?
+
+### Usage
+
+```
+cxas poly readiness [--app-dir DIR] [--format text|json] [--strict]
+```
+
+### Options
+
+| Option | Required | Default | Description |
+|--------|----------|---------|-------------|
+| `--app-dir DIR` | No | `.` (current directory) | Path to the base agent project root. |
+| `--format` | No | `text` | Output format. `json` emits a stable `poly-readiness/v1` report for CI and review artifacts. |
+| `--strict` | No | off | Exit non-zero if any warnings are present. |
+
+### Output
+
+Each channel is marked:
+
+| Status | Meaning |
+|--------|---------|
+| `ready` | The adapter validates, compiles, has no warning-level findings, and has no eval namespace collisions. |
+| `attention` | The adapter has warning-level findings such as missing channel evals or duplicate eval names. |
+| `blocked` | The adapter has validation or compile errors. |
+
+The JSON report includes:
+
+- `schema_version: "poly-readiness/v1"`
+- `summary` counts for ready/attention/blocked channels, errors, warnings, and launch readiness
+- `adapter_errors[]` for malformed cards that could not be parsed
+- `channels[]` with adapter path, AD issues, coverage warnings, diff summary,
+  eval coverage counts, duplicate eval names, and next steps
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | No errors. Warnings may be present unless `--strict` is passed. |
+| `1` | One or more errors, warnings with `--strict`, or a missing base project. |
+
+### Example
+
+```bash
+cxas poly readiness --app-dir examples/bella_notte
+cxas poly readiness --app-dir examples/bella_notte --format json
+```
+
+Example text output:
+
+```
+Poly readiness   2 ready, 0 attention, 0 blocked
+Issues: 0 error(s), 0 warning(s)
+
+chat (ready)   adapters/chat.adapter.yaml
+  diff: 2 agent(s), 2 instruction diff(s), 1 tool add(s), 0 tool remove(s), 1 callback(s)
+  evals: 33 base, 1 channel
+  next: Run cxas poly build, lint the compiled output, and run channel evals.
+```
 
 ---
 

--- a/docs/cli/poly.md
+++ b/docs/cli/poly.md
@@ -88,7 +88,7 @@ cxas poly validate [--app-dir DIR] [--format text|json] [--strict]
 
 | ID | Severity | Check |
 |----|----------|-------|
-| `AD001` | error | Adapter card has required fields (`apiVersion`, `kind`, `metadata.channel`) and valid types (malformed cards are reported here, not as a traceback). |
+| `AD001` | error | Adapter card has required fields (`apiVersion`, `kind`, `metadata.channel`), valid types, and no unknown fields (malformed cards are reported here, not as a traceback). |
 | `AD002` | error | Every agent referenced in `instructionDiffs`, `tools`, `modelOverrides`, `callbacks` exists in `agents/`. |
 | `AD003` | error | `replace_section` diffs set `sectionTag`, and a matching `<sectionTag …>…</sectionTag>` block (attributes allowed) exists in the target instruction. |
 | `AD004` | warning | A tool `remove` references a tool not in the base agent's tool list. |
@@ -139,7 +139,7 @@ cxas poly diff CHANNEL [--app-dir DIR]
 
 ### Output
 
-For each touched agent, the diff shows instruction additions/replacements, tool changes (`+`/`-`), model overrides (`old -> new`), and added callbacks, followed by new tools, merged evaluations, and the deployment overrides.
+For each touched agent, the diff shows instruction additions/replacements, tool changes (`+`/`-`), model overrides (`old -> new`), and added callbacks, followed by new tools, merged evaluations, `gecxConfig` overlays, and deployment overrides.
 
 ### Exit codes
 

--- a/docs/guides/polymorphism.md
+++ b/docs/guides/polymorphism.md
@@ -56,6 +56,36 @@ Each adapter applies, in order:
 
 ---
 
+## Starting a new adapter
+
+Use `cxas poly init` when you already have a channel-neutral base app and want a
+valid starter workflow for a new channel:
+
+```bash
+cxas poly init \
+  --app-dir examples/polymorphic_pizza \
+  --channel sms \
+  --deployment-target TWILIO \
+  --modality VOICE_ONLY \
+  --with-callback before_model \
+  --with-tool send_sms_card
+```
+
+The scaffold flow creates only supported adapter-card fields:
+
+- `adapters/<channel>.adapter.yaml`
+- a starter `adapters/<channel>_evals/` directory unless `--no-eval` is used
+- optional `adapters/<channel>_callbacks/*.py` files referenced by `callbacks`
+- optional `adapters/<channel>_tools/<tool>/` folders referenced by
+  `toolDefinitions`
+
+`init` refuses to overwrite existing files unless `--force` is passed. Use
+`--dry-run` to see the planned files first. The generated text is a starter, not
+production behavior; replace it with real channel instructions, eval assertions,
+tool descriptions, and callback logic.
+
+---
+
 ## Why the output is "just a project"
 
 The single most important property of the engine: **the compiled output is indistinguishable from a hand-authored SCRAPI project.** Every base file appears in the output with its modifications applied; nothing is left in a half-compiled state.
@@ -93,4 +123,4 @@ A good rule of thumb: if you find yourself using `replace_section` on most secti
 ## Next steps
 
 - **[Polymorphism Pattern](../patterns/polymorphism.md)** — a step-by-step walkthrough of the Bella Notte chat and voice adapters.
-- **[`cxas poly` CLI reference](../../cli/poly.md)** — `build`, `validate`, and `diff`.
+- **[`cxas poly` CLI reference](../cli/poly.md)** — `init`, `build`, `validate`, `doctor`, and `diff --json`.

--- a/docs/guides/polymorphism.md
+++ b/docs/guides/polymorphism.md
@@ -36,11 +36,11 @@ examples/bella_notte/                 cxas poly build         output/
 │   ├── Bella_Notte_Host/                                      │   ├── agents/        (chat instructions)
 │   └── Reservation_Agent/                                     │   ├── tools/         (+ send_rich_card)
 ├── tools/                                                     │   ├── evaluations/   (+ chat evals)
-├── evaluations/                                               │   └── deployment.json (WEB_UI / CHAT_ONLY)
+├── evaluations/                                               │   └── gecx-config.json (deployment: WEB_UI / CHAT_ONLY)
 └── adapters/                                                  └── voice/
     ├── chat.adapter.yaml                                          ├── agents/        (voice instructions)
     └── voice.adapter.yaml                                         ├── tools/         (no chat-only tools)
-                                                                   └── deployment.json (GTP / VOICE_ONLY)
+                                                                   └── gecx-config.json (deployment: GTP / VOICE_ONLY)
 ```
 
 Each adapter applies, in order:
@@ -51,7 +51,7 @@ Each adapter applies, in order:
 4. **Model overrides** — set `modelSettings.model` per agent for the channel.
 5. **Callbacks** — append channel-specific callbacks, auto-numbered after any existing ones (`before_model_callbacks_02`, …).
 6. **Evaluations** — merge channel-specific evaluation directories into `evaluations/`.
-7. **Deployment** — emit a `deployment.json` with channel/modality/widget settings, and update `gecx-config.json`.
+7. **Deployment** — fold a `deployment` block (channel/modality/widget settings) into `gecx-config.json` — the file deploy tooling reads — and set `default_channel`/`modality`.
 
 ---
 

--- a/docs/guides/polymorphism.md
+++ b/docs/guides/polymorphism.md
@@ -1,0 +1,95 @@
+---
+title: Polymorphism
+description: Author one agent project at the center and compile channel-optimized variants (chat, voice, …) at the edges, using declarative channel adapter cards.
+---
+
+# Polymorphism
+
+A reservation agent that works beautifully in a web chat widget rarely works well on a phone call. Chat wants Markdown, numbered lists, and rich confirmation cards. Voice wants two-sentence turns, spelled-out numbers, and filler phrases so the line is never silent. The behavior is *mostly* the same — the same tools, the same flow, the same business rules — but the surface differs.
+
+The naive answer is to fork: maintain `bella_notte_chat/` and `bella_notte_voice/` as two full projects. They immediately start to drift. A bug fixed in one isn't fixed in the other; a new tool added to one is forgotten in the other.
+
+**Polymorphism** is the alternative: author the agent **once** at the center, describe the per-channel *deltas* declaratively, and **compile** a complete, channel-optimized project for each target.
+
+---
+
+## The three primitives
+
+| Primitive | What it is | Where it lives |
+|---|---|---|
+| **Canonical Agent Card** | Your existing, channel-neutral agent project — `app.json`, `agents/`, `tools/`, `evaluations/`. Nothing new to learn. | The project root |
+| **Channel Adapter Card** | A small YAML/JSON file describing what changes for one channel: instruction additions, tool add/remove, model overrides, extra callbacks, channel evals, and deployment settings. | `adapters/<channel>.adapter.yaml` |
+| **Polymorphism Engine** | The compiler. Reads the base project + adapter cards and writes one complete project directory per channel. | `cxas poly` / `cxas_scrapi.poly` |
+
+---
+
+## The compilation model
+
+> **Author once at the center, specialize at the edges, compile for each target.**
+
+The base project stays channel-neutral. Each adapter card layers a thin set of deltas on top. The engine deep-copies the base, applies the deltas, and emits a directory that looks exactly like a hand-authored project:
+
+```
+examples/bella_notte/                 cxas poly build         output/
+├── app.json                          ───────────────►        ├── chat/
+├── agents/                                                    │   ├── app.json
+│   ├── Bella_Notte_Host/                                      │   ├── agents/        (chat instructions)
+│   └── Reservation_Agent/                                     │   ├── tools/         (+ send_rich_card)
+├── tools/                                                     │   ├── evaluations/   (+ chat evals)
+├── evaluations/                                               │   └── deployment.json (WEB_UI / CHAT_ONLY)
+└── adapters/                                                  └── voice/
+    ├── chat.adapter.yaml                                          ├── agents/        (voice instructions)
+    └── voice.adapter.yaml                                         ├── tools/         (no chat-only tools)
+                                                                   └── deployment.json (GTP / VOICE_ONLY)
+```
+
+Each adapter applies, in order:
+
+1. **Instruction diffs** — `append`, `prepend`, or `replace_section` (replace an XML `<section>…</section>` block) on a named agent's instruction text.
+2. **Tool modifications** — add or remove tools from an agent's `tools` list.
+3. **Tool definitions** — bring channel-only tools (e.g. `send_rich_card`) into `tools/`.
+4. **Model overrides** — set `modelSettings.model` per agent for the channel.
+5. **Callbacks** — append channel-specific callbacks, auto-numbered after any existing ones (`before_model_callbacks_02`, …).
+6. **Evaluations** — merge channel-specific evaluation directories into `evaluations/`.
+7. **Deployment** — emit a `deployment.json` with channel/modality/widget settings, and update `gecx-config.json`.
+
+---
+
+## Why the output is "just a project"
+
+The single most important property of the engine: **the compiled output is indistinguishable from a hand-authored SCRAPI project.** Every base file appears in the output with its modifications applied; nothing is left in a half-compiled state.
+
+That means all existing tooling works on the output with **zero changes**:
+
+```bash
+cxas poly build --app-dir examples/bella_notte --output-dir ./output
+cxas lint  --app-dir ./output/chat     # ✓ passes
+cxas lint  --app-dir ./output/voice    # ✓ passes
+# run evals, deploy, etc. on ./output/<channel> exactly as usual
+```
+
+There is no special "polymorphic runtime." The polymorphism happens entirely at build time. What you deploy is an ordinary project.
+
+---
+
+## When to use adapters vs. separate agents
+
+Reach for **adapters** when:
+
+- The channels share the same core flow, tools, and business logic.
+- The differences are presentational or tuning (formatting, verbosity, pacing, a handful of channel-only tools).
+- You want a single source of truth and a single place to fix bugs.
+
+Build **separate agents** when:
+
+- The channels have genuinely different conversation graphs or tool sets with little overlap.
+- The "delta" would be larger than the base — at that point an adapter hides more than it reveals.
+
+A good rule of thumb: if you find yourself using `replace_section` on most sections, the channels probably want to be separate agents.
+
+---
+
+## Next steps
+
+- **[Polymorphism Pattern](../patterns/polymorphism.md)** — a step-by-step walkthrough of the Bella Notte chat and voice adapters.
+- **[`cxas poly` CLI reference](../../cli/poly.md)** — `build`, `validate`, and `diff`.

--- a/docs/guides/polymorphism.md
+++ b/docs/guides/polymorphism.md
@@ -86,6 +86,24 @@ tool descriptions, and callback logic.
 
 ---
 
+## Checking launch readiness
+
+Run `cxas poly readiness` before building when a project is heading into CI,
+design-partner review, or launch review:
+
+```bash
+cxas poly readiness --app-dir examples/bella_notte
+cxas poly readiness --app-dir examples/bella_notte --format json
+```
+
+The report composes validation, compileability, diff summaries, and eval
+coverage. Each channel is marked `ready`, `attention`, or `blocked`, with next
+steps for missing channel evals, duplicate eval names that would shadow base
+items, or blocking AD rule issues. Use `--strict` when warnings should block the
+workflow.
+
+---
+
 ## Why the output is "just a project"
 
 The single most important property of the engine: **the compiled output is indistinguishable from a hand-authored SCRAPI project.** Every base file appears in the output with its modifications applied; nothing is left in a half-compiled state.
@@ -123,4 +141,5 @@ A good rule of thumb: if you find yourself using `replace_section` on most secti
 ## Next steps
 
 - **[Polymorphism Pattern](../patterns/polymorphism.md)** — a step-by-step walkthrough of the Bella Notte chat and voice adapters.
-- **[`cxas poly` CLI reference](../cli/poly.md)** — `init`, `build`, `validate`, `doctor`, and `diff --json`.
+- **[`cxas poly` CLI reference](../cli/poly.md)** — `init`, `build`,
+  `validate`, `doctor`, `readiness`, and `diff --json`.

--- a/docs/guides/polymorphism.md
+++ b/docs/guides/polymorphism.md
@@ -18,7 +18,7 @@ The naive answer is to fork: maintain `bella_notte_chat/` and `bella_notte_voice
 | Primitive | What it is | Where it lives |
 |---|---|---|
 | **Canonical Agent Card** | Your existing, channel-neutral agent project — `app.json`, `agents/`, `tools/`, `evaluations/`. Nothing new to learn. | The project root |
-| **Channel Adapter Card** | A small YAML/JSON file describing what changes for one channel: instruction additions, tool add/remove, model overrides, extra callbacks, channel evals, and deployment settings. | `adapters/<channel>.adapter.yaml` |
+| **Channel Adapter Card** | A small YAML/JSON file describing what changes for one channel: instruction additions, tool add/remove, model overrides, runtime config, extra callbacks, channel evals, and deployment settings. | `adapters/<channel>.adapter.yaml` |
 | **Polymorphism Engine** | The compiler. Reads the base project + adapter cards and writes one complete project directory per channel. | `cxas poly` / `cxas_scrapi.poly` |
 
 ---
@@ -51,7 +51,8 @@ Each adapter applies, in order:
 4. **Model overrides** — set `modelSettings.model` per agent for the channel.
 5. **Callbacks** — append channel-specific callbacks, auto-numbered after any existing ones (`before_model_callbacks_02`, …).
 6. **Evaluations** — merge channel-specific evaluation directories into `evaluations/`.
-7. **Deployment** — fold a `deployment` block (channel/modality/widget settings) into `gecx-config.json` — the file deploy tooling reads — and set `default_channel`/`modality`.
+7. **Runtime config** — deep-merge a `gecxConfig` block into `gecx-config.json` for channel defaults such as model or modality.
+8. **Deployment** — fold a `deployment` block (channel/modality/widget settings) into `gecx-config.json` — the file deploy tooling reads — and set `default_channel`/`modality`.
 
 ---
 

--- a/docs/guides/skills/index.md
+++ b/docs/guides/skills/index.md
@@ -24,6 +24,9 @@ The `SKILL.md` file has YAML frontmatter that declares the skill's name, descrip
 │   ├── references/           # Sub-skill definitions (build, run, debug)
 │   ├── scripts/hooks/        # Hook scripts for pre-push and post-update
 │   └── assets/               # Project templates
+├── cxas-polymorphic-adapters/
+│   ├── SKILL.md              # Adapter-card authoring and cxas poly workflows
+│   └── references/           # Authoring, validation, build, and debug guides
 └── cxas-sim-eval/
     └── SKILL.md              # Simulation eval skill
 ```
@@ -65,6 +68,20 @@ Skills are also registered in `.gemini/settings.json`. Invoke from Gemini CLI wi
 | **Debug** | Analyzes failures, proposes fixes, and iterates until a target pass rate is achieved |
 
 The foundry skill acts as a router — when you invoke it, it checks the current state of the environment and routes you to the appropriate sub-skill.
+
+## Polymorphic adapter skill
+
+`cxas-polymorphic-adapters` covers the build-time polymorphism workflow:
+deciding when adapters are a better fit than separate agents, writing
+`adapters/<channel>.adapter.yaml` cards, validating with `cxas poly validate`,
+previewing changes with `cxas poly diff`, building channel-specific projects,
+linting compiled outputs, and debugging `AD001`-`AD010` adapter validation
+issues.
+
+The canonical skill lives at
+`.agents/skills/cxas-polymorphic-adapters/SKILL.md`. Claude-specific and
+Gemini-specific entry points are thin wrappers around that same source so the
+adapter workflow stays consistent across assistants.
 
 ---
 

--- a/docs/patterns/polymorphism.md
+++ b/docs/patterns/polymorphism.md
@@ -92,7 +92,7 @@ Section by section:
 - **`tools` + `toolDefinitions`** — make `send_rich_card` available to the host *and* bring its definition (`send_rich_card.json` + `python_code.py`) into `tools/`. The engine normalizes the tool's code path to the canonical `tools/send_rich_card/python_function/python_code.py`.
 - **`callbacks`** — append a `before_model` callback. The base host already has `before_model_callbacks_01`, so this becomes `before_model_callbacks_02` automatically.
 - **`evaluations`** — fold the `adapters/chat_evals/` directory into the compiled `evaluations/`.
-- **`deployment`** — emit a `deployment.json` for a `WEB_UI` / `CHAT_ONLY` deployment.
+- **`deployment`** — fold a `deployment` block (`channel_type: WEB_UI`, `modality: CHAT_ONLY`, widget settings) into the compiled `gecx-config.json`, and set `default_channel`/`modality`.
 
 ---
 
@@ -184,8 +184,8 @@ tools/
 evaluations/
   + 1 eval(s): Rich_Card_Confirmation
 
-deployment.json
-  + channelType: WEB_UI
+gecx-config.json (deployment)
+  + channel_type: WEB_UI
   + modality: CHAT_ONLY
 ```
 
@@ -203,7 +203,8 @@ cxas lint --app-dir ./output/voice
 # Run the merged eval suite (base + channel goldens) on a channel.
 cxas run --app-dir ./output/chat --eval-dir ./output/chat/evaluations
 
-# Deploy — the compiled deployment.json carries channel/modality settings.
+# Deploy — the compiled gecx-config.json carries the channel/modality and a
+# `deployment` block (channel_type, modality, widget settings).
 ```
 
 This is the payoff of the **[author once at the center](../guides/polymorphism.md#the-compilation-model)** model: you maintain a single Bella Notte agent, and the channel-specific surfaces fall out of two short adapter files.

--- a/docs/patterns/polymorphism.md
+++ b/docs/patterns/polymorphism.md
@@ -1,0 +1,216 @@
+---
+title: Polymorphism Pattern
+description: A step-by-step walkthrough of compiling the Bella Notte agent into channel-optimized chat and voice variants with channel adapter cards.
+---
+
+# Polymorphism Pattern
+
+This page walks through the **Polymorphism Pattern** end to end using the Bella Notte restaurant agent: one base project, two channel adapter cards (chat and voice), and the `cxas poly` compiler that turns them into two complete, deployable projects.
+
+If you haven't read the concept overview yet, start with the **[Polymorphism guide](../guides/polymorphism.md)**.
+
+---
+
+## 1. The base agent
+
+The base project is an ordinary SCRAPI project — nothing about it is polymorphism-specific:
+
+```
+examples/bella_notte/
+├── app.json
+├── gecx-config.json
+├── agents/
+│   ├── Bella_Notte_Host/        # root agent: routes reservation vs. takeout
+│   ├── Reservation_Agent/       # slot-filling specialist
+│   └── Takeout_Agent/
+├── tools/                       # set_active_flow, set_reservation_basics, …
+├── evaluations/                 # shared, channel-neutral goldens
+└── evaluationExpectations/
+```
+
+The base instructions are written to be **channel-neutral**: they describe *what* the host does (greet, route, answer hours/location) without committing to *how* it should look on a screen or sound on a call.
+
+---
+
+## 2. The chat adapter
+
+`examples/bella_notte/adapters/chat.adapter.yaml` specializes the agent for a web chat widget:
+
+```yaml
+apiVersion: poly.cxas.dev/v1
+kind: ChannelAdapter
+metadata:
+  channel: chat
+  displayName: Bella Notte — Chat
+  description: Web chat optimization: markdown, selectable lists, rich cards.
+
+instructionDiffs:
+  - agent: Bella_Notte_Host
+    mode: append
+    content: |
+      <channel_chat>
+      You are responding in a web chat widget that renders Markdown.
+      - Use **bold** for emphasis and short numbered lists for options.
+      - When confirming, call the send_rich_card tool to render a card.
+      </channel_chat>
+  - agent: Reservation_Agent
+    mode: append
+    content: |
+      <channel_chat>
+      Present available time slots as a numbered, selectable list.
+      </channel_chat>
+
+tools:
+  - agent: Bella_Notte_Host
+    add: [send_rich_card]
+
+toolDefinitions:
+  - displayName: send_rich_card
+    toolType: python
+    sourceDir: adapters/chat_tools/send_rich_card
+
+callbacks:
+  - agent: Bella_Notte_Host
+    type: before_model
+    pythonCode: adapters/chat_callbacks/inject_rich_content.py
+    description: Inject rich card formatting hints for chat confirmations.
+
+evaluations:
+  - sourceDir: adapters/chat_evals
+
+deployment:
+  channelType: WEB_UI
+  modality: CHAT_ONLY
+  webWidgetConfig:
+    theme: LIGHT
+    webWidgetTitle: Bella Notte Reservations
+```
+
+Section by section:
+
+- **`instructionDiffs`** — append a `<channel_chat>` block to the host and the reservation agent. `append` keeps all the base behavior and layers chat presentation on top.
+- **`tools` + `toolDefinitions`** — make `send_rich_card` available to the host *and* bring its definition (`send_rich_card.json` + `python_code.py`) into `tools/`. The engine normalizes the tool's code path to the canonical `tools/send_rich_card/python_function/python_code.py`.
+- **`callbacks`** — append a `before_model` callback. The base host already has `before_model_callbacks_01`, so this becomes `before_model_callbacks_02` automatically.
+- **`evaluations`** — fold the `adapters/chat_evals/` directory into the compiled `evaluations/`.
+- **`deployment`** — emit a `deployment.json` for a `WEB_UI` / `CHAT_ONLY` deployment.
+
+---
+
+## 3. The voice adapter
+
+`examples/bella_notte/adapters/voice.adapter.yaml` tunes the same agent for telephony:
+
+```yaml
+apiVersion: poly.cxas.dev/v1
+kind: ChannelAdapter
+metadata:
+  channel: voice
+  displayName: Bella Notte — Voice
+
+instructionDiffs:
+  - agent: Bella_Notte_Host
+    mode: append
+    content: |
+      <channel_voice>
+      You are speaking on a phone call. There is no screen.
+      - Keep every response to two or three short sentences.
+      - Never use Markdown, bullet points, or symbols.
+      - Spell out numbers and times ("six thirty in the evening").
+      - Say a brief filler before tool calls so the line is not silent.
+      </channel_voice>
+  - agent: Reservation_Agent
+    mode: append
+    content: |
+      <channel_voice>
+      Offer at most three available times at once, spoken aloud.
+      Read confirmations back field by field with a short pause between each.
+      </channel_voice>
+
+callbacks:
+  - agent: Bella_Notte_Host
+    type: before_model
+    pythonCode: adapters/voice_callbacks/voice_pacing.py
+    description: Inject voice pacing and filler-phrase hints.
+
+evaluations:
+  - sourceDir: adapters/voice_evals
+
+deployment:
+  channelType: GOOGLE_TELEPHONY_PLATFORM
+  modality: VOICE_ONLY
+  disableBargeInControl: false
+  disableDtmf: false
+```
+
+The voice adapter is almost entirely additive: it never touches the base tool list, because the base host has no chat-only tools to remove. (If a rich-card tool *were* present in the base, you'd add a `tools: [{agent: …, remove: [send_rich_card]}]` here.)
+
+Notice the symmetry: both adapters `append` a channel block and add a `before_model` callback, but they pull behavior in opposite directions — verbose-and-visual vs. terse-and-spoken — from the same base.
+
+---
+
+## 4. Build the channels
+
+```bash
+cxas poly build --app-dir examples/bella_notte --output-dir ./output
+```
+
+```
+Compiled channel 'chat'  -> ./output/chat
+Compiled channel 'voice' -> ./output/voice
+
+Done. 2 channel(s) written to ./output
+```
+
+Each output directory is a complete project. The chat host now lists `send_rich_card`; the voice host does not. The chat instruction carries the `<channel_chat>` block; the voice instruction carries `<channel_voice>`.
+
+Preview exactly what an adapter changes — without writing anything — with `diff`:
+
+```bash
+cxas poly diff chat --app-dir examples/bella_notte
+```
+
+```
+Channel: chat   (adapter: adapters/chat.adapter.yaml)
+
+agents/Bella_Notte_Host
+  instruction: + N line(s) append
+  tools (2 -> 3):
+    + send_rich_card
+  callbacks: + before_model (Inject rich card formatting hints…)
+
+tools/
+  + send_rich_card
+
+evaluations/
+  + 1 eval(s): Rich_Card_Confirmation
+
+deployment.json
+  + channelType: WEB_UI
+  + modality: CHAT_ONLY
+```
+
+---
+
+## 5. Lint, evaluate, and deploy the output
+
+Because each compiled directory *is* a normal project, every existing command works on it unchanged:
+
+```bash
+# Lint each channel — both pass cleanly.
+cxas lint --app-dir ./output/chat
+cxas lint --app-dir ./output/voice
+
+# Run the merged eval suite (base + channel goldens) on a channel.
+cxas run --app-dir ./output/chat --eval-dir ./output/chat/evaluations
+
+# Deploy — the compiled deployment.json carries channel/modality settings.
+```
+
+This is the payoff of the **[author once at the center](../guides/polymorphism.md#the-compilation-model)** model: you maintain a single Bella Notte agent, and the channel-specific surfaces fall out of two short adapter files.
+
+---
+
+## See also
+
+- **[Polymorphism guide](../guides/polymorphism.md)** — concepts and when to use adapters.
+- **[`cxas poly` CLI reference](../../cli/poly.md)** — full command and flag reference.

--- a/docs/patterns/polymorphism.md
+++ b/docs/patterns/polymorphism.md
@@ -237,7 +237,33 @@ deltas plus a flat `deltas[]` list for simple checks.
 
 ---
 
-## 6. Build the channels
+## 6. Check launch readiness
+
+When the adapters look right, run the pre-build readiness report:
+
+```bash
+cxas poly readiness --app-dir examples/bella_notte
+cxas poly readiness --app-dir examples/bella_notte --format json
+```
+
+`readiness` gives you one design-partner review artifact: validation issues,
+compileability, the diff summary, base/channel eval counts, duplicate eval names
+that would shadow base evals in compiled output, and concrete next steps. Use
+`--strict` in CI when warning-level gaps should block launch.
+
+```
+Poly readiness   2 ready, 0 attention, 0 blocked
+Issues: 0 error(s), 0 warning(s)
+
+chat (ready)   adapters/chat.adapter.yaml
+  diff: 2 agent(s), 2 instruction diff(s), 1 tool add(s), 0 tool remove(s), 1 callback(s)
+  evals: 33 base, 1 channel
+  next: Run cxas poly build, lint the compiled output, and run channel evals.
+```
+
+---
+
+## 7. Build the channels
 
 ```bash
 cxas poly build --app-dir examples/bella_notte --output-dir ./output
@@ -254,7 +280,7 @@ Each output directory is a complete project. The chat host now lists `send_rich_
 
 ---
 
-## 7. Lint, evaluate, and deploy the output
+## 8. Lint, evaluate, and deploy the output
 
 Because each compiled directory *is* a normal project, every existing command works on it unchanged:
 

--- a/docs/patterns/polymorphism.md
+++ b/docs/patterns/polymorphism.md
@@ -75,6 +75,10 @@ callbacks:
     pythonCode: adapters/chat_callbacks/inject_rich_content.py
     description: Inject rich card formatting hints for chat confirmations.
 
+gecxConfig:
+  model: gemini-3-pro
+  modality: text
+
 evaluations:
   - sourceDir: adapters/chat_evals
 
@@ -92,7 +96,7 @@ Section by section:
 - **`tools` + `toolDefinitions`** — make `send_rich_card` available to the host *and* bring its definition (`send_rich_card.json` + `python_code.py`) into `tools/`. The engine normalizes the tool's code path to the canonical `tools/send_rich_card/python_function/python_code.py`.
 - **`callbacks`** — append a `before_model` callback. The base host already has `before_model_callbacks_01`, so this becomes `before_model_callbacks_02` automatically.
 - **`evaluations`** — fold the `adapters/chat_evals/` directory into the compiled `evaluations/`.
-- **`deployment`** — fold a `deployment` block (`channel_type: WEB_UI`, `modality: CHAT_ONLY`, widget settings) into the compiled `gecx-config.json`, and set `default_channel`/`modality`.
+- **`gecxConfig` + `deployment`** — fold channel runtime defaults plus a deployment block (`channel_type: WEB_UI`, `modality: CHAT_ONLY`, widget settings) into the compiled `gecx-config.json`, and set `default_channel`/`modality`.
 
 ---
 
@@ -132,6 +136,10 @@ callbacks:
     pythonCode: adapters/voice_callbacks/voice_pacing.py
     description: Inject voice pacing and filler-phrase hints.
 
+gecxConfig:
+  model: gemini-3-flash
+  modality: audio
+
 evaluations:
   - sourceDir: adapters/voice_evals
 
@@ -142,7 +150,7 @@ deployment:
   disableDtmf: false
 ```
 
-The voice adapter is almost entirely additive: it never touches the base tool list, because the base host has no chat-only tools to remove. (If a rich-card tool *were* present in the base, you'd add a `tools: [{agent: …, remove: [send_rich_card]}]` here.)
+The voice adapter is almost entirely additive: it never touches the base tool list, because the base host has no chat-only tools to remove. (If a rich-card tool *were* present in the base, you'd add a `tools: [{agent: …, remove: [send_rich_card]}]` here.) It also sets voice runtime defaults in `gecxConfig`, so the compiled project carries audio modality and a voice-appropriate model before deployment.
 
 Notice the symmetry: both adapters `append` a channel block and add a `before_model` callback, but they pull behavior in opposite directions — verbose-and-visual vs. terse-and-spoken — from the same base.
 
@@ -183,6 +191,9 @@ tools/
 
 evaluations/
   + 1 eval(s): Rich_Card_Confirmation
+
+gecx-config.json (channel config)
+  ~ model: gemini-3-pro
 
 gecx-config.json (deployment)
   + channel_type: WEB_UI

--- a/docs/patterns/polymorphism.md
+++ b/docs/patterns/polymorphism.md
@@ -32,7 +32,32 @@ The base instructions are written to be **channel-neutral**: they describe *what
 
 ---
 
-## 2. The chat adapter
+## 2. Scaffold when adding a new channel
+
+Bella Notte already ships `chat` and `voice` adapters, but a new channel should
+usually start with the scaffold flow:
+
+```bash
+cxas poly init \
+  --app-dir examples/bella_notte \
+  --channel sms \
+  --deployment-target TWILIO \
+  --modality VOICE_ONLY \
+  --with-callback before_model
+```
+
+That writes a valid `adapters/sms.adapter.yaml` plus a starter eval directory
+and callback file. The generated content is intentionally generic; keep the
+adapter shape, then replace the scaffolded instruction block, eval assertion,
+and callback hint with real SMS behavior.
+
+Use `--dry-run` before writing, `--force` only when replacing known scaffold
+files, and `--with-tool <snake_case_name>` when the channel needs a
+channel-only Python tool.
+
+---
+
+## 3. The chat adapter
 
 `examples/bella_notte/adapters/chat.adapter.yaml` specializes the agent for a web chat widget:
 
@@ -100,7 +125,7 @@ Section by section:
 
 ---
 
-## 3. The voice adapter
+## 4. The voice adapter
 
 `examples/bella_notte/adapters/voice.adapter.yaml` tunes the same agent for telephony:
 
@@ -156,7 +181,63 @@ Notice the symmetry: both adapters `append` a channel block and add a `before_mo
 
 ---
 
-## 4. Build the channels
+## 5. Validate and inspect the channels
+
+Validate first:
+
+```bash
+cxas poly validate --app-dir examples/bella_notte
+```
+
+If validation reports an AD rule, ask for the guided form:
+
+```bash
+cxas poly doctor --app-dir examples/bella_notte
+# or
+cxas poly validate --app-dir examples/bella_notte --explain
+```
+
+Doctor uses the same validators as `validate`; it adds the adapter field, any
+related paths, why the rule exists, and a likely fix shape.
+
+Preview exactly what an adapter changes — without writing anything — with
+`diff`. Use text for review and `--json` for CI/tooling:
+
+```bash
+cxas poly diff chat --app-dir examples/bella_notte
+cxas poly diff chat --app-dir examples/bella_notte --json
+```
+
+```
+Channel: chat   (adapter: adapters/chat.adapter.yaml)
+Summary: 2 agent(s), 2 instruction diff(s), 1 tool add(s), 0 tool remove(s), 1 callback(s), 1 eval merge(s)
+
+agents/Bella_Notte_Host (Bella_Notte_Host)
+  instruction: + N line(s) append (agents/Bella_Notte_Host/instruction.txt)
+  tools (2 -> 3):
+    + send_rich_card
+  callbacks: + before_model (Inject rich card formatting hints...)
+
+tools/
+  + send_rich_card (python, adapters/chat_tools/send_rich_card)
+
+evaluations/
+  + 1 item(s): Rich_Card_Confirmation
+
+gecx-config.json (channel config)
+  ~ model: gemini-3-pro
+
+gecx-config.json (deployment)
+  + channel_type: WEB_UI
+  + modality: CHAT_ONLY
+```
+
+The JSON shape is versioned as `poly-diff/v1` and includes grouped `agents[]`
+deltas plus a flat `deltas[]` list for simple checks.
+
+---
+
+## 6. Build the channels
 
 ```bash
 cxas poly build --app-dir examples/bella_notte --output-dir ./output
@@ -171,38 +252,9 @@ Done. 2 channel(s) written to ./output
 
 Each output directory is a complete project. The chat host now lists `send_rich_card`; the voice host does not. The chat instruction carries the `<channel_chat>` block; the voice instruction carries `<channel_voice>`.
 
-Preview exactly what an adapter changes — without writing anything — with `diff`:
-
-```bash
-cxas poly diff chat --app-dir examples/bella_notte
-```
-
-```
-Channel: chat   (adapter: adapters/chat.adapter.yaml)
-
-agents/Bella_Notte_Host
-  instruction: + N line(s) append
-  tools (2 -> 3):
-    + send_rich_card
-  callbacks: + before_model (Inject rich card formatting hints…)
-
-tools/
-  + send_rich_card
-
-evaluations/
-  + 1 eval(s): Rich_Card_Confirmation
-
-gecx-config.json (channel config)
-  ~ model: gemini-3-pro
-
-gecx-config.json (deployment)
-  + channel_type: WEB_UI
-  + modality: CHAT_ONLY
-```
-
 ---
 
-## 5. Lint, evaluate, and deploy the output
+## 7. Lint, evaluate, and deploy the output
 
 Because each compiled directory *is* a normal project, every existing command works on it unchanged:
 
@@ -225,4 +277,4 @@ This is the payoff of the **[author once at the center](../guides/polymorphism.m
 ## See also
 
 - **[Polymorphism guide](../guides/polymorphism.md)** — concepts and when to use adapters.
-- **[`cxas poly` CLI reference](../../cli/poly.md)** — full command and flag reference.
+- **[`cxas poly` CLI reference](../cli/poly.md)** — full command and flag reference.

--- a/docs/superpowers/plans/2026-05-22-poly-readiness.md
+++ b/docs/superpowers/plans/2026-05-22-poly-readiness.md
@@ -1,0 +1,280 @@
+# Poly Readiness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a pre-launch `cxas poly readiness` report that shows whether a polymorphic SCRAPI project is ready for design-partner review and what gaps remain.
+
+**Architecture:** Add a focused `cxas_scrapi.poly.readiness` module that composes existing validators, compiler, and diff reports without changing adapter-card schema or runtime behavior. Wire it into `cli/poly_cli.py` as text and JSON output, then document the workflow in the CLI and polymorphism guide.
+
+**Tech Stack:** Python 3.10+, argparse CLI, dataclasses, existing `PolymorphismEngine`, existing AD validators, existing `build_diff_report`, pytest.
+
+---
+
+### Task 1: Report Builder Tests
+
+**Files:**
+- Create: `tests/cxas_scrapi/poly/test_readiness.py`
+- Create: `src/cxas_scrapi/poly/readiness.py`
+
+- [ ] **Step 1: Write failing tests for the report shape**
+
+```python
+from pathlib import Path
+
+from cxas_scrapi.poly.engine import PolymorphismEngine
+from cxas_scrapi.poly.readiness import build_readiness_report
+
+
+def test_readiness_report_marks_clean_channel_ready(base_dir: Path):
+    engine = PolymorphismEngine(str(base_dir))
+    engine.load_base_project()
+    engine.load_adapter_cards()
+
+    report = build_readiness_report(engine, str(base_dir))
+
+    chat = next(c for c in report["channels"] if c["channel"] == "chat")
+    assert report["schema_version"] == "poly-readiness/v1"
+    assert chat["status"] == "ready"
+    assert chat["compiled"] is True
+    assert chat["diff_summary"]["tools_added"] == 1
+    assert chat["eval_coverage"]["evaluations"]["channel_count"] == 1
+    assert chat["next_steps"] == [
+        "Run cxas poly build, lint the compiled output, and run channel evals."
+    ]
+
+
+def test_readiness_report_flags_adapter_without_channel_evals(base_dir: Path):
+    engine = PolymorphismEngine(str(base_dir))
+    engine.load_base_project()
+    engine.load_adapter_cards()
+
+    report = build_readiness_report(engine, str(base_dir))
+
+    voice = next(c for c in report["channels"] if c["channel"] == "voice")
+    assert voice["status"] == "attention"
+    assert any(issue["rule_id"] == "AD006" for issue in voice["issues"])
+    assert any("channel-specific evaluations" in step for step in voice["next_steps"])
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+uv run --with-editable . --with alive-progress pytest tests/cxas_scrapi/poly/test_readiness.py -q
+```
+
+Expected: import failure for `cxas_scrapi.poly.readiness`.
+
+- [ ] **Step 3: Add minimal report builder**
+
+Create `src/cxas_scrapi/poly/readiness.py` with:
+
+```python
+"""Readiness reports for polymorphic SCRAPI projects."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+from cxas_scrapi.poly.diffing import build_diff_report
+from cxas_scrapi.poly.engine import CompilationError, PolymorphismEngine
+from cxas_scrapi.poly.validators import validate_adapter_card, validate_all_adapters
+
+READINESS_SCHEMA_VERSION = "poly-readiness/v1"
+
+
+def build_readiness_report(engine: PolymorphismEngine, app_dir: str) -> Dict[str, Any]:
+    ...
+```
+
+The function must:
+- Include `schema_version`, `app_dir`, `summary`, `adapter_errors`, and `channels`.
+- Validate each adapter with existing AD rules.
+- Add duplicate-channel AD007 issues from `validate_all_adapters`.
+- Compile valid channels and include `build_diff_report(...)[summary]`.
+- Mark channel `status` as `blocked` for errors, `attention` for warnings, and `ready` otherwise.
+- Add concrete `next_steps` based on blocked/attention/ready state.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run:
+
+```bash
+uv run --with-editable . --with alive-progress pytest tests/cxas_scrapi/poly/test_readiness.py -q
+```
+
+Expected: 2 passed.
+
+### Task 2: Coverage And Duplicate Eval Diagnostics
+
+**Files:**
+- Modify: `src/cxas_scrapi/poly/readiness.py`
+- Modify: `tests/cxas_scrapi/poly/test_readiness.py`
+
+- [ ] **Step 1: Write failing duplicate-name test**
+
+```python
+import shutil
+
+
+def test_readiness_report_warns_when_channel_eval_reuses_base_name(copied_base: Path):
+    base_eval = copied_base / "evaluations" / "Chat_Test_Eval"
+    base_eval.mkdir(parents=True)
+    shutil.copy2(
+        copied_base
+        / "adapters"
+        / "chat_evals"
+        / "Chat_Test_Eval"
+        / "Chat_Test_Eval.yaml",
+        base_eval / "Chat_Test_Eval.yaml",
+    )
+
+    engine = PolymorphismEngine(str(copied_base))
+    engine.load_base_project()
+    engine.load_adapter_cards()
+
+    report = build_readiness_report(engine, str(copied_base))
+
+    chat = next(c for c in report["channels"] if c["channel"] == "chat")
+    assert chat["status"] == "attention"
+    assert chat["eval_coverage"]["evaluations"]["duplicate_names"] == [
+        "Chat_Test_Eval"
+    ]
+    assert any("duplicate evaluation names" in step for step in chat["next_steps"])
+```
+
+- [ ] **Step 2: Run duplicate test to verify RED**
+
+Run:
+
+```bash
+uv run --with-editable . --with alive-progress pytest tests/cxas_scrapi/poly/test_readiness.py::test_readiness_report_warns_when_channel_eval_reuses_base_name -q
+```
+
+Expected: failure because duplicate names are not reported yet.
+
+- [ ] **Step 3: Implement eval namespace checks**
+
+Add helpers in `readiness.py`:
+
+```python
+def _item_names(root: Path, subdir: str) -> List[str]:
+    path = root / subdir
+    if not path.is_dir():
+        return []
+    names: List[str] = []
+    for child in sorted(path.iterdir()):
+        if child.is_dir():
+            names.append(child.name)
+        elif child.suffix in (".json", ".yaml", ".yml"):
+            names.append(child.stem)
+    return names
+```
+
+Use it to populate coverage for `evaluations`, `evaluationExpectations`, and `evaluationDatasets` with `base_count`, `channel_count`, and `duplicate_names`.
+
+- [ ] **Step 4: Run readiness tests**
+
+Run:
+
+```bash
+uv run --with-editable . --with alive-progress pytest tests/cxas_scrapi/poly/test_readiness.py -q
+```
+
+Expected: all readiness tests pass.
+
+### Task 3: CLI Wiring
+
+**Files:**
+- Modify: `src/cxas_scrapi/cli/poly_cli.py`
+- Modify: `tests/cxas_scrapi/poly/test_poly_cli.py`
+
+- [ ] **Step 1: Write failing CLI JSON test**
+
+```python
+def test_cli_readiness_json(base_dir: Path, capsys):
+    code, out, _err = _run_poly(
+        ["readiness", "--app-dir", str(base_dir), "--format", "json"],
+        capsys,
+    )
+
+    assert code == 0
+    report = json.loads(out)
+    assert report["schema_version"] == "poly-readiness/v1"
+    assert any(c["channel"] == "chat" for c in report["channels"])
+```
+
+- [ ] **Step 2: Run CLI test to verify RED**
+
+Run:
+
+```bash
+uv run --with-editable . --with alive-progress pytest tests/cxas_scrapi/poly/test_poly_cli.py::test_cli_readiness_json -q
+```
+
+Expected: argparse error because `readiness` is not registered.
+
+- [ ] **Step 3: Add CLI handler and registration**
+
+Add imports:
+
+```python
+from cxas_scrapi.poly.readiness import build_readiness_report
+```
+
+Add `poly_readiness(args)` that loads the engine, builds the report, prints JSON for `--format json`, renders concise text otherwise, and exits non-zero on errors or on warnings when `--strict` is passed.
+
+Register:
+
+```python
+p_readiness = poly_subparsers.add_parser(
+    "readiness",
+    help="Summarize adapter validation, diffs, eval coverage, and build readiness.",
+)
+p_readiness.add_argument("--app-dir", default=".", help="Path to the agent project root.")
+p_readiness.add_argument("--format", choices=("text", "json"), default="text")
+p_readiness.add_argument("--strict", action="store_true")
+p_readiness.set_defaults(func=poly_readiness)
+```
+
+- [ ] **Step 4: Run CLI test to verify GREEN**
+
+Run:
+
+```bash
+uv run --with-editable . --with alive-progress pytest tests/cxas_scrapi/poly/test_poly_cli.py::test_cli_readiness_json -q
+```
+
+Expected: 1 passed.
+
+### Task 4: Docs And Verification
+
+**Files:**
+- Modify: `docs/cli/poly.md`
+- Modify: `docs/guides/polymorphism.md`
+- Modify: `README.md` if the top-level workflow list needs the new command.
+- Modify: `PLAN.md`, `findings.md`, `progress.md`
+
+- [ ] **Step 1: Document `cxas poly readiness`**
+
+Add it to the command table, include usage, options, text/JSON purpose, exit codes, and where it fits: after `validate/diff` while preparing a launch/design-partner review.
+
+- [ ] **Step 2: Update the polymorphism guide workflow**
+
+Add a short readiness step after `diff`, before `build`, explaining that it catches validation blockers, warning-level coverage gaps, duplicate eval names, and compileability without writing output.
+
+- [ ] **Step 3: Run targeted checks**
+
+Run:
+
+```bash
+git diff --check
+uv run --with-editable . --with alive-progress ruff check src/cxas_scrapi/poly src/cxas_scrapi/cli/poly_cli.py tests/cxas_scrapi/poly
+uv run --with-editable . --with alive-progress pytest tests/cxas_scrapi/poly -q
+uv run --with-editable . --with alive-progress cxas poly readiness --app-dir examples/bella_notte
+uv run --with-editable . --with alive-progress cxas poly readiness --app-dir examples/bella_notte --format json
+```
+
+Expected: checks pass; readiness exits 0 for Bella Notte.

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,6 +2,14 @@
 
 This directory contains examples and sample code for CXAS SCRAPI.
 
+## Runnable demos
+
+- [Bella Notte](./bella_notte) — an Italian-restaurant reservations + takeout
+  agent. The reference polymorphism example, including a slot-filling framework.
+- [Polymorphic Pizza](./polymorphic_pizza) — a beginner-friendly pizza shop with
+  a chat agent and a voice agent compiled from one base project. Start here for a
+  short, copy-paste walkthrough of `cxas poly validate / diff / build`.
+
 ## Agent design examples
 
 - [Mercedes F1 Fan Agent PRD](./mercedes-f1-fan-agent/prd.md) — product requirements document for a voice-first Formula 1 fan concierge example.

--- a/examples/bella_notte/adapters/chat.adapter.yaml
+++ b/examples/bella_notte/adapters/chat.adapter.yaml
@@ -44,6 +44,11 @@ toolDefinitions:
     toolType: python
     sourceDir: adapters/chat_tools/send_rich_card
 
+# Channel-specific runtime defaults folded into the compiled gecx-config.json.
+gecxConfig:
+  model: gemini-3-pro
+  modality: text
+
 # Inject rich-content hints before the model call when a confirmation is due.
 callbacks:
   - agent: Bella_Notte_Host

--- a/examples/bella_notte/adapters/chat.adapter.yaml
+++ b/examples/bella_notte/adapters/chat.adapter.yaml
@@ -1,0 +1,64 @@
+apiVersion: poly.cxas.dev/v1
+kind: ChannelAdapter
+metadata:
+  channel: chat
+  displayName: Bella Notte — Chat
+  description: >-
+    Web chat optimization for Bella Notte. Enables rich, markdown-formatted
+    responses, selectable option lists, and rich confirmation cards.
+
+# Layer chat-specific behavior on top of the base instructions. The base
+# stays channel-neutral; these deltas specialize it for a visual surface.
+instructionDiffs:
+  - agent: Bella_Notte_Host
+    mode: append
+    content: |
+      <channel_chat>
+      You are responding in a web chat widget that renders Markdown.
+      - Use **bold** for emphasis and short numbered lists for options.
+      - When confirming a reservation or order, call the send_rich_card tool
+        to render a structured confirmation card instead of plain text.
+      - Keep paragraphs short; prefer bullets over long prose.
+      </channel_chat>
+
+  - agent: Reservation_Agent
+    mode: append
+    content: |
+      <channel_chat>
+      Present available time slots as a numbered, selectable list, e.g.:
+        1. 6:00 PM
+        2. 6:30 PM
+        3. 7:00 PM
+      Let the guest reply with the number or the time. Echo the chosen slot
+      back in **bold** before booking.
+      </channel_chat>
+
+# Make the rich-card tool available to the host, and define it.
+tools:
+  - agent: Bella_Notte_Host
+    add:
+      - send_rich_card
+
+toolDefinitions:
+  - displayName: send_rich_card
+    toolType: python
+    sourceDir: adapters/chat_tools/send_rich_card
+
+# Inject rich-content hints before the model call when a confirmation is due.
+callbacks:
+  - agent: Bella_Notte_Host
+    type: before_model
+    pythonCode: adapters/chat_callbacks/inject_rich_content.py
+    description: Inject rich card formatting hints for chat confirmations.
+
+# Channel-specific evaluations.
+evaluations:
+  - sourceDir: adapters/chat_evals
+
+# Web UI, chat-only deployment.
+deployment:
+  channelType: WEB_UI
+  modality: CHAT_ONLY
+  webWidgetConfig:
+    theme: LIGHT
+    webWidgetTitle: Bella Notte Reservations

--- a/examples/bella_notte/adapters/chat_callbacks/inject_rich_content.py
+++ b/examples/bella_notte/adapters/chat_callbacks/inject_rich_content.py
@@ -1,0 +1,32 @@
+# pylint: disable=invalid-name,undefined-variable,unused-argument,broad-exception-caught,line-too-long
+"""Before-model callback — chat rich-content hints.
+
+Channel-specific (chat) callback added by the polymorphism engine. When the
+conversation looks like it is about to confirm a reservation or order, it
+nudges the model to render a structured rich card via the send_rich_card
+tool instead of plain text.
+"""
+
+from typing import Optional
+
+
+def before_model_callback(
+    callback_context: CallbackContext,
+    llm_request: LlmRequest,
+) -> Optional[LlmResponse]:
+  """Inject a system hint to use rich card formatting on confirmation."""
+  sm = callback_context.state.get("sm", {})
+  pending = sm.get("pending", {}) if isinstance(sm, dict) else {}
+
+  if pending:
+    hint = (
+        "When confirming details with the guest, call send_rich_card to "
+        "render a confirmation card with a title, the reservation summary, "
+        "and Confirm / Change action buttons."
+    )
+    try:
+      llm_request.append_instructions([hint])
+    except Exception:
+      pass
+
+  return None

--- a/examples/bella_notte/adapters/chat_evals/Rich_Card_Confirmation/Rich_Card_Confirmation.yaml
+++ b/examples/bella_notte/adapters/chat_evals/Rich_Card_Confirmation/Rich_Card_Confirmation.yaml
@@ -1,0 +1,20 @@
+displayName: Rich Card Confirmation
+description: >-
+  Chat channel — when the guest confirms a completed reservation, the agent
+  should render a confirmation via the send_rich_card tool rather than plain
+  text.
+tags:
+  - polymorphism
+  - chat
+  - rich-card
+golden:
+  turns:
+    - steps:
+        - userInput:
+            text: "Yes, that all looks correct — please book it."
+        - expectation:
+            note: Check_SendRichCard_Called
+            toolCall:
+              tool: send_rich_card
+  evaluationExpectations:
+    - No Technical Leakage

--- a/examples/bella_notte/adapters/chat_tools/send_rich_card/python_code.py
+++ b/examples/bella_notte/adapters/chat_tools/send_rich_card/python_code.py
@@ -1,0 +1,39 @@
+"""Render a structured rich card for the chat channel.
+
+Chat-only tool added by the polymorphism engine. Constructs a JSON payload
+representing a confirmation card (title, body, action buttons) that the web
+chat widget renders visually instead of plain text.
+"""
+
+from typing import Any
+
+
+def send_rich_card(
+    title: str,
+    body: str = "",
+    buttons: str = "",
+) -> dict[str, Any]:
+  """Build a rich card payload for the chat widget.
+
+  Args:
+    title: Card heading, e.g. "Reservation Confirmed".
+    body: Short summary text shown under the title.
+    buttons: Comma-separated action button labels (e.g. "Confirm,Change").
+
+  Returns:
+    Dict with stored=True and a 'card' payload on success, or error=True on
+    failure.
+  """
+  if not title:
+    return {"error": True, "error_code": "missing_title"}
+
+  labels = [b.strip() for b in buttons.split(",") if b.strip()]
+  card = {
+      "type": "rich_card",
+      "title": title,
+      "body": body,
+      "buttons": [
+          {"label": label, "action": label.lower()} for label in labels
+      ],
+  }
+  return {"stored": True, "card": card}

--- a/examples/bella_notte/adapters/chat_tools/send_rich_card/send_rich_card.json
+++ b/examples/bella_notte/adapters/chat_tools/send_rich_card/send_rich_card.json
@@ -1,0 +1,9 @@
+{
+  "name": "c1d2e3f4-5a6b-7c8d-9e0f-112233445566",
+  "displayName": "send_rich_card",
+  "pythonFunction": {
+    "name": "send_rich_card",
+    "pythonCode": "tools/send_rich_card/python_function/python_code.py",
+    "description": "Render a structured rich card in the chat widget. Use when confirming a reservation or takeout order: pass a title, a short body summary, and one or more action buttons (e.g. Confirm, Change). Returns a card payload the channel renders visually."
+  }
+}

--- a/examples/bella_notte/adapters/voice.adapter.yaml
+++ b/examples/bella_notte/adapters/voice.adapter.yaml
@@ -39,6 +39,11 @@ instructionDiffs:
 # The base host has no send_rich_card tool, so there is nothing to remove.
 # (If a rich-card tool were present in the base, add a tools.remove here.)
 
+# Channel-specific runtime defaults folded into the compiled gecx-config.json.
+gecxConfig:
+  model: gemini-3-flash
+  modality: audio
+
 # Inject pacing hints before the model call.
 callbacks:
   - agent: Bella_Notte_Host

--- a/examples/bella_notte/adapters/voice.adapter.yaml
+++ b/examples/bella_notte/adapters/voice.adapter.yaml
@@ -1,0 +1,58 @@
+apiVersion: poly.cxas.dev/v1
+kind: ChannelAdapter
+metadata:
+  channel: voice
+  displayName: Bella Notte — Voice
+  description: >-
+    Telephony optimization for Bella Notte. Tunes the agents for spoken,
+    audio-only interaction: short turns, no markup, spelled-out numbers,
+    and slow read-backs.
+
+# Voice deltas: the same base agents, specialized for an audio channel where
+# there is no screen and the user cannot scan a list.
+instructionDiffs:
+  - agent: Bella_Notte_Host
+    mode: append
+    content: |
+      <channel_voice>
+      You are speaking on a phone call. There is no screen.
+      - Keep every response to two or three short sentences.
+      - Never use Markdown, bullet points, emoji, or symbols.
+      - Spell out numbers and times the way a person says them
+        ("six thirty in the evening", not "6:30 PM").
+      - Before calling a tool, say a brief filler such as
+        "Let me check that for you..." so the line is not silent.
+      - Read confirmations back slowly, one detail at a time.
+      </channel_voice>
+
+  - agent: Reservation_Agent
+    mode: append
+    content: |
+      <channel_voice>
+      Offer at most three available times at once, spoken aloud, and ask the
+      guest to pick one. If they want more options, read the next three.
+      When confirming, read the reservation back field by field with a short
+      pause between each: the name, then the party size, then the date, then
+      the time.
+      </channel_voice>
+
+# The base host has no send_rich_card tool, so there is nothing to remove.
+# (If a rich-card tool were present in the base, add a tools.remove here.)
+
+# Inject pacing hints before the model call.
+callbacks:
+  - agent: Bella_Notte_Host
+    type: before_model
+    pythonCode: adapters/voice_callbacks/voice_pacing.py
+    description: Inject voice pacing and filler-phrase hints.
+
+# Channel-specific evaluations.
+evaluations:
+  - sourceDir: adapters/voice_evals
+
+# Telephony, voice-only deployment.
+deployment:
+  channelType: GOOGLE_TELEPHONY_PLATFORM
+  modality: VOICE_ONLY
+  disableBargeInControl: false
+  disableDtmf: false

--- a/examples/bella_notte/adapters/voice_callbacks/voice_pacing.py
+++ b/examples/bella_notte/adapters/voice_callbacks/voice_pacing.py
@@ -1,0 +1,27 @@
+# pylint: disable=invalid-name,undefined-variable,unused-argument,broad-exception-caught,line-too-long
+"""Before-model callback — voice pacing hints.
+
+Channel-specific (voice) callback added by the polymorphism engine. Reminds
+the model to keep spoken turns short and to emit a brief filler phrase
+before long-running tool calls so the caller is not left in silence.
+"""
+
+from typing import Optional
+
+
+def before_model_callback(
+    callback_context: CallbackContext,
+    llm_request: LlmRequest,
+) -> Optional[LlmResponse]:
+  """Inject voice pacing and filler-phrase hints before each model call."""
+  hint = (
+      "Spoken channel: respond in two to three short sentences, no markup. "
+      "Before any tool call, say a brief filler such as "
+      "'Let me check that for you...' so the line is never silent."
+  )
+  try:
+    llm_request.append_instructions([hint])
+  except Exception:
+    pass
+
+  return None

--- a/examples/bella_notte/adapters/voice_evals/Concise_Voice_Response/Concise_Voice_Response.yaml
+++ b/examples/bella_notte/adapters/voice_evals/Concise_Voice_Response/Concise_Voice_Response.yaml
@@ -1,0 +1,18 @@
+displayName: Concise Voice Response
+description: >-
+  Voice channel — the agent's spoken responses must avoid markdown/symbols
+  and stay short, since there is no screen and the text is read aloud.
+tags:
+  - polymorphism
+  - voice
+  - concise
+golden:
+  turns:
+    - steps:
+        - userInput:
+            text: "Hi, I'd like to book a table."
+        - expectation:
+            note: Greeting_Is_Spoken_And_Concise
+  evaluationExpectations:
+    - Concise Voice Persona
+    - No Technical Leakage

--- a/examples/bella_notte/gecx-config.json
+++ b/examples/bella_notte/gecx-config.json
@@ -3,7 +3,7 @@
   "location": "<YOUR_GCP_REGION>",
   "app_name": "bella-notte",
   "deployed_app_id": "<YOUR_DEPLOYED_APP_ID>",
-  "app_dir": "cxas_app/Bella_Notte/",
+  "app_dir": ".",
   "model": "gemini-3-flash",
   "modality": "text",
   "default_channel": "text"

--- a/examples/polymorphic_pizza/README.md
+++ b/examples/polymorphic_pizza/README.md
@@ -90,13 +90,25 @@ uv run cxas poly validate --app-dir examples/polymorphic_pizza
 All 2 adapter card(s) valid.
 ```
 
+If you break an adapter while experimenting, use doctor for the actionable
+version of the same validation:
+
+```bash
+uv run cxas poly doctor --app-dir examples/polymorphic_pizza
+# or
+uv run cxas poly validate --app-dir examples/polymorphic_pizza --explain
+```
+
 ### 2. Preview what each channel changes
 
 `diff` shows exactly what an adapter will do — **without writing any files**.
+Use the default text form for review and `--json` when a script or CI job needs
+stable fields.
 
 ```bash
 uv run cxas poly diff chat  --app-dir examples/polymorphic_pizza
 uv run cxas poly diff voice --app-dir examples/polymorphic_pizza
+uv run cxas poly diff chat  --app-dir examples/polymorphic_pizza --json
 ```
 
 For **chat** you'll see the `Order_Agent` gain a `send_order_card` tool, a chat
@@ -171,6 +183,22 @@ Make a change once and watch it appear in both channels:
 
 Or tweak just one channel by editing `adapters/chat.adapter.yaml` (for example,
 change `webWidgetTitle`) and rebuild — only the chat output changes.
+
+To start a new channel from this same base app, scaffold the first pass:
+
+```bash
+uv run cxas poly init \
+  --app-dir examples/polymorphic_pizza \
+  --channel sms \
+  --deployment-target TWILIO \
+  --modality VOICE_ONLY \
+  --with-callback before_model \
+  --with-tool send_sms_card
+```
+
+That creates `adapters/sms.adapter.yaml`, a starter SMS eval, a starter callback,
+and a channel-only tool folder. Replace the generated placeholder behavior with
+real SMS-specific UX before building.
 
 ---
 

--- a/examples/polymorphic_pizza/README.md
+++ b/examples/polymorphic_pizza/README.md
@@ -1,0 +1,187 @@
+# Polymorphic Pizza — chat + voice from one agent
+
+A complete, runnable demo for a fictional pizza shop, **Polymorphic Pizza**.
+
+You author **one** agent project here. With a single command the polymorphism
+engine compiles it into **two** ready-to-deploy projects:
+
+- a **chat agent** for a web chat widget (Markdown, numbered lists, a visual
+  order-confirmation card), and
+- a **voice agent** for a phone line (short spoken turns, no symbols, prices
+  read aloud).
+
+Same business logic, same tools, one place to fix bugs — the channel
+differences live in two short *adapter cards*.
+
+> New here? Read the one-page idea in the
+> [root README](../../README.md#the-core-idea) first. This page is the
+> hands-on, copy-paste walkthrough.
+
+---
+
+## What's in the box
+
+```
+polymorphic_pizza/
+├── app.json                 # the application (root agent = Pizza_Host)
+├── gecx-config.json         # deployment config (fill in your GCP details to deploy)
+├── cxaslint.yaml            # linter settings for this project
+├── agents/
+│   ├── Pizza_Host/          # greets the customer and routes the request
+│   ├── Order_Agent/         # takes a pizza order start to finish
+│   └── Tracking_Agent/      # looks up the status of an existing order
+├── tools/                   # plain Python functions the agents call
+│   ├── set_active_flow/     #   route to "order" or "track"
+│   ├── get_menu/            #   list sizes, pizzas, toppings, prices
+│   ├── quote_pizza/         #   price one pizza
+│   ├── place_order/         #   place a confirmed order
+│   └── get_order_status/    #   check an order by its number
+├── evaluations/             # channel-neutral tests (shared by both channels)
+└── adapters/                # ← the only channel-specific part
+    ├── chat.adapter.yaml    #   what changes for web chat
+    └── voice.adapter.yaml   #   what changes for the phone
+```
+
+**How the agents fit together:** the customer always meets `Pizza_Host`. When
+they ask to order, the host calls the `set_active_flow` tool and is handed off
+to `Order_Agent`; when they ask about an existing order, it hands off to
+`Tracking_Agent`. (The hand-off is wired up by two small callbacks on the host
+— you don't have to touch them to use the demo.)
+
+---
+
+## Prerequisites
+
+- **Python 3.10+**
+- **[uv](https://docs.astral.sh/uv/)** (the package manager this repo uses)
+
+That's it. Everything below runs **locally** — no Google Cloud account or
+credentials are needed to build and inspect the agents.
+
+---
+
+## Setup (once)
+
+From the **repository root**:
+
+```bash
+uv sync --extra dev
+```
+
+This creates a virtual environment and installs the `cxas` command. Prefix the
+commands below with `uv run` (as shown) and you don't need to activate anything.
+
+---
+
+## Run it, step by step
+
+All commands are run from the repository root.
+
+### 1. Validate the adapter cards
+
+Checks that everything the adapters reference (agents, tools, evals) actually
+exists.
+
+```bash
+uv run cxas poly validate --app-dir examples/polymorphic_pizza
+```
+
+```
+All 2 adapter card(s) valid.
+```
+
+### 2. Preview what each channel changes
+
+`diff` shows exactly what an adapter will do — **without writing any files**.
+
+```bash
+uv run cxas poly diff chat  --app-dir examples/polymorphic_pizza
+uv run cxas poly diff voice --app-dir examples/polymorphic_pizza
+```
+
+For **chat** you'll see the `Order_Agent` gain a `send_order_card` tool, a chat
+formatting block appended to two agents, and a `WEB_UI` deployment. For
+**voice** you'll see spoken-pacing instructions and a `GOOGLE_TELEPHONY_PLATFORM`
+deployment instead.
+
+### 3. Build both channels
+
+```bash
+uv run cxas poly build --app-dir examples/polymorphic_pizza --output-dir ./output
+```
+
+```
+Compiled channel 'chat' -> ./output/chat
+Compiled channel 'voice' -> ./output/voice
+
+Done. 2 channel(s) written to ./output
+```
+
+You now have two complete, independent projects under `./output/`.
+
+### 4. Confirm the output is "just a project"
+
+The compiled output is indistinguishable from a hand-written project, so every
+normal command works on it:
+
+```bash
+uv run cxas lint --app-dir ./output/chat
+uv run cxas lint --app-dir ./output/voice
+```
+
+```
+Lint PASSED (no errors).
+```
+
+From here, `./output/chat` and `./output/voice` can be evaluated and deployed
+exactly like any other CXAS project (that step needs a Google Cloud project —
+see the [official docs](https://googlecloudplatform.github.io/cxas-scrapi/stable/)).
+
+---
+
+## See the difference
+
+Open the same file in each compiled channel and compare:
+
+```bash
+# The order specialist's instructions, chat vs. voice:
+cat ./output/chat/agents/Order_Agent/instruction.txt
+cat ./output/voice/agents/Order_Agent/instruction.txt
+```
+
+| | Chat | Voice |
+|---|---|---|
+| **Instructions add** | Markdown, numbered lists, a confirmation card | 2–3 sentence turns, no symbols, spoken prices |
+| **Extra tool** | `send_order_card` (visual card) | none |
+| **Deployment** | `WEB_UI` / `CHAT_ONLY` | `GOOGLE_TELEPHONY_PLATFORM` / `VOICE_ONLY` |
+| **gecx-config modality** | `text` | `audio` |
+
+Both were generated from the **same** `agents/`, `tools/`, and `evaluations/`.
+
+---
+
+## Try it yourself
+
+Make a change once and watch it appear in both channels:
+
+1. Add a new topping to `tools/get_menu/python_function/python_code.py`.
+2. Re-run the build (step 3). Both `./output/chat` and `./output/voice` pick it
+   up — no copy-paste, no drift.
+
+Or tweak just one channel by editing `adapters/chat.adapter.yaml` (for example,
+change `webWidgetTitle`) and rebuild — only the chat output changes.
+
+---
+
+## How this maps to the engine
+
+- The base project is an ordinary CXAS agent project.
+- Each `adapters/<channel>.adapter.yaml` declares only the *deltas* for that
+  channel: instruction edits, tools to add, callbacks, evaluations, and
+  deployment settings.
+- `cxas poly build` deep-copies the base, applies the deltas, and writes one
+  finished project per channel.
+
+For the full adapter-card reference and the compilation pipeline, see the
+[root README](../../README.md) and the
+[Polymorphism guide](../../docs/guides/polymorphism.md).

--- a/examples/polymorphic_pizza/README.md
+++ b/examples/polymorphic_pizza/README.md
@@ -153,6 +153,7 @@ cat ./output/voice/agents/Order_Agent/instruction.txt
 |---|---|---|
 | **Instructions add** | Markdown, numbered lists, a confirmation card | 2–3 sentence turns, no symbols, spoken prices |
 | **Extra tool** | `send_order_card` (visual card) | none |
+| **Model/runtime config** | `gemini-3-pro`, text modality | `gemini-3-flash`, audio modality |
 | **Deployment** | `WEB_UI` / `CHAT_ONLY` | `GOOGLE_TELEPHONY_PLATFORM` / `VOICE_ONLY` |
 | **gecx-config modality** | `text` | `audio` |
 

--- a/examples/polymorphic_pizza/adapters/chat.adapter.yaml
+++ b/examples/polymorphic_pizza/adapters/chat.adapter.yaml
@@ -1,0 +1,64 @@
+apiVersion: poly.cxas.dev/v1
+kind: ChannelAdapter
+metadata:
+  channel: chat
+  displayName: Polymorphic Pizza — Chat
+  description: >-
+    Web chat optimization for Polymorphic Pizza. Enables rich, markdown
+    responses, numbered topping lists, and a visual order confirmation card.
+
+# Layer chat-specific behavior on top of the channel-neutral base instructions.
+instructionDiffs:
+  - agent: Pizza_Host
+    mode: append
+    content: |
+      <channel_chat>
+      You are responding in a web chat widget that renders Markdown.
+      - Use **bold** for emphasis and short numbered lists for choices.
+      - Keep paragraphs short; prefer bullets over long prose.
+      </channel_chat>
+
+  - agent: Order_Agent
+    mode: append
+    content: |
+      <channel_chat>
+      Present the sizes, specialty pizzas, and toppings as numbered,
+      scannable lists, e.g.:
+        1. Small
+        2. Medium
+        3. Large
+      Let the customer reply with a number or the name. When the order is
+      complete, call {@TOOL: send_order_card} to render a confirmation card
+      with the order summary, the total, and Confirm / Edit buttons instead
+      of plain text.
+      </channel_chat>
+
+# Make the order-card tool available to the order specialist, and define it.
+tools:
+  - agent: Order_Agent
+    add:
+      - send_order_card
+
+toolDefinitions:
+  - displayName: send_order_card
+    toolType: python
+    sourceDir: adapters/chat_tools/send_order_card
+
+# Inject order-card hints before the model call.
+callbacks:
+  - agent: Order_Agent
+    type: before_model
+    pythonCode: adapters/chat_callbacks/inject_order_card.py
+    description: Inject order-card formatting hints for chat confirmations.
+
+# Channel-specific evaluations.
+evaluations:
+  - sourceDir: adapters/chat_evals
+
+# Web UI, chat-only deployment.
+deployment:
+  channelType: WEB_UI
+  modality: CHAT_ONLY
+  webWidgetConfig:
+    theme: LIGHT
+    webWidgetTitle: Polymorphic Pizza

--- a/examples/polymorphic_pizza/adapters/chat.adapter.yaml
+++ b/examples/polymorphic_pizza/adapters/chat.adapter.yaml
@@ -44,6 +44,16 @@ toolDefinitions:
     toolType: python
     sourceDir: adapters/chat_tools/send_order_card
 
+# Chat can spend a little more latency budget on richer reasoning and UI copy.
+modelOverrides:
+  - agent: Order_Agent
+    model: gemini-3-pro
+
+# Channel-specific runtime defaults folded into the compiled gecx-config.json.
+gecxConfig:
+  model: gemini-3-pro
+  modality: text
+
 # Inject order-card hints before the model call.
 callbacks:
   - agent: Order_Agent

--- a/examples/polymorphic_pizza/adapters/chat_callbacks/inject_order_card.py
+++ b/examples/polymorphic_pizza/adapters/chat_callbacks/inject_order_card.py
@@ -1,0 +1,27 @@
+# pylint: disable=invalid-name,undefined-variable,unused-argument,broad-exception-caught,line-too-long
+"""Before-model callback — chat order-card hints.
+
+Channel-specific (chat) callback added by the polymorphism engine. Nudges
+the model to render the final order with the send_order_card tool so the
+customer gets a visual confirmation card instead of plain text.
+"""
+
+from typing import Optional
+
+
+def before_model_callback(
+    callback_context: CallbackContext,
+    llm_request: LlmRequest,
+) -> Optional[LlmResponse]:
+  """Inject a hint to use the order card when confirming."""
+  hint = (
+      "When the order is complete, call send_order_card to render a "
+      "confirmation card with the order summary, the total, and "
+      "Confirm / Edit action buttons."
+  )
+  try:
+    llm_request.append_instructions([hint])
+  except Exception:
+    pass
+
+  return None

--- a/examples/polymorphic_pizza/adapters/chat_evals/Order_Card_On_Confirm/Order_Card_On_Confirm.yaml
+++ b/examples/polymorphic_pizza/adapters/chat_evals/Order_Card_On_Confirm/Order_Card_On_Confirm.yaml
@@ -1,0 +1,18 @@
+displayName: Order Card On Confirm
+description: >-
+  Chat channel — when the order is complete and the customer confirms, the
+  agent should render the confirmation via the send_order_card tool rather
+  than plain text.
+tags:
+  - polymorphism
+  - chat
+  - order-card
+golden:
+  turns:
+    - steps:
+        - userInput:
+            text: "Yes, that's right — please place the order."
+        - expectation:
+            note: Check_SendOrderCard_Called
+            toolCall:
+              tool: send_order_card

--- a/examples/polymorphic_pizza/adapters/chat_tools/send_order_card/python_code.py
+++ b/examples/polymorphic_pizza/adapters/chat_tools/send_order_card/python_code.py
@@ -1,0 +1,41 @@
+"""Render a structured order confirmation card for the chat channel.
+
+Chat-only tool added by the polymorphism engine. Builds a JSON payload that
+the web chat widget renders as a card (title, summary, total, action
+buttons) instead of plain text.
+"""
+
+from typing import Any
+
+
+def send_order_card(
+    title: str,
+    summary: str = "",
+    total: str = "",
+    buttons: str = "",
+) -> dict[str, Any]:
+  """Build an order confirmation card payload.
+
+  Args:
+    title: Card heading, e.g. "Order Confirmed".
+    summary: Short order summary shown under the title.
+    total: The order total as text, e.g. "$18.00".
+    buttons: Comma-separated action button labels (e.g. "Confirm,Edit").
+
+  Returns:
+    Dict with stored=True and a 'card' payload, or error=True if no title.
+  """
+  if not title:
+    return {"error": True, "error_code": "missing_title"}
+
+  labels = [b.strip() for b in buttons.split(",") if b.strip()]
+  card = {
+      "type": "order_card",
+      "title": title,
+      "summary": summary,
+      "total": total,
+      "buttons": [
+          {"label": label, "action": label.lower()} for label in labels
+      ],
+  }
+  return {"stored": True, "card": card}

--- a/examples/polymorphic_pizza/adapters/chat_tools/send_order_card/send_order_card.json
+++ b/examples/polymorphic_pizza/adapters/chat_tools/send_order_card/send_order_card.json
@@ -1,0 +1,9 @@
+{
+  "name": "e8eb5687-c765-46eb-90fe-55c6e548a3bf",
+  "displayName": "send_order_card",
+  "pythonFunction": {
+    "name": "send_order_card",
+    "pythonCode": "tools/send_order_card/python_function/python_code.py",
+    "description": "Render a structured order confirmation card in the chat widget. Pass a title, a short summary of the order, the total, and comma-separated action button labels (e.g. 'Confirm,Edit'). Returns a card payload the widget renders visually."
+  }
+}

--- a/examples/polymorphic_pizza/adapters/voice.adapter.yaml
+++ b/examples/polymorphic_pizza/adapters/voice.adapter.yaml
@@ -1,0 +1,53 @@
+apiVersion: poly.cxas.dev/v1
+kind: ChannelAdapter
+metadata:
+  channel: voice
+  displayName: Polymorphic Pizza — Voice
+  description: >-
+    Telephony optimization for Polymorphic Pizza. Tunes the agents for
+    spoken, audio-only interaction: short turns, no markup, spelled-out
+    prices, and slow read-backs.
+
+# Voice deltas: the same base agents, specialized for an audio channel where
+# there is no screen and the caller cannot scan a list.
+instructionDiffs:
+  - agent: Pizza_Host
+    mode: append
+    content: |
+      <channel_voice>
+      You are speaking on a phone call. There is no screen.
+      - Keep every response to two or three short sentences.
+      - Never use Markdown, bullet points, emoji, or symbols.
+      - Spell out prices and numbers the way a person says them
+        (say "twelve dollars" rather than reading the digits).
+      - Before calling a tool, say a brief filler such as
+        "Let me check that for you..." so the line is not silent.
+      </channel_voice>
+
+  - agent: Order_Agent
+    mode: append
+    content: |
+      <channel_voice>
+      Offer at most three choices at a time, spoken aloud, and ask the caller
+      to pick one. Read the final order back slowly, one detail at a time —
+      the size, then the toppings, then pickup or delivery, then the name —
+      and state the total in spoken dollars before placing it.
+      </channel_voice>
+
+# Inject pacing hints before the model call.
+callbacks:
+  - agent: Order_Agent
+    type: before_model
+    pythonCode: adapters/voice_callbacks/voice_pacing.py
+    description: Inject voice pacing and filler-phrase hints.
+
+# Channel-specific evaluations.
+evaluations:
+  - sourceDir: adapters/voice_evals
+
+# Telephony, voice-only deployment.
+deployment:
+  channelType: GOOGLE_TELEPHONY_PLATFORM
+  modality: VOICE_ONLY
+  disableBargeInControl: false
+  disableDtmf: false

--- a/examples/polymorphic_pizza/adapters/voice.adapter.yaml
+++ b/examples/polymorphic_pizza/adapters/voice.adapter.yaml
@@ -34,6 +34,16 @@ instructionDiffs:
       and state the total in spoken dollars before placing it.
       </channel_voice>
 
+# Voice prioritizes low-latency turns over maximum response depth.
+modelOverrides:
+  - agent: Order_Agent
+    model: gemini-3-flash
+
+# Channel-specific runtime defaults folded into the compiled gecx-config.json.
+gecxConfig:
+  model: gemini-3-flash
+  modality: audio
+
 # Inject pacing hints before the model call.
 callbacks:
   - agent: Order_Agent

--- a/examples/polymorphic_pizza/adapters/voice_callbacks/voice_pacing.py
+++ b/examples/polymorphic_pizza/adapters/voice_callbacks/voice_pacing.py
@@ -1,0 +1,27 @@
+# pylint: disable=invalid-name,undefined-variable,unused-argument,broad-exception-caught,line-too-long
+"""Before-model callback — voice pacing hints.
+
+Channel-specific (voice) callback added by the polymorphism engine. Keeps
+spoken turns short and reminds the model to emit a brief filler before
+long-running tool calls so the caller is never left in silence.
+"""
+
+from typing import Optional
+
+
+def before_model_callback(
+    callback_context: CallbackContext,
+    llm_request: LlmRequest,
+) -> Optional[LlmResponse]:
+  """Inject voice pacing and filler-phrase hints before each model call."""
+  hint = (
+      "Spoken channel: respond in two to three short sentences, no markup, "
+      "and say prices in words. Before any tool call, say a brief filler "
+      "such as 'Let me check that for you...' so the line is never silent."
+  )
+  try:
+    llm_request.append_instructions([hint])
+  except Exception:
+    pass
+
+  return None

--- a/examples/polymorphic_pizza/adapters/voice_evals/Concise_Spoken_Confirm/Concise_Spoken_Confirm.yaml
+++ b/examples/polymorphic_pizza/adapters/voice_evals/Concise_Spoken_Confirm/Concise_Spoken_Confirm.yaml
@@ -1,0 +1,16 @@
+displayName: Concise Spoken Confirm
+description: >-
+  Voice channel — when the caller confirms, the agent should place the order
+  with the place_order tool, keeping the spoken turn short.
+tags:
+  - polymorphism
+  - voice
+golden:
+  turns:
+    - steps:
+        - userInput:
+            text: "Yes, go ahead and place it."
+        - expectation:
+            note: Check_PlaceOrder_Called
+            toolCall:
+              tool: place_order

--- a/examples/polymorphic_pizza/agents/Order_Agent/Order_Agent.json
+++ b/examples/polymorphic_pizza/agents/Order_Agent/Order_Agent.json
@@ -1,0 +1,6 @@
+{
+  "name": "c0f8eec4-4561-49ff-9cc1-0bfc80205073",
+  "displayName": "Order_Agent",
+  "instruction": "agents/Order_Agent/instruction.txt",
+  "tools": ["get_menu", "quote_pizza", "place_order", "end_session"]
+}

--- a/examples/polymorphic_pizza/agents/Order_Agent/instruction.txt
+++ b/examples/polymorphic_pizza/agents/Order_Agent/instruction.txt
@@ -1,0 +1,48 @@
+<role>
+You are the order specialist at Polymorphic Pizza. You take a customer's pizza
+order from start to finish.
+Today is ${current_date}.
+</role>
+
+<persona>
+- Be friendly, efficient, and clear.
+- Never reveal internal system details, variable names, or tool names.
+- Never invent prices — always use the tools for menu and pricing.
+</persona>
+
+<guidelines>
+  <guideline name="prices_from_tools">
+    Whenever the customer asks what is available or how much something costs,
+    call {@TOOL: get_menu}. Before confirming the order, call
+    {@TOOL: quote_pizza} so you can state an accurate price.
+  </guideline>
+</guidelines>
+
+<taskflow>
+  <subtask name="Collect_Order">
+    <step name="Gather_Details">
+      <trigger>You are handling a new order.</trigger>
+      <action>
+        Collect the following, in natural conversation and in any order the
+        customer offers:
+        1. Pizza size — small, medium, or large.
+        2. Toppings — or confirm they want a plain or specialty pizza. Use
+           {@TOOL: get_menu} to share the options if the customer asks.
+        3. Fulfillment — pickup or delivery. If delivery, also collect the
+           delivery address.
+        4. The name for the order.
+        As the pizza takes shape, use {@TOOL: quote_pizza} to tell the customer
+        the price.
+      </action>
+    </step>
+    <step name="Confirm_And_Place">
+      <trigger>You have the size, toppings, fulfillment (and address if it is a
+      delivery), and the name.</trigger>
+      <action>
+        Read the full order back to the customer. Once they confirm, call
+        {@TOOL: place_order}. Relay the EXACT order number, total, and estimated
+        time from the tool result. Do NOT make up an order number or a total.
+      </action>
+    </step>
+  </subtask>
+</taskflow>

--- a/examples/polymorphic_pizza/agents/Pizza_Host/Pizza_Host.json
+++ b/examples/polymorphic_pizza/agents/Pizza_Host/Pizza_Host.json
@@ -1,0 +1,15 @@
+{
+  "name": "961e2e38-9415-4e35-85fe-a73589c03247",
+  "displayName": "Pizza_Host",
+  "instruction": "agents/Pizza_Host/instruction.txt",
+  "tools": ["set_active_flow", "end_session"],
+  "childAgents": ["Order_Agent", "Tracking_Agent"],
+  "beforeModelCallbacks": [{
+    "pythonCode": "agents/Pizza_Host/before_model_callbacks/before_model_callbacks_01/python_code.py",
+    "description": "Hide transfer_to_agent; fire pending transfers."
+  }],
+  "afterToolCallbacks": [{
+    "pythonCode": "agents/Pizza_Host/after_tool_callbacks/after_tool_callbacks_01/python_code.py",
+    "description": "Capture set_active_flow result and prepare transfer."
+  }]
+}

--- a/examples/polymorphic_pizza/agents/Pizza_Host/after_tool_callbacks/after_tool_callbacks_01/python_code.py
+++ b/examples/polymorphic_pizza/agents/Pizza_Host/after_tool_callbacks/after_tool_callbacks_01/python_code.py
@@ -1,0 +1,30 @@
+# pylint: disable=invalid-name,undefined-variable,unused-argument,broad-exception-caught,line-too-long
+"""After-tool callback — transfer routing.
+
+When set_active_flow is called on the Pizza Host, record the target
+specialist in _pending_transfer so the before_model callback can fire the
+agent transfer on the next model call.
+"""
+
+from typing import Any, Optional
+
+
+def after_tool_callback(
+    tool: Tool,
+    tool_input: dict[str, Any],
+    callback_context: CallbackContext,
+    tool_response: dict[str, Any],
+) -> Optional[dict[str, Any]]:
+  """Capture set_active_flow result and prepare the transfer."""
+  if tool.name != "set_active_flow":
+    return None
+
+  result = tool_response.get("result", tool_response)
+  if not result.get("stored"):
+    return None
+
+  target = result.get("target_agent")
+  if target:
+    callback_context.state["_pending_transfer"] = target
+
+  return None

--- a/examples/polymorphic_pizza/agents/Pizza_Host/before_model_callbacks/before_model_callbacks_01/python_code.py
+++ b/examples/polymorphic_pizza/agents/Pizza_Host/before_model_callbacks/before_model_callbacks_01/python_code.py
@@ -1,0 +1,25 @@
+# pylint: disable=invalid-name,undefined-variable,unused-argument,broad-exception-caught,line-too-long
+"""Before-model callback — transfer orchestration.
+
+Hides transfer_to_agent so the model uses set_active_flow instead. When the
+after_tool callback sets _pending_transfer, this callback fires the agent
+transfer deterministically.
+"""
+
+from typing import Optional
+
+
+def before_model_callback(
+    callback_context: CallbackContext,
+    llm_request: LlmRequest,
+) -> Optional[LlmResponse]:
+  """Hide transfer_to_agent; fire pending transfers."""
+  llm_request.config.hide_tool("transfer_to_agent")
+
+  agent = callback_context.state.pop("_pending_transfer", "")
+  if agent:
+    return LlmResponse.from_parts(
+        parts=[Part.from_agent_transfer(agent=agent)],
+    )
+
+  return {"decision": "OK"}

--- a/examples/polymorphic_pizza/agents/Pizza_Host/instruction.txt
+++ b/examples/polymorphic_pizza/agents/Pizza_Host/instruction.txt
@@ -1,0 +1,55 @@
+<role>
+You are Polly, the friendly host at Polymorphic Pizza.
+Today is ${current_date}.
+</role>
+
+<persona>
+- Be warm, upbeat, and concise — like someone who loves great pizza.
+- Speak naturally. Never mention internal system details, variable names,
+  or tool names to the customer.
+</persona>
+
+<guidelines>
+  <guideline name="stay_in_scope">
+    You can ONLY help with placing a pizza order, checking the status of an
+    existing order, or simple shop information (hours and location). Politely
+    redirect anything else back to pizza.
+  </guideline>
+</guidelines>
+
+<taskflow>
+  <subtask name="Greeting">
+    <step name="Welcome">
+      <trigger>Conversation begins.</trigger>
+      <action>
+        Greet the customer warmly: "Welcome to Polymorphic Pizza! I can start a
+        new order, check on an order you've already placed, or answer questions
+        about our hours and location. What can I do for you?"
+      </action>
+    </step>
+  </subtask>
+
+  <subtask name="Intent_Routing">
+    <step name="Route_To_Specialist">
+      <trigger>Customer states their request.</trigger>
+      <action>
+        1. If the customer wants to order food, build a pizza, or mentions any
+           order details (a size, toppings, pickup, or delivery):
+           - SILENT ROUTING: Do NOT say anything to the customer. Generate
+             absolutely NO conversational text (do not say "let me connect you"
+             or mention specialists).
+           - Call {@TOOL: set_active_flow} immediately with flow="order".
+
+        2. If the customer wants to check, track, or ask about the status of an
+           order they already placed:
+           - SILENT ROUTING: Do NOT say anything to the customer. Generate
+             absolutely NO conversational text.
+           - Call {@TOOL: set_active_flow} immediately with flow="track".
+
+        3. If the customer asks about hours or location:
+           - Respond conversationally: We are open every day from 11 AM to
+             11 PM, and we're located downtown on Main Street.
+      </action>
+    </step>
+  </subtask>
+</taskflow>

--- a/examples/polymorphic_pizza/agents/Tracking_Agent/Tracking_Agent.json
+++ b/examples/polymorphic_pizza/agents/Tracking_Agent/Tracking_Agent.json
@@ -1,0 +1,6 @@
+{
+  "name": "de79127e-1d98-4490-8fd1-3231c3f63ac4",
+  "displayName": "Tracking_Agent",
+  "instruction": "agents/Tracking_Agent/instruction.txt",
+  "tools": ["get_order_status", "end_session"]
+}

--- a/examples/polymorphic_pizza/agents/Tracking_Agent/instruction.txt
+++ b/examples/polymorphic_pizza/agents/Tracking_Agent/instruction.txt
@@ -1,0 +1,29 @@
+<role>
+You are the order-status specialist at Polymorphic Pizza. You help customers
+check on an order they already placed.
+Today is ${current_date}.
+</role>
+
+<persona>
+- Be reassuring and concise.
+- Never reveal internal system details, variable names, or tool names.
+</persona>
+
+<taskflow>
+  <subtask name="Track_Order">
+    <step name="Get_Order_Number">
+      <trigger>You are handling an order-status request.</trigger>
+      <action>
+        If you do not already have the order number, ask for it. It looks like
+        "PZA-1A2B3C".
+      </action>
+    </step>
+    <step name="Report_Status">
+      <trigger>You have an order number.</trigger>
+      <action>
+        Call {@TOOL: get_order_status} and relay the current status and the
+        estimated time remaining in a friendly way. Do NOT invent a status.
+      </action>
+    </step>
+  </subtask>
+</taskflow>

--- a/examples/polymorphic_pizza/app.json
+++ b/examples/polymorphic_pizza/app.json
@@ -1,0 +1,24 @@
+{
+  "name": "2ffecf0b-9182-478f-a93c-23378fe8a49d",
+  "displayName": "Polymorphic Pizza",
+  "rootAgent": "Pizza_Host",
+  "loggingSettings": {
+    "conversationLoggingSettings": {
+      "retentionWindow": "31536000s"
+    }
+  },
+  "evaluationMetricsThresholds": {
+    "goldenEvaluationMetricsThresholds": {
+      "turnLevelMetricsThresholds": {
+        "semanticSimilaritySuccessThreshold": 0
+      },
+      "toolMatchingSettings": {
+        "extraToolCallBehavior": "ALLOW"
+      }
+    },
+    "goldenHallucinationMetricBehavior": "DISABLED"
+  },
+  "timeZoneSettings": {
+    "timeZone": "America/Los_Angeles"
+  }
+}

--- a/examples/polymorphic_pizza/cxaslint.yaml
+++ b/examples/polymorphic_pizza/cxaslint.yaml
@@ -1,0 +1,9 @@
+# cxaslint.yaml — Polymorphic Pizza linter configuration
+
+app_dir: .
+
+rules:
+  # These two are style conventions that don't fit this small demo (the same
+  # rules are disabled in the Bella Notte example):
+  T001: "off"  # agent_action error-return pattern — demo tools return {"error": ...}
+  T004: "off"  # helper function name need not match the tool directory name

--- a/examples/polymorphic_pizza/evaluations/Happy_Path_-_Order_Routing/Happy_Path_-_Order_Routing.json
+++ b/examples/polymorphic_pizza/evaluations/Happy_Path_-_Order_Routing/Happy_Path_-_Order_Routing.json
@@ -1,0 +1,34 @@
+{
+  "name": "happy-path-order-routing",
+  "displayName": "Happy Path - Order Routing",
+  "description": "The host silently routes a new-order request to the Order Agent via set_active_flow.",
+  "tags": [
+    "multi-agent",
+    "routing",
+    "order"
+  ],
+  "golden": {
+    "turns": [
+      {
+        "steps": [
+          {
+            "userInput": {
+              "text": "I'd like to order a pizza"
+            }
+          },
+          {
+            "expectation": {
+              "note": "Check_Set_Active_Flow_Order",
+              "toolCall": {
+                "tool": "set_active_flow",
+                "args": {
+                  "flow": "order"
+                }
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/examples/polymorphic_pizza/evaluations/Happy_Path_-_Tracking_Routing/Happy_Path_-_Tracking_Routing.json
+++ b/examples/polymorphic_pizza/evaluations/Happy_Path_-_Tracking_Routing/Happy_Path_-_Tracking_Routing.json
@@ -1,0 +1,34 @@
+{
+  "name": "happy-path-tracking-routing",
+  "displayName": "Happy Path - Tracking Routing",
+  "description": "The host silently routes an order-status request to the Tracking Agent via set_active_flow.",
+  "tags": [
+    "multi-agent",
+    "routing",
+    "track"
+  ],
+  "golden": {
+    "turns": [
+      {
+        "steps": [
+          {
+            "userInput": {
+              "text": "Can you check on my order PZA-1A2B3C?"
+            }
+          },
+          {
+            "expectation": {
+              "note": "Check_Set_Active_Flow_Track",
+              "toolCall": {
+                "tool": "set_active_flow",
+                "args": {
+                  "flow": "track"
+                }
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/examples/polymorphic_pizza/gecx-config.json
+++ b/examples/polymorphic_pizza/gecx-config.json
@@ -1,0 +1,10 @@
+{
+  "gcp_project_id": "<YOUR_GCP_PROJECT_ID>",
+  "location": "<YOUR_GCP_REGION>",
+  "app_name": "polymorphic-pizza",
+  "deployed_app_id": "<YOUR_DEPLOYED_APP_ID>",
+  "app_dir": "cxas_app/Polymorphic_Pizza/",
+  "model": "gemini-3-flash",
+  "modality": "text",
+  "default_channel": "text"
+}

--- a/examples/polymorphic_pizza/todo.md
+++ b/examples/polymorphic_pizza/todo.md
@@ -1,0 +1,8 @@
+# Polymorphic Pizza Build Steps
+
+1. Gather requirements (gate 1)
+2. TDD + user approval (gate 2)
+3. Scaffold app (gate 3)
+4. Lint clean (gate 4)
+5. Generate evals — one eval-writer dispatch per type (gate 5)
+6. Push + verify (gate 6)

--- a/examples/polymorphic_pizza/tools/get_menu/get_menu.json
+++ b/examples/polymorphic_pizza/tools/get_menu/get_menu.json
@@ -1,0 +1,9 @@
+{
+  "name": "5d8674c1-955b-406e-9db8-46f1d4db79ea",
+  "displayName": "get_menu",
+  "pythonFunction": {
+    "name": "get_menu",
+    "pythonCode": "tools/get_menu/python_function/python_code.py",
+    "description": "Return the Polymorphic Pizza menu: pizza sizes and their base prices, a few specialty pizzas, the list of available toppings, and the per-topping price. Use this whenever the customer asks what is available or how much something costs."
+  }
+}

--- a/examples/polymorphic_pizza/tools/get_menu/python_function/python_code.py
+++ b/examples/polymorphic_pizza/tools/get_menu/python_function/python_code.py
@@ -1,0 +1,52 @@
+"""Return the Polymorphic Pizza menu.
+
+Read-only tool. The prices here are the single source of truth that the
+quote_pizza and place_order tools also use, so the agent never has to invent
+a price.
+"""
+
+from typing import Any
+
+
+_SIZE_PRICES = {"small": 9.0, "medium": 12.0, "large": 15.0}
+
+_SPECIALTY_PIZZAS = [
+    "Margherita (tomato, mozzarella, basil)",
+    "Pepperoni Classic",
+    "Veggie Supreme (peppers, onion, mushroom, olive)",
+    "Meat Lovers (pepperoni, sausage, bacon)",
+]
+
+_TOPPINGS = [
+    "pepperoni",
+    "sausage",
+    "bacon",
+    "mushroom",
+    "onion",
+    "green pepper",
+    "olive",
+    "pineapple",
+    "extra cheese",
+    "spinach",
+]
+
+_TOPPING_PRICE = 1.5
+
+
+def get_menu() -> dict[str, Any]:
+  """Return the full menu.
+
+  Returns:
+    Dict with stored=True and a 'menu' payload of sizes, specialty pizzas,
+    toppings, and the per-topping price.
+  """
+  return {
+      "stored": True,
+      "menu": {
+          "sizes": _SIZE_PRICES,
+          "specialty_pizzas": _SPECIALTY_PIZZAS,
+          "toppings": _TOPPINGS,
+          "topping_price": _TOPPING_PRICE,
+          "currency": "USD",
+      },
+  }

--- a/examples/polymorphic_pizza/tools/get_order_status/get_order_status.json
+++ b/examples/polymorphic_pizza/tools/get_order_status/get_order_status.json
@@ -1,0 +1,9 @@
+{
+  "name": "495385a0-b27d-422a-b878-292ed0dd0f24",
+  "displayName": "get_order_status",
+  "pythonFunction": {
+    "name": "get_order_status",
+    "pythonCode": "tools/get_order_status/python_function/python_code.py",
+    "description": "Look up the status of an existing order by its order number (e.g. 'PZA-1A2B3C'). Returns the current stage and an estimated time remaining."
+  }
+}

--- a/examples/polymorphic_pizza/tools/get_order_status/python_function/python_code.py
+++ b/examples/polymorphic_pizza/tools/get_order_status/python_function/python_code.py
@@ -1,0 +1,41 @@
+"""Look up the status of an existing order.
+
+Deterministic mock: the order number maps to a fixed stage so the demo is
+reproducible without a real order database.
+"""
+
+import hashlib
+from typing import Any
+
+
+_STAGES = [
+    ("received", "We have your order and the kitchen is starting on it.", 35),
+    ("in the oven", "Your pizza is baking right now.", 18),
+    ("out for delivery", "Your pizza is on its way to you.", 8),
+    ("ready for pickup", "Your pizza is ready at the counter.", 0),
+]
+
+
+def get_order_status(order_number: str) -> dict[str, Any]:
+  """Return the current status of an order.
+
+  Args:
+    order_number: The order number to look up, e.g. 'PZA-1A2B3C'.
+
+  Returns:
+    Dict with stored=True, the status, a human description, and minutes
+    remaining, or error=True if the order number is empty.
+  """
+  key = str(order_number).strip().upper()
+  if not key:
+    return {"error": True, "error_code": "missing_order_number"}
+
+  digest = hashlib.sha1(key.encode("utf-8")).hexdigest()
+  stage, description, minutes = _STAGES[int(digest, 16) % len(_STAGES)]
+  return {
+      "stored": True,
+      "order_number": key,
+      "status": stage,
+      "description": description,
+      "minutes_remaining": minutes,
+  }

--- a/examples/polymorphic_pizza/tools/place_order/place_order.json
+++ b/examples/polymorphic_pizza/tools/place_order/place_order.json
@@ -1,0 +1,9 @@
+{
+  "name": "120d3921-6b21-43f2-bfbb-2d13b390c8b2",
+  "displayName": "place_order",
+  "pythonFunction": {
+    "name": "place_order",
+    "pythonCode": "tools/place_order/python_function/python_code.py",
+    "description": "Place a confirmed pizza order. Pass the size, comma-separated toppings, fulfillment ('pickup' or 'delivery'), the customer's name, and (for delivery) the address. Returns an order number, the total price including any delivery fee, and an estimated time."
+  }
+}

--- a/examples/polymorphic_pizza/tools/place_order/python_function/python_code.py
+++ b/examples/polymorphic_pizza/tools/place_order/python_function/python_code.py
@@ -1,0 +1,78 @@
+"""Place a confirmed pizza order.
+
+Stateless: the whole order is passed in one call. Returns a deterministic
+order number (derived from the order details) plus the total and an ETA, so
+the demo behaves the same on every run without any backend.
+"""
+
+import hashlib
+from typing import Any
+
+
+_SIZE_PRICES = {"small": 9.0, "medium": 12.0, "large": 15.0}
+_TOPPING_PRICE = 1.5
+_DELIVERY_FEE = 4.0
+_VALID_FULFILLMENT = {"pickup", "delivery"}
+
+
+def _parse_toppings(toppings: str) -> list[str]:
+  return [t.strip() for t in str(toppings).split(",") if t.strip()]
+
+
+def _order_number(seed: str) -> str:
+  digest = hashlib.sha1(seed.encode("utf-8")).hexdigest()
+  return "PZA-" + digest[:6].upper()
+
+
+def place_order(
+    size: str,
+    toppings: str,
+    fulfillment: str,
+    customer_name: str,
+    address: str = "",
+) -> dict[str, Any]:
+  """Place a confirmed pizza order.
+
+  Args:
+    size: 'small', 'medium', or 'large'.
+    toppings: Comma-separated topping names (may be empty).
+    fulfillment: 'pickup' or 'delivery'.
+    customer_name: Name the order is under.
+    address: Delivery address; required when fulfillment is 'delivery'.
+
+  Returns:
+    Dict with stored=True, an order_number, the total, and an ETA in
+    minutes, or error=True with an error_code on invalid input.
+  """
+  size = str(size).lower().strip()
+  fulfillment = str(fulfillment).lower().strip()
+  name = str(customer_name).strip()
+
+  if size not in _SIZE_PRICES:
+    return {"error": True, "error_code": "invalid_size"}
+  if fulfillment not in _VALID_FULFILLMENT:
+    return {"error": True, "error_code": "invalid_fulfillment"}
+  if not name:
+    return {"error": True, "error_code": "missing_name"}
+  if fulfillment == "delivery" and not str(address).strip():
+    return {"error": True, "error_code": "missing_address"}
+
+  topping_list = _parse_toppings(toppings)
+  subtotal = _SIZE_PRICES[size] + len(topping_list) * _TOPPING_PRICE
+  delivery_fee = _DELIVERY_FEE if fulfillment == "delivery" else 0.0
+  total = round(subtotal + delivery_fee, 2)
+  eta = 40 if fulfillment == "delivery" else 20
+
+  seed = f"{name}|{size}|{','.join(topping_list)}|{fulfillment}|{address}"
+  return {
+      "stored": True,
+      "order_number": _order_number(seed),
+      "size": size,
+      "toppings": topping_list,
+      "fulfillment": fulfillment,
+      "customer_name": name,
+      "delivery_fee": delivery_fee,
+      "total": total,
+      "currency": "USD",
+      "eta_minutes": eta,
+  }

--- a/examples/polymorphic_pizza/tools/quote_pizza/python_function/python_code.py
+++ b/examples/polymorphic_pizza/tools/quote_pizza/python_function/python_code.py
@@ -1,0 +1,45 @@
+"""Quote the price of one pizza.
+
+Pure helper the Order Agent calls to give the customer an accurate price
+before placing the order. Prices match the get_menu tool.
+"""
+
+from typing import Any
+
+
+_SIZE_PRICES = {"small": 9.0, "medium": 12.0, "large": 15.0}
+_TOPPING_PRICE = 1.5
+
+
+def _parse_toppings(toppings: str) -> list[str]:
+  return [t.strip() for t in str(toppings).split(",") if t.strip()]
+
+
+def quote_pizza(size: str, toppings: str = "") -> dict[str, Any]:
+  """Calculate the price of a single pizza.
+
+  Args:
+    size: 'small', 'medium', or 'large'.
+    toppings: Comma-separated topping names (may be empty).
+
+  Returns:
+    Dict with stored=True and a price breakdown, or error=True if the size
+    is not on the menu.
+  """
+  size = str(size).lower().strip()
+  if size not in _SIZE_PRICES:
+    return {"error": True, "error_code": "invalid_size"}
+
+  topping_list = _parse_toppings(toppings)
+  base = _SIZE_PRICES[size]
+  toppings_total = round(len(topping_list) * _TOPPING_PRICE, 2)
+  total = round(base + toppings_total, 2)
+  return {
+      "stored": True,
+      "size": size,
+      "toppings": topping_list,
+      "base_price": base,
+      "toppings_total": toppings_total,
+      "total": total,
+      "currency": "USD",
+  }

--- a/examples/polymorphic_pizza/tools/quote_pizza/quote_pizza.json
+++ b/examples/polymorphic_pizza/tools/quote_pizza/quote_pizza.json
@@ -1,0 +1,9 @@
+{
+  "name": "4d287fca-08dd-4c99-bc34-e22e51f8f3e9",
+  "displayName": "quote_pizza",
+  "pythonFunction": {
+    "name": "quote_pizza",
+    "pythonCode": "tools/quote_pizza/python_function/python_code.py",
+    "description": "Calculate the price of a single pizza. Pass the size ('small', 'medium', or 'large') and a comma-separated list of toppings (may be empty). Returns the base price, topping count, and the total."
+  }
+}

--- a/examples/polymorphic_pizza/tools/set_active_flow/python_function/python_code.py
+++ b/examples/polymorphic_pizza/tools/set_active_flow/python_function/python_code.py
@@ -1,0 +1,36 @@
+"""Activate a flow and route to the matching specialist agent.
+
+Setter tool for the root Pizza Host. When called, the host's after_tool
+callback records the target agent and the before_model callback fires a
+deterministic transfer to it.
+"""
+
+from typing import Any
+
+
+_VALID_FLOWS = {"order", "track"}
+
+_FLOW_TO_AGENT = {
+    "order": "Order_Agent",
+    "track": "Tracking_Agent",
+}
+
+
+def set_active_flow(flow: str) -> dict[str, Any]:
+  """Activate a flow and route to the right specialist.
+
+  Args:
+    flow: The flow to activate — 'order' or 'track'.
+
+  Returns:
+    Dict with stored=True, the normalized value, and the target agent on
+    success, or error=True on failure.
+  """
+  flow = str(flow).lower().strip()
+  if flow not in _VALID_FLOWS:
+    return {"error": True, "error_code": "invalid_flow"}
+  result = {"stored": True, "value": flow}
+  target = _FLOW_TO_AGENT.get(flow)
+  if target:
+    result["target_agent"] = target
+  return result

--- a/examples/polymorphic_pizza/tools/set_active_flow/set_active_flow.json
+++ b/examples/polymorphic_pizza/tools/set_active_flow/set_active_flow.json
@@ -1,0 +1,9 @@
+{
+  "name": "efeb46fc-7b4d-4b5b-b661-5d358ea0c3ac",
+  "displayName": "set_active_flow",
+  "pythonFunction": {
+    "name": "set_active_flow",
+    "pythonCode": "tools/set_active_flow/python_function/python_code.py",
+    "description": "Classify the customer's request and route to the right specialist. Valid flows: 'order' (start a new pizza order) and 'track' (check the status of an existing order)."
+  }
+}

--- a/findings.md
+++ b/findings.md
@@ -1,0 +1,75 @@
+# Findings
+
+## PRD Promise Extraction
+- The PRD promises a build-time, additive SCRAPI V1 with:
+  - Channel Adapter Card files under `adapters/`.
+  - A Polymorphism Engine and `cxas poly build` that produce ordinary SCRAPI
+    projects per channel.
+  - Explicit adapter deltas for instructions, channel-only tools, model
+    overrides, callbacks, deployment, and channel evals.
+  - Evaluation composition: base evals plus channel evals with coverage signal.
+  - Auditable compilation: deviations from the base are visible and reviewable.
+  - A Bella Notte reference example as the primary launch artifact.
+  - A design-partner workflow that can reveal schema expressiveness,
+    compilation correctness, and authoring ergonomics gaps.
+
+## Implementation Inventory
+- Present:
+  - `src/cxas_scrapi/poly/models.py` defines strict adapter-card Pydantic
+    models for instruction diffs, tool changes, tool definitions, model
+    overrides, callbacks, eval refs, config overlays, and deployment.
+  - `src/cxas_scrapi/poly/validators.py` provides AD001-AD010 validation and
+    backs the linter/engine contract.
+  - `src/cxas_scrapi/poly/engine.py` compiles one adapter into a complete
+    SCRAPI output directory, copies the base project, applies deltas, and writes
+    a `.poly_build.json` marker.
+  - `src/cxas_scrapi/cli/poly_cli.py` exposes `init`, `build`, `validate`,
+    `doctor`, and `diff`.
+  - `src/cxas_scrapi/poly/diffing.py` emits stable JSON plus human adapter
+    deltas for review.
+  - `src/cxas_scrapi/poly/scaffold.py` supports conservative adapter
+    scaffolding with optional eval/tool/callback starters.
+
+## Gap Matrix
+- Promise: deterministic adapter-card build to ordinary SCRAPI outputs.
+  Status: mostly met. `engine.py`, `poly_cli.py`, and hardening tests cover
+  build, safe output writing, and lintable compiled projects.
+- Promise: explicit, auditable channel deviations.
+  Status: partially met. `cxas poly diff` exposes deltas, but there is no single
+  launch/readiness report that rolls diff, validation, eval coverage, and
+  compileability into a design-partner artifact.
+- Promise: evaluation composition with coverage signal.
+  Status: partially met. The engine merges channel eval directories and AD006
+  warns when an adapter has no eval entries, but no report distinguishes "has an
+  eval sourceDir" from launch-quality channel coverage or flags channel eval
+  names that collide with base evals before write time.
+- Promise: Bella Notte as primary reference example.
+  Status: mostly met. Bella Notte has chat and voice adapters, docs, callbacks,
+  rich card tooling, and evals. It would benefit from a pre-build readiness step
+  in the documented workflow.
+- Promise: structured design-partner learning loop.
+  Status: gap. There is no command that design partners can run to capture the
+  health of a polymorphic project before build/lint/eval/deploy.
+
+## Improvement Candidates
+- Early candidates:
+  - Add an explicit launch/readiness report that checks the PRD's adoption
+    dimensions: per-adapter eval coverage, diff reviewability, buildability,
+    compiled lint readiness, and generated next steps.
+  - Strengthen coverage diagnostics beyond AD006: distinguish "has an eval
+    directory" from "has eval coverage matching meaningful channel deltas."
+  - Add machine-readable audit metadata to build outputs so compiled projects
+    carry source adapter/card lineage and change summaries.
+  - Improve Bella Notte walkthrough docs around design-partner workflow and
+    "do not hand-edit compiled output" launch behavior.
+
+## Selected Slice
+- Implement `cxas poly readiness`:
+  - Text/JSON report with schema version `poly-readiness/v1`.
+  - Per-channel status: `ready`, `attention`, or `blocked`.
+  - Existing AD validation issues, duplicate channel issues, and compileability.
+  - Diff summary from the existing `poly-diff/v1` report builder.
+  - Eval coverage counts and duplicate eval/expectation/dataset names between
+    the base and channel-specific additions.
+  - Actionable next steps that point users back to validate/doctor, channel
+    eval authoring, build, lint, and eval.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -159,6 +159,7 @@ nav:
     - Slot Filling: patterns/slot-filling.md
     - Dynamic Prompting: patterns/dynamic-prompting.md
     - Self-Healing Errors: patterns/self-healing.md
+    - Polymorphism: patterns/polymorphism.md
   - Tutorials:
     - tutorials/index.md
     - Restaurant Reservation: tutorials/restaurant-reservation.md
@@ -203,6 +204,7 @@ nav:
     - Insights:
       - guides/insights/index.md
       - Scorecards: guides/insights/scorecards.md
+    - Polymorphism: guides/polymorphism.md
   - VS Code Extension:
     - vscode/index.md
     - Installation: vscode/installation.md
@@ -230,6 +232,7 @@ nav:
     - cxas local-test: cli/local-test.md
     - cxas init-github-action: cli/init-github-action.md
     - cxas lint: cli/lint.md
+    - cxas poly: cli/poly.md
     - cxas init: cli/init.md
     - cxas insights: cli/insights.md
   - API Reference:

--- a/progress.md
+++ b/progress.md
@@ -34,6 +34,11 @@
 - `uv run --with-editable . --with alive-progress cxas poly build --app-dir examples/bella_notte --output-dir /tmp/poly_prd_alignment_build_c72c_readiness_20260522` - passed: wrote chat and voice outputs.
 - `uv run --with-editable . --with alive-progress cxas lint --app-dir /tmp/poly_prd_alignment_build_c72c_readiness_20260522/chat` - passed: no lint errors.
 - `uv run --with-editable . --with alive-progress cxas lint --app-dir /tmp/poly_prd_alignment_build_c72c_readiness_20260522/voice` - passed: no lint errors.
+- `git commit -m "feat(poly): add launch readiness report"` - created commit `66feb26`.
+- `git push -u origin codex/poly-prd-readiness` - pushed the branch to origin.
+- GitHub connector PR creation failed with `Authentication Failed: Requires authentication`; fell back to authenticated `gh`.
+- `gh pr create --draft --repo GoogleCloudPlatform/cxas-scrapi --base main --head andrewhuot:codex/poly-prd-readiness ...` - opened draft PR https://github.com/GoogleCloudPlatform/cxas-scrapi/pull/172.
 
 ## Errors Encountered
-- None yet.
+- GitHub connector PR creation returned `Authentication Failed: Requires
+  authentication`; authenticated `gh pr create` succeeded as fallback.

--- a/progress.md
+++ b/progress.md
@@ -1,0 +1,39 @@
+# Progress
+
+## Session Log
+- 2026-05-22 01:55 - Started PRD alignment goal. Existing worktree was clean
+  and detached. Existing `PLAN.md` described a completed first-wave DX effort,
+  so it was replaced with the current goal plan.
+- 2026-05-22 02:00 - Reviewed PRD, poly models, validators, engine, CLI,
+  diagnostics, scaffold, docs, examples, and tests.
+- 2026-05-22 02:02 - Created branch `codex/poly-prd-readiness` from detached
+  HEAD.
+- 2026-05-22 02:03 - Selected `cxas poly readiness` as the implementation
+  slice because it directly addresses PRD launch-readiness and design-partner
+  workflow gaps.
+
+## Commands And Results
+- `python3 /Users/andrew/.agents/skills/planning-with-files/scripts/session-catchup.py "$(pwd)"` - completed with no unsynced context reported.
+- `git status --short --branch` - clean detached `HEAD`.
+- `git switch -c codex/poly-prd-readiness` - created and switched to the
+  implementation branch.
+- `uv run --with-editable . --with alive-progress pytest tests/cxas_scrapi/poly/test_readiness.py -q` - RED as expected: `ModuleNotFoundError` for `cxas_scrapi.poly.readiness`.
+- `uv run --with-editable . --with alive-progress pytest tests/cxas_scrapi/poly/test_readiness.py -q` - GREEN: 3 passed, 1 existing pytest config warning.
+- `uv run --with-editable . --with alive-progress pytest tests/cxas_scrapi/poly/test_poly_cli.py::test_cli_readiness_json -q` - RED as expected: argparse did not know the `readiness` subcommand.
+- `uv run --with-editable . --with alive-progress pytest tests/cxas_scrapi/poly/test_poly_cli.py::test_cli_readiness_json -q` - GREEN: 1 passed, 1 existing pytest config warning.
+- `uv run --with-editable . --with alive-progress pytest tests/cxas_scrapi/poly/test_readiness.py tests/cxas_scrapi/poly/test_poly_cli.py -q` - 7 passed, 1 existing pytest config warning.
+- `uv run --with-editable . --with alive-progress ruff check src/cxas_scrapi/poly src/cxas_scrapi/cli/poly_cli.py tests/cxas_scrapi/poly` - first run failed on unused local `warnings` in `readiness.py`; removed it.
+- `uv run --with-editable . --with alive-progress ruff check src/cxas_scrapi/poly src/cxas_scrapi/cli/poly_cli.py tests/cxas_scrapi/poly` - passed.
+- `uv run --with-editable . --with alive-progress cxas poly readiness --app-dir examples/bella_notte` - passed; reported 2 ready channels, 0 warnings/errors.
+- `uv run --with-editable . --with alive-progress cxas poly readiness --app-dir examples/bella_notte --format json` - passed; emitted `poly-readiness/v1` with `launch_ready: true`.
+- `git diff --check` - passed.
+- `uv run --with-editable . --with alive-progress pytest tests/cxas_scrapi/poly -q` - passed: 89 tests, 1 existing pytest config warning.
+- `uv run --with-editable . --with alive-progress cxas poly validate --app-dir examples/bella_notte` - passed: all 2 adapter cards valid.
+- `uv run --with-editable . --with alive-progress cxas poly doctor --app-dir examples/bella_notte` - passed: no doctor findings.
+- `uv run --with-editable . --with alive-progress cxas poly diff chat --app-dir examples/bella_notte --json` - passed: emitted `poly-diff/v1`.
+- `uv run --with-editable . --with alive-progress cxas poly build --app-dir examples/bella_notte --output-dir /tmp/poly_prd_alignment_build_c72c_readiness_20260522` - passed: wrote chat and voice outputs.
+- `uv run --with-editable . --with alive-progress cxas lint --app-dir /tmp/poly_prd_alignment_build_c72c_readiness_20260522/chat` - passed: no lint errors.
+- `uv run --with-editable . --with alive-progress cxas lint --app-dir /tmp/poly_prd_alignment_build_c72c_readiness_20260522/voice` - passed: no lint errors.
+
+## Errors Encountered
+- None yet.

--- a/src/cxas_scrapi/__init__.py
+++ b/src/cxas_scrapi/__init__.py
@@ -48,6 +48,10 @@ from cxas_scrapi.migration.flow_visualizer import (
 from cxas_scrapi.migration.graph_visualizer import HighLevelGraphVisualizer
 from cxas_scrapi.migration.main_visualizer import MainVisualizer
 from cxas_scrapi.migration.playbook_visualizer import PlaybookTreeVisualizer
+
+# Polymorphism Engine
+from cxas_scrapi.poly.engine import PolymorphismEngine
+from cxas_scrapi.poly.models import AdapterCard, CompiledAgentConfig
 from cxas_scrapi.utils.changelog_utils import ChangelogUtils
 
 # Utilities
@@ -90,4 +94,7 @@ __all__ = [
     "HighLevelGraphVisualizer",
     "PlaybookTreeVisualizer",
     "MainVisualizer",
+    "PolymorphismEngine",
+    "AdapterCard",
+    "CompiledAgentConfig",
 ]

--- a/src/cxas_scrapi/cli/main.py
+++ b/src/cxas_scrapi/cli/main.py
@@ -45,6 +45,7 @@ from cxas_scrapi.cli.migration_cli import (
 from cxas_scrapi.cli.migration_cli import (
     register as register_dfcx_cxas_subparsers,
 )
+from cxas_scrapi.cli.poly_cli import register as register_poly_subparser
 from cxas_scrapi.cli.trace_cli import register as register_trace_subparser
 from cxas_scrapi.core.apps import Apps
 from cxas_scrapi.core.evaluations import Evaluations, ExportFormat
@@ -1425,6 +1426,7 @@ def get_parser() -> argparse.ArgumentParser:
             "config",
             "structure",
             "schema",
+            "adapters",
         ],
         help="Only run a specific linter category.",
     )
@@ -1602,6 +1604,9 @@ def get_parser() -> argparse.ArgumentParser:
 
     # Subparsers for 'trace' — observability/debugging for past conversations.
     register_trace_subparser(subparsers)
+
+    # Subparsers for 'poly' — polymorphism engine (channel adapters).
+    register_poly_subparser(subparsers)
 
     return parser
 

--- a/src/cxas_scrapi/cli/poly_cli.py
+++ b/src/cxas_scrapi/cli/poly_cli.py
@@ -81,7 +81,7 @@ def _load_engine(app_dir: str) -> PolymorphismEngine:
 
 def _all_issues(engine: PolymorphismEngine, app_dir: str) -> List[dict]:
     """Parse errors plus validation issues for every loaded adapter."""
-    cards = [c for c, _ in engine.adapters.values()]
+    cards = [c for c, _ in engine.adapter_cards]
     return list(engine.adapter_errors) + validate_all_adapters(cards, app_dir)
 
 
@@ -110,8 +110,8 @@ def poly_build(args: argparse.Namespace) -> None:
 
     # Decide which channels to build and gather issues to gate on.
     if channel == "all":
-        targets = list(engine.adapters.values())
         issues = _all_issues(engine, app_dir)
+        targets = list(engine.adapter_cards)
     else:
         if channel not in engine.adapters:
             console.print(
@@ -124,6 +124,12 @@ def poly_build(args: argparse.Namespace) -> None:
         card, path = engine.adapters[channel]
         targets = [(card, path)]
         issues = validate_adapter_card(card, app_dir)
+        issues.extend(
+            i
+            for i in _all_issues(engine, app_dir)
+            if i.get("rule_id") == "AD007"
+            and f"'{channel}'" in i.get("message", "")
+        )
 
     errors, warnings = _counts(issues)
     if issues:
@@ -240,6 +246,16 @@ def poly_diff(args: argparse.Namespace) -> None:
             _print_issues(engine.adapter_errors)
         sys.exit(1)
     card, card_path = entry
+    duplicate_issues = [
+        i
+        for i in _all_issues(engine, app_dir)
+        if i.get("rule_id") == "AD007"
+        and f"'{channel}'" in i.get("message", "")
+    ]
+    if duplicate_issues:
+        console.print("[red]Error:[/red] duplicate adapter channel:")
+        _print_issues(duplicate_issues)
+        sys.exit(1)
 
     try:
         compiled = engine.compile(card, card_path)
@@ -351,6 +367,11 @@ def poly_diff(args: argparse.Namespace) -> None:
             )
 
     # Deployment (folded into gecx-config.json).
+    if card.gecx_config:
+        console.print("\n[bold cyan]gecx-config.json (channel config)[/bold cyan]")
+        for k, v in sorted(card.gecx_config.items()):
+            console.print(f"  [green]~ {k}: {v}[/green]")
+
     if compiled.deployment:
         console.print("\n[bold cyan]gecx-config.json (deployment)[/bold cyan]")
         for k, v in compiled.deployment.items():

--- a/src/cxas_scrapi/cli/poly_cli.py
+++ b/src/cxas_scrapi/cli/poly_cli.py
@@ -1,0 +1,361 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Argparse handlers for ``cxas poly`` (build, validate, diff).
+
+Drives the Polymorphism Engine from the command line: compile base agent
+projects into channel-optimized variants, validate adapter cards, and show
+a human-readable diff of what an adapter changes.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from rich.console import Console
+
+from cxas_scrapi.poly.engine import (
+    CompilationError,
+    PolymorphismEngine,
+)
+from cxas_scrapi.poly.models import AdapterCard
+from cxas_scrapi.poly.validators import validate_all_adapters
+
+console = Console()
+
+
+def _print_issues(issues: List[dict]) -> int:
+    """Print issue dicts; return the number of errors."""
+    errors = 0
+    for issue in sorted(
+        issues, key=lambda i: (i.get("severity", ""), i.get("rule_id", ""))
+    ):
+        sev = issue.get("severity", "error")
+        rule_id = issue.get("rule_id", "?")
+        path = issue.get("path", "")
+        msg = issue.get("message", "")
+        if sev == "error":
+            errors += 1
+            color = "red"
+            label = "ERROR"
+        elif sev == "warning":
+            color = "yellow"
+            label = "WARN "
+        else:
+            color = "cyan"
+            label = "INFO "
+        console.print(f"  [{color}]{label}[/{color}] [{rule_id}] {path}: {msg}")
+    return errors
+
+
+def _load_engine(app_dir: str) -> PolymorphismEngine:
+    engine = PolymorphismEngine(app_dir)
+    engine.load_base_project()
+    engine.load_adapter_cards()
+    return engine
+
+
+# ── poly build ────────────────────────────────────────────────────────────
+
+
+def poly_build(args: argparse.Namespace) -> None:
+    """Handle ``cxas poly build``."""
+    app_dir = str(Path(getattr(args, "app_dir", ".")).resolve())
+    channel = getattr(args, "channel", "all")
+    output_dir = Path(getattr(args, "output_dir", "./output"))
+
+    try:
+        engine = _load_engine(app_dir)
+    except FileNotFoundError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        sys.exit(1)
+
+    if not engine.adapters:
+        console.print(
+            f"[yellow]No adapter cards found in {app_dir}/adapters.[/yellow]"
+        )
+        sys.exit(1)
+
+    try:
+        if channel == "all":
+            compiled = engine.compile_all()
+        else:
+            if channel not in engine.adapters:
+                console.print(
+                    f"[red]Error:[/red] no adapter for channel '{channel}'. "
+                    f"Available: {', '.join(sorted(engine.adapters))}"
+                )
+                sys.exit(1)
+            card, path = engine.adapters[channel]
+            # Run validation for the single channel too.
+            issues = validate_all_adapters([card], app_dir)
+            if _print_issues(issues):
+                console.print("\n[red]Build aborted: validation errors.[/red]")
+                sys.exit(1)
+            compiled = {channel: engine.compile(card, path)}
+    except CompilationError as e:
+        console.print("[red]Compilation failed:[/red]")
+        _print_issues(e.issues)
+        sys.exit(1)
+
+    for ch, cfg in compiled.items():
+        out = engine.write_output(cfg, str(output_dir / ch))
+        console.print(f"[green]Compiled[/green] channel '{ch}' -> {out}")
+
+    console.print(
+        f"\n[green]Done.[/green] {len(compiled)} channel(s) written to "
+        f"{output_dir.resolve()}"
+    )
+    sys.exit(0)
+
+
+# ── poly validate ───────────────────────────────────────────────────────────
+
+
+def poly_validate(args: argparse.Namespace) -> None:
+    """Handle ``cxas poly validate``."""
+    app_dir = str(Path(getattr(args, "app_dir", ".")).resolve())
+
+    try:
+        engine = PolymorphismEngine(app_dir)
+        engine.load_base_project()
+        cards = engine.load_adapter_cards()
+    except FileNotFoundError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        sys.exit(1)
+    except Exception as e:  # noqa: BLE001 - surface parse errors clearly
+        console.print(f"[red]Failed to parse adapter cards:[/red] {e}")
+        sys.exit(1)
+
+    if not cards:
+        console.print(
+            f"[yellow]No adapter cards found in {app_dir}/adapters.[/yellow]"
+        )
+        sys.exit(0)
+
+    issues = validate_all_adapters(cards, app_dir)
+    if not issues:
+        console.print(f"[green]All {len(cards)} adapter card(s) valid.[/green]")
+        sys.exit(0)
+
+    console.print(f"Validated {len(cards)} adapter card(s) for {app_dir}:\n")
+    errors = _print_issues(issues)
+    warnings = len(issues) - errors
+    console.print(f"\n  {errors} error(s), {warnings} warning(s)")
+    sys.exit(1 if errors else 0)
+
+
+# ── poly diff ────────────────────────────────────────────────────────────────
+
+
+def _find_card(
+    engine: PolymorphismEngine, channel: str
+) -> Optional[AdapterCard]:
+    entry = engine.adapters.get(channel)
+    return entry[0] if entry else None
+
+
+def poly_diff(args: argparse.Namespace) -> None:
+    """Handle ``cxas poly diff <channel>``."""
+    app_dir = str(Path(getattr(args, "app_dir", ".")).resolve())
+    channel = args.channel
+
+    try:
+        engine = _load_engine(app_dir)
+    except FileNotFoundError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        sys.exit(1)
+
+    entry = engine.adapters.get(channel)
+    if entry is None:
+        console.print(
+            f"[red]Error:[/red] no adapter for channel '{channel}'. "
+            f"Available: {', '.join(sorted(engine.adapters)) or '(none)'}"
+        )
+        sys.exit(1)
+    card, card_path = entry
+
+    try:
+        compiled = engine.compile(card, card_path)
+    except CompilationError as e:
+        console.print("[red]Compilation failed:[/red]")
+        _print_issues(e.issues)
+        sys.exit(1)
+
+    rel_card = (
+        Path(card_path).relative_to(Path(app_dir))
+        if Path(card_path).is_relative_to(Path(app_dir))
+        else card_path
+    )
+    console.print(f"[bold]Channel: {channel}[/bold]   (adapter: {rel_card})\n")
+
+    base = engine.base
+    assert base is not None
+
+    # Build a per-agent view of changes.
+    display_to_dir = {b.display_name: name for name, b in base.agents.items()}
+
+    def to_dir(ref: str) -> Optional[str]:
+        if ref in base.agents:
+            return ref
+        return display_to_dir.get(ref)
+
+    touched_agents = set()
+    for d in card.instruction_diffs:
+        touched_agents.add(to_dir(d.agent))
+    for t in card.tools:
+        touched_agents.add(to_dir(t.agent))
+    for m in card.model_overrides:
+        touched_agents.add(to_dir(m.agent))
+    for c in card.callbacks:
+        touched_agents.add(to_dir(c.agent))
+    touched_agents.discard(None)
+
+    for dir_name in sorted(touched_agents):
+        console.print(f"[bold cyan]agents/{dir_name}[/bold cyan]")
+        base_bundle = base.agents[dir_name]
+
+        # Instruction diffs.
+        for d in card.instruction_diffs:
+            if to_dir(d.agent) != dir_name:
+                continue
+            if d.mode == "replace_section":
+                console.print(
+                    f"  instruction: ~ replace_section <{d.section_tag}>"
+                )
+            else:
+                lines = d.content.strip().splitlines()
+                console.print(f"  instruction: + {len(lines)} line(s) {d.mode}")
+                for line in lines[:3]:
+                    console.print(f"    [green]+ {line}[/green]")
+                if len(lines) > 3:
+                    console.print("    [green]+ ...[/green]")
+
+        # Tool changes.
+        base_tools = list(base_bundle.config.get("tools", []))
+        comp_tools = list(compiled.agents[dir_name].get("tools", []))
+        added = [t for t in comp_tools if t not in base_tools]
+        removed = [t for t in base_tools if t not in comp_tools]
+        if added or removed:
+            console.print(f"  tools ({len(base_tools)} -> {len(comp_tools)}):")
+            for t in added:
+                console.print(f"    [green]+ {t}[/green]")
+            for t in removed:
+                console.print(f"    [red]- {t}[/red]")
+
+        # Model override.
+        base_model = (base_bundle.config.get("modelSettings") or {}).get(
+            "model"
+        )
+        comp_model = (compiled.agents[dir_name].get("modelSettings") or {}).get(
+            "model"
+        )
+        if base_model != comp_model:
+            console.print(
+                f"  modelSettings.model: {base_model or '(default)'} -> "
+                f"[green]{comp_model}[/green]"
+            )
+
+        # Added callbacks.
+        for c in card.callbacks:
+            if to_dir(c.agent) != dir_name:
+                continue
+            console.print(
+                f"  callbacks: [green]+ {c.type}[/green] "
+                f"({c.description or c.python_code})"
+            )
+
+    # New tools.
+    if compiled.tools:
+        console.print("\n[bold cyan]tools/[/bold cyan]")
+        for name in sorted(compiled.tools):
+            console.print(f"  [green]+ {name}[/green]")
+
+    # Evaluations.
+    if compiled.evaluations:
+        console.print("\n[bold cyan]evaluations/[/bold cyan]")
+        console.print(
+            f"  [green]+ {len(compiled.evaluations)} eval(s):[/green] "
+            f"{', '.join(sorted(compiled.evaluations))}"
+        )
+
+    # Deployment.
+    if compiled.deployment:
+        console.print("\n[bold cyan]deployment.json[/bold cyan]")
+        for k, v in compiled.deployment.items():
+            console.print(f"  [green]+ {k}: {v}[/green]")
+
+    sys.exit(0)
+
+
+# ── Registration ────────────────────────────────────────────────────────────
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:
+    """Add the ``poly`` subcommand tree to the top-level CLI."""
+    parser_poly = subparsers.add_parser(
+        "poly",
+        help=(
+            "Polymorphism engine: compile a base agent project into "
+            "channel-optimized variants."
+        ),
+    )
+    poly_subparsers = parser_poly.add_subparsers(
+        title="poly commands", dest="poly_command", required=True
+    )
+
+    # build
+    p_build = poly_subparsers.add_parser(
+        "build", help="Compile channel-optimized agent projects."
+    )
+    p_build.add_argument(
+        "--app-dir",
+        default=".",
+        help="Path to the agent project root (default: current directory).",
+    )
+    p_build.add_argument(
+        "--channel",
+        default="all",
+        help="Specific channel to compile, or 'all' (default: all).",
+    )
+    p_build.add_argument(
+        "--output-dir",
+        default="./output",
+        help="Output directory (default: ./output).",
+    )
+    p_build.set_defaults(func=poly_build)
+
+    # validate
+    p_validate = poly_subparsers.add_parser(
+        "validate", help="Validate adapter cards against the project."
+    )
+    p_validate.add_argument(
+        "--app-dir",
+        default=".",
+        help="Path to the agent project root (default: current directory).",
+    )
+    p_validate.set_defaults(func=poly_validate)
+
+    # diff
+    p_diff = poly_subparsers.add_parser(
+        "diff", help="Show what an adapter changes for a channel."
+    )
+    p_diff.add_argument("channel", help="The channel to diff.")
+    p_diff.add_argument(
+        "--app-dir",
+        default=".",
+        help="Path to the agent project root (default: current directory).",
+    )
+    p_diff.set_defaults(func=poly_diff)

--- a/src/cxas_scrapi/cli/poly_cli.py
+++ b/src/cxas_scrapi/cli/poly_cli.py
@@ -40,6 +40,7 @@ from cxas_scrapi.poly.engine import (
     PolymorphismEngine,
 )
 from cxas_scrapi.poly.models import AdapterCard
+from cxas_scrapi.poly.readiness import build_readiness_report
 from cxas_scrapi.poly.scaffold import (
     DEFAULT_DISPLAY_NAME_TEMPLATE,
     ScaffoldOptions,
@@ -238,6 +239,61 @@ def _print_diff_report(report: Dict[str, Any]) -> None:
         console.print("\n[bold cyan]gecx-config.json (deployment)[/bold cyan]")
         for key, value in report["deployment"].items():
             console.print(f"  [green]+ {key}: {value}[/green]")
+
+
+def _print_readiness_report(report: Dict[str, Any]) -> None:
+    """Render a launch-readiness report for human review."""
+    summary = report["summary"]
+    console.print(
+        "[bold]Poly readiness[/bold]   "
+        f"{summary['ready']} ready, "
+        f"{summary['attention']} attention, "
+        f"{summary['blocked']} blocked"
+    )
+    console.print(
+        f"Issues: {summary['errors']} error(s), "
+        f"{summary['warnings']} warning(s)\n"
+    )
+
+    if report["adapter_errors"]:
+        console.print("[bold red]Adapter parse/schema errors[/bold red]")
+        _print_issues(report["adapter_errors"])
+        console.print()
+
+    for channel in report["channels"]:
+        status = channel["status"]
+        color = {
+            "ready": "green",
+            "attention": "yellow",
+            "blocked": "red",
+        }.get(status, "cyan")
+        console.print(
+            f"[bold {color}]{channel['channel']}[/bold {color}] "
+            f"({status})   {channel['adapter_path']}"
+        )
+        if channel["issues"]:
+            _print_issues(channel["issues"])
+        diff = channel["diff_summary"]
+        if diff:
+            console.print(
+                "  diff: "
+                f"{diff['agents_touched']} agent(s), "
+                f"{diff['instruction_diffs']} instruction diff(s), "
+                f"{diff['tools_added']} tool add(s), "
+                f"{diff['tools_removed']} tool remove(s), "
+                f"{diff['callbacks_added']} callback(s)"
+            )
+        coverage = channel["eval_coverage"]["evaluations"]
+        console.print(
+            "  evals: "
+            f"{coverage['base_count']} base, "
+            f"{coverage['channel_count']} channel"
+        )
+        for warning in channel["coverage_warnings"]:
+            console.print(f"  [yellow]WARN [/yellow] {warning['message']}")
+        for step in channel["next_steps"]:
+            console.print(f"  next: {step}")
+        console.print()
 
 
 def _prompt_channels() -> List[str]:
@@ -471,6 +527,40 @@ def poly_doctor(args: argparse.Namespace) -> None:
         _print_explanation_report(report)
 
     sys.exit(1 if _should_fail(report.errors, report.warnings, strict) else 0)
+
+
+# ── poly readiness ───────────────────────────────────────────────────────────
+
+
+def poly_readiness(args: argparse.Namespace) -> None:
+    """Handle ``cxas poly readiness``."""
+    app_dir = str(Path(getattr(args, "app_dir", ".")).resolve())
+    fmt = getattr(args, "format", "text")
+    strict = getattr(args, "strict", False)
+
+    try:
+        engine = PolymorphismEngine(app_dir)
+        engine.load_base_project()
+        engine.load_adapter_cards()
+    except FileNotFoundError as e:
+        if fmt == "json":
+            print(json.dumps({"error": str(e), "channels": []}, indent=2))
+        else:
+            console.print(f"[red]Error:[/red] {e}")
+        sys.exit(1)
+
+    report = build_readiness_report(engine, app_dir)
+    if fmt == "json":
+        print(json.dumps(report, indent=2))
+    else:
+        _print_readiness_report(report)
+
+    summary = report["summary"]
+    sys.exit(
+        1
+        if _should_fail(summary["errors"], summary["warnings"], strict)
+        else 0
+    )
 
 
 # ── poly diff ────────────────────────────────────────────────────────────────
@@ -759,6 +849,32 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         help="Exit non-zero if any warnings are present.",
     )
     p_doctor.set_defaults(func=poly_doctor)
+
+    # readiness
+    p_readiness = poly_subparsers.add_parser(
+        "readiness",
+        help=(
+            "Summarize adapter validation, diffs, eval coverage, and build "
+            "readiness."
+        ),
+    )
+    p_readiness.add_argument(
+        "--app-dir",
+        default=".",
+        help="Path to the agent project root (default: current directory).",
+    )
+    p_readiness.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format (default: text).",
+    )
+    p_readiness.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero if any warnings are present.",
+    )
+    p_readiness.set_defaults(func=poly_readiness)
 
     # diff
     p_diff = poly_subparsers.add_parser(

--- a/src/cxas_scrapi/cli/poly_cli.py
+++ b/src/cxas_scrapi/cli/poly_cli.py
@@ -12,27 +12,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Argparse handlers for ``cxas poly`` (build, validate, diff).
+"""Argparse handlers for ``cxas poly``.
 
 Drives the Polymorphism Engine from the command line: compile base agent
-projects into channel-optimized variants, validate adapter cards, and show
-a human-readable diff of what an adapter changes.  All error paths render
-clean, rule-ID-formatted messages — never a Python traceback.
+projects into channel-optimized variants, scaffold adapter cards, validate
+and explain adapter cards, and show human/JSON diffs of what an adapter
+changes.  All error paths render clean, rule-ID-formatted messages — never a
+Python traceback.
 """
 
 import argparse
 import json
 import sys
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from rich.console import Console
 
+from cxas_scrapi.poly.diagnostics import (
+    ExplainedIssue,
+    ValidationExplanationReport,
+    build_validation_explanation_report,
+)
+from cxas_scrapi.poly.diffing import build_diff_report
 from cxas_scrapi.poly.engine import (
     CompilationError,
     PolymorphismEngine,
 )
 from cxas_scrapi.poly.models import AdapterCard
+from cxas_scrapi.poly.scaffold import (
+    DEFAULT_DISPLAY_NAME_TEMPLATE,
+    ScaffoldOptions,
+    build_scaffold_plan,
+    split_channels,
+    write_scaffold_plan,
+)
 from cxas_scrapi.poly.validators import (
     validate_adapter_card,
     validate_all_adapters,
@@ -83,6 +97,210 @@ def _all_issues(engine: PolymorphismEngine, app_dir: str) -> List[dict]:
     """Parse errors plus validation issues for every loaded adapter."""
     cards = [c for c, _ in engine.adapter_cards]
     return list(engine.adapter_errors) + validate_all_adapters(cards, app_dir)
+
+
+def _should_fail(errors: int, warnings: int, strict: bool) -> bool:
+    """Return whether a command should exit non-zero for issue counts."""
+    return bool(errors or (strict and warnings))
+
+
+def _print_explanation_report(
+    report: ValidationExplanationReport,
+) -> None:
+    """Render doctor/validate explanation output for humans."""
+    if not report.issues:
+        console.print(
+            f"[green]All {report.cards} adapter card(s) valid.[/green]"
+        )
+        console.print("No doctor findings.")
+        return
+
+    console.print(
+        f"Doctor checked {report.cards} adapter card(s): "
+        f"{report.errors} error(s), {report.warnings} warning(s)\n"
+    )
+    for issue in report.issues:
+        _print_explained_issue(issue)
+
+
+def _print_explained_issue(issue: ExplainedIssue) -> None:
+    """Render one enriched validation issue."""
+    color = "red" if issue.severity == "error" else "yellow"
+    label = "ERROR" if issue.severity == "error" else "WARN "
+    console.print(
+        f"[{color}]{label}[/{color}] [{issue.rule_id}] "
+        f"{issue.adapter_path}"
+    )
+    if issue.field_path:
+        console.print(f"  field: {issue.field_path}")
+    if issue.related_paths:
+        console.print(f"  look at: {', '.join(issue.related_paths)}")
+    console.print(f"  what failed: {issue.message}")
+    console.print(f"  why: {issue.why_it_failed}")
+    console.print(f"  likely fix: {issue.likely_fix}\n")
+
+
+def _print_diff_report(report: Dict[str, Any]) -> None:
+    """Render the shared diff report in a compact reviewer-friendly format."""
+    summary = report["summary"]
+    console.print(
+        f"[bold]Channel: {report['channel']}[/bold]   "
+        f"(adapter: {report['adapter_path']})"
+    )
+    console.print(
+        "Summary: "
+        f"{summary['agents_touched']} agent(s), "
+        f"{summary['instruction_diffs']} instruction diff(s), "
+        f"{summary['tools_added']} tool add(s), "
+        f"{summary['tools_removed']} tool remove(s), "
+        f"{summary['callbacks_added']} callback(s), "
+        f"{summary['evaluations_added']} eval merge(s)\n"
+    )
+
+    for agent in report["agents"]:
+        console.print(
+            f"[bold cyan]{agent['path']}[/bold cyan] "
+            f"({agent['display_name']})"
+        )
+        for diff in agent["instruction_diffs"]:
+            mode = diff["mode"]
+            if mode == "replace_section":
+                console.print(
+                    "  instruction: "
+                    f"~ replace_section <{diff['section_tag']}> "
+                    f"({diff['path']})"
+                )
+            else:
+                console.print(
+                    f"  instruction: + {diff['line_count']} line(s) "
+                    f"{mode} ({diff['path']})"
+                )
+            for line in diff["preview"]:
+                console.print(f"    [green]+ {line}[/green]")
+            if diff["line_count"] > len(diff["preview"]):
+                console.print("    [green]+ ...[/green]")
+
+        tools = agent["tools"]
+        if tools["added"] or tools["removed"]:
+            console.print(
+                "  tools "
+                f"({tools['before_count']} -> {tools['after_count']}):"
+            )
+            for tool in tools["added"]:
+                console.print(f"    [green]+ {tool}[/green]")
+            for tool in tools["removed"]:
+                console.print(f"    [red]- {tool}[/red]")
+
+        model = agent["model"]
+        if model is not None:
+            console.print(
+                "  modelSettings.model: "
+                f"{model['before'] or '(default)'} -> "
+                f"[green]{model['after']}[/green]"
+            )
+
+        for callback in agent["callbacks_added"]:
+            desc = callback["description"] or callback["python_code"]
+            console.print(
+                f"  callbacks: [green]+ {callback['type']}[/green] "
+                f"({desc})"
+            )
+
+    if report["tool_definitions_added"]:
+        console.print("\n[bold cyan]tools/[/bold cyan]")
+        for tool in report["tool_definitions_added"]:
+            console.print(
+                f"  [green]+ {tool['display_name']}[/green] "
+                f"({tool['tool_type']}, {tool['source_dir']})"
+            )
+
+    merges = report["evaluation_merges"]
+    for label, names in (
+        ("evaluations", merges["evaluations"]),
+        ("evaluationExpectations", merges["evaluation_expectations"]),
+        ("evaluationDatasets", merges["evaluation_datasets"]),
+    ):
+        if names:
+            console.print(f"\n[bold cyan]{label}/[/bold cyan]")
+            console.print(
+                f"  [green]+ {len(names)} item(s):[/green] "
+                f"{', '.join(names)}"
+            )
+
+    if report["gecx_config_overlay"]:
+        console.print(
+            "\n[bold cyan]gecx-config.json (channel config)[/bold cyan]"
+        )
+        for key, value in sorted(report["gecx_config_overlay"].items()):
+            console.print(f"  [green]~ {key}: {value}[/green]")
+
+    if report["deployment"]:
+        console.print("\n[bold cyan]gecx-config.json (deployment)[/bold cyan]")
+        for key, value in report["deployment"].items():
+            console.print(f"  [green]+ {key}: {value}[/green]")
+
+
+def _prompt_channels() -> List[str]:
+    """Ask for channels only when stdin is interactive."""
+    if not sys.stdin.isatty():
+        raise ValueError(
+            "No --channel provided. Pass --channel for non-interactive use."
+        )
+    raw = input("Channel(s), comma-separated [chat]: ").strip() or "chat"
+    return split_channels([raw])
+
+
+# ── poly init ─────────────────────────────────────────────────────────────
+
+
+def poly_init(args: argparse.Namespace) -> None:
+    """Handle ``cxas poly init``."""
+    app_dir = Path(getattr(args, "app_dir", ".")).resolve()
+    try:
+        channels = split_channels(getattr(args, "channel", []) or [])
+        if not channels:
+            channels = _prompt_channels()
+        options = ScaffoldOptions(
+            app_dir=app_dir,
+            channels=channels,
+            target_agent=getattr(args, "agent", None),
+            display_name=getattr(args, "display_name", None),
+            display_name_template=getattr(
+                args,
+                "display_name_template",
+                DEFAULT_DISPLAY_NAME_TEMPLATE,
+            ),
+            deployment_target=getattr(args, "deployment_target", "auto"),
+            modality=getattr(args, "modality", "auto"),
+            include_eval=not getattr(args, "no_eval", False),
+            tools=getattr(args, "with_tool", []) or [],
+            callback_types=getattr(args, "with_callback", []) or [],
+        )
+        plan = build_scaffold_plan(options)
+        written = write_scaffold_plan(
+            plan,
+            force=getattr(args, "force", False),
+            dry_run=getattr(args, "dry_run", False),
+        )
+    except (FileNotFoundError, FileExistsError, ValueError) as e:
+        console.print(f"[red]Error:[/red] {e}")
+        sys.exit(1)
+
+    action = "Would write" if getattr(args, "dry_run", False) else "Created"
+    console.print(
+        f"[green]{action}[/green] {len(written)} file(s) for "
+        f"{len(plan.channels)} channel(s) targeting agent "
+        f"'{plan.target_agent}'."
+    )
+    for path in written:
+        console.print(f"  {path.relative_to(plan.app_dir)}")
+    console.print("\nNext:")
+    console.print(f"  cxas poly validate --app-dir {plan.app_dir}")
+    for channel in plan.channels:
+        console.print(
+            f"  cxas poly diff {channel.channel} --app-dir {plan.app_dir}"
+        )
+    sys.exit(0)
 
 
 # ── poly build ────────────────────────────────────────────────────────────
@@ -169,6 +387,7 @@ def poly_validate(args: argparse.Namespace) -> None:
     app_dir = str(Path(getattr(args, "app_dir", ".")).resolve())
     fmt = getattr(args, "format", "text")
     strict = getattr(args, "strict", False)
+    explain = getattr(args, "explain", False)
 
     try:
         engine = PolymorphismEngine(app_dir)
@@ -180,6 +399,16 @@ def poly_validate(args: argparse.Namespace) -> None:
         else:
             console.print(f"[red]Error:[/red] {e}")
         sys.exit(1)
+
+    if explain:
+        report = build_validation_explanation_report(engine, app_dir)
+        if fmt == "json":
+            print(json.dumps(report.to_dict(), indent=2))
+        else:
+            _print_explanation_report(report)
+        sys.exit(
+            1 if _should_fail(report.errors, report.warnings, strict) else 0
+        )
 
     issues = list(engine.adapter_errors) + validate_all_adapters(cards, app_dir)
     errors, warnings = _counts(issues)
@@ -197,7 +426,7 @@ def poly_validate(args: argparse.Namespace) -> None:
                 indent=2,
             )
         )
-        sys.exit(1 if (errors or (strict and warnings)) else 0)
+        sys.exit(1 if _should_fail(errors, warnings, strict) else 0)
 
     if not cards and not engine.adapter_errors:
         console.print(
@@ -212,7 +441,36 @@ def poly_validate(args: argparse.Namespace) -> None:
     console.print(f"Validated {len(cards)} adapter card(s) for {app_dir}:\n")
     _print_issues(issues)
     console.print(f"\n  {errors} error(s), {warnings} warning(s)")
-    sys.exit(1 if (errors or (strict and warnings)) else 0)
+    sys.exit(1 if _should_fail(errors, warnings, strict) else 0)
+
+
+# ── poly doctor ────────────────────────────────────────────────────────────
+
+
+def poly_doctor(args: argparse.Namespace) -> None:
+    """Handle ``cxas poly doctor``."""
+    app_dir = str(Path(getattr(args, "app_dir", ".")).resolve())
+    fmt = getattr(args, "format", "text")
+    strict = getattr(args, "strict", False)
+
+    try:
+        engine = PolymorphismEngine(app_dir)
+        engine.load_base_project()
+        engine.load_adapter_cards()
+    except FileNotFoundError as e:
+        if fmt == "json":
+            print(json.dumps({"error": str(e), "issues": []}, indent=2))
+        else:
+            console.print(f"[red]Error:[/red] {e}")
+        sys.exit(1)
+
+    report = build_validation_explanation_report(engine, app_dir)
+    if fmt == "json":
+        print(json.dumps(report.to_dict(), indent=2))
+    else:
+        _print_explanation_report(report)
+
+    sys.exit(1 if _should_fail(report.errors, report.warnings, strict) else 0)
 
 
 # ── poly diff ────────────────────────────────────────────────────────────────
@@ -229,21 +487,37 @@ def poly_diff(args: argparse.Namespace) -> None:
     """Handle ``cxas poly diff <channel>``."""
     app_dir = str(Path(getattr(args, "app_dir", ".")).resolve())
     channel = args.channel
+    as_json = getattr(args, "json", False)
 
     try:
         engine = _load_engine(app_dir)
     except FileNotFoundError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        if as_json:
+            print(json.dumps({"error": str(e), "issues": []}, indent=2))
+        else:
+            console.print(f"[red]Error:[/red] {e}")
         sys.exit(1)
 
     entry = engine.adapters.get(channel)
     if entry is None:
-        console.print(
-            f"[red]Error:[/red] no adapter for channel '{channel}'. "
-            f"Available: {', '.join(sorted(engine.adapters)) or '(none)'}"
+        message = (
+            f"no adapter for channel '{channel}'. Available: "
+            f"{', '.join(sorted(engine.adapters)) or '(none)'}"
         )
-        if engine.adapter_errors:
-            _print_issues(engine.adapter_errors)
+        if as_json:
+            print(
+                json.dumps(
+                    {
+                        "error": message,
+                        "issues": engine.adapter_errors,
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            console.print(f"[red]Error:[/red] {message}")
+            if engine.adapter_errors:
+                _print_issues(engine.adapter_errors)
         sys.exit(1)
     card, card_path = entry
     duplicate_issues = [
@@ -253,129 +527,49 @@ def poly_diff(args: argparse.Namespace) -> None:
         and f"'{channel}'" in i.get("message", "")
     ]
     if duplicate_issues:
-        console.print("[red]Error:[/red] duplicate adapter channel:")
-        _print_issues(duplicate_issues)
+        if as_json:
+            print(
+                json.dumps(
+                    {
+                        "error": "duplicate adapter channel",
+                        "issues": duplicate_issues,
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            console.print("[red]Error:[/red] duplicate adapter channel:")
+            _print_issues(duplicate_issues)
         sys.exit(1)
 
     try:
         compiled = engine.compile(card, card_path)
     except CompilationError as e:
-        console.print("[red]Compilation failed:[/red]")
-        _print_issues(e.issues)
+        if as_json:
+            print(
+                json.dumps(
+                    {
+                        "error": "Compilation failed",
+                        "issues": e.issues,
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            console.print("[red]Compilation failed:[/red]")
+            _print_issues(e.issues)
         sys.exit(1)
 
-    rel_card = (
-        Path(card_path).relative_to(Path(app_dir))
-        if Path(card_path).is_relative_to(Path(app_dir))
-        else card_path
+    report = build_diff_report(
+        engine=engine,
+        card=card,
+        card_path=card_path,
+        compiled=compiled,
     )
-    console.print(f"[bold]Channel: {channel}[/bold]   (adapter: {rel_card})\n")
-
-    base = engine.base
-    assert base is not None
-
-    # Build a per-agent view of changes.
-    display_to_dir = {b.display_name: name for name, b in base.agents.items()}
-
-    def to_dir(ref: str) -> Optional[str]:
-        if ref in base.agents:
-            return ref
-        return display_to_dir.get(ref)
-
-    touched_agents = set()
-    for d in card.instruction_diffs:
-        touched_agents.add(to_dir(d.agent))
-    for t in card.tools:
-        touched_agents.add(to_dir(t.agent))
-    for m in card.model_overrides:
-        touched_agents.add(to_dir(m.agent))
-    for c in card.callbacks:
-        touched_agents.add(to_dir(c.agent))
-    touched_agents.discard(None)
-
-    for dir_name in sorted(touched_agents):
-        console.print(f"[bold cyan]agents/{dir_name}[/bold cyan]")
-        base_bundle = base.agents[dir_name]
-
-        # Instruction diffs.
-        for d in card.instruction_diffs:
-            if to_dir(d.agent) != dir_name:
-                continue
-            if d.mode == "replace_section":
-                console.print(
-                    f"  instruction: ~ replace_section <{d.section_tag}>"
-                )
-            else:
-                lines = d.content.strip().splitlines()
-                console.print(f"  instruction: + {len(lines)} line(s) {d.mode}")
-                for line in lines[:3]:
-                    console.print(f"    [green]+ {line}[/green]")
-                if len(lines) > 3:
-                    console.print("    [green]+ ...[/green]")
-
-        # Tool changes.
-        base_tools = list(base_bundle.config.get("tools", []))
-        comp_tools = list(compiled.agents[dir_name].get("tools", []))
-        added = [t for t in comp_tools if t not in base_tools]
-        removed = [t for t in base_tools if t not in comp_tools]
-        if added or removed:
-            console.print(f"  tools ({len(base_tools)} -> {len(comp_tools)}):")
-            for t in added:
-                console.print(f"    [green]+ {t}[/green]")
-            for t in removed:
-                console.print(f"    [red]- {t}[/red]")
-
-        # Model override.
-        base_model = (base_bundle.config.get("modelSettings") or {}).get(
-            "model"
-        )
-        comp_model = (compiled.agents[dir_name].get("modelSettings") or {}).get(
-            "model"
-        )
-        if base_model != comp_model:
-            console.print(
-                f"  modelSettings.model: {base_model or '(default)'} -> "
-                f"[green]{comp_model}[/green]"
-            )
-
-        # Added callbacks.
-        for c in card.callbacks:
-            if to_dir(c.agent) != dir_name:
-                continue
-            console.print(
-                f"  callbacks: [green]+ {c.type}[/green] "
-                f"({c.description or c.python_code})"
-            )
-
-    # New tools.
-    if compiled.tools:
-        console.print("\n[bold cyan]tools/[/bold cyan]")
-        for name in sorted(compiled.tools):
-            console.print(f"  [green]+ {name}[/green]")
-
-    # Evaluations / expectations / datasets.
-    for label, items in (
-        ("evaluations", compiled.evaluations),
-        ("evaluationExpectations", compiled.evaluation_expectations),
-        ("evaluationDatasets", compiled.evaluation_datasets),
-    ):
-        if items:
-            console.print(f"\n[bold cyan]{label}/[/bold cyan]")
-            console.print(
-                f"  [green]+ {len(items)} item(s):[/green] "
-                f"{', '.join(sorted(items))}"
-            )
-
-    # Deployment (folded into gecx-config.json).
-    if card.gecx_config:
-        console.print("\n[bold cyan]gecx-config.json (channel config)[/bold cyan]")
-        for k, v in sorted(card.gecx_config.items()):
-            console.print(f"  [green]~ {k}: {v}[/green]")
-
-    if compiled.deployment:
-        console.print("\n[bold cyan]gecx-config.json (deployment)[/bold cyan]")
-        for k, v in compiled.deployment.items():
-            console.print(f"  [green]+ {k}: {v}[/green]")
+    if as_json:
+        print(json.dumps(report, indent=2))
+    else:
+        _print_diff_report(report)
 
     sys.exit(0)
 
@@ -395,6 +589,96 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     poly_subparsers = parser_poly.add_subparsers(
         title="poly commands", dest="poly_command", required=True
     )
+
+    # init
+    p_init = poly_subparsers.add_parser(
+        "init", help="Scaffold starter channel adapter cards."
+    )
+    p_init.add_argument(
+        "--app-dir",
+        default=".",
+        help="Path to the agent project root (default: current directory).",
+    )
+    p_init.add_argument(
+        "--channel",
+        action="append",
+        help=(
+            "Channel id to scaffold. Repeat or comma-separate for multiple "
+            "channels. If omitted in a TTY, prompts interactively."
+        ),
+    )
+    p_init.add_argument(
+        "--agent",
+        help=(
+            "Agent directory/displayName to target for starter deltas "
+            "(default: app rootAgent)."
+        ),
+    )
+    p_init.add_argument(
+        "--display-name",
+        help="Display name for a single scaffolded adapter.",
+    )
+    p_init.add_argument(
+        "--display-name-template",
+        default=DEFAULT_DISPLAY_NAME_TEMPLATE,
+        help=(
+            "Template for adapter display names; supports {app}, {channel}, "
+            "{channel_title}, {channel_slug}."
+        ),
+    )
+    p_init.add_argument(
+        "--deployment-target",
+        default="auto",
+        help=(
+            "Deployment channelType to scaffold: auto, none, or a supported "
+            "enum such as WEB_UI, API, GOOGLE_TELEPHONY_PLATFORM."
+        ),
+    )
+    p_init.add_argument(
+        "--modality",
+        default="auto",
+        help=(
+            "Deployment modality to scaffold: auto, none, CHAT_ONLY, "
+            "VOICE_ONLY, CHAT_AND_VOICE, or CHAT_VOICE_AND_VIDEO."
+        ),
+    )
+    p_init.add_argument(
+        "--with-tool",
+        action="append",
+        help=(
+            "Create a channel-only python tool and reference it from the "
+            "adapter. May be repeated."
+        ),
+    )
+    p_init.add_argument(
+        "--with-callback",
+        action="append",
+        choices=(
+            "before_model",
+            "after_model",
+            "before_tool",
+            "after_tool",
+            "before_agent",
+            "after_agent",
+        ),
+        help="Create and reference a starter channel callback.",
+    )
+    p_init.add_argument(
+        "--no-eval",
+        action="store_true",
+        help="Do not scaffold a starter channel eval directory.",
+    )
+    p_init.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print planned files without writing them.",
+    )
+    p_init.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite scaffold files if they already exist.",
+    )
+    p_init.set_defaults(func=poly_init)
 
     # build
     p_build = poly_subparsers.add_parser(
@@ -447,7 +731,34 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         action="store_true",
         help="Exit non-zero if any warnings are present.",
     )
+    p_validate.add_argument(
+        "--explain",
+        action="store_true",
+        help="Explain each validation issue with likely fixes.",
+    )
     p_validate.set_defaults(func=poly_validate)
+
+    # doctor
+    p_doctor = poly_subparsers.add_parser(
+        "doctor", help="Explain adapter validation issues and likely fixes."
+    )
+    p_doctor.add_argument(
+        "--app-dir",
+        default=".",
+        help="Path to the agent project root (default: current directory).",
+    )
+    p_doctor.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format (default: text).",
+    )
+    p_doctor.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero if any warnings are present.",
+    )
+    p_doctor.set_defaults(func=poly_doctor)
 
     # diff
     p_diff = poly_subparsers.add_parser(
@@ -458,5 +769,10 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         "--app-dir",
         default=".",
         help="Path to the agent project root (default: current directory).",
+    )
+    p_diff.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a stable machine-readable diff report.",
     )
     p_diff.set_defaults(func=poly_diff)

--- a/src/cxas_scrapi/cli/poly_cli.py
+++ b/src/cxas_scrapi/cli/poly_cli.py
@@ -16,13 +16,15 @@
 
 Drives the Polymorphism Engine from the command line: compile base agent
 projects into channel-optimized variants, validate adapter cards, and show
-a human-readable diff of what an adapter changes.
+a human-readable diff of what an adapter changes.  All error paths render
+clean, rule-ID-formatted messages — never a Python traceback.
 """
 
 import argparse
+import json
 import sys
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from rich.console import Console
 
@@ -31,9 +33,19 @@ from cxas_scrapi.poly.engine import (
     PolymorphismEngine,
 )
 from cxas_scrapi.poly.models import AdapterCard
-from cxas_scrapi.poly.validators import validate_all_adapters
+from cxas_scrapi.poly.validators import (
+    validate_adapter_card,
+    validate_all_adapters,
+)
 
 console = Console()
+
+
+def _counts(issues: List[dict]) -> Tuple[int, int]:
+    """Return ``(errors, warnings)`` for a list of issue dicts."""
+    errors = sum(1 for i in issues if i.get("severity") == "error")
+    warnings = sum(1 for i in issues if i.get("severity") == "warning")
+    return errors, warnings
 
 
 def _print_issues(issues: List[dict]) -> int:
@@ -67,6 +79,12 @@ def _load_engine(app_dir: str) -> PolymorphismEngine:
     return engine
 
 
+def _all_issues(engine: PolymorphismEngine, app_dir: str) -> List[dict]:
+    """Parse errors plus validation issues for every loaded adapter."""
+    cards = [c for c, _ in engine.adapters.values()]
+    return list(engine.adapter_errors) + validate_all_adapters(cards, app_dir)
+
+
 # ── poly build ────────────────────────────────────────────────────────────
 
 
@@ -75,6 +93,8 @@ def poly_build(args: argparse.Namespace) -> None:
     app_dir = str(Path(getattr(args, "app_dir", ".")).resolve())
     channel = getattr(args, "channel", "all")
     output_dir = Path(getattr(args, "output_dir", "./output"))
+    force = getattr(args, "force", False)
+    strict = getattr(args, "strict", False)
 
     try:
         engine = _load_engine(app_dir)
@@ -82,40 +102,54 @@ def poly_build(args: argparse.Namespace) -> None:
         console.print(f"[red]Error:[/red] {e}")
         sys.exit(1)
 
-    if not engine.adapters:
+    if not engine.adapters and not engine.adapter_errors:
         console.print(
             f"[yellow]No adapter cards found in {app_dir}/adapters.[/yellow]"
         )
         sys.exit(1)
 
+    # Decide which channels to build and gather issues to gate on.
+    if channel == "all":
+        targets = list(engine.adapters.values())
+        issues = _all_issues(engine, app_dir)
+    else:
+        if channel not in engine.adapters:
+            console.print(
+                f"[red]Error:[/red] no adapter for channel '{channel}'. "
+                f"Available: {', '.join(sorted(engine.adapters)) or '(none)'}"
+            )
+            if engine.adapter_errors:
+                _print_issues(engine.adapter_errors)
+            sys.exit(1)
+        card, path = engine.adapters[channel]
+        targets = [(card, path)]
+        issues = validate_adapter_card(card, app_dir)
+
+    errors, warnings = _counts(issues)
+    if issues:
+        _print_issues(issues)
+    if errors or (strict and warnings):
+        console.print("\n[red]Build aborted: validation errors.[/red]")
+        sys.exit(1)
+
     try:
-        if channel == "all":
-            compiled = engine.compile_all()
-        else:
-            if channel not in engine.adapters:
-                console.print(
-                    f"[red]Error:[/red] no adapter for channel '{channel}'. "
-                    f"Available: {', '.join(sorted(engine.adapters))}"
-                )
-                sys.exit(1)
-            card, path = engine.adapters[channel]
-            # Run validation for the single channel too.
-            issues = validate_all_adapters([card], app_dir)
-            if _print_issues(issues):
-                console.print("\n[red]Build aborted: validation errors.[/red]")
-                sys.exit(1)
-            compiled = {channel: engine.compile(card, path)}
+        for card, path in targets:
+            ch = card.metadata.channel
+            compiled = engine.compile(card, path, validate=False)
+            out = engine.write_output(
+                compiled, str(output_dir / ch), force=force
+            )
+            console.print(f"[green]Compiled[/green] channel '{ch}' -> {out}")
     except CompilationError as e:
         console.print("[red]Compilation failed:[/red]")
         _print_issues(e.issues)
         sys.exit(1)
-
-    for ch, cfg in compiled.items():
-        out = engine.write_output(cfg, str(output_dir / ch))
-        console.print(f"[green]Compiled[/green] channel '{ch}' -> {out}")
+    except (FileExistsError, ValueError) as e:
+        console.print(f"[red]Error:[/red] {e}")
+        sys.exit(1)
 
     console.print(
-        f"\n[green]Done.[/green] {len(compiled)} channel(s) written to "
+        f"\n[green]Done.[/green] {len(targets)} channel(s) written to "
         f"{output_dir.resolve()}"
     )
     sys.exit(0)
@@ -127,34 +161,52 @@ def poly_build(args: argparse.Namespace) -> None:
 def poly_validate(args: argparse.Namespace) -> None:
     """Handle ``cxas poly validate``."""
     app_dir = str(Path(getattr(args, "app_dir", ".")).resolve())
+    fmt = getattr(args, "format", "text")
+    strict = getattr(args, "strict", False)
 
     try:
         engine = PolymorphismEngine(app_dir)
         engine.load_base_project()
         cards = engine.load_adapter_cards()
     except FileNotFoundError as e:
-        console.print(f"[red]Error:[/red] {e}")
-        sys.exit(1)
-    except Exception as e:  # noqa: BLE001 - surface parse errors clearly
-        console.print(f"[red]Failed to parse adapter cards:[/red] {e}")
+        if fmt == "json":
+            print(json.dumps({"error": str(e), "issues": []}, indent=2))
+        else:
+            console.print(f"[red]Error:[/red] {e}")
         sys.exit(1)
 
-    if not cards:
+    issues = list(engine.adapter_errors) + validate_all_adapters(cards, app_dir)
+    errors, warnings = _counts(issues)
+
+    if fmt == "json":
+        print(
+            json.dumps(
+                {
+                    "app_dir": app_dir,
+                    "cards": len(cards),
+                    "errors": errors,
+                    "warnings": warnings,
+                    "issues": issues,
+                },
+                indent=2,
+            )
+        )
+        sys.exit(1 if (errors or (strict and warnings)) else 0)
+
+    if not cards and not engine.adapter_errors:
         console.print(
             f"[yellow]No adapter cards found in {app_dir}/adapters.[/yellow]"
         )
         sys.exit(0)
 
-    issues = validate_all_adapters(cards, app_dir)
     if not issues:
         console.print(f"[green]All {len(cards)} adapter card(s) valid.[/green]")
         sys.exit(0)
 
     console.print(f"Validated {len(cards)} adapter card(s) for {app_dir}:\n")
-    errors = _print_issues(issues)
-    warnings = len(issues) - errors
+    _print_issues(issues)
     console.print(f"\n  {errors} error(s), {warnings} warning(s)")
-    sys.exit(1 if errors else 0)
+    sys.exit(1 if (errors or (strict and warnings)) else 0)
 
 
 # ── poly diff ────────────────────────────────────────────────────────────────
@@ -184,6 +236,8 @@ def poly_diff(args: argparse.Namespace) -> None:
             f"[red]Error:[/red] no adapter for channel '{channel}'. "
             f"Available: {', '.join(sorted(engine.adapters)) or '(none)'}"
         )
+        if engine.adapter_errors:
+            _print_issues(engine.adapter_errors)
         sys.exit(1)
     card, card_path = entry
 
@@ -283,17 +337,22 @@ def poly_diff(args: argparse.Namespace) -> None:
         for name in sorted(compiled.tools):
             console.print(f"  [green]+ {name}[/green]")
 
-    # Evaluations.
-    if compiled.evaluations:
-        console.print("\n[bold cyan]evaluations/[/bold cyan]")
-        console.print(
-            f"  [green]+ {len(compiled.evaluations)} eval(s):[/green] "
-            f"{', '.join(sorted(compiled.evaluations))}"
-        )
+    # Evaluations / expectations / datasets.
+    for label, items in (
+        ("evaluations", compiled.evaluations),
+        ("evaluationExpectations", compiled.evaluation_expectations),
+        ("evaluationDatasets", compiled.evaluation_datasets),
+    ):
+        if items:
+            console.print(f"\n[bold cyan]{label}/[/bold cyan]")
+            console.print(
+                f"  [green]+ {len(items)} item(s):[/green] "
+                f"{', '.join(sorted(items))}"
+            )
 
-    # Deployment.
+    # Deployment (folded into gecx-config.json).
     if compiled.deployment:
-        console.print("\n[bold cyan]deployment.json[/bold cyan]")
+        console.print("\n[bold cyan]gecx-config.json (deployment)[/bold cyan]")
         for k, v in compiled.deployment.items():
             console.print(f"  [green]+ {k}: {v}[/green]")
 
@@ -335,6 +394,16 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         default="./output",
         help="Output directory (default: ./output).",
     )
+    p_build.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite a non-empty output directory not created by poly.",
+    )
+    p_build.add_argument(
+        "--strict",
+        action="store_true",
+        help="Treat warnings as errors (abort the build).",
+    )
     p_build.set_defaults(func=poly_build)
 
     # validate
@@ -345,6 +414,17 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         "--app-dir",
         default=".",
         help="Path to the agent project root (default: current directory).",
+    )
+    p_validate.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format (default: text).",
+    )
+    p_validate.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero if any warnings are present.",
     )
     p_validate.set_defaults(func=poly_validate)
 

--- a/src/cxas_scrapi/poly/__init__.py
+++ b/src/cxas_scrapi/poly/__init__.py
@@ -15,8 +15,9 @@
 """Polymorphism Engine for cxas-scrapi.
 
 Compiles a single base agent project plus channel adapter cards into
-channel-optimized agent project directories that are byte-for-byte
-indistinguishable from hand-authored projects.
+channel-optimized agent project directories that are structurally equivalent
+to hand-authored projects — indistinguishable to SCRAPI tooling (lint, eval,
+deploy all run on the output unchanged).
 
 This package is intentionally GCP-free — it performs pure local file
 operations and does not import ``google.cloud.*``.

--- a/src/cxas_scrapi/poly/__init__.py
+++ b/src/cxas_scrapi/poly/__init__.py
@@ -1,0 +1,57 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Polymorphism Engine for cxas-scrapi.
+
+Compiles a single base agent project plus channel adapter cards into
+channel-optimized agent project directories that are byte-for-byte
+indistinguishable from hand-authored projects.
+
+This package is intentionally GCP-free — it performs pure local file
+operations and does not import ``google.cloud.*``.
+"""
+
+from cxas_scrapi.poly.engine import (
+    CompilationError,
+    PolymorphismEngine,
+)
+from cxas_scrapi.poly.models import (
+    AdapterCard,
+    AdapterMetadata,
+    CallbackDefinition,
+    CompiledAgentConfig,
+    DeploymentOverride,
+    EvalReference,
+    InstructionDiff,
+    ModelOverride,
+    ToolDefinition,
+    ToolModification,
+    WebWidgetConfig,
+)
+
+__all__ = [
+    "AdapterCard",
+    "AdapterMetadata",
+    "CallbackDefinition",
+    "CompilationError",
+    "CompiledAgentConfig",
+    "DeploymentOverride",
+    "EvalReference",
+    "InstructionDiff",
+    "ModelOverride",
+    "PolymorphismEngine",
+    "ToolDefinition",
+    "ToolModification",
+    "WebWidgetConfig",
+]

--- a/src/cxas_scrapi/poly/diagnostics.py
+++ b/src/cxas_scrapi/poly/diagnostics.py
@@ -1,0 +1,382 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Guided explanations for adapter validation issues.
+
+This module deliberately does not decide whether a card is valid.  It enriches
+issues emitted by ``validators.py`` so ``cxas poly doctor`` can tell developers
+where to look and what kind of fix usually resolves each AD rule.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from cxas_scrapi.poly.engine import PolymorphismEngine
+from cxas_scrapi.poly.models import AdapterCard
+from cxas_scrapi.poly.validators import (
+    validate_adapter_card,
+    validate_all_adapters,
+)
+
+
+@dataclass(frozen=True)
+class RuleGuide:
+    """Static, user-facing explanation for one validator rule."""
+
+    what: str
+    why: str
+    fix: str
+
+
+@dataclass(frozen=True)
+class ExplainedIssue:
+    """A validator issue plus concrete debugging guidance."""
+
+    rule_id: str
+    severity: str
+    message: str
+    path: str
+    adapter_path: str
+    field_path: Optional[str]
+    related_paths: List[str] = field(default_factory=list)
+    what_failed: str = ""
+    why_it_failed: str = ""
+    likely_fix: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a stable JSON-serializable representation."""
+        return {
+            "rule_id": self.rule_id,
+            "severity": self.severity,
+            "message": self.message,
+            "path": self.path,
+            "adapter_path": self.adapter_path,
+            "field_path": self.field_path,
+            "related_paths": self.related_paths,
+            "what_failed": self.what_failed,
+            "why_it_failed": self.why_it_failed,
+            "likely_fix": self.likely_fix,
+        }
+
+
+@dataclass(frozen=True)
+class ValidationExplanationReport:
+    """Structured report returned by doctor/explain flows."""
+
+    app_dir: str
+    cards: int
+    errors: int
+    warnings: int
+    issues: List[ExplainedIssue]
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a stable JSON-serializable report."""
+        return {
+            "app_dir": self.app_dir,
+            "cards": self.cards,
+            "errors": self.errors,
+            "warnings": self.warnings,
+            "issues": [issue.to_dict() for issue in self.issues],
+        }
+
+
+RULE_GUIDES: Dict[str, RuleGuide] = {
+    "AD001": RuleGuide(
+        what="The adapter file could not be parsed as a valid ChannelAdapter.",
+        why=(
+            "The engine validates schema before compilation so misspelled, "
+            "missing, or unknown fields cannot be silently ignored."
+        ),
+        fix=(
+            "Fix the YAML/JSON shape. Start with apiVersion, kind: "
+            "ChannelAdapter, and metadata.channel plus metadata.displayName."
+        ),
+    ),
+    "AD002": RuleGuide(
+        what="The adapter references an agent that the base app does not have.",
+        why=(
+            "Instruction diffs, tool changes, model overrides, and callbacks "
+            "must target an existing agent directory or displayName."
+        ),
+        fix=(
+            "Use a name from agents/<agent>/<agent>.json displayName or the "
+            "agent directory name, or add the missing agent to the base app."
+        ),
+    ),
+    "AD003": RuleGuide(
+        what="A replace_section instruction diff cannot be applied.",
+        why=(
+            "replace_section is only safe when the target instruction has a "
+            "stable XML section tag for the compiler to replace."
+        ),
+        fix=(
+            "Add the missing sectionTag, add the XML block to the base "
+            "instruction, or switch the diff to append/prepend."
+        ),
+    ),
+    "AD004": RuleGuide(
+        what="The adapter tries to remove a tool the base agent does not list.",
+        why=(
+            "Removing a non-existent tool is a no-op and often means the "
+            "target agent or tool name is wrong."
+        ),
+        fix=(
+            "Remove the no-op remove entry, or correct the tool name and "
+            "target agent so it matches the base agent JSON."
+        ),
+    ),
+    "AD005": RuleGuide(
+        what=(
+            "A referenced tool, callback, eval, expectation, or dataset is "
+            "missing."
+        ),
+        why=(
+            "The compiler only copies files that exist under the direct app "
+            "root, and tool adds must resolve to a base tool, platform tool, "
+            "or same-card toolDefinitions entry."
+        ),
+        fix=(
+            "Create the referenced sourceDir/pythonCode path, correct the "
+            "relative path from the app root, or add a matching "
+            "toolDefinitions entry."
+        ),
+    ),
+    "AD006": RuleGuide(
+        what="The adapter has no channel-specific evaluations.",
+        why=(
+            "Behavior-changing channel deltas should usually carry at least "
+            "one eval so chat/voice/API behavior does not drift unnoticed."
+        ),
+        fix=(
+            "Add evaluations: [{sourceDir: adapters/<channel>_evals}], or "
+            "intentionally accept the warning for a non-behavioral adapter."
+        ),
+    ),
+    "AD007": RuleGuide(
+        what="Two or more adapter cards declare the same metadata.channel.",
+        why=(
+            "The compiler writes one output directory and deployment id per "
+            "channel, so duplicate channel names are ambiguous."
+        ),
+        fix=(
+            "Give each adapter a unique metadata.channel and matching filename."
+        ),
+    ),
+    "AD008": RuleGuide(
+        what="An adapter path resolves outside the app root.",
+        why=(
+            "Adapter sources must be local project files; absolute paths and "
+            "'..' escapes would make builds unsafe and non-portable."
+        ),
+        fix=(
+            "Move the file under the app root and reference it with a "
+            "project-relative sourceDir or pythonCode path."
+        ),
+    ),
+    "AD009": RuleGuide(
+        what="The deployment block uses an unsupported enum value.",
+        why=(
+            "The poly package stays GCP-free but still limits deployment "
+            "values to the enums the current deploy tooling understands."
+        ),
+        fix=(
+            "Use one of the supported channelType, modality, or theme values "
+            "from cxas_scrapi.poly.models."
+        ),
+    ),
+    "AD010": RuleGuide(
+        what="A channel-only toolDefinition has an unsupported toolType.",
+        why=(
+            "The compiler currently knows how to normalize python tools and "
+            "copy openapi tool directories; other types would not compile "
+            "predictably."
+        ),
+        fix="Use toolType: python or toolType: openapi.",
+    ),
+}
+
+
+def build_validation_explanation_report(
+    engine: PolymorphismEngine,
+    app_dir: str,
+) -> ValidationExplanationReport:
+    """Run current validators and enrich their issues for doctor output."""
+    root = Path(app_dir).resolve()
+    issues: List[ExplainedIssue] = []
+
+    for raw in engine.adapter_errors:
+        issues.append(_explain(raw, root, raw.get("path", "adapters")))
+
+    for card, card_path in engine.adapter_cards:
+        adapter_rel = _rel(root, card_path)
+        for raw in validate_adapter_card(card, str(root)):
+            issues.append(_explain(raw, root, adapter_rel, card))
+
+    cards = [card for card, _path in engine.adapter_cards]
+    for raw in _duplicate_channel_issues(cards, str(root)):
+        issues.append(_explain(raw, root, raw.get("path", "adapters")))
+
+    errors = sum(1 for i in issues if i.severity == "error")
+    warnings = sum(1 for i in issues if i.severity == "warning")
+    return ValidationExplanationReport(
+        app_dir=str(root),
+        cards=len(engine.adapter_cards),
+        errors=errors,
+        warnings=warnings,
+        issues=issues,
+    )
+
+
+def _duplicate_channel_issues(
+    cards: Iterable[AdapterCard], app_dir: str
+) -> List[Dict[str, Any]]:
+    return [
+        issue
+        for issue in validate_all_adapters(list(cards), app_dir)
+        if issue.get("rule_id") == "AD007"
+    ]
+
+
+def _explain(
+    issue: Dict[str, Any],
+    root: Path,
+    adapter_path: str,
+    card: Optional[AdapterCard] = None,
+) -> ExplainedIssue:
+    rule_id = str(issue.get("rule_id", "?"))
+    guide = RULE_GUIDES.get(
+        rule_id,
+        RuleGuide(
+            what="The adapter validator reported an issue.",
+            why="The card did not satisfy a current validator rule.",
+            fix="Inspect the adapter and referenced source files.",
+        ),
+    )
+    message = str(issue.get("message", ""))
+    field_path = _field_path(message)
+    related_paths = _related_paths(message, root, card)
+    return ExplainedIssue(
+        rule_id=rule_id,
+        severity=str(issue.get("severity", "error")),
+        message=message,
+        path=str(issue.get("path", adapter_path)),
+        adapter_path=adapter_path,
+        field_path=field_path,
+        related_paths=related_paths,
+        what_failed=guide.what,
+        why_it_failed=guide.why,
+        likely_fix=guide.fix,
+    )
+
+
+def _field_path(message: str) -> Optional[str]:
+    field_match = re.search(
+        r"(instructionDiffs|tools|toolDefinitions|callbacks|"
+        r"evaluations|evaluationExpectations|evaluationDatasets)"
+        r"\[\d+\](?:\.[A-Za-z0-9_]+)?",
+        message,
+    )
+    if field_match:
+        return field_match.group(0)
+    dep_match = re.search(
+        r"deployment(?:\.webWidgetConfig)?\.[A-Za-z0-9_]+",
+        message,
+    )
+    if dep_match:
+        return dep_match.group(0)
+    if "metadata.channel" in message:
+        return "metadata.channel"
+    return None
+
+
+def _related_paths(
+    message: str,
+    root: Path,
+    card: Optional[AdapterCard],
+) -> List[str]:
+    paths: List[str] = []
+    for ref in _quoted_path_refs(message):
+        paths.append(ref)
+
+    agent = _agent_ref(message)
+    if agent is not None:
+        instruction_path = _instruction_path_for(root, agent)
+        if instruction_path is not None:
+            paths.append(_rel(root, instruction_path))
+
+    # For missing evaluation warnings, point developers at the conventional
+    # starter path even when no concrete sourceDir appears in the message.
+    if "no evaluations" in message and card is not None:
+        paths.append(f"adapters/{card.metadata.channel}_evals")
+
+    seen: set[str] = set()
+    unique: List[str] = []
+    for path in paths:
+        if path not in seen:
+            seen.add(path)
+            unique.append(path)
+    return unique
+
+
+def _quoted_path_refs(message: str) -> List[str]:
+    refs: List[str] = []
+    for quoted in re.findall(r"'([^']+)'", message):
+        if "/" in quoted or quoted.endswith(".py"):
+            refs.append(quoted)
+    return refs
+
+
+def _agent_ref(message: str) -> Optional[str]:
+    match = re.search(r"agent '([^']+)'", message)
+    if match:
+        return match.group(1)
+    return None
+
+
+def _instruction_path_for(root: Path, agent_ref: str) -> Optional[Path]:
+    agents_dir = root / "agents"
+    if not agents_dir.exists():
+        return None
+
+    for agent_dir in sorted(agents_dir.iterdir()):
+        if not agent_dir.is_dir():
+            continue
+        config_path = agent_dir / f"{agent_dir.name}.json"
+        if not config_path.exists():
+            continue
+        try:
+            config = json.loads(config_path.read_text())
+        except (OSError, ValueError):
+            continue
+        if agent_ref not in (agent_dir.name, config.get("displayName")):
+            continue
+        ref = config.get("instruction")
+        if isinstance(ref, str):
+            return root / ref
+        fallback = agent_dir / "instruction.txt"
+        return fallback if fallback.exists() else None
+    return None
+
+
+def _rel(root: Path, path: Path | str) -> str:
+    candidate = Path(path)
+    try:
+        return str(candidate.relative_to(root))
+    except ValueError:
+        return str(candidate)

--- a/src/cxas_scrapi/poly/diffing.py
+++ b/src/cxas_scrapi/poly/diffing.py
@@ -1,0 +1,240 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Stable diff reports for ``cxas poly diff``.
+
+The CLI renders both human text and ``--json`` from this report so CI tooling
+and reviewers reason from the same compiled delta.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from cxas_scrapi.poly.engine import PolymorphismEngine
+from cxas_scrapi.poly.models import AdapterCard, CompiledAgentConfig
+
+DIFF_SCHEMA_VERSION = "poly-diff/v1"
+
+
+def build_diff_report(
+    *,
+    engine: PolymorphismEngine,
+    card: AdapterCard,
+    card_path: Path,
+    compiled: CompiledAgentConfig,
+) -> Dict[str, Any]:
+    """Build a stable, machine-readable adapter delta report."""
+    if engine.base is None:
+        engine.load_base_project()
+    assert engine.base is not None
+
+    root = engine.app_dir
+    display_to_dir = {
+        bundle.display_name: name
+        for name, bundle in engine.base.agents.items()
+    }
+
+    def to_dir(agent_ref: str) -> Optional[str]:
+        if agent_ref in engine.base.agents:
+            return agent_ref
+        return display_to_dir.get(agent_ref)
+
+    touched = set()
+    for diff in card.instruction_diffs:
+        touched.add(to_dir(diff.agent))
+    for tool_change in card.tools:
+        touched.add(to_dir(tool_change.agent))
+    for model in card.model_overrides:
+        touched.add(to_dir(model.agent))
+    for callback in card.callbacks:
+        touched.add(to_dir(callback.agent))
+    touched.discard(None)
+
+    agents: List[Dict[str, Any]] = []
+    deltas: List[Dict[str, Any]] = []
+    for dir_name in sorted(touched):
+        assert dir_name is not None
+        base_bundle = engine.base.agents[dir_name]
+        compiled_agent = compiled.agents[dir_name]
+        agent_report: Dict[str, Any] = {
+            "agent": dir_name,
+            "display_name": base_bundle.display_name,
+            "path": f"agents/{dir_name}",
+            "instruction_diffs": [],
+            "tools": {"added": [], "removed": []},
+            "model": None,
+            "callbacks_added": [],
+        }
+
+        for diff in card.instruction_diffs:
+            if to_dir(diff.agent) != dir_name:
+                continue
+            item = {
+                "mode": diff.mode,
+                "section_tag": diff.section_tag,
+                "line_count": _line_count(diff.content),
+                "preview": _preview(diff.content),
+                "path": f"agents/{dir_name}/instruction.txt",
+            }
+            agent_report["instruction_diffs"].append(item)
+            deltas.append(
+                {
+                    "type": "instruction",
+                    "agent": dir_name,
+                    **item,
+                }
+            )
+
+        base_tools = list(base_bundle.config.get("tools", []) or [])
+        compiled_tools = list(compiled_agent.get("tools", []) or [])
+        added = [tool for tool in compiled_tools if tool not in base_tools]
+        removed = [tool for tool in base_tools if tool not in compiled_tools]
+        agent_report["tools"] = {
+            "before_count": len(base_tools),
+            "after_count": len(compiled_tools),
+            "added": added,
+            "removed": removed,
+        }
+        for tool in added:
+            deltas.append(
+                {"type": "tool_add", "agent": dir_name, "tool": tool}
+            )
+        for tool in removed:
+            deltas.append(
+                {"type": "tool_remove", "agent": dir_name, "tool": tool}
+            )
+
+        before_model = (base_bundle.config.get("modelSettings") or {}).get(
+            "model"
+        )
+        after_model = (compiled_agent.get("modelSettings") or {}).get("model")
+        if before_model != after_model:
+            model_delta = {
+                "before": before_model,
+                "after": after_model,
+                "changed": True,
+            }
+            agent_report["model"] = model_delta
+            deltas.append(
+                {
+                    "type": "model_override",
+                    "agent": dir_name,
+                    **model_delta,
+                }
+            )
+
+        for callback in card.callbacks:
+            if to_dir(callback.agent) != dir_name:
+                continue
+            item = {
+                "type": callback.type,
+                "python_code": callback.python_code,
+                "description": callback.description,
+            }
+            agent_report["callbacks_added"].append(item)
+            deltas.append(
+                {
+                    "type": "callback_add",
+                    "agent": dir_name,
+                    "callback_type": callback.type,
+                    "python_code": callback.python_code,
+                    "description": callback.description,
+                }
+            )
+
+        agents.append(agent_report)
+
+    tools_added = [
+        {
+            "display_name": td.display_name,
+            "tool_type": td.tool_type,
+            "source_dir": td.source_dir,
+        }
+        for td in card.tool_definitions
+    ]
+    for tool in tools_added:
+        deltas.append({"type": "tool_definition_add", **tool})
+
+    evals = {
+        "evaluations": sorted(compiled.evaluations),
+        "evaluation_expectations": sorted(compiled.evaluation_expectations),
+        "evaluation_datasets": sorted(compiled.evaluation_datasets),
+    }
+    for kind, names in evals.items():
+        for name in names:
+            deltas.append({"type": f"{kind}_merge", "name": name})
+
+    deployment = compiled.deployment or {}
+    if deployment:
+        deltas.append({"type": "deployment", "values": deployment})
+
+    gecx_config = card.gecx_config
+    if gecx_config:
+        deltas.append({"type": "gecx_config_overlay", "values": gecx_config})
+
+    return {
+        "schema_version": DIFF_SCHEMA_VERSION,
+        "channel": card.metadata.channel,
+        "adapter_path": _rel(root, card_path),
+        "app_dir": str(root),
+        "summary": {
+            "agents_touched": len(agents),
+            "instruction_diffs": sum(
+                len(agent["instruction_diffs"]) for agent in agents
+            ),
+            "tools_added": sum(
+                len(agent["tools"]["added"]) for agent in agents
+            ),
+            "tools_removed": sum(
+                len(agent["tools"]["removed"]) for agent in agents
+            ),
+            "tool_definitions_added": len(tools_added),
+            "callbacks_added": sum(
+                len(agent["callbacks_added"]) for agent in agents
+            ),
+            "evaluations_added": len(evals["evaluations"]),
+            "evaluation_expectations_added": len(
+                evals["evaluation_expectations"]
+            ),
+            "evaluation_datasets_added": len(evals["evaluation_datasets"]),
+            "deployment_changed": bool(deployment),
+            "gecx_config_changed": bool(gecx_config),
+        },
+        "agents": agents,
+        "tool_definitions_added": tools_added,
+        "evaluation_merges": evals,
+        "gecx_config_overlay": gecx_config,
+        "deployment": deployment,
+        "deltas": deltas,
+    }
+
+
+def _line_count(content: str) -> int:
+    stripped = content.strip()
+    if not stripped:
+        return 0
+    return len(stripped.splitlines())
+
+
+def _preview(content: str, limit: int = 3) -> List[str]:
+    return content.strip().splitlines()[:limit]
+
+
+def _rel(root: Path, path: Path) -> str:
+    try:
+        return str(path.relative_to(root))
+    except ValueError:
+        return str(path)

--- a/src/cxas_scrapi/poly/engine.py
+++ b/src/cxas_scrapi/poly/engine.py
@@ -24,18 +24,29 @@ import json
 import re
 import shutil
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import yaml
+from pydantic import ValidationError
 
+from cxas_scrapi.poly.instructions import apply_instruction_diff
 from cxas_scrapi.poly.models import (
     AdapterCard,
     CompiledAgentConfig,
     DeploymentOverride,
-    InstructionDiff,
 )
-from cxas_scrapi.poly.validators import validate_all_adapters
+from cxas_scrapi.poly.validators import (
+    resolve_within,
+    validate_adapter_card,
+    validate_all_adapters,
+)
+
+# Marker file written into every compiled channel directory.  Its presence
+# tells a later build that the directory is a poly artifact and is therefore
+# safe to overwrite (see ``write_output``).
+_POLY_MARKER = ".poly_build.json"
 
 # Logical callback type -> agent-JSON field name (camelCase).
 CALLBACK_TYPE_TO_FIELD: Dict[str, str] = {
@@ -60,6 +71,25 @@ CALLBACK_TYPE_TO_DIR: Dict[str, str] = {
 # Top-level base-project items that the engine reconstructs (rather than
 # copying verbatim) when writing output.
 _RECONSTRUCTED_ITEMS = {"adapters", "agents", "app.json", "gecx-config.json"}
+
+
+def _format_validation_error(e: ValidationError) -> str:
+    """Render a pydantic ``ValidationError`` as a short field-pointed string."""
+    parts: List[str] = []
+    for err in e.errors():
+        loc = ".".join(str(x) for x in err.get("loc", ()))
+        msg = err.get("msg", "")
+        parts.append(f"{loc}: {msg}" if loc else msg)
+    return "; ".join(parts) or str(e)
+
+
+def _is_relative_to(a: Path, b: Path) -> bool:
+    """True if path ``a`` is ``b`` or lives somewhere under ``b``."""
+    try:
+        a.relative_to(b)
+        return True
+    except ValueError:
+        return False
 
 
 class CompilationError(Exception):
@@ -133,6 +163,10 @@ class PolymorphismEngine:
         self.base: Optional[BaseProject] = None
         # channel -> (card, card_path)
         self.adapters: Dict[str, Tuple[AdapterCard, Path]] = {}
+        # Per-file parse / schema errors collected by ``load_adapter_cards``
+        # (issue dicts).  A malformed card is recorded here instead of raising,
+        # so one bad card never blocks compiling the others.
+        self.adapter_errors: List[Dict[str, Any]] = []
 
     # ── Loading ──────────────────────────────────────────────────────────
 
@@ -245,12 +279,15 @@ class PolymorphismEngine:
         """Glob and parse all adapter cards under ``adapters/``.
 
         Recognizes ``*.adapter.yaml``, ``*.adapter.yml`` and
-        ``*.adapter.json``.  Populates ``self.adapters`` keyed by channel
-        and returns the parsed cards in filename order.
+        ``*.adapter.json``.  Populates ``self.adapters`` keyed by channel and
+        returns the successfully parsed cards in filename order.  A card that
+        fails to parse or validate is recorded in ``self.adapter_errors`` (as
+        an ``AD001`` issue dict) and skipped — it never raises.
         """
         adapters_dir = self.app_dir / "adapters"
         cards: List[AdapterCard] = []
         self.adapters = {}
+        self.adapter_errors = []
         if not adapters_dir.exists():
             return cards
 
@@ -260,56 +297,94 @@ class PolymorphismEngine:
             + list(adapters_dir.glob("*.adapter.json"))
         )
         for path in paths:
-            raw = path.read_text()
-            if path.suffix == ".json":
-                data = json.loads(raw)
-            else:
-                data = yaml.safe_load(raw)
-            card = AdapterCard.model_validate(data)
+            rel = path.name
+            try:
+                raw = path.read_text()
+                data = (
+                    json.loads(raw)
+                    if path.suffix == ".json"
+                    else yaml.safe_load(raw)
+                )
+            except (OSError, json.JSONDecodeError, yaml.YAMLError) as e:
+                self._record_card_error(
+                    rel, f"Adapter card is not valid {path.suffix}: {e}"
+                )
+                continue
+            if not isinstance(data, dict):
+                self._record_card_error(
+                    rel, "Adapter card must be a mapping/object."
+                )
+                continue
+            try:
+                card = AdapterCard.model_validate(data)
+            except ValidationError as e:
+                self._record_card_error(
+                    rel,
+                    "Adapter card schema invalid: "
+                    + _format_validation_error(e),
+                )
+                continue
             cards.append(card)
             self.adapters[card.metadata.channel] = (card, path)
         return cards
 
+    def _record_card_error(self, rel: str, message: str) -> None:
+        self.adapter_errors.append(
+            {
+                "rule_id": "AD001",
+                "severity": "error",
+                "message": message,
+                "path": f"adapters/{rel}",
+            }
+        )
+
     # ── Compilation ──────────────────────────────────────────────────────
 
     def compile(
-        self, adapter: AdapterCard, card_path: Optional[Path] = None
+        self,
+        adapter: AdapterCard,
+        card_path: Optional[Path] = None,
+        validate: bool = True,
     ) -> CompiledAgentConfig:
         """Compile the base project against one adapter card.
 
+        Validation (:func:`validate_adapter_card`) runs first and is the single
+        source of truth: a card that validates clean always compiles.  The apply
+        steps below therefore trust the validated card and do not re-implement
+        existence/section checks.
+
         Args:
             adapter: The parsed adapter card.
-            card_path: Path to the adapter card file, used to resolve
-                relative paths (``pythonCode``, ``sourceDir``).  Defaults
-                to ``<app_dir>/adapters`` when not provided.
+            card_path: Path to the adapter card file (currently informational;
+                all adapter paths resolve relative to the project root).
+            validate: Run ``validate_adapter_card`` first and raise on errors.
+                ``compile_all`` sets this False after running the full
+                cross-adapter validation pass once.
 
         Returns:
             A fully resolved ``CompiledAgentConfig``.
 
         Raises:
-            CompilationError: if a referenced agent or instruction section
-                cannot be resolved.
+            CompilationError: if validation finds any error-severity issue.
         """
         if self.base is None:
             self.load_base_project()
         assert self.base is not None
 
         channel = adapter.metadata.channel
-        card_dir = (
-            card_path.parent
-            if card_path is not None
-            else self.app_dir / "adapters"
-        )
+
+        if validate:
+            errors = [
+                i
+                for i in validate_adapter_card(adapter, str(self.app_dir))
+                if i.get("severity") == "error"
+            ]
+            if errors:
+                raise CompilationError(errors)
 
         def resolve_path(ref: str) -> Path:
-            """Resolve an adapter path: app_dir-relative (per spec) first,
-            then card-relative as a fallback."""
-            primary = (self.app_dir / ref).resolve()
-            if primary.exists():
-                return primary
-            return (card_dir / ref).resolve()
-
-        issues: List[Dict[str, Any]] = []
+            path, _inside = resolve_within(str(self.app_dir), ref)
+            return path
 
         # Step 1: deep copy mutable base state.
         agent_configs: Dict[str, Dict[str, Any]] = {
@@ -327,57 +402,20 @@ class PolymorphismEngine:
             b.display_name: name for name, b in self.base.agents.items()
         }
 
-        def resolve_agent(ref: str) -> Optional[str]:
-            if ref in agent_configs:
-                return ref
-            return display_to_dir.get(ref)
+        def resolve_agent(ref: str) -> str:
+            # Validated card: the agent always resolves.
+            return ref if ref in agent_configs else display_to_dir[ref]
 
         # Step 2: instruction diffs.
-        for i, diff in enumerate(adapter.instruction_diffs):
+        for diff in adapter.instruction_diffs:
             dir_name = resolve_agent(diff.agent)
-            if dir_name is None:
-                issues.append(
-                    {
-                        "rule_id": "AD002",
-                        "severity": "error",
-                        "message": (
-                            f"Agent '{diff.agent}' in instructionDiffs[{i}] "
-                            "does not exist."
-                        ),
-                        "path": channel,
-                    }
-                )
-                continue
-            try:
-                instructions[dir_name] = self._apply_instruction_diff(
-                    instructions[dir_name], diff
-                )
-            except ValueError as e:
-                issues.append(
-                    {
-                        "rule_id": "AD003",
-                        "severity": "error",
-                        "message": str(e),
-                        "path": channel,
-                    }
-                )
+            instructions[dir_name] = apply_instruction_diff(
+                instructions[dir_name], diff
+            )
 
         # Step 3: tool add / remove.
         for mod in adapter.tools:
-            dir_name = resolve_agent(mod.agent)
-            if dir_name is None:
-                issues.append(
-                    {
-                        "rule_id": "AD002",
-                        "severity": "error",
-                        "message": (
-                            f"Agent '{mod.agent}' in tools does not exist."
-                        ),
-                        "path": channel,
-                    }
-                )
-                continue
-            cfg = agent_configs[dir_name]
+            cfg = agent_configs[resolve_agent(mod.agent)]
             tool_list = list(cfg.get("tools", []))
             for t in mod.add:
                 if t not in tool_list:
@@ -388,74 +426,32 @@ class PolymorphismEngine:
         # Step 4: channel-specific tool definitions.
         new_tools: Dict[str, Dict[str, Any]] = {}
         new_tool_code: Dict[str, str] = {}
+        tool_source_dirs: Dict[str, str] = {}
         for td in adapter.tool_definitions:
             src = resolve_path(td.source_dir)
-            cfg, rel, code = self._read_tool_dir(src, td.display_name)
-            if cfg is None:
-                issues.append(
-                    {
-                        "rule_id": "AD005",
-                        "severity": "error",
-                        "message": (
-                            f"Tool definition '{td.display_name}' sourceDir "
-                            f"'{td.source_dir}' is missing or has no JSON."
-                        ),
-                        "path": channel,
-                    }
-                )
-                continue
-            new_tools[td.display_name] = cfg
-            if code is not None:
-                new_tool_code[td.display_name] = code
+            if td.tool_type == "python":
+                cfg, _rel, code = self._read_tool_dir(src, td.display_name)
+                if cfg is not None:
+                    new_tools[td.display_name] = cfg
+                    if code is not None:
+                        new_tool_code[td.display_name] = code
+            else:
+                # Non-python (e.g. openapi): copy the source directory verbatim
+                # so any spec/aux files come along unchanged.
+                cfg = self._read_tool_config(src, td.display_name)
+                if cfg is not None:
+                    new_tools[td.display_name] = cfg
+                tool_source_dirs[td.display_name] = str(src)
 
         # Step 5: model overrides.
         for mo in adapter.model_overrides:
-            dir_name = resolve_agent(mo.agent)
-            if dir_name is None:
-                issues.append(
-                    {
-                        "rule_id": "AD002",
-                        "severity": "error",
-                        "message": (
-                            f"Agent '{mo.agent}' in modelOverrides does not "
-                            "exist."
-                        ),
-                        "path": channel,
-                    }
-                )
-                continue
-            cfg = agent_configs[dir_name]
+            cfg = agent_configs[resolve_agent(mo.agent)]
             cfg.setdefault("modelSettings", {})["model"] = mo.model
 
         # Step 6: channel-specific callbacks.
         for cb in adapter.callbacks:
             dir_name = resolve_agent(cb.agent)
-            if dir_name is None:
-                issues.append(
-                    {
-                        "rule_id": "AD002",
-                        "severity": "error",
-                        "message": (
-                            f"Agent '{cb.agent}' in callbacks does not exist."
-                        ),
-                        "path": channel,
-                    }
-                )
-                continue
             code_path = resolve_path(cb.python_code)
-            if not code_path.exists():
-                issues.append(
-                    {
-                        "rule_id": "AD005",
-                        "severity": "error",
-                        "message": (
-                            f"Callback pythonCode '{cb.python_code}' not "
-                            f"found for agent '{cb.agent}'."
-                        ),
-                        "path": channel,
-                    }
-                )
-                continue
             cfg = agent_configs[dir_name]
             field_name = CALLBACK_TYPE_TO_FIELD[cb.type]
             dir_kind = CALLBACK_TYPE_TO_DIR[cb.type]
@@ -467,11 +463,18 @@ class PolymorphismEngine:
             )
             callback_code[rel] = code_path.read_text()
 
-        # Step 7: merge channel evaluations.
+        # Step 7: merge channel evaluations / expectations / datasets.
         evaluations: Dict[str, Dict[str, Any]] = {}
         for ev in adapter.evaluations:
-            src = resolve_path(ev.source_dir)
-            evaluations.update(self._read_eval_dir(src))
+            evaluations.update(self._read_eval_dir(resolve_path(ev.source_dir)))
+        expectations: Dict[str, Dict[str, Any]] = {}
+        for ev in adapter.evaluation_expectations:
+            expectations.update(
+                self._read_eval_dir(resolve_path(ev.source_dir))
+            )
+        datasets: Dict[str, Dict[str, Any]] = {}
+        for ev in adapter.evaluation_datasets:
+            datasets.update(self._read_eval_dir(resolve_path(ev.source_dir)))
 
         # Step 8: deployment + gecx config.
         gecx_config = copy.deepcopy(self.base.gecx_config)
@@ -484,14 +487,18 @@ class PolymorphismEngine:
             deployment = self._build_deployment(
                 adapter.deployment, adapter.metadata.display_name, channel
             )
-            modality = adapter.deployment.modality
+            # Fold the per-channel deployment block into gecx-config.json — the
+            # file deploy/lint tooling reads — rather than an orphan file.
+            gecx_config["deployment"] = deployment
+            modality = adapter.deployment.modality or (
+                adapter.deployment.web_widget_config.modality
+                if adapter.deployment.web_widget_config
+                else None
+            )
             if modality:
                 gecx_config["modality"] = (
                     "audio" if "VOICE" in modality.upper() else "text"
                 )
-
-        if issues:
-            raise CompilationError(issues)
 
         return CompiledAgentConfig(
             channel=channel,
@@ -501,7 +508,10 @@ class PolymorphismEngine:
             agent_instructions=instructions,
             tools=new_tools,
             tool_code=new_tool_code,
+            tool_source_dirs=tool_source_dirs,
             evaluations=evaluations,
+            evaluation_expectations=expectations,
+            evaluation_datasets=datasets,
             deployment=deployment,
             callback_code=callback_code,
         )
@@ -521,7 +531,8 @@ class PolymorphismEngine:
         cards = self.load_adapter_cards()
 
         adapters = [c for c, _ in self.adapters.values()]
-        issues = validate_all_adapters(adapters, str(self.app_dir))
+        issues = list(self.adapter_errors)
+        issues += validate_all_adapters(adapters, str(self.app_dir))
         errors = [i for i in issues if i.get("severity") == "error"]
         if errors:
             raise CompilationError(errors)
@@ -529,13 +540,18 @@ class PolymorphismEngine:
         result: Dict[str, CompiledAgentConfig] = {}
         for card in cards:
             _, path = self.adapters[card.metadata.channel]
-            result[card.metadata.channel] = self.compile(card, path)
+            result[card.metadata.channel] = self.compile(
+                card, path, validate=False
+            )
         return result
 
     # ── Output ───────────────────────────────────────────────────────────
 
     def write_output(
-        self, compiled: CompiledAgentConfig, output_dir: str
+        self,
+        compiled: CompiledAgentConfig,
+        output_dir: str,
+        force: bool = False,
     ) -> Path:
         """Write a compiled config as a complete agent project directory.
 
@@ -544,11 +560,40 @@ class PolymorphismEngine:
         agents, app.json and gecx-config.json are reconstructed from the
         compiled state; channel-specific tools/evaluations are added.
 
+        Safety: the target is replaced only when it is empty, was produced by a
+        previous ``cxas poly build`` (carries the ``.poly_build.json`` marker),
+        or ``force`` is True.  It never overlaps the source project directory.
+
         Returns:
             The output directory path.
+
+        Raises:
+            ValueError: if ``output_dir`` overlaps the base project directory.
+            FileExistsError: if the target exists, is non-empty, was not
+                produced by poly, and ``force`` is False.
         """
         out = Path(output_dir).resolve()
+
+        if (
+            out == self.app_dir
+            or _is_relative_to(out, self.app_dir)
+            or _is_relative_to(self.app_dir, out)
+        ):
+            raise ValueError(
+                f"Refusing to write output to '{out}': it overlaps the base "
+                f"project '{self.app_dir}'. Choose an --output-dir outside the "
+                "project."
+            )
+
         if out.exists():
+            is_empty = not any(out.iterdir())
+            is_poly = (out / _POLY_MARKER).is_file()
+            if not (force or is_empty or is_poly):
+                raise FileExistsError(
+                    f"Refusing to overwrite '{out}': it is not empty and was "
+                    "not created by 'cxas poly build'. Re-run with "
+                    "force/--force to overwrite it."
+                )
             shutil.rmtree(out)
         out.mkdir(parents=True, exist_ok=True)
 
@@ -585,7 +630,12 @@ class PolymorphismEngine:
 
         # 3. Channel-specific tool definitions (base tools already copied).
         for tool_name, cfg in compiled.tools.items():
+            src_dir = compiled.tool_source_dirs.get(tool_name)
             tool_out = out / "tools" / tool_name
+            if src_dir is not None:
+                # Non-python tool: copy the whole source dir verbatim.
+                shutil.copytree(Path(src_dir), tool_out, dirs_exist_ok=True)
+                continue
             tool_out.mkdir(parents=True, exist_ok=True)
             self._write_json(tool_out / f"{tool_name}.json", cfg)
             code = compiled.tool_code.get(tool_name)
@@ -597,23 +647,32 @@ class PolymorphismEngine:
                 code_path.parent.mkdir(parents=True, exist_ok=True)
                 code_path.write_text(code)
 
-        # 4. Channel-specific evaluations (base evals already copied).
-        for eval_name, data in compiled.evaluations.items():
-            eval_out = out / "evaluations" / eval_name
-            eval_out.mkdir(parents=True, exist_ok=True)
-            self._write_json(eval_out / f"{eval_name}.json", data)
+        # 4. Channel-specific evals / expectations / datasets (base copied).
+        for subdir, items in (
+            ("evaluations", compiled.evaluations),
+            ("evaluationExpectations", compiled.evaluation_expectations),
+            ("evaluationDatasets", compiled.evaluation_datasets),
+        ):
+            for name, data in items.items():
+                item_out = out / subdir / name
+                item_out.mkdir(parents=True, exist_ok=True)
+                self._write_json(item_out / f"{name}.json", data)
 
-        for exp_name, data in compiled.evaluation_expectations.items():
-            exp_out = out / "evaluationExpectations" / exp_name
-            exp_out.mkdir(parents=True, exist_ok=True)
-            self._write_json(exp_out / f"{exp_name}.json", data)
-
-        # 5. Root config files.
+        # 5. Root config files.  Per-channel deployment settings live inside
+        # gecx-config.json (compiled.gecx_config["deployment"]).
         self._write_json(out / "app.json", compiled.app_config)
         if compiled.gecx_config:
             self._write_json(out / "gecx-config.json", compiled.gecx_config)
-        if compiled.deployment is not None:
-            self._write_json(out / "deployment.json", compiled.deployment)
+
+        # 6. Build marker (dotfile, not copied into the next build's source).
+        self._write_json(
+            out / _POLY_MARKER,
+            {
+                "channel": compiled.channel,
+                "source": str(self.app_dir),
+                "generated_at": datetime.now(timezone.utc).isoformat(),
+            },
+        )
 
         return out
 
@@ -638,31 +697,6 @@ class PolymorphismEngine:
         if indices:
             return max(indices) + 1
         return len(entries or []) + 1
-
-    @staticmethod
-    def _apply_instruction_diff(text: str, diff: InstructionDiff) -> str:
-        if diff.mode == "append":
-            sep = "" if text.endswith("\n") else "\n"
-            return f"{text}{sep}\n{diff.content}"
-        if diff.mode == "prepend":
-            return f"{diff.content}\n\n{text}"
-        # replace_section
-        tag = diff.section_tag
-        if not tag:
-            raise ValueError(
-                f"replace_section requires sectionTag (agent '{diff.agent}')."
-            )
-        pattern = re.compile(
-            rf"<{re.escape(tag)}\b[^>]*>.*?</{re.escape(tag)}>",
-            re.DOTALL,
-        )
-        if not pattern.search(text):
-            raise ValueError(
-                f"AD003: section <{tag}> not found in instruction for "
-                f"agent '{diff.agent}'."
-            )
-        replacement = f"<{tag}>\n{diff.content.rstrip()}\n</{tag}>"
-        return pattern.sub(lambda _m: replacement, text, count=1)
 
     def _read_tool_dir(
         self, src: Path, display_name: str
@@ -704,6 +738,20 @@ class PolymorphismEngine:
             config["pythonFunction"]["pythonCode"] = canonical
 
         return config, canonical, code
+
+    def _read_tool_config(
+        self, src: Path, display_name: str
+    ) -> Optional[Dict[str, Any]]:
+        """Read a non-python tool's JSON config verbatim (no normalization)."""
+        if not src.exists() or not src.is_dir():
+            return None
+        json_path = src / f"{display_name}.json"
+        if not json_path.exists():
+            candidates = list(src.glob("*.json"))
+            if not candidates:
+                return None
+            json_path = candidates[0]
+        return self._read_json(json_path)
 
     def _read_eval_dir(self, src: Path) -> Dict[str, Dict[str, Any]]:
         """Read all evaluation files under a source directory.
@@ -748,23 +796,30 @@ class PolymorphismEngine:
     def _build_deployment(
         override: DeploymentOverride, display_name: str, channel: str
     ) -> Dict[str, Any]:
-        out: Dict[str, Any] = {}
+        """Build the gecx-config ``deployment`` block.
+
+        Keys use snake_case to match both ``gecx-config.json`` convention and
+        the kwargs of ``cxas_scrapi.core.deployments.Deployments`` so a deploy
+        step can consume it directly.
+        """
+        out: Dict[str, Any] = {
+            "deployment_id": channel,
+            "display_name": display_name,
+        }
         if override.channel_type is not None:
-            out["channelType"] = override.channel_type
+            out["channel_type"] = override.channel_type
         if override.modality is not None:
             out["modality"] = override.modality
         if override.disable_dtmf is not None:
-            out["disableDtmf"] = override.disable_dtmf
+            out["disable_dtmf"] = override.disable_dtmf
         if override.disable_barge_in_control is not None:
-            out["disableBargeInControl"] = override.disable_barge_in_control
+            out["disable_barge_in_control"] = override.disable_barge_in_control
         wwc = override.web_widget_config
         if wwc is not None:
             if wwc.theme is not None:
                 out["theme"] = wwc.theme
             if wwc.web_widget_title is not None:
-                out["webWidgetTitle"] = wwc.web_widget_title
+                out["web_widget_title"] = wwc.web_widget_title
             if wwc.modality is not None and "modality" not in out:
                 out["modality"] = wwc.modality
-        out["displayName"] = display_name
-        out["deploymentId"] = channel
         return out

--- a/src/cxas_scrapi/poly/engine.py
+++ b/src/cxas_scrapi/poly/engine.py
@@ -1,0 +1,770 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Polymorphism compilation engine.
+
+Reads a base agent project from disk plus channel adapter cards, then
+compiles channel-optimized agent project directories.  Pure local file
+I/O — no ``google.cloud.*`` imports and no network access.
+"""
+
+import copy
+import json
+import re
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import yaml
+
+from cxas_scrapi.poly.models import (
+    AdapterCard,
+    CompiledAgentConfig,
+    DeploymentOverride,
+    InstructionDiff,
+)
+from cxas_scrapi.poly.validators import validate_all_adapters
+
+# Logical callback type -> agent-JSON field name (camelCase).
+CALLBACK_TYPE_TO_FIELD: Dict[str, str] = {
+    "before_model": "beforeModelCallbacks",
+    "after_model": "afterModelCallbacks",
+    "before_tool": "beforeToolCallbacks",
+    "after_tool": "afterToolCallbacks",
+    "before_agent": "beforeAgentCallbacks",
+    "after_agent": "afterAgentCallbacks",
+}
+
+# Logical callback type -> on-disk directory name (snake_case).
+CALLBACK_TYPE_TO_DIR: Dict[str, str] = {
+    "before_model": "before_model_callbacks",
+    "after_model": "after_model_callbacks",
+    "before_tool": "before_tool_callbacks",
+    "after_tool": "after_tool_callbacks",
+    "before_agent": "before_agent_callbacks",
+    "after_agent": "after_agent_callbacks",
+}
+
+# Top-level base-project items that the engine reconstructs (rather than
+# copying verbatim) when writing output.
+_RECONSTRUCTED_ITEMS = {"adapters", "agents", "app.json", "gecx-config.json"}
+
+
+class CompilationError(Exception):
+    """Raised when compilation cannot proceed.
+
+    Carries the full list of validation/compilation issue dicts (each with
+    ``rule_id``, ``severity``, ``message``, ``path``) so callers can render
+    every problem at once instead of failing on the first.
+    """
+
+    def __init__(self, issues: List[Dict[str, Any]]):
+        self.issues = issues
+        n = len(issues)
+        super().__init__(
+            f"{n} compilation error(s):\n"
+            + "\n".join(
+                f"  [{i.get('severity', 'error')}] {i.get('rule_id', '?')} "
+                f"{i.get('path', '')}: {i.get('message', '')}"
+                for i in issues
+            )
+        )
+
+
+@dataclass
+class AgentBundle:
+    """In-memory representation of one base agent."""
+
+    dir_name: str
+    display_name: str
+    config: Dict[str, Any]
+    instruction: str
+    # rel_path (from project root) -> python source for every existing
+    # callback referenced by this agent's JSON.
+    callback_code: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class ToolBundle:
+    """In-memory representation of one base tool."""
+
+    dir_name: str
+    config: Dict[str, Any]
+    code_rel_path: Optional[str] = None
+    code: Optional[str] = None
+
+
+@dataclass
+class BaseProject:
+    """Loaded state of the base agent project."""
+
+    app_json: Dict[str, Any]
+    gecx_config: Dict[str, Any]
+    agents: Dict[str, AgentBundle]
+    tools: Dict[str, ToolBundle]
+
+
+class PolymorphismEngine:
+    """Compiles a base agent project plus adapter cards into per-channel
+    output projects."""
+
+    def __init__(self, app_dir: str):
+        """Initialize the engine.
+
+        Args:
+            app_dir: Path to the root of the base agent project (the
+                directory that directly contains ``app.json``, ``agents/``,
+                ``tools/``, etc.).  The nested gecx-skills layout is not
+                supported for poly base projects.
+        """
+        self.app_dir = Path(app_dir).resolve()
+        self.base: Optional[BaseProject] = None
+        # channel -> (card, card_path)
+        self.adapters: Dict[str, Tuple[AdapterCard, Path]] = {}
+
+    # ── Loading ──────────────────────────────────────────────────────────
+
+    def load_base_project(self) -> BaseProject:
+        """Read the base project from disk into memory.
+
+        Reads ``app.json``, every agent (config + instruction + callback
+        code), and every tool (config + code).  Stores the result on
+        ``self.base`` and returns it.
+        """
+        if not (self.app_dir / "app.json").exists():
+            raise FileNotFoundError(
+                f"No app.json found in {self.app_dir}. The poly engine "
+                "requires a direct project layout."
+            )
+
+        app_json = self._read_json(self.app_dir / "app.json")
+        gecx_config: Dict[str, Any] = {}
+        gecx_path = self.app_dir / "gecx-config.json"
+        if gecx_path.exists():
+            gecx_config = self._read_json(gecx_path)
+
+        agents: Dict[str, AgentBundle] = {}
+        agents_dir = self.app_dir / "agents"
+        if agents_dir.exists():
+            for agent_dir in sorted(agents_dir.iterdir()):
+                if not agent_dir.is_dir():
+                    continue
+                bundle = self._load_agent(agent_dir)
+                if bundle is not None:
+                    agents[bundle.dir_name] = bundle
+
+        tools: Dict[str, ToolBundle] = {}
+        tools_dir = self.app_dir / "tools"
+        if tools_dir.exists():
+            for tool_dir in sorted(tools_dir.iterdir()):
+                if not tool_dir.is_dir():
+                    continue
+                bundle = self._load_tool(tool_dir)
+                if bundle is not None:
+                    tools[bundle.dir_name] = bundle
+
+        self.base = BaseProject(
+            app_json=app_json,
+            gecx_config=gecx_config,
+            agents=agents,
+            tools=tools,
+        )
+        return self.base
+
+    def _load_agent(self, agent_dir: Path) -> Optional[AgentBundle]:
+        config_path = agent_dir / f"{agent_dir.name}.json"
+        if not config_path.exists():
+            return None
+        config = self._read_json(config_path)
+        display_name = config.get("displayName", agent_dir.name)
+
+        instruction = ""
+        inst_ref = config.get("instruction")
+        if inst_ref:
+            inst_path = self.app_dir / inst_ref
+            if inst_path.exists():
+                instruction = inst_path.read_text()
+
+        callback_code: Dict[str, str] = {}
+        for field_name in CALLBACK_TYPE_TO_FIELD.values():
+            for entry in config.get(field_name, []) or []:
+                rel = entry.get("pythonCode")
+                if not rel:
+                    continue
+                code_path = self.app_dir / rel
+                if code_path.exists():
+                    callback_code[rel] = code_path.read_text()
+
+        return AgentBundle(
+            dir_name=agent_dir.name,
+            display_name=display_name,
+            config=config,
+            instruction=instruction,
+            callback_code=callback_code,
+        )
+
+    def _load_tool(self, tool_dir: Path) -> Optional[ToolBundle]:
+        json_path = tool_dir / f"{tool_dir.name}.json"
+        if not json_path.exists():
+            candidates = list(tool_dir.glob("*.json"))
+            if not candidates:
+                return None
+            json_path = candidates[0]
+        config = self._read_json(json_path)
+
+        code_rel_path = None
+        code = None
+        py_fn = config.get("pythonFunction") or {}
+        ref = py_fn.get("pythonCode")
+        if ref:
+            code_path = self.app_dir / ref
+            if code_path.exists():
+                code_rel_path = ref
+                code = code_path.read_text()
+
+        return ToolBundle(
+            dir_name=tool_dir.name,
+            config=config,
+            code_rel_path=code_rel_path,
+            code=code,
+        )
+
+    def load_adapter_cards(self) -> List[AdapterCard]:
+        """Glob and parse all adapter cards under ``adapters/``.
+
+        Recognizes ``*.adapter.yaml``, ``*.adapter.yml`` and
+        ``*.adapter.json``.  Populates ``self.adapters`` keyed by channel
+        and returns the parsed cards in filename order.
+        """
+        adapters_dir = self.app_dir / "adapters"
+        cards: List[AdapterCard] = []
+        self.adapters = {}
+        if not adapters_dir.exists():
+            return cards
+
+        paths = sorted(
+            list(adapters_dir.glob("*.adapter.yaml"))
+            + list(adapters_dir.glob("*.adapter.yml"))
+            + list(adapters_dir.glob("*.adapter.json"))
+        )
+        for path in paths:
+            raw = path.read_text()
+            if path.suffix == ".json":
+                data = json.loads(raw)
+            else:
+                data = yaml.safe_load(raw)
+            card = AdapterCard.model_validate(data)
+            cards.append(card)
+            self.adapters[card.metadata.channel] = (card, path)
+        return cards
+
+    # ── Compilation ──────────────────────────────────────────────────────
+
+    def compile(
+        self, adapter: AdapterCard, card_path: Optional[Path] = None
+    ) -> CompiledAgentConfig:
+        """Compile the base project against one adapter card.
+
+        Args:
+            adapter: The parsed adapter card.
+            card_path: Path to the adapter card file, used to resolve
+                relative paths (``pythonCode``, ``sourceDir``).  Defaults
+                to ``<app_dir>/adapters`` when not provided.
+
+        Returns:
+            A fully resolved ``CompiledAgentConfig``.
+
+        Raises:
+            CompilationError: if a referenced agent or instruction section
+                cannot be resolved.
+        """
+        if self.base is None:
+            self.load_base_project()
+        assert self.base is not None
+
+        channel = adapter.metadata.channel
+        card_dir = (
+            card_path.parent
+            if card_path is not None
+            else self.app_dir / "adapters"
+        )
+
+        def resolve_path(ref: str) -> Path:
+            """Resolve an adapter path: app_dir-relative (per spec) first,
+            then card-relative as a fallback."""
+            primary = (self.app_dir / ref).resolve()
+            if primary.exists():
+                return primary
+            return (card_dir / ref).resolve()
+
+        issues: List[Dict[str, Any]] = []
+
+        # Step 1: deep copy mutable base state.
+        agent_configs: Dict[str, Dict[str, Any]] = {
+            name: copy.deepcopy(b.config)
+            for name, b in self.base.agents.items()
+        }
+        instructions: Dict[str, str] = {
+            name: b.instruction for name, b in self.base.agents.items()
+        }
+        callback_code: Dict[str, str] = {}
+        for b in self.base.agents.values():
+            callback_code.update(copy.deepcopy(b.callback_code))
+
+        display_to_dir = {
+            b.display_name: name for name, b in self.base.agents.items()
+        }
+
+        def resolve_agent(ref: str) -> Optional[str]:
+            if ref in agent_configs:
+                return ref
+            return display_to_dir.get(ref)
+
+        # Step 2: instruction diffs.
+        for i, diff in enumerate(adapter.instruction_diffs):
+            dir_name = resolve_agent(diff.agent)
+            if dir_name is None:
+                issues.append(
+                    {
+                        "rule_id": "AD002",
+                        "severity": "error",
+                        "message": (
+                            f"Agent '{diff.agent}' in instructionDiffs[{i}] "
+                            "does not exist."
+                        ),
+                        "path": channel,
+                    }
+                )
+                continue
+            try:
+                instructions[dir_name] = self._apply_instruction_diff(
+                    instructions[dir_name], diff
+                )
+            except ValueError as e:
+                issues.append(
+                    {
+                        "rule_id": "AD003",
+                        "severity": "error",
+                        "message": str(e),
+                        "path": channel,
+                    }
+                )
+
+        # Step 3: tool add / remove.
+        for mod in adapter.tools:
+            dir_name = resolve_agent(mod.agent)
+            if dir_name is None:
+                issues.append(
+                    {
+                        "rule_id": "AD002",
+                        "severity": "error",
+                        "message": (
+                            f"Agent '{mod.agent}' in tools does not exist."
+                        ),
+                        "path": channel,
+                    }
+                )
+                continue
+            cfg = agent_configs[dir_name]
+            tool_list = list(cfg.get("tools", []))
+            for t in mod.add:
+                if t not in tool_list:
+                    tool_list.append(t)
+            tool_list = [t for t in tool_list if t not in set(mod.remove)]
+            cfg["tools"] = tool_list
+
+        # Step 4: channel-specific tool definitions.
+        new_tools: Dict[str, Dict[str, Any]] = {}
+        new_tool_code: Dict[str, str] = {}
+        for td in adapter.tool_definitions:
+            src = resolve_path(td.source_dir)
+            cfg, rel, code = self._read_tool_dir(src, td.display_name)
+            if cfg is None:
+                issues.append(
+                    {
+                        "rule_id": "AD005",
+                        "severity": "error",
+                        "message": (
+                            f"Tool definition '{td.display_name}' sourceDir "
+                            f"'{td.source_dir}' is missing or has no JSON."
+                        ),
+                        "path": channel,
+                    }
+                )
+                continue
+            new_tools[td.display_name] = cfg
+            if code is not None:
+                new_tool_code[td.display_name] = code
+
+        # Step 5: model overrides.
+        for mo in adapter.model_overrides:
+            dir_name = resolve_agent(mo.agent)
+            if dir_name is None:
+                issues.append(
+                    {
+                        "rule_id": "AD002",
+                        "severity": "error",
+                        "message": (
+                            f"Agent '{mo.agent}' in modelOverrides does not "
+                            "exist."
+                        ),
+                        "path": channel,
+                    }
+                )
+                continue
+            cfg = agent_configs[dir_name]
+            cfg.setdefault("modelSettings", {})["model"] = mo.model
+
+        # Step 6: channel-specific callbacks.
+        for cb in adapter.callbacks:
+            dir_name = resolve_agent(cb.agent)
+            if dir_name is None:
+                issues.append(
+                    {
+                        "rule_id": "AD002",
+                        "severity": "error",
+                        "message": (
+                            f"Agent '{cb.agent}' in callbacks does not exist."
+                        ),
+                        "path": channel,
+                    }
+                )
+                continue
+            code_path = resolve_path(cb.python_code)
+            if not code_path.exists():
+                issues.append(
+                    {
+                        "rule_id": "AD005",
+                        "severity": "error",
+                        "message": (
+                            f"Callback pythonCode '{cb.python_code}' not "
+                            f"found for agent '{cb.agent}'."
+                        ),
+                        "path": channel,
+                    }
+                )
+                continue
+            cfg = agent_configs[dir_name]
+            field_name = CALLBACK_TYPE_TO_FIELD[cb.type]
+            dir_kind = CALLBACK_TYPE_TO_DIR[cb.type]
+            idx = self._next_callback_index(cfg.get(field_name, []))
+            sub = f"{dir_kind}_{idx:02d}"
+            rel = f"agents/{dir_name}/{dir_kind}/{sub}/python_code.py"
+            cfg.setdefault(field_name, []).append(
+                {"pythonCode": rel, "description": cb.description}
+            )
+            callback_code[rel] = code_path.read_text()
+
+        # Step 7: merge channel evaluations.
+        evaluations: Dict[str, Dict[str, Any]] = {}
+        for ev in adapter.evaluations:
+            src = resolve_path(ev.source_dir)
+            evaluations.update(self._read_eval_dir(src))
+
+        # Step 8: deployment + gecx config.
+        gecx_config = copy.deepcopy(self.base.gecx_config)
+        gecx_config["default_channel"] = channel
+        # The compiled output is always a direct-layout project rooted at
+        # the channel directory, so the linter's app_dir must be ".".
+        gecx_config["app_dir"] = "."
+        deployment: Optional[Dict[str, Any]] = None
+        if adapter.deployment is not None:
+            deployment = self._build_deployment(
+                adapter.deployment, adapter.metadata.display_name, channel
+            )
+            modality = adapter.deployment.modality
+            if modality:
+                gecx_config["modality"] = (
+                    "audio" if "VOICE" in modality.upper() else "text"
+                )
+
+        if issues:
+            raise CompilationError(issues)
+
+        return CompiledAgentConfig(
+            channel=channel,
+            app_config=copy.deepcopy(self.base.app_json),
+            gecx_config=gecx_config,
+            agents=agent_configs,
+            agent_instructions=instructions,
+            tools=new_tools,
+            tool_code=new_tool_code,
+            evaluations=evaluations,
+            deployment=deployment,
+            callback_code=callback_code,
+        )
+
+    def compile_all(self) -> Dict[str, CompiledAgentConfig]:
+        """Validate and compile every adapter card.
+
+        Returns:
+            A dict mapping channel name to its ``CompiledAgentConfig``.
+
+        Raises:
+            CompilationError: if validation produces any ERROR-severity
+                issues.
+        """
+        if self.base is None:
+            self.load_base_project()
+        cards = self.load_adapter_cards()
+
+        adapters = [c for c, _ in self.adapters.values()]
+        issues = validate_all_adapters(adapters, str(self.app_dir))
+        errors = [i for i in issues if i.get("severity") == "error"]
+        if errors:
+            raise CompilationError(errors)
+
+        result: Dict[str, CompiledAgentConfig] = {}
+        for card in cards:
+            _, path = self.adapters[card.metadata.channel]
+            result[card.metadata.channel] = self.compile(card, path)
+        return result
+
+    # ── Output ───────────────────────────────────────────────────────────
+
+    def write_output(
+        self, compiled: CompiledAgentConfig, output_dir: str
+    ) -> Path:
+        """Write a compiled config as a complete agent project directory.
+
+        Untouched base items (tools/, evaluations/, evaluationExpectations/,
+        evaluationDatasets/, cxaslint.yaml, etc.) are copied verbatim;
+        agents, app.json and gecx-config.json are reconstructed from the
+        compiled state; channel-specific tools/evaluations are added.
+
+        Returns:
+            The output directory path.
+        """
+        out = Path(output_dir).resolve()
+        if out.exists():
+            shutil.rmtree(out)
+        out.mkdir(parents=True, exist_ok=True)
+
+        # 1. Verbatim copy of untouched base items.
+        for item in sorted(self.app_dir.iterdir()):
+            if item.name in _RECONSTRUCTED_ITEMS or item.name.startswith("."):
+                continue
+            dest = out / item.name
+            if item.is_dir():
+                shutil.copytree(item, dest)
+            else:
+                shutil.copy2(item, dest)
+
+        # 2. Reconstruct agents (configs + instructions + callbacks).
+        for dir_name, cfg in compiled.agents.items():
+            agent_out = out / "agents" / dir_name
+            agent_out.mkdir(parents=True, exist_ok=True)
+            self._write_json(agent_out / f"{dir_name}.json", cfg)
+            inst = compiled.agent_instructions.get(dir_name)
+            if inst is not None:
+                inst_ref = cfg.get("instruction")
+                inst_path = (
+                    out / inst_ref
+                    if inst_ref
+                    else agent_out / "instruction.txt"
+                )
+                inst_path.parent.mkdir(parents=True, exist_ok=True)
+                inst_path.write_text(inst)
+
+        for rel, code in compiled.callback_code.items():
+            dest = out / rel
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_text(code)
+
+        # 3. Channel-specific tool definitions (base tools already copied).
+        for tool_name, cfg in compiled.tools.items():
+            tool_out = out / "tools" / tool_name
+            tool_out.mkdir(parents=True, exist_ok=True)
+            self._write_json(tool_out / f"{tool_name}.json", cfg)
+            code = compiled.tool_code.get(tool_name)
+            if code is not None:
+                ref = (cfg.get("pythonFunction") or {}).get("pythonCode")
+                if not ref:
+                    ref = f"tools/{tool_name}/python_function/python_code.py"
+                code_path = out / ref
+                code_path.parent.mkdir(parents=True, exist_ok=True)
+                code_path.write_text(code)
+
+        # 4. Channel-specific evaluations (base evals already copied).
+        for eval_name, data in compiled.evaluations.items():
+            eval_out = out / "evaluations" / eval_name
+            eval_out.mkdir(parents=True, exist_ok=True)
+            self._write_json(eval_out / f"{eval_name}.json", data)
+
+        for exp_name, data in compiled.evaluation_expectations.items():
+            exp_out = out / "evaluationExpectations" / exp_name
+            exp_out.mkdir(parents=True, exist_ok=True)
+            self._write_json(exp_out / f"{exp_name}.json", data)
+
+        # 5. Root config files.
+        self._write_json(out / "app.json", compiled.app_config)
+        if compiled.gecx_config:
+            self._write_json(out / "gecx-config.json", compiled.gecx_config)
+        if compiled.deployment is not None:
+            self._write_json(out / "deployment.json", compiled.deployment)
+
+        return out
+
+    # ── Helpers ──────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _read_json(path: Path) -> Dict[str, Any]:
+        return json.loads(path.read_text())
+
+    @staticmethod
+    def _write_json(path: Path, data: Dict[str, Any]) -> None:
+        path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+
+    @staticmethod
+    def _next_callback_index(entries: List[Dict[str, Any]]) -> int:
+        indices: List[int] = []
+        for entry in entries or []:
+            ref = entry.get("pythonCode", "")
+            m = re.search(r"_(\d+)/python_code\.py$", ref)
+            if m:
+                indices.append(int(m.group(1)))
+        if indices:
+            return max(indices) + 1
+        return len(entries or []) + 1
+
+    @staticmethod
+    def _apply_instruction_diff(text: str, diff: InstructionDiff) -> str:
+        if diff.mode == "append":
+            sep = "" if text.endswith("\n") else "\n"
+            return f"{text}{sep}\n{diff.content}"
+        if diff.mode == "prepend":
+            return f"{diff.content}\n\n{text}"
+        # replace_section
+        tag = diff.section_tag
+        if not tag:
+            raise ValueError(
+                f"replace_section requires sectionTag (agent '{diff.agent}')."
+            )
+        pattern = re.compile(
+            rf"<{re.escape(tag)}\b[^>]*>.*?</{re.escape(tag)}>",
+            re.DOTALL,
+        )
+        if not pattern.search(text):
+            raise ValueError(
+                f"AD003: section <{tag}> not found in instruction for "
+                f"agent '{diff.agent}'."
+            )
+        replacement = f"<{tag}>\n{diff.content.rstrip()}\n</{tag}>"
+        return pattern.sub(lambda _m: replacement, text, count=1)
+
+    def _read_tool_dir(
+        self, src: Path, display_name: str
+    ) -> Tuple[Optional[Dict[str, Any]], Optional[str], Optional[str]]:
+        """Read a tool definition directory.
+
+        Returns ``(config, code_rel_path, code)``.  The config's
+        ``pythonFunction.pythonCode`` is normalized to the canonical output
+        location ``tools/<name>/python_function/python_code.py``.
+        """
+        if not src.exists() or not src.is_dir():
+            return None, None, None
+        json_path = src / f"{display_name}.json"
+        if not json_path.exists():
+            candidates = list(src.glob("*.json"))
+            if not candidates:
+                return None, None, None
+            json_path = candidates[0]
+        config = self._read_json(json_path)
+
+        canonical = f"tools/{display_name}/python_function/python_code.py"
+        code = None
+        # Prefer the path the JSON references; fall back to a bare
+        # python_code.py in the source dir.
+        py_fn = config.get("pythonFunction") or {}
+        ref = py_fn.get("pythonCode")
+        candidate_paths = []
+        if ref:
+            candidate_paths.append(src / Path(ref).name)
+            candidate_paths.append(self.app_dir / ref)
+        candidate_paths.append(src / "python_code.py")
+        candidate_paths.append(src / "python_function" / "python_code.py")
+        for cp in candidate_paths:
+            if cp.exists():
+                code = cp.read_text()
+                break
+
+        if "pythonFunction" in config:
+            config["pythonFunction"]["pythonCode"] = canonical
+
+        return config, canonical, code
+
+    def _read_eval_dir(self, src: Path) -> Dict[str, Dict[str, Any]]:
+        """Read all evaluation files under a source directory.
+
+        Each immediate subdirectory is treated as one evaluation named
+        ``<dir>`` containing ``<dir>.{yaml,yml,json}``.  Loose files at the
+        top level are also accepted.
+        """
+        result: Dict[str, Dict[str, Any]] = {}
+        if not src.exists() or not src.is_dir():
+            return result
+        for child in sorted(src.iterdir()):
+            if child.is_dir():
+                for cand in (
+                    child / f"{child.name}.json",
+                    child / f"{child.name}.yaml",
+                    child / f"{child.name}.yml",
+                ):
+                    if cand.exists():
+                        result[child.name] = self._load_data_file(cand)
+                        break
+                else:
+                    files = (
+                        list(child.glob("*.json"))
+                        + list(child.glob("*.yaml"))
+                        + list(child.glob("*.yml"))
+                    )
+                    if files:
+                        result[child.name] = self._load_data_file(files[0])
+            elif child.suffix in (".json", ".yaml", ".yml"):
+                result[child.stem] = self._load_data_file(child)
+        return result
+
+    @staticmethod
+    def _load_data_file(path: Path) -> Dict[str, Any]:
+        raw = path.read_text()
+        if path.suffix == ".json":
+            return json.loads(raw)
+        return yaml.safe_load(raw)
+
+    @staticmethod
+    def _build_deployment(
+        override: DeploymentOverride, display_name: str, channel: str
+    ) -> Dict[str, Any]:
+        out: Dict[str, Any] = {}
+        if override.channel_type is not None:
+            out["channelType"] = override.channel_type
+        if override.modality is not None:
+            out["modality"] = override.modality
+        if override.disable_dtmf is not None:
+            out["disableDtmf"] = override.disable_dtmf
+        if override.disable_barge_in_control is not None:
+            out["disableBargeInControl"] = override.disable_barge_in_control
+        wwc = override.web_widget_config
+        if wwc is not None:
+            if wwc.theme is not None:
+                out["theme"] = wwc.theme
+            if wwc.web_widget_title is not None:
+                out["webWidgetTitle"] = wwc.web_widget_title
+            if wwc.modality is not None and "modality" not in out:
+                out["modality"] = wwc.modality
+        out["displayName"] = display_name
+        out["deploymentId"] = channel
+        return out

--- a/src/cxas_scrapi/poly/engine.py
+++ b/src/cxas_scrapi/poly/engine.py
@@ -163,6 +163,7 @@ class PolymorphismEngine:
         self.base: Optional[BaseProject] = None
         # channel -> (card, card_path)
         self.adapters: Dict[str, Tuple[AdapterCard, Path]] = {}
+        self.adapter_cards: List[Tuple[AdapterCard, Path]] = []
         # Per-file parse / schema errors collected by ``load_adapter_cards``
         # (issue dicts).  A malformed card is recorded here instead of raising,
         # so one bad card never blocks compiling the others.
@@ -287,6 +288,7 @@ class PolymorphismEngine:
         adapters_dir = self.app_dir / "adapters"
         cards: List[AdapterCard] = []
         self.adapters = {}
+        self.adapter_cards = []
         self.adapter_errors = []
         if not adapters_dir.exists():
             return cards
@@ -325,6 +327,7 @@ class PolymorphismEngine:
                 )
                 continue
             cards.append(card)
+            self.adapter_cards.append((card, path))
             self.adapters[card.metadata.channel] = (card, path)
         return cards
 
@@ -478,6 +481,7 @@ class PolymorphismEngine:
 
         # Step 8: deployment + gecx config.
         gecx_config = copy.deepcopy(self.base.gecx_config)
+        self._deep_merge(gecx_config, adapter.gecx_config)
         gecx_config["default_channel"] = channel
         # The compiled output is always a direct-layout project rooted at
         # the channel directory, so the linter's app_dir must be ".".
@@ -528,9 +532,9 @@ class PolymorphismEngine:
         """
         if self.base is None:
             self.load_base_project()
-        cards = self.load_adapter_cards()
+        self.load_adapter_cards()
 
-        adapters = [c for c, _ in self.adapters.values()]
+        adapters = [c for c, _ in self.adapter_cards]
         issues = list(self.adapter_errors)
         issues += validate_all_adapters(adapters, str(self.app_dir))
         errors = [i for i in issues if i.get("severity") == "error"]
@@ -538,8 +542,7 @@ class PolymorphismEngine:
             raise CompilationError(errors)
 
         result: Dict[str, CompiledAgentConfig] = {}
-        for card in cards:
-            _, path = self.adapters[card.metadata.channel]
+        for card, path in self.adapter_cards:
             result[card.metadata.channel] = self.compile(
                 card, path, validate=False
             )
@@ -558,7 +561,8 @@ class PolymorphismEngine:
         Untouched base items (tools/, evaluations/, evaluationExpectations/,
         evaluationDatasets/, cxaslint.yaml, etc.) are copied verbatim;
         agents, app.json and gecx-config.json are reconstructed from the
-        compiled state; channel-specific tools/evaluations are added.
+        compiled state; channel-specific tools/evaluations/runtime config are
+        added.
 
         Safety: the target is replaced only when it is empty, was produced by a
         previous ``cxas poly build`` (carries the ``.poly_build.json`` marker),
@@ -685,6 +689,18 @@ class PolymorphismEngine:
     @staticmethod
     def _write_json(path: Path, data: Dict[str, Any]) -> None:
         path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+
+    @staticmethod
+    def _deep_merge(target: Dict[str, Any], overlay: Dict[str, Any]) -> None:
+        """Recursively merge ``overlay`` into ``target`` in place."""
+        for key, value in overlay.items():
+            if (
+                isinstance(value, dict)
+                and isinstance(target.get(key), dict)
+            ):
+                PolymorphismEngine._deep_merge(target[key], value)
+            else:
+                target[key] = copy.deepcopy(value)
 
     @staticmethod
     def _next_callback_index(entries: List[Dict[str, Any]]) -> int:

--- a/src/cxas_scrapi/poly/instructions.py
+++ b/src/cxas_scrapi/poly/instructions.py
@@ -1,0 +1,82 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared instruction-text helpers for the Polymorphism Engine.
+
+Both the compiler (``poly.engine``) and the adapter validators
+(``poly.validators``) need to reason about XML-style ``<section>`` blocks in
+agent instructions in exactly the same way.  Keeping the matcher here — rather
+than duplicating it in each module — guarantees that ``cxas poly validate`` and
+``cxas poly build`` agree: a card that validates clean always compiles, and a
+card that fails to compile is always reported by validation first.
+
+Pure functions, no I/O, depends only on :mod:`poly.models`.
+"""
+
+import re
+from functools import lru_cache
+from typing import Pattern
+
+from cxas_scrapi.poly.models import InstructionDiff
+
+
+@lru_cache(maxsize=256)
+def section_regex(tag: str) -> Pattern[str]:
+    """Return the compiled regex that matches a ``<tag ...>...</tag>`` block.
+
+    Attributes on the opening tag are allowed; a matching closing tag is
+    required.  The match is non-greedy and spans newlines.
+    """
+    return re.compile(
+        rf"<{re.escape(tag)}\b[^>]*>.*?</{re.escape(tag)}>",
+        re.DOTALL,
+    )
+
+
+def has_section(text: str, tag: str) -> bool:
+    """True if ``text`` contains a complete ``<tag>...</tag>`` block."""
+    if not tag:
+        return False
+    return bool(section_regex(tag).search(text))
+
+
+def apply_instruction_diff(text: str, diff: InstructionDiff) -> str:
+    """Apply one :class:`InstructionDiff` to ``text`` and return the result.
+
+    Raises:
+        ValueError: if ``mode == "replace_section"`` and either ``sectionTag``
+            is missing or the section is not present in ``text``.  The message
+            is prefixed with ``AD003`` so callers can surface it consistently.
+    """
+    if diff.mode == "append":
+        sep = "" if text.endswith("\n") else "\n"
+        return f"{text}{sep}\n{diff.content}"
+    if diff.mode == "prepend":
+        return f"{diff.content}\n\n{text}"
+
+    # replace_section
+    tag = diff.section_tag
+    if not tag:
+        raise ValueError(
+            f"AD003: replace_section requires sectionTag (agent "
+            f"'{diff.agent}')."
+        )
+    pattern = section_regex(tag)
+    if not pattern.search(text):
+        raise ValueError(
+            f"AD003: section <{tag}> not found in instruction for agent "
+            f"'{diff.agent}'."
+        )
+    replacement = f"<{tag}>\n{diff.content.rstrip()}\n</{tag}>"
+    return pattern.sub(lambda _m: replacement, text, count=1)

--- a/src/cxas_scrapi/poly/models.py
+++ b/src/cxas_scrapi/poly/models.py
@@ -1,0 +1,202 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pydantic data models for the Polymorphism Engine.
+
+Defines the schema for channel adapter cards — declarative deltas applied
+to a base agent project to produce channel-optimized variants — plus the
+in-memory shape of a compiled project (``CompiledAgentConfig``).
+"""
+
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# Both ``populate_by_name`` (so YAML camelCase aliases work alongside
+# snake_case Python attribute access) and ``protected_namespaces=()`` (to
+# allow field names like ``model_overrides`` and ``model`` without Pydantic
+# v2 warnings about the reserved ``model_`` namespace) are needed on every
+# model in this module.
+_MODEL_CONFIG = ConfigDict(populate_by_name=True, protected_namespaces=())
+
+# Logical callback types accepted in adapter cards.  These map to JSON
+# field names like ``beforeModelCallbacks`` at compile time — see
+# ``poly.engine.CALLBACK_TYPE_TO_FIELD``.
+CallbackType = Literal[
+    "before_model",
+    "after_model",
+    "before_tool",
+    "after_tool",
+    "before_agent",
+    "after_agent",
+]
+
+
+class AdapterMetadata(BaseModel):
+    """Metadata about the channel adapter."""
+
+    model_config = _MODEL_CONFIG
+
+    channel: str
+    display_name: str = Field(alias="displayName")
+    description: str = ""
+
+
+class InstructionDiff(BaseModel):
+    """A modification to an agent's instruction text."""
+
+    model_config = _MODEL_CONFIG
+
+    agent: str
+    mode: Literal["append", "prepend", "replace_section"]
+    section_tag: Optional[str] = Field(default=None, alias="sectionTag")
+    content: str
+
+
+class ToolModification(BaseModel):
+    """Tools to add or remove from an agent's tool list."""
+
+    model_config = _MODEL_CONFIG
+
+    agent: str
+    add: List[str] = Field(default_factory=list)
+    remove: List[str] = Field(default_factory=list)
+
+
+class ToolDefinition(BaseModel):
+    """A new tool definition only available in this channel.
+
+    ``source_dir`` points at a directory under the adapter card's parent
+    containing ``<display_name>.json`` and ``python_code.py`` (or the
+    standard ``python_function/python_code.py`` layout).
+    """
+
+    model_config = _MODEL_CONFIG
+
+    display_name: str = Field(alias="displayName")
+    tool_type: str = Field(alias="toolType")
+    source_dir: str = Field(alias="sourceDir")
+
+
+class ModelOverride(BaseModel):
+    """Override the model for a specific agent in this channel."""
+
+    model_config = _MODEL_CONFIG
+
+    agent: str
+    model: str
+
+
+class CallbackDefinition(BaseModel):
+    """A channel-specific callback to add to an agent.
+
+    ``python_code`` is a path (relative to the adapter card's parent
+    directory) to a ``.py`` file whose contents will be copied into the
+    compiled output and referenced from the agent JSON.
+    """
+
+    model_config = _MODEL_CONFIG
+
+    agent: str
+    type: CallbackType
+    python_code: str = Field(alias="pythonCode")
+    description: str = ""
+
+
+class EvalReference(BaseModel):
+    """Reference to a directory of channel-specific evaluations."""
+
+    model_config = _MODEL_CONFIG
+
+    source_dir: str = Field(alias="sourceDir")
+
+
+class WebWidgetConfig(BaseModel):
+    """Web widget configuration for deployment."""
+
+    model_config = _MODEL_CONFIG
+
+    theme: Optional[str] = None
+    modality: Optional[str] = None
+    web_widget_title: Optional[str] = Field(
+        default=None, alias="webWidgetTitle"
+    )
+
+
+class DeploymentOverride(BaseModel):
+    """Channel-specific deployment configuration."""
+
+    model_config = _MODEL_CONFIG
+
+    channel_type: Optional[str] = Field(default=None, alias="channelType")
+    modality: Optional[str] = None
+    disable_barge_in_control: Optional[bool] = Field(
+        default=None, alias="disableBargeInControl"
+    )
+    disable_dtmf: Optional[bool] = Field(default=None, alias="disableDtmf")
+    web_widget_config: Optional[WebWidgetConfig] = Field(
+        default=None, alias="webWidgetConfig"
+    )
+
+
+class AdapterCard(BaseModel):
+    """Complete channel adapter card definition."""
+
+    model_config = _MODEL_CONFIG
+
+    api_version: str = Field(alias="apiVersion")
+    kind: Literal["ChannelAdapter"]
+    metadata: AdapterMetadata
+    instruction_diffs: List[InstructionDiff] = Field(
+        default_factory=list, alias="instructionDiffs"
+    )
+    tools: List[ToolModification] = Field(default_factory=list)
+    tool_definitions: List[ToolDefinition] = Field(
+        default_factory=list, alias="toolDefinitions"
+    )
+    model_overrides: List[ModelOverride] = Field(
+        default_factory=list, alias="modelOverrides"
+    )
+    callbacks: List[CallbackDefinition] = Field(default_factory=list)
+    evaluations: List[EvalReference] = Field(default_factory=list)
+    deployment: Optional[DeploymentOverride] = None
+
+
+class CompiledAgentConfig(BaseModel):
+    """The fully compiled, channel-specific agent project state.
+
+    A pure-data snapshot of what ``PolymorphismEngine.write_output`` will
+    serialize to disk.  Holding it as a model — rather than writing files
+    directly during ``compile()`` — lets callers introspect or transform
+    the output before writing.
+    """
+
+    model_config = _MODEL_CONFIG
+
+    channel: str
+    app_config: Dict[str, Any]
+    gecx_config: Dict[str, Any] = Field(default_factory=dict)
+    agents: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
+    agent_instructions: Dict[str, str] = Field(default_factory=dict)
+    tools: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
+    tool_code: Dict[str, str] = Field(default_factory=dict)
+    evaluations: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
+    evaluation_expectations: Dict[str, Dict[str, Any]] = Field(
+        default_factory=dict
+    )
+    deployment: Optional[Dict[str, Any]] = None
+    # Callback code keyed by ``(agent, cb_dir_name, cb_index)`` ->
+    # python source text.  Written to disk under each agent's standard
+    # callback directory tree.
+    callback_code: Dict[str, str] = Field(default_factory=dict)

--- a/src/cxas_scrapi/poly/models.py
+++ b/src/cxas_scrapi/poly/models.py
@@ -16,7 +16,8 @@
 
 Defines the schema for channel adapter cards — declarative deltas applied
 to a base agent project to produce channel-optimized variants — plus the
-in-memory shape of a compiled project (``CompiledAgentConfig``).
+in-memory shape of a compiled project (``CompiledAgentConfig``).  Unknown
+adapter fields are rejected so misspelled deltas do not disappear silently.
 """
 
 from typing import Any, Dict, List, Literal, Optional
@@ -28,7 +29,11 @@ from pydantic import BaseModel, ConfigDict, Field
 # allow field names like ``model_overrides`` and ``model`` without Pydantic
 # v2 warnings about the reserved ``model_`` namespace) are needed on every
 # model in this module.
-_MODEL_CONFIG = ConfigDict(populate_by_name=True, protected_namespaces=())
+_MODEL_CONFIG = ConfigDict(
+    populate_by_name=True,
+    protected_namespaces=(),
+    extra="forbid",
+)
 
 # Logical callback types accepted in adapter cards.  These map to JSON
 # field names like ``beforeModelCallbacks`` at compile time — see
@@ -200,6 +205,7 @@ class AdapterCard(BaseModel):
     evaluation_datasets: List[EvalReference] = Field(
         default_factory=list, alias="evaluationDatasets"
     )
+    gecx_config: Dict[str, Any] = Field(default_factory=dict, alias="gecxConfig")
     deployment: Optional[DeploymentOverride] = None
 
 

--- a/src/cxas_scrapi/poly/models.py
+++ b/src/cxas_scrapi/poly/models.py
@@ -205,7 +205,9 @@ class AdapterCard(BaseModel):
     evaluation_datasets: List[EvalReference] = Field(
         default_factory=list, alias="evaluationDatasets"
     )
-    gecx_config: Dict[str, Any] = Field(default_factory=dict, alias="gecxConfig")
+    gecx_config: Dict[str, Any] = Field(
+        default_factory=dict, alias="gecxConfig"
+    )
     deployment: Optional[DeploymentOverride] = None
 
 

--- a/src/cxas_scrapi/poly/models.py
+++ b/src/cxas_scrapi/poly/models.py
@@ -42,6 +42,30 @@ CallbackType = Literal[
     "after_agent",
 ]
 
+# Allowed adapter ``deployment`` values.  These mirror the enums in
+# ``cxas_scrapi.core.deployments.Deployments`` (ChannelType / Modality / Theme)
+# but are hardcoded here on purpose: the ``poly`` package stays GCP-free and
+# must not import ``google.cloud.*``.  Keep these lists in sync with that class.
+CHANNEL_TYPES = (
+    "WEB_UI",
+    "API",
+    "TWILIO",
+    "GOOGLE_TELEPHONY_PLATFORM",
+    "CONTACT_CENTER_AS_A_SERVICE",
+    "FIVE9",
+    "CONTACT_CENTER_INTEGRATION",
+)
+MODALITIES = (
+    "CHAT_AND_VOICE",
+    "VOICE_ONLY",
+    "CHAT_ONLY",
+    "CHAT_VOICE_AND_VIDEO",
+)
+THEMES = ("LIGHT", "DARK")
+
+# Tool definition types the engine knows how to compile.
+SUPPORTED_TOOL_TYPES = ("python", "openapi")
+
 
 class AdapterMetadata(BaseModel):
     """Metadata about the channel adapter."""
@@ -170,6 +194,12 @@ class AdapterCard(BaseModel):
     )
     callbacks: List[CallbackDefinition] = Field(default_factory=list)
     evaluations: List[EvalReference] = Field(default_factory=list)
+    evaluation_expectations: List[EvalReference] = Field(
+        default_factory=list, alias="evaluationExpectations"
+    )
+    evaluation_datasets: List[EvalReference] = Field(
+        default_factory=list, alias="evaluationDatasets"
+    )
     deployment: Optional[DeploymentOverride] = None
 
 
@@ -191,10 +221,18 @@ class CompiledAgentConfig(BaseModel):
     agent_instructions: Dict[str, str] = Field(default_factory=dict)
     tools: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
     tool_code: Dict[str, str] = Field(default_factory=dict)
+    # Channel tool name -> absolute source directory, for tool types that are
+    # copied verbatim (e.g. ``openapi``) rather than reconstructed from a
+    # single JSON + ``python_code.py``.  In-memory only.
+    tool_source_dirs: Dict[str, str] = Field(default_factory=dict)
     evaluations: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
     evaluation_expectations: Dict[str, Dict[str, Any]] = Field(
         default_factory=dict
     )
+    evaluation_datasets: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
+    # The resolved per-channel deployment block.  Also stored under
+    # ``gecx_config["deployment"]`` (the file deploy tooling reads); kept here
+    # too so callers like ``cxas poly diff`` can introspect it directly.
     deployment: Optional[Dict[str, Any]] = None
     # Callback code keyed by ``(agent, cb_dir_name, cb_index)`` ->
     # python source text.  Written to disk under each agent's standard

--- a/src/cxas_scrapi/poly/readiness.py
+++ b/src/cxas_scrapi/poly/readiness.py
@@ -1,0 +1,301 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Launch-readiness reports for polymorphic SCRAPI projects.
+
+The readiness report is a design-partner review artifact: it composes the
+existing adapter validators, compiler, and diff report into one summary without
+adding a second validation contract.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from cxas_scrapi.poly.diffing import build_diff_report
+from cxas_scrapi.poly.engine import CompilationError, PolymorphismEngine
+from cxas_scrapi.poly.models import AdapterCard, EvalReference
+from cxas_scrapi.poly.validators import (
+    validate_adapter_card,
+    validate_all_adapters,
+)
+
+READINESS_SCHEMA_VERSION = "poly-readiness/v1"
+
+_EVAL_SURFACES: Tuple[Tuple[str, str, str], ...] = (
+    ("evaluations", "evaluations", "evaluations"),
+    (
+        "evaluation_expectations",
+        "evaluationExpectations",
+        "evaluationExpectations",
+    ),
+    ("evaluation_datasets", "evaluationDatasets", "evaluationDatasets"),
+)
+
+
+def build_readiness_report(
+    engine: PolymorphismEngine, app_dir: str
+) -> Dict[str, Any]:
+    """Build a pre-launch readiness report for all adapter cards.
+
+    The caller is expected to load the base project and adapter cards first, but
+    this function defensively does so when needed.
+    """
+    root = Path(app_dir).resolve()
+    if engine.base is None:
+        engine.load_base_project()
+    if not engine.adapter_cards and not engine.adapter_errors:
+        engine.load_adapter_cards()
+
+    duplicate_issues = _duplicate_channel_issues(engine, str(root))
+    channels: List[Dict[str, Any]] = []
+
+    for card, card_path in engine.adapter_cards:
+        channel = card.metadata.channel
+        issues = validate_adapter_card(card, str(root))
+        issues.extend(
+            issue
+            for issue in duplicate_issues
+            if f"'{channel}'" in issue.get("message", "")
+        )
+        errors = _count(issues, "error")
+        compiled = None
+        diff_summary: Optional[Dict[str, Any]] = None
+        compile_issue: Optional[Dict[str, Any]] = None
+        if errors == 0:
+            try:
+                compiled = engine.compile(card, card_path, validate=False)
+                diff = build_diff_report(
+                    engine=engine,
+                    card=card,
+                    card_path=card_path,
+                    compiled=compiled,
+                )
+                diff_summary = diff["summary"]
+            except CompilationError as exc:
+                compile_issue = {
+                    "rule_id": "COMPILE",
+                    "severity": "error",
+                    "message": str(exc),
+                    "path": _rel(root, card_path),
+                }
+                issues.extend(exc.issues or [compile_issue])
+            except Exception as exc:  # pragma: no cover - defensive boundary
+                compile_issue = {
+                    "rule_id": "COMPILE",
+                    "severity": "error",
+                    "message": str(exc),
+                    "path": _rel(root, card_path),
+                }
+                issues.append(compile_issue)
+
+        eval_coverage = _eval_coverage(root, card)
+        coverage_warnings = _coverage_warnings(eval_coverage)
+        status = _status(issues, coverage_warnings)
+        channels.append(
+            {
+                "channel": channel,
+                "display_name": card.metadata.display_name,
+                "adapter_path": _rel(root, card_path),
+                "status": status,
+                "compiled": compiled is not None and compile_issue is None,
+                "issues": issues,
+                "coverage_warnings": coverage_warnings,
+                "diff_summary": diff_summary,
+                "eval_coverage": eval_coverage,
+                "next_steps": _next_steps(
+                    status=status,
+                    issues=issues,
+                    coverage_warnings=coverage_warnings,
+                    app_dir=str(root),
+                ),
+            }
+        )
+
+    summary = _summary(engine.adapter_errors, channels)
+    return {
+        "schema_version": READINESS_SCHEMA_VERSION,
+        "app_dir": str(root),
+        "summary": summary,
+        "adapter_errors": list(engine.adapter_errors),
+        "channels": channels,
+    }
+
+
+def _duplicate_channel_issues(
+    engine: PolymorphismEngine, app_dir: str
+) -> List[Dict[str, Any]]:
+    cards = [card for card, _path in engine.adapter_cards]
+    return [
+        issue
+        for issue in validate_all_adapters(cards, app_dir)
+        if issue.get("rule_id") == "AD007"
+    ]
+
+
+def _eval_coverage(root: Path, card: AdapterCard) -> Dict[str, Dict[str, Any]]:
+    coverage: Dict[str, Dict[str, Any]] = {}
+    for attr, yaml_key, directory in _EVAL_SURFACES:
+        base_names = _item_names(root / directory)
+        refs = getattr(card, attr)
+        channel_names = _names_from_refs(root, refs)
+        coverage[yaml_key] = {
+            "base_count": len(base_names),
+            "channel_count": len(channel_names),
+            "channel_names": channel_names,
+            "duplicate_names": sorted(set(base_names) & set(channel_names)),
+        }
+    return coverage
+
+
+def _names_from_refs(root: Path, refs: Iterable[EvalReference]) -> List[str]:
+    names: List[str] = []
+    for ref in refs:
+        names.extend(_item_names(root / ref.source_dir))
+    return sorted(dict.fromkeys(names))
+
+
+def _item_names(path: Path) -> List[str]:
+    if not path.is_dir():
+        return []
+    names: List[str] = []
+    for child in sorted(path.iterdir()):
+        if child.is_dir():
+            names.append(child.name)
+        elif child.suffix in (".json", ".yaml", ".yml"):
+            names.append(child.stem)
+    return names
+
+
+def _coverage_warnings(
+    eval_coverage: Dict[str, Dict[str, Any]]
+) -> List[Dict[str, Any]]:
+    warnings: List[Dict[str, Any]] = []
+    for surface, coverage in eval_coverage.items():
+        duplicates = coverage["duplicate_names"]
+        if duplicates:
+            warnings.append(
+                {
+                    "surface": surface,
+                    "message": (
+                        f"{surface} has duplicate evaluation names that "
+                        "will shadow base items when compiled: "
+                        f"{', '.join(duplicates)}"
+                    ),
+                    "duplicate_names": duplicates,
+                }
+            )
+    return warnings
+
+
+def _status(
+    issues: List[Dict[str, Any]],
+    coverage_warnings: List[Dict[str, Any]],
+) -> str:
+    if any(issue.get("severity") == "error" for issue in issues):
+        return "blocked"
+    if any(issue.get("severity") == "warning" for issue in issues):
+        return "attention"
+    if coverage_warnings:
+        return "attention"
+    return "ready"
+
+
+def _next_steps(
+    *,
+    status: str,
+    issues: List[Dict[str, Any]],
+    coverage_warnings: List[Dict[str, Any]],
+    app_dir: str,
+) -> List[str]:
+    if status == "ready":
+        return [
+            "Run cxas poly build, lint the compiled output, and run channel "
+            "evals."
+        ]
+
+    steps: List[str] = []
+    if any(issue.get("severity") == "error" for issue in issues):
+        steps.append(
+            f"Run cxas poly doctor --app-dir {app_dir} to inspect blocking "
+            "AD issues."
+        )
+    if any(issue.get("rule_id") == "AD006" for issue in issues):
+        steps.append(
+            "Add channel-specific evaluations for this adapter or document why "
+            "the adapter is non-behavioral."
+        )
+    if coverage_warnings:
+        duplicate_names = sorted(
+            {
+                name
+                for warning in coverage_warnings
+                for name in warning["duplicate_names"]
+            }
+        )
+        steps.append(
+            "Rename duplicate evaluation names before build so channel evals "
+            f"do not shadow base evals: {', '.join(duplicate_names)}."
+        )
+    if any(issue.get("severity") == "warning" for issue in issues):
+        steps.append(
+            "Review warning-level AD issues before treating this channel as "
+            "launch-ready."
+        )
+    if not steps:
+        steps.append(
+            "Review attention items before building and running channel evals."
+        )
+    return steps
+
+
+def _summary(
+    adapter_errors: List[Dict[str, Any]],
+    channels: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    errors = _count(adapter_errors, "error")
+    warnings = _count(adapter_errors, "warning")
+    coverage_warnings = 0
+    for channel in channels:
+        errors += _count(channel["issues"], "error")
+        warnings += _count(channel["issues"], "warning")
+        coverage_warnings += len(channel["coverage_warnings"])
+    blocked = sum(1 for channel in channels if channel["status"] == "blocked")
+    attention = sum(
+        1 for channel in channels if channel["status"] == "attention"
+    )
+    ready = sum(1 for channel in channels if channel["status"] == "ready")
+    warnings += coverage_warnings
+    return {
+        "channels": len(channels),
+        "ready": ready,
+        "attention": attention,
+        "blocked": blocked,
+        "errors": errors,
+        "warnings": warnings,
+        "coverage_warnings": coverage_warnings,
+        "launch_ready": bool(channels) and errors == 0 and warnings == 0,
+    }
+
+
+def _count(issues: List[Dict[str, Any]], severity: str) -> int:
+    return sum(1 for issue in issues if issue.get("severity") == severity)
+
+
+def _rel(root: Path, path: Path) -> str:
+    try:
+        return str(path.relative_to(root))
+    except ValueError:
+        return str(path)

--- a/src/cxas_scrapi/poly/scaffold.py
+++ b/src/cxas_scrapi/poly/scaffold.py
@@ -1,0 +1,555 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Scaffold planner for ``cxas poly init``.
+
+The planner builds a deterministic list of files before anything is written.
+That keeps the CLI honest about exactly which current adapter-card fields it
+uses, lets tests validate the result without shelling out, and gives future
+template work one small seam to extend.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+import yaml
+
+from cxas_scrapi.poly.engine import CALLBACK_TYPE_TO_DIR, PolymorphismEngine
+from cxas_scrapi.poly.models import CHANNEL_TYPES, MODALITIES, CallbackType
+
+DEFAULT_DISPLAY_NAME_TEMPLATE = "{app} - {channel_title}"
+
+_CHANNEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
+_TOOL_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+_CHANNEL_DEFAULTS: Dict[str, Tuple[str, str]] = {
+    "api": ("API", "CHAT_ONLY"),
+    "chat": ("WEB_UI", "CHAT_ONLY"),
+    "phone": ("GOOGLE_TELEPHONY_PLATFORM", "VOICE_ONLY"),
+    "telephony": ("GOOGLE_TELEPHONY_PLATFORM", "VOICE_ONLY"),
+    "voice": ("GOOGLE_TELEPHONY_PLATFORM", "VOICE_ONLY"),
+    "web": ("WEB_UI", "CHAT_ONLY"),
+}
+
+_CALLBACK_FUNCTIONS: Dict[str, str] = {
+    "before_model": "before_model_callback",
+    "after_model": "after_model_callback",
+    "before_tool": "before_tool_callback",
+    "after_tool": "after_tool_callback",
+    "before_agent": "before_agent_callback",
+    "after_agent": "after_agent_callback",
+}
+
+
+@dataclass(frozen=True)
+class ScaffoldFile:
+    """One file that ``cxas poly init`` intends to materialize."""
+
+    path: Path
+    content: str
+
+
+@dataclass(frozen=True)
+class ChannelScaffold:
+    """Scaffold metadata for a single adapter channel."""
+
+    channel: str
+    adapter_path: Path
+    display_name: str
+    deployment_target: Optional[str]
+    modality: Optional[str]
+
+
+@dataclass(frozen=True)
+class ScaffoldPlan:
+    """A complete, writable scaffold plan for one base project."""
+
+    app_dir: Path
+    target_agent: str
+    channels: List[ChannelScaffold]
+    files: List[ScaffoldFile] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ScaffoldOptions:
+    """Options accepted by the scaffold planner.
+
+    The CLI converts flags and prompts into this type so validation and file
+    generation stay independent of argparse.
+    """
+
+    app_dir: Path
+    channels: Sequence[str]
+    target_agent: Optional[str] = None
+    display_name: Optional[str] = None
+    display_name_template: str = DEFAULT_DISPLAY_NAME_TEMPLATE
+    deployment_target: str = "auto"
+    modality: str = "auto"
+    include_eval: bool = True
+    tools: Sequence[str] = ()
+    callback_types: Sequence[CallbackType] = ()
+
+
+def build_scaffold_plan(options: ScaffoldOptions) -> ScaffoldPlan:
+    """Build a deterministic scaffold plan from an existing base app.
+
+    The plan only includes fields supported by the current ``AdapterCard``
+    model, which prevents the init flow from promising runtime behavior the
+    engine cannot compile today.
+    """
+    app_dir = options.app_dir.resolve()
+    engine = PolymorphismEngine(str(app_dir))
+    base = engine.load_base_project()
+    app_name = str(base.app_json.get("displayName") or app_dir.name)
+    target_agent = _resolve_target_agent(engine, options.target_agent)
+
+    channels = [_normalize_channel(c) for c in options.channels]
+    if not channels:
+        raise ValueError("At least one channel is required.")
+    if len(set(channels)) != len(channels):
+        raise ValueError("Channel names must be unique.")
+
+    tools = [_normalize_tool_name(t) for t in options.tools]
+    callback_types = list(options.callback_types)
+    files: List[ScaffoldFile] = []
+    channel_plans: List[ChannelScaffold] = []
+
+    for channel in channels:
+        display_name = _display_name_for(options, app_name, channel, channels)
+        deployment_target, modality = _resolve_deployment(
+            channel, options.deployment_target, options.modality
+        )
+        adapter = _adapter_dict(
+            channel=channel,
+            display_name=display_name,
+            app_name=app_name,
+            target_agent=target_agent,
+            deployment_target=deployment_target,
+            modality=modality,
+            include_eval=options.include_eval,
+            tools=tools,
+            callback_types=callback_types,
+        )
+        adapter_path = app_dir / "adapters" / f"{channel}.adapter.yaml"
+        files.append(
+            ScaffoldFile(
+                path=adapter_path,
+                content=yaml.safe_dump(adapter, sort_keys=False),
+            )
+        )
+
+        if options.include_eval:
+            eval_name = f"{_title_token(channel)}_Smoke"
+            eval_path = (
+                app_dir
+                / "adapters"
+                / f"{channel}_evals"
+                / eval_name
+                / f"{eval_name}.yaml"
+            )
+            files.append(
+                ScaffoldFile(
+                    path=eval_path,
+                    content=yaml.safe_dump(
+                        _eval_dict(channel, display_name),
+                        sort_keys=False,
+                    ),
+                )
+            )
+
+        for tool in tools:
+            files.extend(_tool_files(app_dir, app_name, channel, tool))
+
+        for callback_type in callback_types:
+            files.append(
+                _callback_file(app_dir, channel, callback_type, target_agent)
+            )
+
+        channel_plans.append(
+            ChannelScaffold(
+                channel=channel,
+                adapter_path=adapter_path,
+                display_name=display_name,
+                deployment_target=deployment_target,
+                modality=modality,
+            )
+        )
+
+    return ScaffoldPlan(
+        app_dir=app_dir,
+        target_agent=target_agent,
+        channels=channel_plans,
+        files=files,
+    )
+
+
+def write_scaffold_plan(
+    plan: ScaffoldPlan,
+    *,
+    force: bool = False,
+    dry_run: bool = False,
+) -> List[Path]:
+    """Write a scaffold plan without clobbering user files by default."""
+    existing = [f.path for f in plan.files if f.path.exists()]
+    if existing and not force:
+        rels = ", ".join(str(p.relative_to(plan.app_dir)) for p in existing)
+        raise FileExistsError(
+            "Refusing to overwrite existing scaffold file(s): "
+            f"{rels}. Re-run with --force to replace them."
+        )
+
+    written: List[Path] = []
+    if dry_run:
+        return [f.path for f in plan.files]
+
+    for file in plan.files:
+        file.path.parent.mkdir(parents=True, exist_ok=True)
+        file.path.write_text(file.content)
+        written.append(file.path)
+    return written
+
+
+def _resolve_target_agent(
+    engine: PolymorphismEngine, requested: Optional[str]
+) -> str:
+    assert engine.base is not None
+    agents = engine.base.agents
+    display_to_dir = {b.display_name: name for name, b in agents.items()}
+    if requested:
+        if requested in agents:
+            return requested
+        if requested in display_to_dir:
+            return display_to_dir[requested]
+        raise ValueError(
+            f"Agent '{requested}' was not found. Available agents: "
+            f"{', '.join(sorted(agents)) or '(none)'}"
+        )
+
+    root = engine.base.app_json.get("rootAgent")
+    if isinstance(root, str):
+        if root in agents:
+            return root
+        if root in display_to_dir:
+            return display_to_dir[root]
+    if agents:
+        return sorted(agents)[0]
+    raise ValueError("No agents found under agents/.")
+
+
+def _normalize_channel(channel: str) -> str:
+    cleaned = channel.strip()
+    if not cleaned:
+        raise ValueError("Channel names may not be empty.")
+    if not _CHANNEL_RE.match(cleaned):
+        raise ValueError(
+            "Channel names must start with a letter or number and contain "
+            "only letters, numbers, underscores, or hyphens."
+        )
+    return cleaned
+
+
+def _normalize_tool_name(tool_name: str) -> str:
+    cleaned = tool_name.strip()
+    if not _TOOL_RE.match(cleaned):
+        raise ValueError(
+            "Tool names scaffolded by poly init must be snake_case, start "
+            "with a lowercase letter, and contain only lowercase letters, "
+            "numbers, or underscores."
+        )
+    return cleaned
+
+
+def _display_name_for(
+    options: ScaffoldOptions,
+    app_name: str,
+    channel: str,
+    all_channels: Sequence[str],
+) -> str:
+    if options.display_name is not None:
+        if len(all_channels) > 1:
+            raise ValueError(
+                "--display-name can only be used with one channel."
+            )
+        return options.display_name
+    return options.display_name_template.format(
+        app=app_name,
+        channel=channel,
+        channel_title=_title(channel),
+        channel_slug=channel,
+    )
+
+
+def _resolve_deployment(
+    channel: str, deployment_target: str, modality: str
+) -> Tuple[Optional[str], Optional[str]]:
+    resolved_target: Optional[str]
+    resolved_modality: Optional[str]
+
+    if deployment_target == "none":
+        resolved_target = None
+    elif deployment_target == "auto":
+        default_target, _default_modality = _CHANNEL_DEFAULTS.get(
+            channel.lower(), (None, None)
+        )
+        resolved_target = default_target
+    else:
+        if deployment_target not in CHANNEL_TYPES:
+            raise ValueError(
+                "--deployment-target must be 'auto', 'none', or one of "
+                f"{', '.join(CHANNEL_TYPES)}."
+            )
+        resolved_target = deployment_target
+
+    if modality == "none":
+        resolved_modality = None
+    elif modality == "auto" and deployment_target == "none":
+        resolved_modality = None
+    elif modality == "auto":
+        _default_target, default_modality = _CHANNEL_DEFAULTS.get(
+            channel.lower(), (None, None)
+        )
+        resolved_modality = default_modality
+    else:
+        if modality not in MODALITIES:
+            raise ValueError(
+                "--modality must be 'auto', 'none', or one of "
+                f"{', '.join(MODALITIES)}."
+            )
+        resolved_modality = modality
+
+    return resolved_target, resolved_modality
+
+
+def _adapter_dict(
+    *,
+    channel: str,
+    display_name: str,
+    app_name: str,
+    target_agent: str,
+    deployment_target: Optional[str],
+    modality: Optional[str],
+    include_eval: bool,
+    tools: Sequence[str],
+    callback_types: Sequence[str],
+) -> Dict[str, Any]:
+    adapter: Dict[str, Any] = {
+        "apiVersion": "poly.cxas.dev/v1",
+        "kind": "ChannelAdapter",
+        "metadata": {
+            "channel": channel,
+            "displayName": display_name,
+            "description": (
+                f"Starter {channel} adapter for {app_name}. Replace the "
+                "scaffolded notes with channel-specific behavior."
+            ),
+        },
+        "instructionDiffs": [
+            {
+                "agent": target_agent,
+                "mode": "append",
+                "content": _instruction_block(channel),
+            }
+        ],
+    }
+
+    if tools:
+        adapter["tools"] = [{"agent": target_agent, "add": list(tools)}]
+        adapter["toolDefinitions"] = [
+            {
+                "displayName": tool,
+                "toolType": "python",
+                "sourceDir": f"adapters/{channel}_tools/{tool}",
+            }
+            for tool in tools
+        ]
+
+    if callback_types:
+        adapter["callbacks"] = [
+            {
+                "agent": target_agent,
+                "type": callback_type,
+                "pythonCode": (
+                    f"adapters/{channel}_callbacks/{callback_type}.py"
+                ),
+                "description": (
+                    f"Starter {channel} {callback_type} callback. Replace "
+                    "with channel-specific runtime hints."
+                ),
+            }
+            for callback_type in callback_types
+        ]
+
+    if include_eval:
+        adapter["evaluations"] = [
+            {"sourceDir": f"adapters/{channel}_evals"}
+        ]
+
+    if deployment_target is not None or modality is not None:
+        deployment: Dict[str, Any] = {}
+        if deployment_target is not None:
+            deployment["channelType"] = deployment_target
+        if modality is not None:
+            deployment["modality"] = modality
+        if deployment_target == "WEB_UI":
+            deployment["webWidgetConfig"] = {
+                "theme": "LIGHT",
+                "webWidgetTitle": display_name,
+            }
+        adapter["deployment"] = deployment
+
+    return adapter
+
+
+def _instruction_block(channel: str) -> str:
+    tag = f"channel_{_xml_token(channel)}"
+    return (
+        f"<{tag}>\n"
+        f"Starter {channel} channel notes:\n"
+        "- Replace this block with behavior that belongs only in this "
+        "channel.\n"
+        "- Keep shared business logic in the base agent.\n"
+        f"</{tag}>\n"
+    )
+
+
+def _eval_dict(channel: str, display_name: str) -> Dict[str, Any]:
+    return {
+        "displayName": f"{_title(channel)} Smoke",
+        "description": (
+            f"Starter {channel} evaluation generated for {display_name}. "
+            "Replace with a real channel-specific golden."
+        ),
+        "tags": ["polymorphism", channel, "scaffold"],
+        "golden": {
+            "turns": [
+                {
+                    "steps": [
+                        {"userInput": {"text": "hello"}},
+                        {
+                            "expectation": {
+                                "note": (
+                                    f"Check_{_title_token(channel)}_Response"
+                                )
+                            }
+                        },
+                    ]
+                }
+            ]
+        },
+    }
+
+
+def _tool_files(
+    app_dir: Path, app_name: str, channel: str, tool_name: str
+) -> List[ScaffoldFile]:
+    tool_dir = app_dir / "adapters" / f"{channel}_tools" / tool_name
+    tool_id = uuid.uuid5(
+        uuid.NAMESPACE_URL, f"{app_name}:{channel}:{tool_name}"
+    )
+    tool_json = {
+        "name": str(tool_id),
+        "displayName": tool_name,
+        "pythonFunction": {
+            "name": tool_name,
+            "pythonCode": f"tools/{tool_name}/python_function/python_code.py",
+            "description": (
+                f"Starter {channel}-only tool. Replace the implementation "
+                "and description with the channel-specific action this "
+                "adapter needs."
+            ),
+        },
+    }
+    return [
+        ScaffoldFile(
+            path=tool_dir / f"{tool_name}.json",
+            content=json.dumps(tool_json, indent=2) + "\n",
+        ),
+        ScaffoldFile(
+            path=tool_dir / "python_code.py",
+            content=_tool_code(tool_name, channel),
+        ),
+    ]
+
+
+def _tool_code(tool_name: str, channel: str) -> str:
+    return (
+        '"""Starter channel-only tool generated by cxas poly init."""\n\n'
+        "from typing import Any\n\n\n"
+        f"def {tool_name}(summary: str = \"\") -> dict[str, Any]:\n"
+        f"  \"\"\"Return a starter payload for the {channel} channel.\"\"\"\n"
+        "  return {\n"
+        '      "stored": True,\n'
+        f'      "channel": "{channel}",\n'
+        '      "summary": summary,\n'
+        "  }\n"
+    )
+
+
+def _callback_file(
+    app_dir: Path, channel: str, callback_type: str, target_agent: str
+) -> ScaffoldFile:
+    callback_dir = CALLBACK_TYPE_TO_DIR[callback_type]
+    path = app_dir / "adapters" / f"{channel}_callbacks" / f"{callback_type}.py"
+    function_name = _CALLBACK_FUNCTIONS[callback_type]
+    content = (
+        "# pylint: disable=unused-argument,broad-exception-caught\n"
+        f'"""Starter {callback_type} callback for the {channel} adapter."""\n\n'
+        "from typing import Any, Optional\n\n\n"
+        f"def {function_name}(\n"
+        "    callback_context: Any,\n"
+        "    llm_request: Any,\n"
+        ") -> Optional[Any]:\n"
+        f"  \"\"\"Inject starter {channel} hints for {target_agent}.\"\"\"\n"
+        "  hint = (\n"
+        f'      "Starter {channel} channel hint. Replace this callback with "\n'
+        '      "real channel-specific runtime behavior, or delete it if "\n'
+        '      "static instruction diffs are enough."\n'
+        "  )\n"
+        "  try:\n"
+        "    llm_request.append_instructions([hint])\n"
+        "  except Exception:\n"
+        "    return None\n"
+        "  return None\n"
+    )
+    # The directory name is referenced in comments for maintainers, while the
+    # adapter card references only the project-relative pythonCode path.
+    if callback_dir not in CALLBACK_TYPE_TO_DIR.values():
+        raise ValueError(f"Unsupported callback type: {callback_type}")
+    return ScaffoldFile(path=path, content=content)
+
+
+def _title(channel: str) -> str:
+    return " ".join(part.capitalize() for part in re.split(r"[-_]+", channel))
+
+
+def _title_token(channel: str) -> str:
+    return "_".join(part.capitalize() for part in re.split(r"[-_]+", channel))
+
+
+def _xml_token(channel: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_]+", "_", channel).strip("_") or "channel"
+
+
+def split_channels(values: Iterable[str]) -> List[str]:
+    """Split comma-delimited ``--channel`` values while preserving order."""
+    channels: List[str] = []
+    for value in values:
+        channels.extend(p.strip() for p in value.split(",") if p.strip())
+    return channels

--- a/src/cxas_scrapi/poly/validators.py
+++ b/src/cxas_scrapi/poly/validators.py
@@ -26,7 +26,7 @@ Note on rule IDs: the original spec proposed ``A001``-``A007`` but those
 collide with the existing ``config`` lint rules, so adapter rules use the
 ``AD`` prefix.
 
-    AD001  schema / required fields
+    AD001  schema / required fields / unknown fields
     AD002  referenced agents exist
     AD003  replace_section sectionTag present and the section exists
     AD004  tool remove targets a tool the base agent actually has  (warning)

--- a/src/cxas_scrapi/poly/validators.py
+++ b/src/cxas_scrapi/poly/validators.py
@@ -12,26 +12,53 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Adapter card validators (AD001-AD007).
+"""Adapter card validators (AD001-AD010).
 
 Pure local validation run before compilation.  Each function returns a
 list of issue dicts shaped like ``LintResult``: ``{rule_id, severity,
 message, path}``.  These same checks back the ``adapters`` lint rule
-category (see ``utils/lint_rules/adapters.py``).
+category (see ``utils/lint_rules/adapters.py``) and are the **single source
+of truth** the engine relies on — ``engine.compile`` runs them up front so a
+card that validates clean always compiles, and a card that would fail to
+compile is always reported here first.
 
 Note on rule IDs: the original spec proposed ``A001``-``A007`` but those
 collide with the existing ``config`` lint rules, so adapter rules use the
 ``AD`` prefix.
+
+    AD001  schema / required fields
+    AD002  referenced agents exist
+    AD003  replace_section sectionTag present and the section exists
+    AD004  tool remove targets a tool the base agent actually has  (warning)
+    AD005  referenced source missing / tool add has no definition
+    AD006  adapter declares at least one evaluations entry          (warning)
+    AD007  two adapters target the same channel
+    AD008  a referenced path escapes the project root
+    AD009  deployment channelType/modality/theme is a known value
+    AD010  toolDefinitions.toolType is supported
 """
 
 import json
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
-from cxas_scrapi.poly.models import AdapterCard
+from cxas_scrapi.poly.instructions import has_section
+from cxas_scrapi.poly.models import (
+    CHANNEL_TYPES,
+    MODALITIES,
+    SUPPORTED_TOOL_TYPES,
+    THEMES,
+    AdapterCard,
+)
 
 ERROR = "error"
 WARNING = "warning"
+
+# Runtime-provided tools that are always valid as an agent tool reference,
+# even though they have no directory under ``tools/``.  Mirrors
+# ``cxas_scrapi.utils.linter.LintContext.platform_tools`` — kept local to avoid
+# an import cycle (linter -> lint_rules -> adapters -> validators).
+PLATFORM_TOOLS = frozenset({"end_session", "customize_response"})
 
 
 # ── Filesystem helpers ───────────────────────────────────────────────────
@@ -46,6 +73,23 @@ def _read_json(path: Path) -> Optional[Dict[str, Any]]:
         return json.loads(path.read_text())
     except (OSError, json.JSONDecodeError):
         return None
+
+
+def resolve_within(app_dir: str, ref: str) -> Tuple[Path, bool]:
+    """Resolve an adapter-relative path and report whether it stays in scope.
+
+    Adapter ``sourceDir``/``pythonCode`` references are interpreted relative to
+    the project root (``app_dir``).  Returns ``(resolved_path, is_inside)``
+    where ``is_inside`` is False for absolute paths or anything that escapes the
+    root via ``..`` — the engine and validators both refuse those.
+    """
+    base = Path(app_dir).resolve()
+    candidate = (base / ref).resolve()
+    try:
+        candidate.relative_to(base)
+        return candidate, True
+    except ValueError:
+        return candidate, False
 
 
 def _agent_dir_for(app_dir: str, agent_name: str) -> Optional[Path]:
@@ -110,12 +154,33 @@ def _get_instruction_text(app_dir: str, agent_name: str) -> str:
     return ""
 
 
-def _get_project_tool_names(app_dir: str) -> List[str]:
-    """List all tool display names from the ``tools/`` directory."""
+def _get_project_tool_names(app_dir: str) -> set:
+    """All tool names referenceable in the base project.
+
+    Includes each tool's ``displayName`` (the canonical reference, since agent
+    ``tools`` lists use display names) plus the directory name as a fallback.
+    """
     tools = Path(app_dir) / "tools"
+    names: set = set()
     if not tools.exists():
-        return []
-    return [d.name for d in sorted(tools.iterdir()) if d.is_dir()]
+        return names
+    for d in sorted(tools.iterdir()):
+        if not d.is_dir():
+            continue
+        names.add(d.name)
+        cfg = _read_json(d / f"{d.name}.json")
+        if cfg is None:
+            for cand in d.glob("*.json"):
+                cfg = _read_json(cand)
+                if cfg:
+                    break
+        if cfg and cfg.get("displayName"):
+            names.add(cfg["displayName"])
+    return names
+
+
+def _dir_has_json(path: Path) -> bool:
+    return path.is_dir() and any(path.rglob("*.json"))
 
 
 # ── Validation ───────────────────────────────────────────────────────────
@@ -126,24 +191,28 @@ def validate_adapter_card(
 ) -> List[Dict[str, Any]]:
     """Validate a single adapter card against the project structure.
 
-    Returns a list of issue dicts (may be empty).  Covers AD001-AD006;
-    cross-adapter AD007 is handled by :func:`validate_all_adapters`.
+    Returns a list of issue dicts (may be empty).  Covers AD001-AD006 and
+    AD008-AD010; cross-adapter AD007 is handled by
+    :func:`validate_all_adapters`.
     """
     issues: List[Dict[str, Any]] = []
     channel = adapter.metadata.channel
     where = f"adapters ({channel})"
 
-    # AD001 — required fields / valid types.  The card is already parsed,
-    # so we only assert the channel identifier is non-empty here.
-    if not channel:
+    def add(rule_id: str, severity: str, message: str) -> None:
         issues.append(
             {
-                "rule_id": "AD001",
-                "severity": ERROR,
-                "message": "Adapter metadata.channel must be non-empty.",
+                "rule_id": rule_id,
+                "severity": severity,
+                "message": message,
                 "path": where,
             }
         )
+
+    # AD001 — required fields / valid types.  The card is already parsed, so we
+    # only assert the channel identifier is non-empty here.
+    if not channel:
+        add("AD001", ERROR, "Adapter metadata.channel must be non-empty.")
 
     known_agents = set(_get_agent_display_names(app_dir))
     # Also accept directory names so a card may reference either form.
@@ -153,16 +222,11 @@ def validate_adapter_card(
 
     def check_agent(agent: str, section: str, idx: int) -> bool:
         if agent not in known_agents:
-            issues.append(
-                {
-                    "rule_id": "AD002",
-                    "severity": ERROR,
-                    "message": (
-                        f"Agent '{agent}' referenced in {section}[{idx}] does "
-                        "not exist in agents/ directory"
-                    ),
-                    "path": where,
-                }
+            add(
+                "AD002",
+                ERROR,
+                f"Agent '{agent}' referenced in {section}[{idx}] does not "
+                "exist in agents/ directory",
             )
             return False
         return True
@@ -182,36 +246,25 @@ def validate_adapter_card(
         if diff.mode != "replace_section":
             continue
         if not diff.section_tag:
-            issues.append(
-                {
-                    "rule_id": "AD003",
-                    "severity": ERROR,
-                    "message": (
-                        f"instructionDiffs[{i}] uses replace_section but has "
-                        "no sectionTag"
-                    ),
-                    "path": where,
-                }
+            add(
+                "AD003",
+                ERROR,
+                f"instructionDiffs[{i}] uses replace_section but has no "
+                "sectionTag",
             )
             continue
         if diff.agent not in known_agents:
             continue
         text = _get_instruction_text(app_dir, diff.agent)
-        if f"<{diff.section_tag}>" not in text:
-            issues.append(
-                {
-                    "rule_id": "AD003",
-                    "severity": ERROR,
-                    "message": (
-                        f"Section <{diff.section_tag}> from "
-                        f"instructionDiffs[{i}] not found in instruction for "
-                        f"agent '{diff.agent}'"
-                    ),
-                    "path": where,
-                }
+        if not has_section(text, diff.section_tag):
+            add(
+                "AD003",
+                ERROR,
+                f"Section <{diff.section_tag}> from instructionDiffs[{i}] not "
+                f"found in instruction for agent '{diff.agent}'",
             )
 
-    project_tools = set(_get_project_tool_names(app_dir))
+    project_tools = _get_project_tool_names(app_dir)
     defined_tools = {td.display_name for td in adapter.tool_definitions}
 
     # AD004 — removing a tool not present in the base agent's tools list.
@@ -220,43 +273,134 @@ def validate_adapter_card(
         base_tools = set(_get_agent_tools(app_dir, mod.agent))
         for t in mod.remove:
             if t not in base_tools:
-                issues.append(
-                    {
-                        "rule_id": "AD004",
-                        "severity": WARNING,
-                        "message": (
-                            f"tools[{i}] removes '{t}' which is not in agent "
-                            f"'{mod.agent}' base tools list"
-                        ),
-                        "path": where,
-                    }
+                add(
+                    "AD004",
+                    WARNING,
+                    f"tools[{i}] removes '{t}' which is not in agent "
+                    f"'{mod.agent}' base tools list",
                 )
         for t in mod.add:
-            if t not in project_tools and t not in defined_tools:
-                issues.append(
-                    {
-                        "rule_id": "AD005",
-                        "severity": ERROR,
-                        "message": (
-                            f"tools[{i}] adds '{t}' which has no definition in "
-                            "tools/ and no matching toolDefinitions entry"
-                        ),
-                        "path": where,
-                    }
+            if (
+                t not in project_tools
+                and t not in defined_tools
+                and t not in PLATFORM_TOOLS
+            ):
+                add(
+                    "AD005",
+                    ERROR,
+                    f"tools[{i}] adds '{t}' which has no definition in tools/, "
+                    "no matching toolDefinitions entry, and is not a platform "
+                    "tool",
+                )
+
+    # AD010 — toolDefinitions declare a supported toolType.
+    # AD008/AD005 — toolDefinitions sourceDir is in-scope and present.
+    for i, td in enumerate(adapter.tool_definitions):
+        if td.tool_type not in SUPPORTED_TOOL_TYPES:
+            add(
+                "AD010",
+                ERROR,
+                f"toolDefinitions[{i}] toolType '{td.tool_type}' is not "
+                "supported (expected one of "
+                f"{', '.join(SUPPORTED_TOOL_TYPES)})",
+            )
+        path, inside = resolve_within(app_dir, td.source_dir)
+        if not inside:
+            add(
+                "AD008",
+                ERROR,
+                f"toolDefinitions[{i}] sourceDir '{td.source_dir}' resolves "
+                "outside the project root",
+            )
+        elif not _dir_has_json(path):
+            add(
+                "AD005",
+                ERROR,
+                f"toolDefinitions[{i}] sourceDir '{td.source_dir}' is missing "
+                "or contains no JSON definition",
+            )
+
+    # AD008/AD005 — callback pythonCode is in-scope and present.
+    for i, cb in enumerate(adapter.callbacks):
+        path, inside = resolve_within(app_dir, cb.python_code)
+        if not inside:
+            add(
+                "AD008",
+                ERROR,
+                f"callbacks[{i}] pythonCode '{cb.python_code}' resolves "
+                "outside the project root",
+            )
+        elif not path.is_file():
+            add(
+                "AD005",
+                ERROR,
+                f"callbacks[{i}] pythonCode '{cb.python_code}' was not found "
+                f"for agent '{cb.agent}'",
+            )
+
+    # AD008/AD005 — evaluation/expectation/dataset sourceDirs.
+    for label, refs in (
+        ("evaluations", adapter.evaluations),
+        ("evaluationExpectations", adapter.evaluation_expectations),
+        ("evaluationDatasets", adapter.evaluation_datasets),
+    ):
+        for i, ev in enumerate(refs):
+            path, inside = resolve_within(app_dir, ev.source_dir)
+            if not inside:
+                add(
+                    "AD008",
+                    ERROR,
+                    f"{label}[{i}] sourceDir '{ev.source_dir}' resolves "
+                    "outside the project root",
+                )
+            elif not path.is_dir():
+                add(
+                    "AD005",
+                    ERROR,
+                    f"{label}[{i}] sourceDir '{ev.source_dir}' does not exist",
+                )
+
+    # AD009 — deployment uses known channelType / modality / theme values.
+    dep = adapter.deployment
+    if dep is not None:
+        ct = dep.channel_type
+        if ct is not None and ct not in CHANNEL_TYPES:
+            add(
+                "AD009",
+                ERROR,
+                f"deployment.channelType '{dep.channel_type}' is not one of "
+                f"{', '.join(CHANNEL_TYPES)}",
+            )
+        if dep.modality is not None and dep.modality not in MODALITIES:
+            add(
+                "AD009",
+                ERROR,
+                f"deployment.modality '{dep.modality}' is not one of "
+                f"{', '.join(MODALITIES)}",
+            )
+        wwc = dep.web_widget_config
+        if wwc is not None:
+            if wwc.theme is not None and wwc.theme not in THEMES:
+                add(
+                    "AD009",
+                    ERROR,
+                    f"deployment.webWidgetConfig.theme '{wwc.theme}' is not "
+                    f"one of {', '.join(THEMES)}",
+                )
+            if wwc.modality is not None and wwc.modality not in MODALITIES:
+                add(
+                    "AD009",
+                    ERROR,
+                    f"deployment.webWidgetConfig.modality '{wwc.modality}' is "
+                    f"not one of {', '.join(MODALITIES)}",
                 )
 
     # AD006 — adapter has no evaluations.
     if not adapter.evaluations:
-        issues.append(
-            {
-                "rule_id": "AD006",
-                "severity": WARNING,
-                "message": (
-                    f"Adapter for channel '{channel}' has no evaluations "
-                    "entries"
-                ),
-                "path": where,
-            }
+        add(
+            "AD006",
+            WARNING,
+            f"Adapter for channel '{channel}' has no evaluations entries",
         )
 
     return issues

--- a/src/cxas_scrapi/poly/validators.py
+++ b/src/cxas_scrapi/poly/validators.py
@@ -1,0 +1,291 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Adapter card validators (AD001-AD007).
+
+Pure local validation run before compilation.  Each function returns a
+list of issue dicts shaped like ``LintResult``: ``{rule_id, severity,
+message, path}``.  These same checks back the ``adapters`` lint rule
+category (see ``utils/lint_rules/adapters.py``).
+
+Note on rule IDs: the original spec proposed ``A001``-``A007`` but those
+collide with the existing ``config`` lint rules, so adapter rules use the
+``AD`` prefix.
+"""
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from cxas_scrapi.poly.models import AdapterCard
+
+ERROR = "error"
+WARNING = "warning"
+
+
+# ── Filesystem helpers ───────────────────────────────────────────────────
+
+
+def _agents_dir(app_dir: str) -> Path:
+    return Path(app_dir) / "agents"
+
+
+def _read_json(path: Path) -> Optional[Dict[str, Any]]:
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _agent_dir_for(app_dir: str, agent_name: str) -> Optional[Path]:
+    """Resolve an agent reference (display name or dir name) to its dir."""
+    agents = _agents_dir(app_dir)
+    if not agents.exists():
+        return None
+    direct = agents / agent_name
+    if direct.is_dir() and (direct / f"{agent_name}.json").exists():
+        return direct
+    for d in sorted(agents.iterdir()):
+        if not d.is_dir():
+            continue
+        cfg = _read_json(d / f"{d.name}.json")
+        if cfg and cfg.get("displayName") == agent_name:
+            return d
+    return None
+
+
+def _get_agent_display_names(app_dir: str) -> List[str]:
+    """List all agent display names from the ``agents/`` directory."""
+    agents = _agents_dir(app_dir)
+    names: List[str] = []
+    if not agents.exists():
+        return names
+    for d in sorted(agents.iterdir()):
+        if not d.is_dir():
+            continue
+        cfg = _read_json(d / f"{d.name}.json")
+        if cfg and cfg.get("displayName"):
+            names.append(cfg["displayName"])
+        else:
+            names.append(d.name)
+    return names
+
+
+def _get_agent_tools(app_dir: str, agent_name: str) -> List[str]:
+    """Read an agent's JSON and return its tools list."""
+    d = _agent_dir_for(app_dir, agent_name)
+    if d is None:
+        return []
+    cfg = _read_json(d / f"{d.name}.json")
+    if not cfg:
+        return []
+    return list(cfg.get("tools", []) or [])
+
+
+def _get_instruction_text(app_dir: str, agent_name: str) -> str:
+    """Read and return the instruction text for an agent."""
+    d = _agent_dir_for(app_dir, agent_name)
+    if d is None:
+        return ""
+    cfg = _read_json(d / f"{d.name}.json")
+    ref = (cfg or {}).get("instruction")
+    if ref:
+        inst = Path(app_dir) / ref
+        if inst.exists():
+            return inst.read_text()
+    fallback = d / "instruction.txt"
+    if fallback.exists():
+        return fallback.read_text()
+    return ""
+
+
+def _get_project_tool_names(app_dir: str) -> List[str]:
+    """List all tool display names from the ``tools/`` directory."""
+    tools = Path(app_dir) / "tools"
+    if not tools.exists():
+        return []
+    return [d.name for d in sorted(tools.iterdir()) if d.is_dir()]
+
+
+# ── Validation ───────────────────────────────────────────────────────────
+
+
+def validate_adapter_card(
+    adapter: AdapterCard, app_dir: str
+) -> List[Dict[str, Any]]:
+    """Validate a single adapter card against the project structure.
+
+    Returns a list of issue dicts (may be empty).  Covers AD001-AD006;
+    cross-adapter AD007 is handled by :func:`validate_all_adapters`.
+    """
+    issues: List[Dict[str, Any]] = []
+    channel = adapter.metadata.channel
+    where = f"adapters ({channel})"
+
+    # AD001 — required fields / valid types.  The card is already parsed,
+    # so we only assert the channel identifier is non-empty here.
+    if not channel:
+        issues.append(
+            {
+                "rule_id": "AD001",
+                "severity": ERROR,
+                "message": "Adapter metadata.channel must be non-empty.",
+                "path": where,
+            }
+        )
+
+    known_agents = set(_get_agent_display_names(app_dir))
+    # Also accept directory names so a card may reference either form.
+    agents_root = _agents_dir(app_dir)
+    if agents_root.exists():
+        known_agents |= {d.name for d in agents_root.iterdir() if d.is_dir()}
+
+    def check_agent(agent: str, section: str, idx: int) -> bool:
+        if agent not in known_agents:
+            issues.append(
+                {
+                    "rule_id": "AD002",
+                    "severity": ERROR,
+                    "message": (
+                        f"Agent '{agent}' referenced in {section}[{idx}] does "
+                        "not exist in agents/ directory"
+                    ),
+                    "path": where,
+                }
+            )
+            return False
+        return True
+
+    # AD002 — referenced agents exist.
+    for i, diff in enumerate(adapter.instruction_diffs):
+        check_agent(diff.agent, "instructionDiffs", i)
+    for i, mod in enumerate(adapter.tools):
+        check_agent(mod.agent, "tools", i)
+    for i, mo in enumerate(adapter.model_overrides):
+        check_agent(mo.agent, "modelOverrides", i)
+    for i, cb in enumerate(adapter.callbacks):
+        check_agent(cb.agent, "callbacks", i)
+
+    # AD003 — replace_section requires sectionTag present in instruction.
+    for i, diff in enumerate(adapter.instruction_diffs):
+        if diff.mode != "replace_section":
+            continue
+        if not diff.section_tag:
+            issues.append(
+                {
+                    "rule_id": "AD003",
+                    "severity": ERROR,
+                    "message": (
+                        f"instructionDiffs[{i}] uses replace_section but has "
+                        "no sectionTag"
+                    ),
+                    "path": where,
+                }
+            )
+            continue
+        if diff.agent not in known_agents:
+            continue
+        text = _get_instruction_text(app_dir, diff.agent)
+        if f"<{diff.section_tag}>" not in text:
+            issues.append(
+                {
+                    "rule_id": "AD003",
+                    "severity": ERROR,
+                    "message": (
+                        f"Section <{diff.section_tag}> from "
+                        f"instructionDiffs[{i}] not found in instruction for "
+                        f"agent '{diff.agent}'"
+                    ),
+                    "path": where,
+                }
+            )
+
+    project_tools = set(_get_project_tool_names(app_dir))
+    defined_tools = {td.display_name for td in adapter.tool_definitions}
+
+    # AD004 — removing a tool not present in the base agent's tools list.
+    # AD005 — adding a tool with no definition anywhere.
+    for i, mod in enumerate(adapter.tools):
+        base_tools = set(_get_agent_tools(app_dir, mod.agent))
+        for t in mod.remove:
+            if t not in base_tools:
+                issues.append(
+                    {
+                        "rule_id": "AD004",
+                        "severity": WARNING,
+                        "message": (
+                            f"tools[{i}] removes '{t}' which is not in agent "
+                            f"'{mod.agent}' base tools list"
+                        ),
+                        "path": where,
+                    }
+                )
+        for t in mod.add:
+            if t not in project_tools and t not in defined_tools:
+                issues.append(
+                    {
+                        "rule_id": "AD005",
+                        "severity": ERROR,
+                        "message": (
+                            f"tools[{i}] adds '{t}' which has no definition in "
+                            "tools/ and no matching toolDefinitions entry"
+                        ),
+                        "path": where,
+                    }
+                )
+
+    # AD006 — adapter has no evaluations.
+    if not adapter.evaluations:
+        issues.append(
+            {
+                "rule_id": "AD006",
+                "severity": WARNING,
+                "message": (
+                    f"Adapter for channel '{channel}' has no evaluations "
+                    "entries"
+                ),
+                "path": where,
+            }
+        )
+
+    return issues
+
+
+def validate_all_adapters(
+    adapters: List[AdapterCard], app_dir: str
+) -> List[Dict[str, Any]]:
+    """Validate all adapter cards, including cross-adapter checks (AD007)."""
+    issues: List[Dict[str, Any]] = []
+    for adapter in adapters:
+        issues.extend(validate_adapter_card(adapter, app_dir))
+
+    # AD007 — two adapters targeting the same channel.
+    seen: Dict[str, int] = {}
+    for adapter in adapters:
+        ch = adapter.metadata.channel
+        seen[ch] = seen.get(ch, 0) + 1
+    for ch, count in seen.items():
+        if count > 1:
+            issues.append(
+                {
+                    "rule_id": "AD007",
+                    "severity": ERROR,
+                    "message": (
+                        f"{count} adapter cards target the same channel '{ch}'"
+                    ),
+                    "path": "adapters",
+                }
+            )
+
+    return issues

--- a/src/cxas_scrapi/utils/lint_rules/__init__.py
+++ b/src/cxas_scrapi/utils/lint_rules/__init__.py
@@ -15,6 +15,7 @@
 """Import all rule modules to trigger @rule decorator registration."""
 
 from cxas_scrapi.utils.lint_rules import (  # noqa: F401
+    adapters,
     callbacks,
     config,
     evals,

--- a/src/cxas_scrapi/utils/lint_rules/adapters.py
+++ b/src/cxas_scrapi/utils/lint_rules/adapters.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Channel adapter card lint rules (AD001-AD007).
+"""Channel adapter card lint rules (AD001-AD010).
 
 Fires when the linter discovers an ``adapters/`` directory containing
 ``*.adapter.{yaml,yml,json}`` files.  These rules reuse the validation
@@ -25,12 +25,14 @@ prefix.
 """
 
 import json
+from functools import lru_cache
 from pathlib import Path
 from typing import List, Optional, Tuple
 
 import yaml
 from pydantic import ValidationError
 
+from cxas_scrapi.poly.engine import _format_validation_error
 from cxas_scrapi.poly.models import AdapterCard
 from cxas_scrapi.poly.validators import (
     validate_adapter_card,
@@ -45,30 +47,38 @@ from cxas_scrapi.utils.linter import (
 )
 
 
-def _parse_raw(content: str, file_path: Path):
-    if file_path.suffix == ".json":
-        return json.loads(content)
-    return yaml.safe_load(content)
-
-
-def _parse_card(
-    content: str, file_path: Path
+@lru_cache(maxsize=128)
+def _parse_card_cached(
+    content: str, suffix: str
 ) -> Tuple[Optional[AdapterCard], Optional[str]]:
-    """Parse an adapter file into an ``AdapterCard``.
+    """Parse adapter ``content`` into an ``AdapterCard`` (memoized).
 
-    Returns ``(card, None)`` on success or ``(None, message)`` on a parse
-    or schema error.
+    Keyed by ``(content, suffix)`` so the seven adapter rules that run over the
+    same file don't each re-parse it.  Returns ``(card, None)`` on success or
+    ``(None, message)`` on a parse or schema error.
     """
     try:
-        data = _parse_raw(content, file_path)
+        data = (
+            json.loads(content)
+            if suffix == ".json"
+            else yaml.safe_load(content)
+        )
     except (yaml.YAMLError, json.JSONDecodeError) as e:
-        return None, f"Adapter card is not valid {file_path.suffix}: {e}"
+        return None, f"Adapter card is not valid {suffix}: {e}"
     if not isinstance(data, dict):
         return None, "Adapter card must be a mapping/object."
     try:
         return AdapterCard.model_validate(data), None
     except ValidationError as e:
-        return None, f"Adapter card schema invalid: {e}"
+        return None, (
+            "Adapter card schema invalid: " + _format_validation_error(e)
+        )
+
+
+def _parse_card(
+    content: str, file_path: Path
+) -> Tuple[Optional[AdapterCard], Optional[str]]:
+    return _parse_card_cached(content, file_path.suffix)
 
 
 def _app_dir_for(file_path: Path) -> str:
@@ -82,6 +92,23 @@ def _issues_for(file_path: Path, content: str, rule_id: str) -> List[str]:
         return []
     issues = validate_adapter_card(card, _app_dir_for(file_path))
     return [i["message"] for i in issues if i["rule_id"] == rule_id]
+
+
+class _AdapterRule(Rule):
+    """Base for adapter rules that delegate to ``validate_adapter_card``.
+
+    Subclasses set ``id``/``name``/``description``/``default_severity``; the
+    matching issues are pulled from the shared validator for the rule's ``id``.
+    """
+
+    def check(
+        self, file_path: Path, content: str, context: LintContext
+    ) -> List[LintResult]:
+        rel = str(file_path.relative_to(context.project_root))
+        return [
+            self.make_result(file=rel, message=m)
+            for m in _issues_for(file_path, content, self.id)
+        ]
 
 
 @rule("adapters")
@@ -102,24 +129,15 @@ class AdapterSchemaValid(Rule):
 
 
 @rule("adapters")
-class AdapterAgentRefsExist(Rule):
+class AdapterAgentRefsExist(_AdapterRule):
     id = "AD002"
     name = "adapter-agent-refs-exist"
     description = "Adapter references only agents that exist in agents/"
     default_severity = Severity.ERROR
 
-    def check(
-        self, file_path: Path, content: str, context: LintContext
-    ) -> List[LintResult]:
-        rel = str(file_path.relative_to(context.project_root))
-        return [
-            self.make_result(file=rel, message=m)
-            for m in _issues_for(file_path, content, "AD002")
-        ]
-
 
 @rule("adapters")
-class AdapterReplaceSectionExists(Rule):
+class AdapterReplaceSectionExists(_AdapterRule):
     id = "AD003"
     name = "adapter-replace-section-exists"
     description = (
@@ -128,67 +146,32 @@ class AdapterReplaceSectionExists(Rule):
     )
     default_severity = Severity.ERROR
 
-    def check(
-        self, file_path: Path, content: str, context: LintContext
-    ) -> List[LintResult]:
-        rel = str(file_path.relative_to(context.project_root))
-        return [
-            self.make_result(file=rel, message=m)
-            for m in _issues_for(file_path, content, "AD003")
-        ]
-
 
 @rule("adapters")
-class AdapterRemoveUnknownTool(Rule):
+class AdapterRemoveUnknownTool(_AdapterRule):
     id = "AD004"
     name = "adapter-remove-unknown-tool"
     description = "Tool remove references a tool in the base agent's list"
     default_severity = Severity.WARNING
 
-    def check(
-        self, file_path: Path, content: str, context: LintContext
-    ) -> List[LintResult]:
-        rel = str(file_path.relative_to(context.project_root))
-        return [
-            self.make_result(file=rel, message=m)
-            for m in _issues_for(file_path, content, "AD004")
-        ]
-
 
 @rule("adapters")
-class AdapterAddUndefinedTool(Rule):
+class AdapterAddUndefinedTool(_AdapterRule):
     id = "AD005"
     name = "adapter-add-undefined-tool"
     description = (
-        "Tool add references a tool defined in tools/ or toolDefinitions"
+        "Tool add references a tool defined in tools/ or toolDefinitions, and "
+        "referenced source files exist"
     )
     default_severity = Severity.ERROR
 
-    def check(
-        self, file_path: Path, content: str, context: LintContext
-    ) -> List[LintResult]:
-        rel = str(file_path.relative_to(context.project_root))
-        return [
-            self.make_result(file=rel, message=m)
-            for m in _issues_for(file_path, content, "AD005")
-        ]
-
 
 @rule("adapters")
-class AdapterHasEvaluations(Rule):
+class AdapterHasEvaluations(_AdapterRule):
     id = "AD006"
     name = "adapter-has-evaluations"
     description = "Adapter declares at least one evaluations entry"
     default_severity = Severity.WARNING
-
-    def check(
-        self, file_path: Path, content: str, context: LintContext
-    ) -> List[LintResult]:
-        rel = str(file_path.relative_to(context.project_root))
-        return [
-            self.make_result(file=rel, message=m)
-            for m in _issues_for(file_path, content, "AD006")
-        ]
 
 
 @rule("adapters")
@@ -227,3 +210,31 @@ class AdapterDuplicateChannel(Rule):
                 if i["rule_id"] == "AD007" and channel in i["message"]:
                     return [self.make_result(file=rel, message=i["message"])]
         return []
+
+
+@rule("adapters")
+class AdapterPathInScope(_AdapterRule):
+    id = "AD008"
+    name = "adapter-path-in-scope"
+    description = (
+        "Referenced sourceDir/pythonCode paths stay within the project root"
+    )
+    default_severity = Severity.ERROR
+
+
+@rule("adapters")
+class AdapterDeploymentValues(_AdapterRule):
+    id = "AD009"
+    name = "adapter-deployment-values"
+    description = (
+        "deployment channelType/modality/theme use known, supported values"
+    )
+    default_severity = Severity.ERROR
+
+
+@rule("adapters")
+class AdapterToolType(_AdapterRule):
+    id = "AD010"
+    name = "adapter-tooltype-supported"
+    description = "toolDefinitions declare a supported toolType"
+    default_severity = Severity.ERROR

--- a/src/cxas_scrapi/utils/lint_rules/adapters.py
+++ b/src/cxas_scrapi/utils/lint_rules/adapters.py
@@ -1,0 +1,229 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Channel adapter card lint rules (AD001-AD007).
+
+Fires when the linter discovers an ``adapters/`` directory containing
+``*.adapter.{yaml,yml,json}`` files.  These rules reuse the validation
+logic in ``cxas_scrapi.poly.validators`` so the linter and
+``cxas poly validate`` stay in lockstep.
+
+Rule-ID note: the original spec proposed ``A001``-``A007`` but the
+``config`` category already owns those, so adapter rules use the ``AD``
+prefix.
+"""
+
+import json
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import yaml
+from pydantic import ValidationError
+
+from cxas_scrapi.poly.models import AdapterCard
+from cxas_scrapi.poly.validators import (
+    validate_adapter_card,
+    validate_all_adapters,
+)
+from cxas_scrapi.utils.linter import (
+    LintContext,
+    LintResult,
+    Rule,
+    Severity,
+    rule,
+)
+
+
+def _parse_raw(content: str, file_path: Path):
+    if file_path.suffix == ".json":
+        return json.loads(content)
+    return yaml.safe_load(content)
+
+
+def _parse_card(
+    content: str, file_path: Path
+) -> Tuple[Optional[AdapterCard], Optional[str]]:
+    """Parse an adapter file into an ``AdapterCard``.
+
+    Returns ``(card, None)`` on success or ``(None, message)`` on a parse
+    or schema error.
+    """
+    try:
+        data = _parse_raw(content, file_path)
+    except (yaml.YAMLError, json.JSONDecodeError) as e:
+        return None, f"Adapter card is not valid {file_path.suffix}: {e}"
+    if not isinstance(data, dict):
+        return None, "Adapter card must be a mapping/object."
+    try:
+        return AdapterCard.model_validate(data), None
+    except ValidationError as e:
+        return None, f"Adapter card schema invalid: {e}"
+
+
+def _app_dir_for(file_path: Path) -> str:
+    """Project root for an adapter file at ``<app>/adapters/<file>``."""
+    return str(file_path.parent.parent)
+
+
+def _issues_for(file_path: Path, content: str, rule_id: str) -> List[str]:
+    card, err = _parse_card(content, file_path)
+    if err is not None or card is None:
+        return []
+    issues = validate_adapter_card(card, _app_dir_for(file_path))
+    return [i["message"] for i in issues if i["rule_id"] == rule_id]
+
+
+@rule("adapters")
+class AdapterSchemaValid(Rule):
+    id = "AD001"
+    name = "adapter-schema-valid"
+    description = "Adapter card has required fields and valid types"
+    default_severity = Severity.ERROR
+
+    def check(
+        self, file_path: Path, content: str, context: LintContext
+    ) -> List[LintResult]:
+        rel = str(file_path.relative_to(context.project_root))
+        _card, err = _parse_card(content, file_path)
+        if err is not None:
+            return [self.make_result(file=rel, message=err)]
+        return []
+
+
+@rule("adapters")
+class AdapterAgentRefsExist(Rule):
+    id = "AD002"
+    name = "adapter-agent-refs-exist"
+    description = "Adapter references only agents that exist in agents/"
+    default_severity = Severity.ERROR
+
+    def check(
+        self, file_path: Path, content: str, context: LintContext
+    ) -> List[LintResult]:
+        rel = str(file_path.relative_to(context.project_root))
+        return [
+            self.make_result(file=rel, message=m)
+            for m in _issues_for(file_path, content, "AD002")
+        ]
+
+
+@rule("adapters")
+class AdapterReplaceSectionExists(Rule):
+    id = "AD003"
+    name = "adapter-replace-section-exists"
+    description = (
+        "replace_section diffs set sectionTag and the tag exists in the "
+        "target instruction"
+    )
+    default_severity = Severity.ERROR
+
+    def check(
+        self, file_path: Path, content: str, context: LintContext
+    ) -> List[LintResult]:
+        rel = str(file_path.relative_to(context.project_root))
+        return [
+            self.make_result(file=rel, message=m)
+            for m in _issues_for(file_path, content, "AD003")
+        ]
+
+
+@rule("adapters")
+class AdapterRemoveUnknownTool(Rule):
+    id = "AD004"
+    name = "adapter-remove-unknown-tool"
+    description = "Tool remove references a tool in the base agent's list"
+    default_severity = Severity.WARNING
+
+    def check(
+        self, file_path: Path, content: str, context: LintContext
+    ) -> List[LintResult]:
+        rel = str(file_path.relative_to(context.project_root))
+        return [
+            self.make_result(file=rel, message=m)
+            for m in _issues_for(file_path, content, "AD004")
+        ]
+
+
+@rule("adapters")
+class AdapterAddUndefinedTool(Rule):
+    id = "AD005"
+    name = "adapter-add-undefined-tool"
+    description = (
+        "Tool add references a tool defined in tools/ or toolDefinitions"
+    )
+    default_severity = Severity.ERROR
+
+    def check(
+        self, file_path: Path, content: str, context: LintContext
+    ) -> List[LintResult]:
+        rel = str(file_path.relative_to(context.project_root))
+        return [
+            self.make_result(file=rel, message=m)
+            for m in _issues_for(file_path, content, "AD005")
+        ]
+
+
+@rule("adapters")
+class AdapterHasEvaluations(Rule):
+    id = "AD006"
+    name = "adapter-has-evaluations"
+    description = "Adapter declares at least one evaluations entry"
+    default_severity = Severity.WARNING
+
+    def check(
+        self, file_path: Path, content: str, context: LintContext
+    ) -> List[LintResult]:
+        rel = str(file_path.relative_to(context.project_root))
+        return [
+            self.make_result(file=rel, message=m)
+            for m in _issues_for(file_path, content, "AD006")
+        ]
+
+
+@rule("adapters")
+class AdapterDuplicateChannel(Rule):
+    id = "AD007"
+    name = "adapter-duplicate-channel"
+    description = "No two adapter cards target the same metadata.channel"
+    default_severity = Severity.ERROR
+
+    def check(
+        self, file_path: Path, content: str, context: LintContext
+    ) -> List[LintResult]:
+        rel = str(file_path.relative_to(context.project_root))
+        this_card, err = _parse_card(content, file_path)
+        if err is not None or this_card is None:
+            return []
+
+        adapters_dir = file_path.parent
+        cards: List[AdapterCard] = []
+        for p in sorted(adapters_dir.iterdir()):
+            if not (
+                p.name.endswith(".adapter.yaml")
+                or p.name.endswith(".adapter.yml")
+                or p.name.endswith(".adapter.json")
+            ):
+                continue
+            card, perr = _parse_card(p.read_text(), p)
+            if perr is None and card is not None:
+                cards.append(card)
+
+        channel = this_card.metadata.channel
+        count = sum(1 for c in cards if c.metadata.channel == channel)
+        if count > 1:
+            issues = validate_all_adapters(cards, _app_dir_for(file_path))
+            for i in issues:
+                if i["rule_id"] == "AD007" and channel in i["message"]:
+                    return [self.make_result(file=rel, message=i["message"])]
+        return []

--- a/src/cxas_scrapi/utils/linter.py
+++ b/src/cxas_scrapi/utils/linter.py
@@ -576,6 +576,26 @@ class Discovery:
     def discover_evaluation_expectations(self) -> dict[str, Path]:
         return self._discover_resource_dirs("evaluation_expectations")
 
+    def discover_adapters(self) -> dict[str, Path]:
+        """Return ``{filename: path}`` for channel adapter cards.
+
+        Scans ``app_root/adapters/`` for ``*.adapter.{yaml,yml,json}``.
+        """
+        if not self.app_root:
+            return {}
+        adapters_dir = self.app_root / "adapters"
+        if not adapters_dir.exists():
+            return {}
+        result = {}
+        for p in sorted(adapters_dir.iterdir()):
+            if p.is_file() and (
+                p.name.endswith(".adapter.yaml")
+                or p.name.endswith(".adapter.yml")
+                or p.name.endswith(".adapter.json")
+            ):
+                result[p.name] = p
+        return result
+
     def dir_name_to_display(self, dir_name: str) -> str:
         """Convert directory name to display name."""
         return dir_name.replace("_", " ")
@@ -772,6 +792,9 @@ def run_rules(  # noqa: C901
 
     # Evals
     _lint_files(_get_rules("evals"), discovery.discover_evals())
+
+    # Adapters — channel adapter cards (poly engine)
+    _lint_files(_get_rules("adapters"), discovery.discover_adapters())
 
     # Config — app config + agent configs
     config_rules = _get_rules("config")

--- a/tests/cxas_scrapi/poly/conftest.py
+++ b/tests/cxas_scrapi/poly/conftest.py
@@ -24,6 +24,7 @@ _TESTS_ROOT = Path(__file__).resolve().parents[2]
 _REPO_ROOT = _TESTS_ROOT.parent
 _BASE_FIXTURE = _TESTS_ROOT / "testdata" / "poly" / "base"
 _BELLA_NOTTE = _REPO_ROOT / "examples" / "bella_notte"
+_POLYMORPHIC_PIZZA = _REPO_ROOT / "examples" / "polymorphic_pizza"
 
 
 @pytest.fixture
@@ -46,3 +47,11 @@ def bella_notte_dir() -> Path:
     if not (_BELLA_NOTTE / "app.json").exists():
         pytest.skip("examples/bella_notte not available")
     return _BELLA_NOTTE
+
+
+@pytest.fixture
+def polymorphic_pizza_dir() -> Path:
+    """Path to the Polymorphic Pizza product-demo project."""
+    if not (_POLYMORPHIC_PIZZA / "app.json").exists():
+        pytest.skip("examples/polymorphic_pizza not available")
+    return _POLYMORPHIC_PIZZA

--- a/tests/cxas_scrapi/poly/conftest.py
+++ b/tests/cxas_scrapi/poly/conftest.py
@@ -1,0 +1,38 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared fixtures for polymorphism engine tests."""
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+# tests/cxas_scrapi/poly/conftest.py -> tests/
+_TESTS_ROOT = Path(__file__).resolve().parents[2]
+_BASE_FIXTURE = _TESTS_ROOT / "testdata" / "poly" / "base"
+
+
+@pytest.fixture
+def base_dir() -> Path:
+    """Path to the committed minimal poly base project fixture."""
+    return _BASE_FIXTURE
+
+
+@pytest.fixture
+def copied_base(tmp_path: Path) -> Path:
+    """A writable copy of the base fixture under ``tmp_path``."""
+    dest = tmp_path / "base"
+    shutil.copytree(_BASE_FIXTURE, dest)
+    return dest

--- a/tests/cxas_scrapi/poly/conftest.py
+++ b/tests/cxas_scrapi/poly/conftest.py
@@ -19,9 +19,11 @@ from pathlib import Path
 
 import pytest
 
-# tests/cxas_scrapi/poly/conftest.py -> tests/
+# tests/cxas_scrapi/poly/conftest.py -> tests/ -> repo root
 _TESTS_ROOT = Path(__file__).resolve().parents[2]
+_REPO_ROOT = _TESTS_ROOT.parent
 _BASE_FIXTURE = _TESTS_ROOT / "testdata" / "poly" / "base"
+_BELLA_NOTTE = _REPO_ROOT / "examples" / "bella_notte"
 
 
 @pytest.fixture
@@ -36,3 +38,11 @@ def copied_base(tmp_path: Path) -> Path:
     dest = tmp_path / "base"
     shutil.copytree(_BASE_FIXTURE, dest)
     return dest
+
+
+@pytest.fixture
+def bella_notte_dir() -> Path:
+    """Path to the real Bella Notte example project (a lint-clean base)."""
+    if not (_BELLA_NOTTE / "app.json").exists():
+        pytest.skip("examples/bella_notte not available")
+    return _BELLA_NOTTE

--- a/tests/cxas_scrapi/poly/test_adapter_lint_rules.py
+++ b/tests/cxas_scrapi/poly/test_adapter_lint_rules.py
@@ -1,0 +1,125 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the adapters lint-rule category (AD001-AD007)."""
+
+from pathlib import Path
+
+import pytest
+
+from cxas_scrapi.utils.lint_rules.adapters import (
+    AdapterAddUndefinedTool,
+    AdapterAgentRefsExist,
+    AdapterDuplicateChannel,
+    AdapterHasEvaluations,
+    AdapterReplaceSectionExists,
+    AdapterSchemaValid,
+)
+from cxas_scrapi.utils.linter import LintContext, build_registry
+
+
+@pytest.fixture
+def ctx(copied_base: Path) -> LintContext:
+    return LintContext(
+        project_root=copied_base,
+        app_dir=copied_base,
+        evals_dir=copied_base / "evals",
+    )
+
+
+def _adapter(copied_base: Path, name: str) -> Path:
+    return copied_base / "adapters" / name
+
+
+def test_ad001_valid_schema_passes(ctx, copied_base):
+    f = _adapter(copied_base, "chat.adapter.yaml")
+    results = AdapterSchemaValid().check(f, f.read_text(), ctx)
+    assert results == []
+
+
+def test_ad001_invalid_schema_reported(ctx, copied_base):
+    f = _adapter(copied_base, "broken.adapter.yaml")
+    f.write_text("apiVersion: v1\nkind: NotAnAdapter\n")
+    results = AdapterSchemaValid().check(f, f.read_text(), ctx)
+    assert len(results) == 1
+    assert results[0].rule_id == "AD001"
+
+
+def test_ad002_missing_agent_reported(ctx, copied_base):
+    f = _adapter(copied_base, "bad.adapter.yaml")
+    f.write_text(
+        "apiVersion: v1\n"
+        "kind: ChannelAdapter\n"
+        "metadata: {channel: bad, displayName: Bad}\n"
+        "instructionDiffs:\n"
+        "  - {agent: Ghost, mode: append, content: x}\n"
+    )
+    results = AdapterAgentRefsExist().check(f, f.read_text(), ctx)
+    assert any(r.rule_id == "AD002" for r in results)
+
+
+def test_ad003_missing_section_reported(ctx, copied_base):
+    f = _adapter(copied_base, "rs.adapter.yaml")
+    f.write_text(
+        "apiVersion: v1\n"
+        "kind: ChannelAdapter\n"
+        "metadata: {channel: rs, displayName: RS}\n"
+        "instructionDiffs:\n"
+        "  - {agent: Test_Agent, mode: replace_section, "
+        "sectionTag: nope, content: x}\n"
+    )
+    results = AdapterReplaceSectionExists().check(f, f.read_text(), ctx)
+    assert any(r.rule_id == "AD003" for r in results)
+
+
+def test_ad005_undefined_tool_reported(ctx, copied_base):
+    f = _adapter(copied_base, "t.adapter.yaml")
+    f.write_text(
+        "apiVersion: v1\n"
+        "kind: ChannelAdapter\n"
+        "metadata: {channel: t, displayName: T}\n"
+        "tools:\n"
+        "  - {agent: Test_Agent, add: [ghost_tool]}\n"
+    )
+    results = AdapterAddUndefinedTool().check(f, f.read_text(), ctx)
+    assert any(r.rule_id == "AD005" for r in results)
+
+
+def test_ad006_no_evaluations_warns(ctx, copied_base):
+    f = _adapter(copied_base, "voice.adapter.yaml")
+    results = AdapterHasEvaluations().check(f, f.read_text(), ctx)
+    assert any(r.rule_id == "AD006" for r in results)
+
+
+def test_ad007_duplicate_channel_reported(ctx, copied_base):
+    # Add a second adapter that also targets "chat".
+    dup = _adapter(copied_base, "chat2.adapter.yaml")
+    dup.write_text(
+        "apiVersion: v1\n"
+        "kind: ChannelAdapter\n"
+        "metadata: {channel: chat, displayName: Chat2}\n"
+        "evaluations:\n"
+        "  - {sourceDir: adapters/chat_evals}\n"
+    )
+    f = _adapter(copied_base, "chat.adapter.yaml")
+    results = AdapterDuplicateChannel().check(f, f.read_text(), ctx)
+    assert any(r.rule_id == "AD007" for r in results)
+
+
+def test_rules_autoregister_in_registry():
+    registry = build_registry()
+    ids = {r.id for r in registry.rules_for_category("adapters")}
+    assert {"AD001", "AD002", "AD003", "AD004", "AD005", "AD006", "AD007"} <= (
+        ids
+    )

--- a/tests/cxas_scrapi/poly/test_adapter_lint_rules.py
+++ b/tests/cxas_scrapi/poly/test_adapter_lint_rules.py
@@ -21,10 +21,13 @@ import pytest
 from cxas_scrapi.utils.lint_rules.adapters import (
     AdapterAddUndefinedTool,
     AdapterAgentRefsExist,
+    AdapterDeploymentValues,
     AdapterDuplicateChannel,
     AdapterHasEvaluations,
+    AdapterPathInScope,
     AdapterReplaceSectionExists,
     AdapterSchemaValid,
+    AdapterToolType,
 )
 from cxas_scrapi.utils.linter import LintContext, build_registry
 
@@ -117,9 +120,58 @@ def test_ad007_duplicate_channel_reported(ctx, copied_base):
     assert any(r.rule_id == "AD007" for r in results)
 
 
+def test_ad008_path_escape_reported(ctx, copied_base):
+    f = _adapter(copied_base, "esc.adapter.yaml")
+    f.write_text(
+        "apiVersion: v1\n"
+        "kind: ChannelAdapter\n"
+        "metadata: {channel: esc, displayName: Esc}\n"
+        "callbacks:\n"
+        "  - {agent: Test_Agent, type: before_model, "
+        "pythonCode: ../../../etc/passwd}\n"
+    )
+    results = AdapterPathInScope().check(f, f.read_text(), ctx)
+    assert any(r.rule_id == "AD008" for r in results)
+
+
+def test_ad009_bad_deployment_reported(ctx, copied_base):
+    f = _adapter(copied_base, "dep.adapter.yaml")
+    f.write_text(
+        "apiVersion: v1\n"
+        "kind: ChannelAdapter\n"
+        "metadata: {channel: dep, displayName: Dep}\n"
+        "deployment: {channelType: BOGUS}\n"
+    )
+    results = AdapterDeploymentValues().check(f, f.read_text(), ctx)
+    assert any(r.rule_id == "AD009" for r in results)
+
+
+def test_ad010_bad_tooltype_reported(ctx, copied_base):
+    f = _adapter(copied_base, "tt.adapter.yaml")
+    f.write_text(
+        "apiVersion: v1\n"
+        "kind: ChannelAdapter\n"
+        "metadata: {channel: tt, displayName: TT}\n"
+        "toolDefinitions:\n"
+        "  - {displayName: x, toolType: wasm, "
+        "sourceDir: adapters/chat_tools/extra_tool}\n"
+    )
+    results = AdapterToolType().check(f, f.read_text(), ctx)
+    assert any(r.rule_id == "AD010" for r in results)
+
+
 def test_rules_autoregister_in_registry():
     registry = build_registry()
     ids = {r.id for r in registry.rules_for_category("adapters")}
-    assert {"AD001", "AD002", "AD003", "AD004", "AD005", "AD006", "AD007"} <= (
-        ids
-    )
+    assert {
+        "AD001",
+        "AD002",
+        "AD003",
+        "AD004",
+        "AD005",
+        "AD006",
+        "AD007",
+        "AD008",
+        "AD009",
+        "AD010",
+    } <= ids

--- a/tests/cxas_scrapi/poly/test_diagnostics.py
+++ b/tests/cxas_scrapi/poly/test_diagnostics.py
@@ -1,0 +1,67 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for guided poly validation diagnostics."""
+
+from pathlib import Path
+
+from cxas_scrapi.poly.diagnostics import build_validation_explanation_report
+from cxas_scrapi.poly.engine import PolymorphismEngine
+
+
+def test_validation_explanation_points_to_field_and_fix(copied_base: Path):
+    (copied_base / "adapters" / "bad.adapter.yaml").write_text(
+        "apiVersion: poly.cxas.dev/v1\n"
+        "kind: ChannelAdapter\n"
+        "metadata:\n"
+        "  channel: bad\n"
+        "  displayName: Bad\n"
+        "instructionDiffs:\n"
+        "  - agent: Ghost\n"
+        "    mode: append\n"
+        "    content: x\n"
+    )
+    engine = PolymorphismEngine(str(copied_base))
+    engine.load_base_project()
+    engine.load_adapter_cards()
+
+    report = build_validation_explanation_report(engine, str(copied_base))
+
+    ad002 = next(i for i in report.issues if i.rule_id == "AD002")
+    assert ad002.adapter_path == "adapters/bad.adapter.yaml"
+    assert ad002.field_path == "instructionDiffs[0]"
+    assert "existing agent" in ad002.why_it_failed
+    assert "agents/<agent>" in ad002.likely_fix
+
+    ad006 = next(
+        i
+        for i in report.issues
+        if i.rule_id == "AD006"
+        and i.adapter_path == "adapters/bad.adapter.yaml"
+    )
+    assert ad006.severity == "warning"
+    assert "adapters/bad_evals" in ad006.related_paths
+
+
+def test_validation_explanation_report_json_shape(base_dir: Path):
+    engine = PolymorphismEngine(str(base_dir))
+    engine.load_base_project()
+    engine.load_adapter_cards()
+
+    report = build_validation_explanation_report(engine, str(base_dir))
+    data = report.to_dict()
+
+    assert data["app_dir"] == str(base_dir.resolve())
+    assert data["cards"] == 2
+    assert "issues" in data

--- a/tests/cxas_scrapi/poly/test_diffing.py
+++ b/tests/cxas_scrapi/poly/test_diffing.py
@@ -1,0 +1,55 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for stable poly diff reports."""
+
+import json
+from pathlib import Path
+
+from cxas_scrapi.poly.diffing import DIFF_SCHEMA_VERSION, build_diff_report
+from cxas_scrapi.poly.engine import PolymorphismEngine
+
+
+def test_build_diff_report_surfaces_meaningful_deltas(base_dir: Path):
+    engine = PolymorphismEngine(str(base_dir))
+    engine.load_base_project()
+    engine.load_adapter_cards()
+    card, path = engine.adapters["chat"]
+    compiled = engine.compile(card, path)
+
+    report = build_diff_report(
+        engine=engine,
+        card=card,
+        card_path=path,
+        compiled=compiled,
+    )
+
+    assert report["schema_version"] == DIFF_SCHEMA_VERSION
+    assert report["channel"] == "chat"
+    assert report["adapter_path"] == "adapters/chat.adapter.yaml"
+    assert report["summary"]["agents_touched"] == 1
+    assert report["summary"]["tools_added"] == 1
+    assert report["summary"]["callbacks_added"] == 1
+    assert report["summary"]["deployment_changed"] is True
+    assert report["tool_definitions_added"][0]["display_name"] == "extra_tool"
+    assert report["evaluation_merges"]["evaluations"] == ["Chat_Test_Eval"]
+    assert report["deployment"]["channel_type"] == "WEB_UI"
+    assert any(delta["type"] == "tool_add" for delta in report["deltas"])
+    assert any(
+        delta["type"] == "callback_add"
+        and delta["callback_type"] == "before_model"
+        for delta in report["deltas"]
+    )
+
+    json.dumps(report)

--- a/tests/cxas_scrapi/poly/test_engine.py
+++ b/tests/cxas_scrapi/poly/test_engine.py
@@ -1,0 +1,320 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for cxas_scrapi.poly.engine."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from cxas_scrapi.poly.engine import CompilationError, PolymorphismEngine
+from cxas_scrapi.poly.models import AdapterCard
+
+
+def _engine(base: Path) -> PolymorphismEngine:
+    eng = PolymorphismEngine(str(base))
+    eng.load_base_project()
+    eng.load_adapter_cards()
+    return eng
+
+
+def _compiled(eng: PolymorphismEngine, channel: str):
+    card, path = eng.adapters[channel]
+    return eng.compile(card, path)
+
+
+# ── Loading ──────────────────────────────────────────────────────────────
+
+
+def test_load_base_project(base_dir: Path):
+    eng = PolymorphismEngine(str(base_dir))
+    base = eng.load_base_project()
+    assert base.app_json["displayName"] == "Poly Test App"
+    assert "Test_Agent" in base.agents
+    agent = base.agents["Test_Agent"]
+    assert agent.display_name == "Test_Agent"
+    assert agent.config["tools"] == ["test_tool", "end_session"]
+    assert "<channel_behavior>" in agent.instruction
+    assert "test_tool" in base.tools
+    # Base callback code is loaded keyed by its rel path.
+    assert any("before_model_callbacks_01" in k for k in agent.callback_code)
+
+
+def test_load_base_project_requires_app_json(tmp_path: Path):
+    (tmp_path / "agents").mkdir()
+    eng = PolymorphismEngine(str(tmp_path))
+    with pytest.raises(FileNotFoundError):
+        eng.load_base_project()
+
+
+def test_load_adapter_cards(base_dir: Path):
+    eng = PolymorphismEngine(str(base_dir))
+    eng.load_base_project()
+    cards = eng.load_adapter_cards()
+    channels = {c.metadata.channel for c in cards}
+    assert channels == {"chat", "voice"}
+    assert set(eng.adapters) == {"chat", "voice"}
+    assert all(isinstance(c, AdapterCard) for c in cards)
+
+
+# ── Instruction diffs ──────────────────────────────────────────────────────
+
+
+def test_instruction_append(base_dir: Path):
+    eng = _engine(base_dir)
+    compiled = _compiled(eng, "chat")
+    text = compiled.agent_instructions["Test_Agent"]
+    assert text.endswith("Chat-specific: use markdown and numbered lists.\n")
+    # Base content preserved.
+    assert "You are a test agent." in text
+
+
+def test_instruction_prepend(copied_base: Path):
+    card = AdapterCard.model_validate(
+        {
+            "apiVersion": "v1",
+            "kind": "ChannelAdapter",
+            "metadata": {"channel": "pre", "displayName": "Pre"},
+            "instructionDiffs": [
+                {
+                    "agent": "Test_Agent",
+                    "mode": "prepend",
+                    "content": "PREPENDED LINE",
+                }
+            ],
+        }
+    )
+    eng = PolymorphismEngine(str(copied_base))
+    eng.load_base_project()
+    compiled = eng.compile(card)
+    text = compiled.agent_instructions["Test_Agent"]
+    assert text.startswith("PREPENDED LINE")
+    assert "You are a test agent." in text
+
+
+def test_instruction_replace_section(base_dir: Path):
+    eng = _engine(base_dir)
+    compiled = _compiled(eng, "voice")
+    text = compiled.agent_instructions["Test_Agent"]
+    assert "Default channel behavior here." not in text
+    assert "Voice channel: keep responses short" in text
+    # Tags preserved around replacement.
+    assert "<channel_behavior>" in text and "</channel_behavior>" in text
+
+
+def test_replace_section_missing_tag_raises(copied_base: Path):
+    card = AdapterCard.model_validate(
+        {
+            "apiVersion": "v1",
+            "kind": "ChannelAdapter",
+            "metadata": {"channel": "x", "displayName": "X"},
+            "instructionDiffs": [
+                {
+                    "agent": "Test_Agent",
+                    "mode": "replace_section",
+                    "sectionTag": "no_such_tag",
+                    "content": "y",
+                }
+            ],
+        }
+    )
+    eng = PolymorphismEngine(str(copied_base))
+    eng.load_base_project()
+    with pytest.raises(CompilationError):
+        eng.compile(card)
+
+
+# ── Tools ──────────────────────────────────────────────────────────────────
+
+
+def test_tool_add(base_dir: Path):
+    eng = _engine(base_dir)
+    compiled = _compiled(eng, "chat")
+    assert "extra_tool" in compiled.agents["Test_Agent"]["tools"]
+    # The new tool definition is captured for output.
+    assert "extra_tool" in compiled.tools
+
+
+def test_tool_remove(base_dir: Path):
+    eng = _engine(base_dir)
+    compiled = _compiled(eng, "voice")
+    assert "test_tool" not in compiled.agents["Test_Agent"]["tools"]
+
+
+def test_tool_definition_pythoncode_normalized(base_dir: Path):
+    eng = _engine(base_dir)
+    compiled = _compiled(eng, "chat")
+    cfg = compiled.tools["extra_tool"]
+    assert (
+        cfg["pythonFunction"]["pythonCode"]
+        == "tools/extra_tool/python_function/python_code.py"
+    )
+
+
+# ── Model overrides & callbacks ───────────────────────────────────────────
+
+
+def test_model_override(base_dir: Path):
+    eng = _engine(base_dir)
+    compiled = _compiled(eng, "chat")
+    assert (
+        compiled.agents["Test_Agent"]["modelSettings"]["model"]
+        == "gemini-3-pro"
+    )
+
+
+def test_callback_append_next_index(base_dir: Path):
+    eng = _engine(base_dir)
+    compiled = _compiled(eng, "chat")
+    cbs = compiled.agents["Test_Agent"]["beforeModelCallbacks"]
+    assert len(cbs) == 2
+    assert cbs[1]["pythonCode"].endswith(
+        "before_model_callbacks/before_model_callbacks_02/python_code.py"
+    )
+    assert cbs[1]["pythonCode"] in compiled.callback_code
+
+
+def test_base_callback_preserved(base_dir: Path):
+    eng = _engine(base_dir)
+    compiled = _compiled(eng, "voice")
+    # Base before_model_callbacks_01 still present and its code carried.
+    paths = [
+        c["pythonCode"]
+        for c in compiled.agents["Test_Agent"]["beforeModelCallbacks"]
+    ]
+    assert any("before_model_callbacks_01" in p for p in paths)
+
+
+# ── Deployment & evaluations ──────────────────────────────────────────────
+
+
+def test_deployment_built(base_dir: Path):
+    eng = _engine(base_dir)
+    compiled = _compiled(eng, "chat")
+    assert compiled.deployment["channelType"] == "WEB_UI"
+    assert compiled.deployment["modality"] == "CHAT_ONLY"
+    assert compiled.deployment["theme"] == "LIGHT"
+
+
+def test_evaluations_merged(base_dir: Path):
+    eng = _engine(base_dir)
+    compiled = _compiled(eng, "chat")
+    assert "Chat_Test_Eval" in compiled.evaluations
+
+
+# ── compile_all ────────────────────────────────────────────────────────────
+
+
+def test_compile_all_one_config_per_channel(base_dir: Path):
+    eng = PolymorphismEngine(str(base_dir))
+    result = eng.compile_all()
+    assert set(result) == {"chat", "voice"}
+
+
+def test_compile_all_raises_on_bad_adapter(copied_base: Path):
+    bad = copied_base / "adapters" / "broken.adapter.yaml"
+    bad.write_text(
+        "apiVersion: v1\n"
+        "kind: ChannelAdapter\n"
+        "metadata:\n"
+        "  channel: broken\n"
+        "  displayName: Broken\n"
+        "instructionDiffs:\n"
+        "  - agent: Nonexistent_Agent\n"
+        "    mode: append\n"
+        "    content: x\n"
+    )
+    eng = PolymorphismEngine(str(copied_base))
+    with pytest.raises(CompilationError) as exc:
+        eng.compile_all()
+    assert any(i["rule_id"] == "AD002" for i in exc.value.issues)
+
+
+def test_base_not_mutated_across_compiles(base_dir: Path):
+    eng = _engine(base_dir)
+    _compiled(eng, "chat")  # adds extra_tool to a copy
+    # The base bundle's tools list must be untouched.
+    assert eng.base.agents["Test_Agent"].config["tools"] == [
+        "test_tool",
+        "end_session",
+    ]
+
+
+# ── write_output ───────────────────────────────────────────────────────────
+
+
+def test_write_output_structure(base_dir: Path, tmp_path: Path):
+    eng = _engine(base_dir)
+    compiled = _compiled(eng, "chat")
+    out = eng.write_output(compiled, str(tmp_path / "chat"))
+
+    assert (out / "app.json").exists()
+    assert (out / "gecx-config.json").exists()
+    assert (out / "deployment.json").exists()
+    agent_json = out / "agents" / "Test_Agent" / "Test_Agent.json"
+    assert agent_json.exists()
+    assert (out / "agents" / "Test_Agent" / "instruction.txt").exists()
+    # New callback file written.
+    assert (
+        out
+        / "agents"
+        / "Test_Agent"
+        / "before_model_callbacks"
+        / "before_model_callbacks_02"
+        / "python_code.py"
+    ).exists()
+    # Base tool copied verbatim, new tool written.
+    assert (out / "tools" / "test_tool" / "test_tool.json").exists()
+    assert (
+        out / "tools" / "extra_tool" / "python_function" / "python_code.py"
+    ).exists()
+    # Channel eval merged.
+    assert (
+        out / "evaluations" / "Chat_Test_Eval" / "Chat_Test_Eval.json"
+    ).exists()
+
+
+def test_write_output_agent_json_valid(base_dir: Path, tmp_path: Path):
+    eng = _engine(base_dir)
+    compiled = _compiled(eng, "chat")
+    out = eng.write_output(compiled, str(tmp_path / "chat"))
+
+    cfg = json.loads(
+        (out / "agents" / "Test_Agent" / "Test_Agent.json").read_text()
+    )
+    # Every callback pythonCode path resolves to a real file.
+    for cb in cfg["beforeModelCallbacks"]:
+        assert (out / cb["pythonCode"]).exists()
+    # Every listed tool has a directory in the output.
+    for tool in cfg["tools"]:
+        if tool == "end_session":
+            continue  # platform tool, no directory
+        assert (out / "tools" / tool).is_dir()
+    # gecx app_dir normalized to "." for lintability.
+    gecx = json.loads((out / "gecx-config.json").read_text())
+    assert gecx["app_dir"] == "."
+    assert gecx["default_channel"] == "chat"
+
+
+def test_write_output_voice_excludes_removed_tool_from_list(
+    base_dir: Path, tmp_path: Path
+):
+    eng = _engine(base_dir)
+    compiled = _compiled(eng, "voice")
+    out = eng.write_output(compiled, str(tmp_path / "voice"))
+    cfg = json.loads(
+        (out / "agents" / "Test_Agent" / "Test_Agent.json").read_text()
+    )
+    assert "test_tool" not in cfg["tools"]

--- a/tests/cxas_scrapi/poly/test_engine.py
+++ b/tests/cxas_scrapi/poly/test_engine.py
@@ -219,6 +219,34 @@ def test_deployment_voice_sets_audio_modality(base_dir: Path):
     assert compiled.gecx_config["modality"] == "audio"
 
 
+def test_gecx_config_overlay_deep_merges_before_channel_defaults(copied_base: Path):
+    card = AdapterCard.model_validate(
+        {
+            "apiVersion": "v1",
+            "kind": "ChannelAdapter",
+            "metadata": {"channel": "voice", "displayName": "Voice"},
+            "gecxConfig": {
+                "model": "gemini-3-flash-lite",
+                "default_channel": "wrong",
+                "runtime": {"turnTimeoutMs": 800},
+            },
+            "evaluations": [{"sourceDir": "adapters/chat_evals"}],
+            "deployment": {
+                "channelType": "GOOGLE_TELEPHONY_PLATFORM",
+                "modality": "VOICE_ONLY",
+            },
+        }
+    )
+    eng = PolymorphismEngine(str(copied_base))
+    eng.load_base_project()
+    compiled = eng.compile(card)
+    assert compiled.gecx_config["model"] == "gemini-3-flash-lite"
+    assert compiled.gecx_config["runtime"]["turnTimeoutMs"] == 800
+    assert compiled.gecx_config["default_channel"] == "voice"
+    assert compiled.gecx_config["app_dir"] == "."
+    assert compiled.gecx_config["modality"] == "audio"
+
+
 def test_evaluations_merged(base_dir: Path):
     eng = _engine(base_dir)
     compiled = _compiled(eng, "chat")
@@ -251,6 +279,23 @@ def test_compile_all_raises_on_bad_adapter(copied_base: Path):
     with pytest.raises(CompilationError) as exc:
         eng.compile_all()
     assert any(i["rule_id"] == "AD002" for i in exc.value.issues)
+
+
+def test_compile_all_raises_on_duplicate_channels(copied_base: Path):
+    dup = copied_base / "adapters" / "duplicate_chat.adapter.yaml"
+    dup.write_text(
+        "apiVersion: v1\n"
+        "kind: ChannelAdapter\n"
+        "metadata:\n"
+        "  channel: chat\n"
+        "  displayName: Duplicate Chat\n"
+        "evaluations:\n"
+        "  - sourceDir: adapters/chat_evals\n"
+    )
+    eng = PolymorphismEngine(str(copied_base))
+    with pytest.raises(CompilationError) as exc:
+        eng.compile_all()
+    assert any(i["rule_id"] == "AD007" for i in exc.value.issues)
 
 
 def test_base_not_mutated_across_compiles(base_dir: Path):

--- a/tests/cxas_scrapi/poly/test_engine.py
+++ b/tests/cxas_scrapi/poly/test_engine.py
@@ -219,7 +219,9 @@ def test_deployment_voice_sets_audio_modality(base_dir: Path):
     assert compiled.gecx_config["modality"] == "audio"
 
 
-def test_gecx_config_overlay_deep_merges_before_channel_defaults(copied_base: Path):
+def test_gecx_config_overlay_deep_merges_before_channel_defaults(
+    copied_base: Path,
+):
     card = AdapterCard.model_validate(
         {
             "apiVersion": "v1",

--- a/tests/cxas_scrapi/poly/test_engine.py
+++ b/tests/cxas_scrapi/poly/test_engine.py
@@ -203,9 +203,20 @@ def test_base_callback_preserved(base_dir: Path):
 def test_deployment_built(base_dir: Path):
     eng = _engine(base_dir)
     compiled = _compiled(eng, "chat")
-    assert compiled.deployment["channelType"] == "WEB_UI"
+    # snake_case block matching Deployments.create_deployment kwargs.
+    assert compiled.deployment["channel_type"] == "WEB_UI"
     assert compiled.deployment["modality"] == "CHAT_ONLY"
     assert compiled.deployment["theme"] == "LIGHT"
+    assert compiled.deployment["deployment_id"] == "chat"
+    # Folded into gecx-config.json (the file deploy tooling reads).
+    assert compiled.gecx_config["deployment"] == compiled.deployment
+
+
+def test_deployment_voice_sets_audio_modality(base_dir: Path):
+    eng = _engine(base_dir)
+    compiled = _compiled(eng, "voice")
+    assert compiled.deployment["channel_type"] == "GOOGLE_TELEPHONY_PLATFORM"
+    assert compiled.gecx_config["modality"] == "audio"
 
 
 def test_evaluations_merged(base_dir: Path):
@@ -262,7 +273,10 @@ def test_write_output_structure(base_dir: Path, tmp_path: Path):
 
     assert (out / "app.json").exists()
     assert (out / "gecx-config.json").exists()
-    assert (out / "deployment.json").exists()
+    # Deployment now lives inside gecx-config.json, not a standalone file.
+    assert not (out / "deployment.json").exists()
+    gecx = json.loads((out / "gecx-config.json").read_text())
+    assert gecx["deployment"]["channel_type"] == "WEB_UI"
     agent_json = out / "agents" / "Test_Agent" / "Test_Agent.json"
     assert agent_json.exists()
     assert (out / "agents" / "Test_Agent" / "instruction.txt").exists()

--- a/tests/cxas_scrapi/poly/test_hardening.py
+++ b/tests/cxas_scrapi/poly/test_hardening.py
@@ -68,6 +68,29 @@ def test_compiled_output_lints_clean(bella_notte_dir: Path, tmp_path: Path):
         )
 
 
+def test_polymorphic_pizza_showcases_channel_specific_runtime_config(
+    polymorphic_pizza_dir: Path,
+):
+    """The product demo proves model/runtime config differs by channel."""
+    eng = PolymorphismEngine(str(polymorphic_pizza_dir))
+    compiled = eng.compile_all()
+    chat = compiled["chat"]
+    voice = compiled["voice"]
+
+    assert chat.gecx_config["model"] == "gemini-3-pro"
+    assert chat.gecx_config["modality"] == "text"
+    assert chat.agents["Order_Agent"]["modelSettings"]["model"] == "gemini-3-pro"
+    assert "send_order_card" in chat.agents["Order_Agent"]["tools"]
+
+    assert voice.gecx_config["model"] == "gemini-3-flash"
+    assert voice.gecx_config["modality"] == "audio"
+    assert (
+        voice.agents["Order_Agent"]["modelSettings"]["model"]
+        == "gemini-3-flash"
+    )
+    assert "send_order_card" not in voice.agents["Order_Agent"]["tools"]
+
+
 # ── Safe output writer ─────────────────────────────────────────────────────
 
 

--- a/tests/cxas_scrapi/poly/test_hardening.py
+++ b/tests/cxas_scrapi/poly/test_hardening.py
@@ -1,0 +1,271 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Production-hardening tests for the Polymorphism Engine.
+
+Covers the guarantees that make the output safe to lint/eval/deploy: the
+compiled project actually lints clean (round-trip), the writer never destroys
+unrelated data, malformed cards never crash, paths can't escape the project,
+and the half-built features (toolType, eval expectations/datasets) work.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from cxas_scrapi.poly.engine import PolymorphismEngine
+from cxas_scrapi.poly.models import AdapterCard
+from cxas_scrapi.utils.linter import (
+    Discovery,
+    LintConfig,
+    LintReport,
+    build_context,
+    build_registry,
+    run_rules,
+)
+
+# ── Round-trip: compiled output lints clean ───────────────────────────────
+
+
+def _lint_errors(app_dir: Path):
+    """Run the real linter on a project in-process; return error results."""
+    registry = build_registry()
+    project_root = app_dir.resolve()
+    config = LintConfig.load(project_root)
+    a_dir = project_root / config.app_dir
+    e_dir = project_root / config.evals_dir
+    discovery = Discovery(a_dir, e_dir)
+    assert discovery.app_root, f"no app root discovered under {a_dir}"
+    context = build_context(project_root, config, discovery)
+    report = LintReport()
+    run_rules(registry, config, context, discovery, report)
+    return report.errors
+
+
+def test_compiled_output_lints_clean(bella_notte_dir: Path, tmp_path: Path):
+    """The headline guarantee: every compiled channel lints with zero errors."""
+    eng = PolymorphismEngine(str(bella_notte_dir))
+    compiled = eng.compile_all()
+    assert set(compiled) == {"chat", "voice"}
+    for channel, cfg in compiled.items():
+        out = eng.write_output(cfg, str(tmp_path / channel))
+        errors = _lint_errors(out)
+        assert errors == [], (
+            f"channel '{channel}' output has lint errors: "
+            + "; ".join(f"{e.rule_id} {e.file}" for e in errors)
+        )
+
+
+# ── Safe output writer ─────────────────────────────────────────────────────
+
+
+def _chat(eng: PolymorphismEngine):
+    card, path = eng.adapters["chat"]
+    return eng.compile(card, path)
+
+
+def _engine(base: Path) -> PolymorphismEngine:
+    eng = PolymorphismEngine(str(base))
+    eng.load_base_project()
+    eng.load_adapter_cards()
+    return eng
+
+
+def test_write_refuses_to_clobber_foreign_dir(base_dir: Path, tmp_path: Path):
+    eng = _engine(base_dir)
+    compiled = _chat(eng)
+    out = tmp_path / "chat"
+    out.mkdir()
+    (out / "precious.txt").write_text("do not delete")
+    with pytest.raises(FileExistsError):
+        eng.write_output(compiled, str(out))
+    assert (out / "precious.txt").exists()  # untouched
+
+
+def test_write_force_overwrites(base_dir: Path, tmp_path: Path):
+    eng = _engine(base_dir)
+    compiled = _chat(eng)
+    out = tmp_path / "chat"
+    out.mkdir()
+    (out / "precious.txt").write_text("do not delete")
+    eng.write_output(compiled, str(out), force=True)
+    assert not (out / "precious.txt").exists()
+    assert (out / "app.json").exists()
+
+
+def test_write_rebuild_ok_when_poly_owned(base_dir: Path, tmp_path: Path):
+    eng = _engine(base_dir)
+    compiled = _chat(eng)
+    out = tmp_path / "chat"
+    eng.write_output(compiled, str(out))  # first build writes the marker
+    assert (out / ".poly_build.json").is_file()
+    # Second build into the same (poly-owned) dir succeeds without force.
+    eng.write_output(compiled, str(out))
+    assert (out / "app.json").exists()
+
+
+def test_write_refuses_overlap_with_app_dir(base_dir: Path):
+    eng = _engine(base_dir)
+    compiled = _chat(eng)
+    with pytest.raises(ValueError):
+        eng.write_output(compiled, str(base_dir / "inside"))
+    with pytest.raises(ValueError):
+        eng.write_output(compiled, str(base_dir))
+
+
+# ── Malformed cards never crash ────────────────────────────────────────────
+
+
+def test_malformed_card_collected_not_raised(copied_base: Path):
+    (copied_base / "adapters" / "broken.adapter.yaml").write_text(
+        "apiVersion: v1\nkind: ChannelAdapter\nmetadata:\n  displayName: X\n"
+    )
+    eng = PolymorphismEngine(str(copied_base))
+    eng.load_base_project()
+    cards = eng.load_adapter_cards()  # must not raise
+    channels = {c.metadata.channel for c in cards}
+    assert channels == {"chat", "voice"}  # good cards still parsed
+    assert any(e["rule_id"] == "AD001" for e in eng.adapter_errors)
+
+
+def test_invalid_yaml_card_collected(copied_base: Path):
+    (copied_base / "adapters" / "bad.adapter.yaml").write_text(
+        "this: : not: valid: yaml: ["
+    )
+    eng = PolymorphismEngine(str(copied_base))
+    eng.load_base_project()
+    eng.load_adapter_cards()
+    assert any(e["rule_id"] == "AD001" for e in eng.adapter_errors)
+
+
+# ── toolType handling ──────────────────────────────────────────────────────
+
+
+def test_openapi_tool_copied_verbatim(copied_base: Path):
+    # Create a non-python tool source dir with an aux spec file.
+    src = copied_base / "adapters" / "api_tools" / "lookup_api"
+    src.mkdir(parents=True)
+    (src / "lookup_api.json").write_text(
+        json.dumps({"displayName": "lookup_api", "openApiSpec": "spec.yaml"})
+    )
+    (src / "spec.yaml").write_text("openapi: 3.0.0\n")
+    card = AdapterCard.model_validate(
+        {
+            "apiVersion": "v1",
+            "kind": "ChannelAdapter",
+            "metadata": {"channel": "api", "displayName": "Api"},
+            "toolDefinitions": [
+                {
+                    "displayName": "lookup_api",
+                    "toolType": "openapi",
+                    "sourceDir": "adapters/api_tools/lookup_api",
+                }
+            ],
+            "evaluations": [{"sourceDir": "adapters/chat_evals"}],
+        }
+    )
+    eng = PolymorphismEngine(str(copied_base))
+    eng.load_base_project()
+    compiled = eng.compile(card)
+    out = eng.write_output(compiled, str(copied_base.parent / "api_out"))
+    # Both the JSON and the aux spec file are present, unchanged.
+    assert (out / "tools" / "lookup_api" / "lookup_api.json").exists()
+    assert (out / "tools" / "lookup_api" / "spec.yaml").exists()
+
+
+# ── Eval expectations / datasets ───────────────────────────────────────────
+
+
+def test_eval_expectations_and_datasets_merged(copied_base: Path):
+    exp = copied_base / "adapters" / "chat_exp" / "Chat_Exp"
+    exp.mkdir(parents=True)
+    (exp / "Chat_Exp.json").write_text(
+        json.dumps({"displayName": "Chat_Exp", "llmCriteria": {"prompt": "ok"}})
+    )
+    ds = copied_base / "adapters" / "chat_ds" / "Chat_DS"
+    ds.mkdir(parents=True)
+    (ds / "Chat_DS.json").write_text(
+        json.dumps({"displayName": "Chat_DS", "evaluations": []})
+    )
+    card = AdapterCard.model_validate(
+        {
+            "apiVersion": "v1",
+            "kind": "ChannelAdapter",
+            "metadata": {"channel": "chat", "displayName": "Chat"},
+            "evaluations": [{"sourceDir": "adapters/chat_evals"}],
+            "evaluationExpectations": [{"sourceDir": "adapters/chat_exp"}],
+            "evaluationDatasets": [{"sourceDir": "adapters/chat_ds"}],
+        }
+    )
+    eng = PolymorphismEngine(str(copied_base))
+    eng.load_base_project()
+    compiled = eng.compile(card)
+    assert "Chat_Exp" in compiled.evaluation_expectations
+    assert "Chat_DS" in compiled.evaluation_datasets
+    out = eng.write_output(compiled, str(copied_base.parent / "ev_out"))
+    assert (
+        out / "evaluationExpectations" / "Chat_Exp" / "Chat_Exp.json"
+    ).exists()
+    assert (out / "evaluationDatasets" / "Chat_DS" / "Chat_DS.json").exists()
+
+
+# ── Platform tools & attribute sections (engine side) ──────────────────────
+
+
+def test_platform_tool_add_allowed(copied_base: Path):
+    card = AdapterCard.model_validate(
+        {
+            "apiVersion": "v1",
+            "kind": "ChannelAdapter",
+            "metadata": {"channel": "p", "displayName": "P"},
+            "tools": [{"agent": "Test_Agent", "add": ["customize_response"]}],
+            "evaluations": [{"sourceDir": "adapters/chat_evals"}],
+        }
+    )
+    eng = PolymorphismEngine(str(copied_base))
+    eng.load_base_project()
+    compiled = eng.compile(card)  # must not raise on the platform tool
+    assert "customize_response" in compiled.agents["Test_Agent"]["tools"]
+
+
+def test_replace_section_with_attributes(copied_base: Path):
+    inst = copied_base / "agents" / "Test_Agent" / "instruction.txt"
+    inst.write_text(
+        inst.read_text().replace(
+            "<channel_behavior>", '<channel_behavior priority="high">'
+        )
+    )
+    card = AdapterCard.model_validate(
+        {
+            "apiVersion": "v1",
+            "kind": "ChannelAdapter",
+            "metadata": {"channel": "rs", "displayName": "RS"},
+            "instructionDiffs": [
+                {
+                    "agent": "Test_Agent",
+                    "mode": "replace_section",
+                    "sectionTag": "channel_behavior",
+                    "content": "new voice text",
+                }
+            ],
+            "evaluations": [{"sourceDir": "adapters/chat_evals"}],
+        }
+    )
+    eng = PolymorphismEngine(str(copied_base))
+    eng.load_base_project()
+    compiled = eng.compile(card)  # previously a false AD003 / crash
+    text = compiled.agent_instructions["Test_Agent"]
+    assert "new voice text" in text
+    assert "Default channel behavior here." not in text

--- a/tests/cxas_scrapi/poly/test_hardening.py
+++ b/tests/cxas_scrapi/poly/test_hardening.py
@@ -79,7 +79,10 @@ def test_polymorphic_pizza_showcases_channel_specific_runtime_config(
 
     assert chat.gecx_config["model"] == "gemini-3-pro"
     assert chat.gecx_config["modality"] == "text"
-    assert chat.agents["Order_Agent"]["modelSettings"]["model"] == "gemini-3-pro"
+    assert (
+        chat.agents["Order_Agent"]["modelSettings"]["model"]
+        == "gemini-3-pro"
+    )
     assert "send_order_card" in chat.agents["Order_Agent"]["tools"]
 
     assert voice.gecx_config["model"] == "gemini-3-flash"

--- a/tests/cxas_scrapi/poly/test_models.py
+++ b/tests/cxas_scrapi/poly/test_models.py
@@ -125,3 +125,28 @@ def test_populate_by_name_accepts_snake_case():
     )
     assert card.api_version == "v1"
     assert card.metadata.display_name == "C"
+
+
+def test_unknown_adapter_fields_raise():
+    data = _valid_card_dict()
+    data["gecxCongif"] = {"modality": "audio"}
+    with pytest.raises(ValidationError):
+        AdapterCard.model_validate(data)
+
+
+def test_unknown_nested_adapter_fields_raise():
+    data = _valid_card_dict()
+    data["deployment"]["webWidgetConfig"]["webWidgitTitle"] = "Typo"
+    with pytest.raises(ValidationError):
+        AdapterCard.model_validate(data)
+
+
+def test_gecx_config_overlay_parses_as_delta():
+    data = _valid_card_dict()
+    data["gecxConfig"] = {
+        "model": "gemini-3-pro",
+        "runtime": {"turnTimeoutMs": 800},
+    }
+    card = AdapterCard.model_validate(data)
+    assert card.gecx_config["model"] == "gemini-3-pro"
+    assert card.gecx_config["runtime"]["turnTimeoutMs"] == 800

--- a/tests/cxas_scrapi/poly/test_models.py
+++ b/tests/cxas_scrapi/poly/test_models.py
@@ -1,0 +1,127 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for cxas_scrapi.poly.models."""
+
+import pytest
+from pydantic import ValidationError
+
+from cxas_scrapi.poly.models import AdapterCard
+
+
+def _valid_card_dict() -> dict:
+    return {
+        "apiVersion": "poly.cxas.dev/v1",
+        "kind": "ChannelAdapter",
+        "metadata": {
+            "channel": "chat",
+            "displayName": "Chat Adapter",
+            "description": "Chat optimization.",
+        },
+        "instructionDiffs": [
+            {
+                "agent": "Host",
+                "mode": "append",
+                "content": "Be brief.",
+            }
+        ],
+        "tools": [{"agent": "Host", "add": ["x"], "remove": ["y"]}],
+        "toolDefinitions": [
+            {
+                "displayName": "x",
+                "toolType": "python",
+                "sourceDir": "adapters/tools/x",
+            }
+        ],
+        "modelOverrides": [{"agent": "Host", "model": "gemini-3-pro"}],
+        "callbacks": [
+            {
+                "agent": "Host",
+                "type": "before_model",
+                "pythonCode": "adapters/cb/x.py",
+                "description": "hint",
+            }
+        ],
+        "evaluations": [{"sourceDir": "adapters/evals"}],
+        "deployment": {
+            "channelType": "WEB_UI",
+            "modality": "CHAT_ONLY",
+            "webWidgetConfig": {"theme": "LIGHT", "webWidgetTitle": "Hi"},
+        },
+    }
+
+
+def test_parses_valid_card_with_camelcase_aliases():
+    card = AdapterCard.model_validate(_valid_card_dict())
+    assert card.api_version == "poly.cxas.dev/v1"
+    assert card.metadata.channel == "chat"
+    assert card.metadata.display_name == "Chat Adapter"
+    assert card.instruction_diffs[0].mode == "append"
+    assert card.tool_definitions[0].source_dir == "adapters/tools/x"
+    assert card.model_overrides[0].model == "gemini-3-pro"
+    assert card.callbacks[0].python_code == "adapters/cb/x.py"
+    assert card.evaluations[0].source_dir == "adapters/evals"
+    assert card.deployment.channel_type == "WEB_UI"
+    assert card.deployment.web_widget_config.web_widget_title == "Hi"
+
+
+def test_minimal_card_defaults_are_empty():
+    card = AdapterCard.model_validate(
+        {
+            "apiVersion": "v1",
+            "kind": "ChannelAdapter",
+            "metadata": {"channel": "voice", "displayName": "V"},
+        }
+    )
+    assert card.instruction_diffs == []
+    assert card.tools == []
+    assert card.tool_definitions == []
+    assert card.model_overrides == []
+    assert card.callbacks == []
+    assert card.evaluations == []
+    assert card.deployment is None
+
+
+def test_missing_required_fields_raises():
+    with pytest.raises(ValidationError):
+        AdapterCard.model_validate(
+            {"kind": "ChannelAdapter", "metadata": {"channel": "chat"}}
+        )
+
+
+def test_wrong_kind_raises():
+    data = _valid_card_dict()
+    data["kind"] = "SomethingElse"
+    with pytest.raises(ValidationError):
+        AdapterCard.model_validate(data)
+
+
+def test_invalid_instruction_mode_raises():
+    data = _valid_card_dict()
+    data["instructionDiffs"][0]["mode"] = "bogus"
+    with pytest.raises(ValidationError):
+        AdapterCard.model_validate(data)
+
+
+def test_populate_by_name_accepts_snake_case():
+    # populate_by_name=True means Python field names also work as input keys.
+    card = AdapterCard.model_validate(
+        {
+            "api_version": "v1",
+            "kind": "ChannelAdapter",
+            "metadata": {"channel": "chat", "display_name": "C"},
+        }
+    )
+    assert card.api_version == "v1"
+    assert card.metadata.display_name == "C"

--- a/tests/cxas_scrapi/poly/test_poly_cli.py
+++ b/tests/cxas_scrapi/poly/test_poly_cli.py
@@ -63,6 +63,19 @@ def test_cli_doctor_explains_bad_adapter(copied_base: Path, capsys):
     assert "adapters/bad.adapter.yaml" in out
 
 
+def test_cli_readiness_json(base_dir: Path, capsys):
+    code, out, _err = _run_poly(
+        ["readiness", "--app-dir", str(base_dir), "--format", "json"],
+        capsys,
+    )
+
+    assert code == 0
+    report = json.loads(out)
+    assert report["schema_version"] == "poly-readiness/v1"
+    assert report["summary"]["channels"] == 2
+    assert any(c["channel"] == "chat" for c in report["channels"])
+
+
 def test_cli_init_scaffolds_channel(copied_base: Path, capsys):
     code, out, _err = _run_poly(
         [

--- a/tests/cxas_scrapi/poly/test_poly_cli.py
+++ b/tests/cxas_scrapi/poly/test_poly_cli.py
@@ -1,0 +1,91 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CLI smoke tests for first-wave poly DX commands."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from cxas_scrapi.cli.main import get_parser
+
+
+def _run_poly(args: list[str], capsys) -> tuple[int, str, str]:
+    parser = get_parser()
+    namespace = parser.parse_args(["poly", *args])
+    with pytest.raises(SystemExit) as exc:
+        namespace.func(namespace)
+    captured = capsys.readouterr()
+    return int(exc.value.code), captured.out, captured.err
+
+
+def test_cli_diff_json(base_dir: Path, capsys):
+    code, out, _err = _run_poly(
+        ["diff", "chat", "--app-dir", str(base_dir), "--json"],
+        capsys,
+    )
+
+    assert code == 0
+    report = json.loads(out)
+    assert report["schema_version"] == "poly-diff/v1"
+    assert report["summary"]["tools_added"] == 1
+
+
+def test_cli_doctor_explains_bad_adapter(copied_base: Path, capsys):
+    (copied_base / "adapters" / "bad.adapter.yaml").write_text(
+        "apiVersion: poly.cxas.dev/v1\n"
+        "kind: ChannelAdapter\n"
+        "metadata: {channel: bad, displayName: Bad}\n"
+        "tools:\n"
+        "  - {agent: Test_Agent, add: [ghost_tool]}\n"
+    )
+
+    code, out, _err = _run_poly(
+        ["doctor", "--app-dir", str(copied_base)],
+        capsys,
+    )
+
+    assert code == 1
+    assert "AD005" in out
+    assert "likely fix" in out
+    assert "adapters/bad.adapter.yaml" in out
+
+
+def test_cli_init_scaffolds_channel(copied_base: Path, capsys):
+    code, out, _err = _run_poly(
+        [
+            "init",
+            "--app-dir",
+            str(copied_base),
+            "--channel",
+            "sms",
+            "--deployment-target",
+            "TWILIO",
+            "--modality",
+            "VOICE_ONLY",
+            "--with-tool",
+            "send_sms_card",
+            "--with-callback",
+            "before_model",
+        ],
+        capsys,
+    )
+
+    assert code == 0
+    assert "adapters/sms.adapter.yaml" in out
+    assert (copied_base / "adapters" / "sms.adapter.yaml").exists()
+    assert (
+        copied_base / "adapters" / "sms_tools" / "send_sms_card"
+    ).is_dir()

--- a/tests/cxas_scrapi/poly/test_readiness.py
+++ b/tests/cxas_scrapi/poly/test_readiness.py
@@ -1,0 +1,84 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for polymorphic project readiness reports."""
+
+import shutil
+from pathlib import Path
+
+from cxas_scrapi.poly.engine import PolymorphismEngine
+from cxas_scrapi.poly.readiness import build_readiness_report
+
+
+def test_readiness_report_marks_clean_channel_ready(base_dir: Path):
+    engine = PolymorphismEngine(str(base_dir))
+    engine.load_base_project()
+    engine.load_adapter_cards()
+
+    report = build_readiness_report(engine, str(base_dir))
+
+    chat = next(c for c in report["channels"] if c["channel"] == "chat")
+    assert report["schema_version"] == "poly-readiness/v1"
+    assert chat["status"] == "ready"
+    assert chat["compiled"] is True
+    assert chat["diff_summary"]["tools_added"] == 1
+    assert chat["eval_coverage"]["evaluations"]["channel_count"] == 1
+    assert chat["next_steps"] == [
+        "Run cxas poly build, lint the compiled output, and run channel evals."
+    ]
+
+
+def test_readiness_report_flags_adapter_without_channel_evals(base_dir: Path):
+    engine = PolymorphismEngine(str(base_dir))
+    engine.load_base_project()
+    engine.load_adapter_cards()
+
+    report = build_readiness_report(engine, str(base_dir))
+
+    voice = next(c for c in report["channels"] if c["channel"] == "voice")
+    assert voice["status"] == "attention"
+    assert any(issue["rule_id"] == "AD006" for issue in voice["issues"])
+    assert any(
+        "channel-specific evaluations" in step
+        for step in voice["next_steps"]
+    )
+
+
+def test_readiness_report_warns_when_channel_eval_reuses_base_name(
+    copied_base: Path,
+):
+    base_eval = copied_base / "evaluations" / "Chat_Test_Eval"
+    base_eval.mkdir(parents=True)
+    shutil.copy2(
+        copied_base
+        / "adapters"
+        / "chat_evals"
+        / "Chat_Test_Eval"
+        / "Chat_Test_Eval.yaml",
+        base_eval / "Chat_Test_Eval.yaml",
+    )
+    engine = PolymorphismEngine(str(copied_base))
+    engine.load_base_project()
+    engine.load_adapter_cards()
+
+    report = build_readiness_report(engine, str(copied_base))
+
+    chat = next(c for c in report["channels"] if c["channel"] == "chat")
+    assert chat["status"] == "attention"
+    assert chat["eval_coverage"]["evaluations"]["duplicate_names"] == [
+        "Chat_Test_Eval"
+    ]
+    assert any(
+        "duplicate evaluation names" in step for step in chat["next_steps"]
+    )

--- a/tests/cxas_scrapi/poly/test_scaffold.py
+++ b/tests/cxas_scrapi/poly/test_scaffold.py
@@ -1,0 +1,101 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for cxas_scrapi.poly.scaffold."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from cxas_scrapi.poly.engine import PolymorphismEngine
+from cxas_scrapi.poly.scaffold import (
+    ScaffoldOptions,
+    build_scaffold_plan,
+    write_scaffold_plan,
+)
+from cxas_scrapi.poly.validators import validate_adapter_card
+
+
+def test_scaffold_writes_valid_adapter_assets(copied_base: Path):
+    plan = build_scaffold_plan(
+        ScaffoldOptions(
+            app_dir=copied_base,
+            channels=["sms"],
+            deployment_target="TWILIO",
+            modality="VOICE_ONLY",
+            tools=["send_sms_card"],
+            callback_types=["before_model"],
+        )
+    )
+
+    written = write_scaffold_plan(plan)
+    rels = {str(path.relative_to(copied_base)) for path in written}
+
+    assert "adapters/sms.adapter.yaml" in rels
+    assert "adapters/sms_evals/Sms_Smoke/Sms_Smoke.yaml" in rels
+    assert "adapters/sms_tools/send_sms_card/send_sms_card.json" in rels
+    assert "adapters/sms_tools/send_sms_card/python_code.py" in rels
+    assert "adapters/sms_callbacks/before_model.py" in rels
+
+    engine = PolymorphismEngine(str(copied_base))
+    engine.load_base_project()
+    engine.load_adapter_cards()
+    card, path = engine.adapters["sms"]
+    assert validate_adapter_card(card, str(copied_base)) == []
+
+    compiled = engine.compile(card, path)
+    assert compiled.deployment["channel_type"] == "TWILIO"
+    assert compiled.deployment["modality"] == "VOICE_ONLY"
+    assert "send_sms_card" in compiled.agents["Test_Agent"]["tools"]
+    assert "send_sms_card" in compiled.tools
+    assert "Sms_Smoke" in compiled.evaluations
+
+
+def test_scaffold_refuses_to_overwrite_existing_files(copied_base: Path):
+    plan = build_scaffold_plan(
+        ScaffoldOptions(app_dir=copied_base, channels=["sms"])
+    )
+    write_scaffold_plan(plan)
+
+    with pytest.raises(FileExistsError):
+        write_scaffold_plan(plan)
+
+
+def test_scaffold_dry_run_does_not_write(copied_base: Path):
+    plan = build_scaffold_plan(
+        ScaffoldOptions(app_dir=copied_base, channels=["sms"])
+    )
+
+    planned = write_scaffold_plan(plan, dry_run=True)
+
+    assert planned
+    assert not (copied_base / "adapters" / "sms.adapter.yaml").exists()
+
+
+def test_scaffold_deployment_none_omits_deployment(copied_base: Path):
+    plan = build_scaffold_plan(
+        ScaffoldOptions(
+            app_dir=copied_base,
+            channels=["chatbot"],
+            deployment_target="none",
+        )
+    )
+
+    adapter_file = next(
+        file for file in plan.files if file.path.name == "chatbot.adapter.yaml"
+    )
+    adapter = yaml.safe_load(adapter_file.content)
+
+    assert "deployment" not in adapter

--- a/tests/cxas_scrapi/poly/test_validators.py
+++ b/tests/cxas_scrapi/poly/test_validators.py
@@ -1,0 +1,141 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for cxas_scrapi.poly.validators (AD001-AD007)."""
+
+from pathlib import Path
+
+from cxas_scrapi.poly.models import AdapterCard
+from cxas_scrapi.poly.validators import (
+    validate_adapter_card,
+    validate_all_adapters,
+)
+
+
+def _card(**overrides) -> AdapterCard:
+    data = {
+        "apiVersion": "v1",
+        "kind": "ChannelAdapter",
+        "metadata": {"channel": "chat", "displayName": "Chat"},
+        "evaluations": [{"sourceDir": "adapters/chat_evals"}],
+    }
+    data.update(overrides)
+    return AdapterCard.model_validate(data)
+
+
+def _ids(issues) -> set:
+    return {i["rule_id"] for i in issues}
+
+
+def test_valid_chat_adapter_passes(base_dir: Path):
+    card = _card(
+        instructionDiffs=[
+            {"agent": "Test_Agent", "mode": "append", "content": "x"}
+        ],
+        tools=[{"agent": "Test_Agent", "add": ["test_tool"]}],
+    )
+    issues = validate_adapter_card(card, str(base_dir))
+    assert issues == []
+
+
+def test_ad002_missing_agent(base_dir: Path):
+    card = _card(
+        instructionDiffs=[
+            {"agent": "Nonexistent", "mode": "append", "content": "x"}
+        ]
+    )
+    issues = validate_adapter_card(card, str(base_dir))
+    assert "AD002" in _ids(issues)
+    assert any("Nonexistent" in i["message"] for i in issues)
+
+
+def test_ad003_replace_section_missing_tag(base_dir: Path):
+    card = _card(
+        instructionDiffs=[
+            {
+                "agent": "Test_Agent",
+                "mode": "replace_section",
+                "sectionTag": "does_not_exist",
+                "content": "x",
+            }
+        ]
+    )
+    issues = validate_adapter_card(card, str(base_dir))
+    assert "AD003" in _ids(issues)
+
+
+def test_ad003_replace_section_present_tag_ok(base_dir: Path):
+    card = _card(
+        instructionDiffs=[
+            {
+                "agent": "Test_Agent",
+                "mode": "replace_section",
+                "sectionTag": "channel_behavior",
+                "content": "x",
+            }
+        ]
+    )
+    issues = validate_adapter_card(card, str(base_dir))
+    assert "AD003" not in _ids(issues)
+
+
+def test_ad004_remove_unknown_tool_warns(base_dir: Path):
+    card = _card(tools=[{"agent": "Test_Agent", "remove": ["not_a_tool"]}])
+    issues = validate_adapter_card(card, str(base_dir))
+    ad004 = [i for i in issues if i["rule_id"] == "AD004"]
+    assert ad004 and ad004[0]["severity"] == "warning"
+
+
+def test_ad005_add_undefined_tool_errors(base_dir: Path):
+    card = _card(tools=[{"agent": "Test_Agent", "add": ["ghost_tool"]}])
+    issues = validate_adapter_card(card, str(base_dir))
+    ad005 = [i for i in issues if i["rule_id"] == "AD005"]
+    assert ad005 and ad005[0]["severity"] == "error"
+
+
+def test_ad005_add_tool_with_definition_ok(base_dir: Path):
+    card = _card(
+        tools=[{"agent": "Test_Agent", "add": ["brand_new"]}],
+        toolDefinitions=[
+            {
+                "displayName": "brand_new",
+                "toolType": "python",
+                "sourceDir": "adapters/chat_tools/extra_tool",
+            }
+        ],
+    )
+    issues = validate_adapter_card(card, str(base_dir))
+    assert "AD005" not in _ids(issues)
+
+
+def test_ad006_no_evaluations_warns(base_dir: Path):
+    card = _card(evaluations=[])
+    issues = validate_adapter_card(card, str(base_dir))
+    ad006 = [i for i in issues if i["rule_id"] == "AD006"]
+    assert ad006 and ad006[0]["severity"] == "warning"
+
+
+def test_ad007_duplicate_channel(base_dir: Path):
+    a = _card()
+    b = _card()  # same channel "chat"
+    issues = validate_all_adapters([a, b], str(base_dir))
+    ad007 = [i for i in issues if i["rule_id"] == "AD007"]
+    assert ad007 and ad007[0]["severity"] == "error"
+
+
+def test_ad007_distinct_channels_ok(base_dir: Path):
+    a = _card()
+    b = _card(metadata={"channel": "voice", "displayName": "Voice"})
+    issues = validate_all_adapters([a, b], str(base_dir))
+    assert "AD007" not in _ids(issues)

--- a/tests/cxas_scrapi/poly/test_validators.py
+++ b/tests/cxas_scrapi/poly/test_validators.py
@@ -139,3 +139,122 @@ def test_ad007_distinct_channels_ok(base_dir: Path):
     b = _card(metadata={"channel": "voice", "displayName": "Voice"})
     issues = validate_all_adapters([a, b], str(base_dir))
     assert "AD007" not in _ids(issues)
+
+
+def test_ad005_platform_tool_add_ok(base_dir: Path):
+    card = _card(tools=[{"agent": "Test_Agent", "add": ["customize_response"]}])
+    issues = validate_adapter_card(card, str(base_dir))
+    assert "AD005" not in _ids(issues)
+
+
+def test_ad005_missing_callback_source(base_dir: Path):
+    card = _card(
+        callbacks=[
+            {
+                "agent": "Test_Agent",
+                "type": "before_model",
+                "pythonCode": "adapters/chat_callbacks/nope.py",
+            }
+        ]
+    )
+    issues = validate_adapter_card(card, str(base_dir))
+    assert any(
+        i["rule_id"] == "AD005" and "pythonCode" in i["message"] for i in issues
+    )
+
+
+def test_ad005_missing_eval_sourcedir(base_dir: Path):
+    card = _card(evaluations=[{"sourceDir": "adapters/does_not_exist"}])
+    issues = validate_adapter_card(card, str(base_dir))
+    assert any(
+        i["rule_id"] == "AD005" and "evaluations" in i["message"]
+        for i in issues
+    )
+
+
+def test_ad008_path_escapes_project(base_dir: Path):
+    card = _card(
+        callbacks=[
+            {
+                "agent": "Test_Agent",
+                "type": "before_model",
+                "pythonCode": "../../../../etc/passwd",
+            }
+        ]
+    )
+    issues = validate_adapter_card(card, str(base_dir))
+    ad008 = [i for i in issues if i["rule_id"] == "AD008"]
+    assert ad008 and ad008[0]["severity"] == "error"
+
+
+def test_ad009_invalid_channel_type(base_dir: Path):
+    card = _card(deployment={"channelType": "NOT_A_CHANNEL"})
+    issues = validate_adapter_card(card, str(base_dir))
+    assert any(
+        i["rule_id"] == "AD009" and "channelType" in i["message"]
+        for i in issues
+    )
+
+
+def test_ad009_invalid_modality(base_dir: Path):
+    card = _card(deployment={"modality": "SUPER_HD"})
+    issues = validate_adapter_card(card, str(base_dir))
+    assert any(
+        i["rule_id"] == "AD009" and "modality" in i["message"] for i in issues
+    )
+
+
+def test_ad009_valid_deployment_ok(base_dir: Path):
+    card = _card(
+        deployment={
+            "channelType": "WEB_UI",
+            "modality": "CHAT_ONLY",
+            "webWidgetConfig": {"theme": "LIGHT"},
+        }
+    )
+    issues = validate_adapter_card(card, str(base_dir))
+    assert "AD009" not in _ids(issues)
+
+
+def test_ad010_unsupported_tool_type(base_dir: Path):
+    card = _card(
+        tools=[{"agent": "Test_Agent", "add": ["x"]}],
+        toolDefinitions=[
+            {
+                "displayName": "x",
+                "toolType": "wasm",
+                "sourceDir": "adapters/chat_tools/extra_tool",
+            }
+        ],
+    )
+    issues = validate_adapter_card(card, str(base_dir))
+    assert any(
+        i["rule_id"] == "AD010" and "wasm" in i["message"] for i in issues
+    )
+
+
+def test_replace_section_with_attributes_passes(copied_base: Path):
+    inst = copied_base / "agents" / "Test_Agent" / "instruction.txt"
+    inst.write_text(
+        inst.read_text().replace(
+            "<channel_behavior>", '<channel_behavior priority="high">'
+        )
+    )
+    card = AdapterCard.model_validate(
+        {
+            "apiVersion": "v1",
+            "kind": "ChannelAdapter",
+            "metadata": {"channel": "chat", "displayName": "Chat"},
+            "instructionDiffs": [
+                {
+                    "agent": "Test_Agent",
+                    "mode": "replace_section",
+                    "sectionTag": "channel_behavior",
+                    "content": "x",
+                }
+            ],
+            "evaluations": [{"sourceDir": "adapters/chat_evals"}],
+        }
+    )
+    issues = validate_adapter_card(card, str(copied_base))
+    assert "AD003" not in _ids(issues)

--- a/tests/testdata/poly/base/adapters/chat.adapter.yaml
+++ b/tests/testdata/poly/base/adapters/chat.adapter.yaml
@@ -1,0 +1,42 @@
+apiVersion: poly.cxas.dev/v1
+kind: ChannelAdapter
+metadata:
+  channel: chat
+  displayName: Test Chat Adapter
+  description: Chat adapter for the poly engine test fixture.
+
+instructionDiffs:
+  - agent: Test_Agent
+    mode: append
+    content: |
+      Chat-specific: use markdown and numbered lists.
+
+tools:
+  - agent: Test_Agent
+    add:
+      - extra_tool
+
+toolDefinitions:
+  - displayName: extra_tool
+    toolType: python
+    sourceDir: adapters/chat_tools/extra_tool
+
+modelOverrides:
+  - agent: Test_Agent
+    model: gemini-3-pro
+
+callbacks:
+  - agent: Test_Agent
+    type: before_model
+    pythonCode: adapters/chat_callbacks/inject_context.py
+    description: Chat-only context injection.
+
+evaluations:
+  - sourceDir: adapters/chat_evals
+
+deployment:
+  channelType: WEB_UI
+  modality: CHAT_ONLY
+  webWidgetConfig:
+    theme: LIGHT
+    webWidgetTitle: Test Chat

--- a/tests/testdata/poly/base/adapters/chat_callbacks/inject_context.py
+++ b/tests/testdata/poly/base/adapters/chat_callbacks/inject_context.py
@@ -1,0 +1,3 @@
+def before_model_callback(callback_context, llm_request):
+    """Chat-only before-model callback (test stub)."""
+    return None

--- a/tests/testdata/poly/base/adapters/chat_evals/Chat_Test_Eval/Chat_Test_Eval.yaml
+++ b/tests/testdata/poly/base/adapters/chat_evals/Chat_Test_Eval/Chat_Test_Eval.yaml
@@ -1,0 +1,12 @@
+displayName: Chat Test Eval
+description: Chat-only evaluation used by the poly engine test fixture.
+tags:
+  - poly
+  - chat
+golden:
+  turns:
+    - steps:
+        - userInput:
+            text: hi
+        - expectation:
+            note: Check_Chat_Greeting

--- a/tests/testdata/poly/base/adapters/chat_tools/extra_tool/extra_tool.json
+++ b/tests/testdata/poly/base/adapters/chat_tools/extra_tool/extra_tool.json
@@ -1,0 +1,9 @@
+{
+  "name": "00000000-0000-0000-0000-000000000004",
+  "displayName": "extra_tool",
+  "pythonFunction": {
+    "name": "extra_tool",
+    "pythonCode": "tools/extra_tool/python_function/python_code.py",
+    "description": "A chat-only extra tool."
+  }
+}

--- a/tests/testdata/poly/base/adapters/chat_tools/extra_tool/python_code.py
+++ b/tests/testdata/poly/base/adapters/chat_tools/extra_tool/python_code.py
@@ -1,0 +1,3 @@
+def extra_tool() -> dict:
+    """A chat-only extra tool."""
+    return {"ok": True}

--- a/tests/testdata/poly/base/adapters/voice.adapter.yaml
+++ b/tests/testdata/poly/base/adapters/voice.adapter.yaml
@@ -1,0 +1,30 @@
+apiVersion: poly.cxas.dev/v1
+kind: ChannelAdapter
+metadata:
+  channel: voice
+  displayName: Test Voice Adapter
+  description: Voice adapter for the poly engine test fixture.
+
+instructionDiffs:
+  - agent: Test_Agent
+    mode: replace_section
+    sectionTag: channel_behavior
+    content: |
+      Voice channel: keep responses short, no markdown, spell out numbers.
+
+tools:
+  - agent: Test_Agent
+    remove:
+      - test_tool
+
+callbacks:
+  - agent: Test_Agent
+    type: before_model
+    pythonCode: adapters/voice_callbacks/voice_pacing.py
+    description: Voice pacing hints.
+
+deployment:
+  channelType: GOOGLE_TELEPHONY_PLATFORM
+  modality: VOICE_ONLY
+  disableDtmf: false
+  disableBargeInControl: false

--- a/tests/testdata/poly/base/adapters/voice_callbacks/voice_pacing.py
+++ b/tests/testdata/poly/base/adapters/voice_callbacks/voice_pacing.py
@@ -1,0 +1,3 @@
+def before_model_callback(callback_context, llm_request):
+    """Voice-only before-model callback (test stub)."""
+    return None

--- a/tests/testdata/poly/base/agents/Test_Agent/Test_Agent.json
+++ b/tests/testdata/poly/base/agents/Test_Agent/Test_Agent.json
@@ -1,0 +1,12 @@
+{
+  "name": "00000000-0000-0000-0000-000000000002",
+  "displayName": "Test_Agent",
+  "instruction": "agents/Test_Agent/instruction.txt",
+  "tools": ["test_tool", "end_session"],
+  "beforeModelCallbacks": [
+    {
+      "pythonCode": "agents/Test_Agent/before_model_callbacks/before_model_callbacks_01/python_code.py",
+      "description": "Base before-model callback"
+    }
+  ]
+}

--- a/tests/testdata/poly/base/agents/Test_Agent/before_model_callbacks/before_model_callbacks_01/python_code.py
+++ b/tests/testdata/poly/base/agents/Test_Agent/before_model_callbacks/before_model_callbacks_01/python_code.py
@@ -1,0 +1,3 @@
+def before_model_callback(callback_context, llm_request):
+    """Base before-model callback (no-op)."""
+    return None

--- a/tests/testdata/poly/base/agents/Test_Agent/instruction.txt
+++ b/tests/testdata/poly/base/agents/Test_Agent/instruction.txt
@@ -1,0 +1,7 @@
+You are a test agent.
+
+<channel_behavior>
+Default channel behavior here.
+</channel_behavior>
+
+Always be helpful.

--- a/tests/testdata/poly/base/app.json
+++ b/tests/testdata/poly/base/app.json
@@ -1,0 +1,5 @@
+{
+  "name": "00000000-0000-0000-0000-000000000001",
+  "displayName": "Poly Test App",
+  "rootAgent": "Test_Agent"
+}

--- a/tests/testdata/poly/base/gecx-config.json
+++ b/tests/testdata/poly/base/gecx-config.json
@@ -1,0 +1,9 @@
+{
+  "gcp_project_id": "<YOUR_GCP_PROJECT_ID>",
+  "location": "<YOUR_GCP_REGION>",
+  "app_name": "poly-test",
+  "deployed_app_id": "<YOUR_DEPLOYED_APP_ID>",
+  "model": "gemini-3-flash",
+  "modality": "text",
+  "default_channel": "text"
+}

--- a/tests/testdata/poly/base/tools/test_tool/python_function/python_code.py
+++ b/tests/testdata/poly/base/tools/test_tool/python_function/python_code.py
@@ -1,0 +1,3 @@
+def test_tool() -> dict:
+    """A test tool that does nothing."""
+    return {"ok": True}

--- a/tests/testdata/poly/base/tools/test_tool/test_tool.json
+++ b/tests/testdata/poly/base/tools/test_tool/test_tool.json
@@ -1,0 +1,9 @@
+{
+  "name": "00000000-0000-0000-0000-000000000003",
+  "displayName": "test_tool",
+  "pythonFunction": {
+    "name": "test_tool",
+    "pythonCode": "tools/test_tool/python_function/python_code.py",
+    "description": "A test tool that does nothing."
+  }
+}


### PR DESCRIPTION
## Summary
- Add `cxas poly readiness` as a pre-build launch/design-partner report for polymorphic projects.
- Compose existing AD validation, compileability, `poly-diff/v1` summaries, eval coverage counts, duplicate eval-name warnings, and channel-specific next steps into text and `poly-readiness/v1` JSON output.
- Update README, CLI docs, guide/pattern docs, and include PRD gap/planning artifacts for the launch-readiness slice.

## Why
The PRD's V1 primitives are mostly present, but the workflow lacked a single artifact that tells design partners whether a project is launch-ready before build/lint/eval/deploy. This closes that gap without changing the build-time-only adapter contract or adding unsupported adapter-card fields.

## Validation
- `git diff --check`
- `uv run --with-editable . --with alive-progress ruff check src/cxas_scrapi/poly src/cxas_scrapi/cli/poly_cli.py tests/cxas_scrapi/poly`
- `uv run --with-editable . --with alive-progress pytest tests/cxas_scrapi/poly -q` (89 passed, 1 existing pytest config warning)
- `uv run --with-editable . --with alive-progress cxas poly readiness --app-dir examples/bella_notte`
- `uv run --with-editable . --with alive-progress cxas poly readiness --app-dir examples/bella_notte --format json`
- `uv run --with-editable . --with alive-progress cxas poly validate --app-dir examples/bella_notte`
- `uv run --with-editable . --with alive-progress cxas poly doctor --app-dir examples/bella_notte`
- `uv run --with-editable . --with alive-progress cxas poly diff chat --app-dir examples/bella_notte --json`
- `uv run --with-editable . --with alive-progress cxas poly build --app-dir examples/bella_notte --output-dir /tmp/poly_prd_alignment_build_c72c_readiness_20260522`
- `uv run --with-editable . --with alive-progress cxas lint --app-dir /tmp/poly_prd_alignment_build_c72c_readiness_20260522/chat`
- `uv run --with-editable . --with alive-progress cxas lint --app-dir /tmp/poly_prd_alignment_build_c72c_readiness_20260522/voice`
