### PR TITLE
feat(bella_notte): structured logging, config validation, then_direct…

### DIFF
--- a/examples/bella_notte/agents/Bella_Notte_Host/before_model_callbacks/before_model_callbacks_01/python_code.py
+++ b/examples/bella_notte/agents/Bella_Notte_Host/before_model_callbacks/before_model_callbacks_01/python_code.py
@@ -1,25 +1,481 @@
 # pylint: disable=invalid-name,undefined-variable,unused-argument,broad-exception-caught,line-too-long
-"""Before-model callback — transfer orchestration.
+"""Before-model callback — DAG engine orchestration.
 
-Hides transfer_to_agent so the LLM uses set_active_flow instead.
-When set_active_flow's after_tool_callback sets _pending_transfer,
-this callback fires the agent transfer deterministically.
+FRAMEWORK CODE — fully generic across all agents.
+Config-driven: reads config_id from state (set by before_agent),
+bootstrap/gate from {config_id}_dag (stashed in SM on first load).
 """
-
+import json as json_lib
+import logging
+import re
 from typing import Optional
+
+
+_SM_KEY = "sm"
+
+_RAW_CONFIGS = {}
+_CROSS_VALIDATED = False
+
+_FRAMEWORK_SENTINEL = "<!-- slot-framework -->"
+
+_EVENT_TAG_PATTERN = re.compile(r"<event>(.*?)</event>")
+
+_TRANSFER_MARKERS = ("transfer_to_agent", "<context>", "</context>")
+
+_LEVEL_MAP = {"DEBUG": logging.DEBUG, "INFO": logging.INFO,
+              "WARN": logging.WARNING, "ERROR": logging.ERROR}
+_LEVEL_ORDER = {"DEBUG": 0, "INFO": 1, "WARN": 2, "ERROR": 3}
+_logger = logging.getLogger("slot_filling.before_model")
+
+
+def _log(sm, tag, level="INFO", **data):
+  """Emit structured log entry; append to sm["_log"].
+
+  Args:
+    sm: Session state machine dict (callback_context.state).
+    tag: Short label identifying the log event.
+    level: Severity — DEBUG, INFO, WARN, or ERROR.
+    **data: Arbitrary key-value payload for the log entry.
+  """
+  min_level = sm.get("_log_level", "INFO")
+  if _LEVEL_ORDER.get(level, 1) < _LEVEL_ORDER.get(min_level, 1):
+    return
+  entry = {"src": "before_model", "tag": tag, "level": level,
+           "data": {k: v for k, v in data.items() if v is not None}}
+  _logger.log(_LEVEL_MAP.get(level, logging.INFO),
+              json_lib.dumps(entry, default=str))
+  sm.setdefault("_log", []).append(entry)
+
+
+def _is_real_user_text(txt):
+  """Filter out CES transfer markers and empty strings."""
+  stripped = txt.strip()
+  if not stripped:
+    return False
+  for marker in _TRANSFER_MARKERS:
+    if marker in stripped:
+      return False
+  return True
+
+
+def _probe_available_tools(raw, tools):
+  """Probe the CES runtime to find which config-referenced tools exist.
+
+  CES's tools object supports hasattr/getattr but not dir(), so we
+  extract every tool name referenced in the DAG config (setters, task
+  tools, bootstrap tool) and check each one individually.
+
+  Args:
+    raw: The raw DAG config dict.
+    tools: CES runtime tools object.
+
+  Returns:
+    Tuple of (available, missing) — both sorted lists of tool name strings.
+  """
+  referenced = set()
+  for s in raw.get("slots", []):
+    if s.get("setter"):
+      referenced.add(s["setter"])
+  for t in raw.get("tasks", []):
+    if t.get("tool"):
+      referenced.add(t["tool"])
+  bstrap = raw.get("bootstrap", {})
+  if isinstance(bstrap, dict) and bstrap.get("tool"):
+    referenced.add(bstrap["tool"])
+  available = sorted(n for n in referenced if hasattr(tools, n))
+  missing = sorted(referenced - set(available))
+  return available, missing
+
+
+_READBACK_BLOCK = """\
+<readback_protocol>
+After calling setter tools, the values in <readback_scope> below need
+your confirmation with the guest before continuing.
+
+Read back the pending values naturally in one sentence and ask
+"Is that correct?" Use digits for numbers. Then STOP — do not ask
+any new questions or move to the next topic.
+
+- "yes" → call confirm_pending
+- "no" without correction → call reject_pending
+- User corrects or adds info → call the appropriate setter first
+
+Always capture new information, even alongside a yes/no.
+</readback_protocol>"""
+
+
+def _make_collection_block(
+    tool_selection: str, slot_ordering: str, prereq_note: str = "",
+) -> str:
+  ts = tool_selection or (
+      "   (Determine the correct setter from tool names and descriptions.)"
+  )
+  ordering = slot_ordering or "natural order"
+  prereq = prereq_note
+  return f"""\
+<slot_filling_protocol>
+1. CALL TOOLS FIRST: After each user message, call ALL matching setter tools
+   BEFORE generating text. Never defer a setter call when info is available.
+   Call setters even for invalid input — the system validates automatically.
+   Look at the FULL conversation — if the user already provided information
+   that maps to an unfilled slot, call the setter now. Do not re-ask.
+
+2. NEXT STEP: If a system directive appears below, it describes the next
+   needed value. If the conversation already contains enough information
+   to determine that value, call the setter tool directly — do not ask
+   the user to repeat themselves. Otherwise, rephrase the directive in
+   your own words to ask the user.
+
+3. TOOL SELECTION:
+{ts}
+
+4. ORDERING: {ordering}. Accept info out of order.{f' {prereq}' if prereq else ''}
+</slot_filling_protocol>"""
+
+
+def _build_phase_suffix(sm, result):
+  """Build minimal phase-specific SI suffix from engine result."""
+  status = sm.get("status", "in_progress")
+  if status in ("complete", "escalated"):
+    return ""
+
+  si_suffix = result.get("si_suffix", "")
+  msg = result.get("message", "")
+  inline_confirmed = result.get("inline_confirmed", False)
+  event_prefilled = result.get("event_prefilled", False)
+  has_readback = "<readback_scope>" in si_suffix
+  has_pending = bool(sm.get("pending"))
+
+  parts = []
+
+  if (has_readback or has_pending) and not inline_confirmed:
+    parts.append(_READBACK_BLOCK)
+    if si_suffix:
+      parts.append(si_suffix)
+  else:
+    parts.append(_make_collection_block(
+        sm.get("_tool_selection", ""),
+        sm.get("_slot_ordering", ""),
+        sm.get("_prereq_note", ""),
+    ))
+    if si_suffix:
+      parts.append(si_suffix)
+
+    if event_prefilled and si_suffix:
+      if "<system_directive>" not in "\n".join(parts):
+        parts.append(si_suffix)
+
+    if msg and "<system_directive>" not in "\n".join(parts):
+      parts.append(
+          f"\n<system_directive>\n{msg}\n</system_directive>"
+      )
+
+  steer_directive = result.get("steer_back_directive", "")
+  if steer_directive:
+    parts.append(f"\n<steer_back>\n{steer_directive}\n</steer_back>")
+
+  return "\n".join(parts)
+
+
+def _inject_phase_suffix(llm_request, phase_suffix):
+  """Replace any previous framework suffix with the new one."""
+  sentinel_suffix = f"\n\n{_FRAMEWORK_SENTINEL}\n{phase_suffix}"
+  si = llm_request.config.system_instruction
+  if si:
+    if hasattr(si, "parts") and si.parts:
+      text = si.parts[0].text or ""
+      idx = text.find(_FRAMEWORK_SENTINEL)
+      if idx >= 0:
+        text = text[:idx]
+      si.parts[0].text = text + sentinel_suffix
+    elif isinstance(si, str):
+      idx = si.find(_FRAMEWORK_SENTINEL)
+      if idx >= 0:
+        si = si[:idx]
+      llm_request.config.system_instruction = si + sentinel_suffix
 
 
 def before_model_callback(
     callback_context: CallbackContext,
     llm_request: LlmRequest,
 ) -> Optional[LlmResponse]:
-  """Hide transfer_to_agent; fire pending transfers."""
+  """CES entry point: run DAG engine before each LLM call."""
+  llm_request.config.hide_tool("slot_filling_engine")
   llm_request.config.hide_tool("transfer_to_agent")
+
+  sm = callback_context.state.get(_SM_KEY, {})
 
   agent = callback_context.state.pop("_pending_transfer", "")
   if agent:
+    _log(sm, "transfer_dispatched", agent=agent)
+    callback_context.state[_SM_KEY] = sm
     return LlmResponse.from_parts(
         parts=[Part.from_agent_transfer(agent=agent)],
     )
+
+  # ── Resolve config_id from state (set by before_agent) ──────
+  config_id = callback_context.state.get("_active_config_id")
+  if not config_id:
+    return {"decision": "OK"}
+
+  llm_request.config.hide_tool(f"{config_id}_dag")
+  llm_request.config.hide_tool("validate_dag_config")
+
+  # ── Load raw config (cached per config_id) ─────────────────
+  global _CROSS_VALIDATED  # pylint: disable=global-statement
+  if config_id not in _RAW_CONFIGS:
+    dag_tool = getattr(tools, f"{config_id}_dag")
+    _RAW_CONFIGS[config_id] = dag_tool({}).json()["result"]
+    raw = _RAW_CONFIGS[config_id]
+    _log(sm, "config_loaded", config_id=config_id,
+         n_slots=len(raw.get("slots", [])),
+         n_tasks=len(raw.get("tasks", [])))
+    available, missing = _probe_available_tools(raw, tools)
+    if missing:
+      _log(sm, "missing_tools", "WARN", missing=missing)
+    v = tools.validate_dag_config(
+        {"input_data": {"raw_config": raw, "available_tools": available}},
+    ).json()["result"]
+    if not v["valid"]:
+      _log(sm, "config_validation_failed", "ERROR", errors=v["errors"])
+    if not _CROSS_VALIDATED:
+      try:
+        config_map = json_lib.loads(
+            callback_context.state.get("agent_config_map", "{}"))
+        all_ids = set(config_map.values())
+        if all_ids and all_ids <= set(_RAW_CONFIGS):
+          cross = tools.validate_dag_config(
+              {"input_data": {"all_configs": {
+                  cid: _RAW_CONFIGS[cid] for cid in all_ids
+              }}},
+          ).json()["result"]
+          if not cross.get("cross_config", {}).get("valid", True):
+            _log(sm, "cross_config_validation_failed", "ERROR",
+                 errors=cross["cross_config"]["errors"])
+          _CROSS_VALIDATED = True
+      except Exception:  # pylint: disable=broad-except
+        pass
+  raw_config = _RAW_CONFIGS[config_id]
+
+  if sm.get("_config_id") != config_id:
+    sm["_config_id"] = config_id
+    sm["_first_engine_run"] = True
+    sm["_bootstrap"] = raw_config.get("bootstrap")
+    sm["_gate_slot"] = raw_config.get("gate_slot")
+    setter_slots = {}
+    multi_setter_slots = {}
+    slot_requires = {}
+    slot_validates = {}
+    for slot_def in raw_config.get("slots", []):
+      setter = slot_def.get("setter")
+      setter_field = slot_def.get("setter_field")
+      if setter:
+        if setter_field:
+          multi_setter_slots.setdefault(
+              setter, {},
+          )[setter_field] = slot_def["name"]
+        else:
+          setter_slots[setter] = slot_def["name"]
+      if slot_def.get("requires"):
+        slot_requires[slot_def["name"]] = slot_def["requires"]
+      if slot_def.get("validate_against"):
+        slot_validates[slot_def["name"]] = slot_def["validate_against"]
+    sm["_setter_slots"] = setter_slots
+    sm["_multi_setter_slots"] = multi_setter_slots
+    sm["_slot_requires"] = slot_requires
+    sm["_slot_validates"] = slot_validates
+    executor_tasks = {}
+    for task_def in raw_config.get("tasks", []):
+      tool_name = task_def.get("tool")
+      if tool_name:
+        executor_tasks[tool_name] = {
+            "task_name": task_def["name"],
+            "outputs": task_def.get("outputs", {}),
+            "success_check": task_def.get("success_check", "success"),
+            "terminal": task_def.get("terminal", False),
+        }
+    sm["_executor_tasks"] = executor_tasks
+  callback_context.state[_SM_KEY] = sm
+
+  # ── Gate: skip engine until gate_slot is filled ─────────────
+  gate_slot = raw_config.get("gate_slot")
+  if gate_slot and not sm.get("filled", {}).get(gate_slot):
+    _log(sm, "gate_active", "DEBUG", config_id=config_id, gate_slot=gate_slot)
+    if llm_request.contents:
+      for content in reversed(llm_request.contents):
+        if getattr(content, "role", "") == "user":
+          for part in getattr(content, "parts", []):
+            txt = getattr(part, "text", "")
+            if _is_real_user_text(txt):
+              callback_context.state["_gate_user_text"] = txt
+              break
+          if callback_context.state.get("_gate_user_text"):
+            break
+    ts_lines = []
+    for slot_def in raw_config.get("slots", []):
+      setter = slot_def.get("setter")
+      hint = slot_def.get("hint", slot_def["name"])
+      if setter:
+        ts_lines.append(f"   - {hint} → {setter}")
+    ts = "\n".join(ts_lines)
+    phase_suffix = _make_collection_block(ts, "", "")
+    _inject_phase_suffix(llm_request, phase_suffix)
+    llm_request.config.hide_tool("end_session")
+    return {"decision": "OK"}
+
+  if sm.get("status") in ("complete", "escalated"):
+    return {"decision": "OK"}
+
+  # Flow active — only the engine can end the session (via preemption)
+  llm_request.config.hide_tool("end_session")
+
+  # ── Transfer slots: read structured data from Root Agent ───
+  transfer_slots = callback_context.state.get("_transfer_slots", {})
+  if transfer_slots and raw_config:
+    filled = sm.get("filled", {})
+    consumed = []
+    for slot_def in raw_config.get("slots", []):
+      sn = slot_def["name"]
+      if sn not in transfer_slots:
+        continue
+      if sn in filled or sn in sm.get("pending", {}):
+        consumed.append(sn)
+        continue
+      cond_str = slot_def.get("condition")
+      if cond_str:
+        try:
+          if not eval(cond_str)(filled):  # pylint: disable=eval-used
+            continue
+        except Exception:  # pylint: disable=broad-except
+          continue
+      sm.setdefault("pending", {})[sn] = transfer_slots[sn]
+      consumed.append(sn)
+    if consumed:
+      _log(sm, "transfer_slots_consumed", slots=consumed)
+    for sn in consumed:
+      transfer_slots.pop(sn, None)
+    if not transfer_slots:
+      callback_context.state.pop("_transfer_slots", None)
+    else:
+      callback_context.state["_transfer_slots"] = transfer_slots
+
+  last_user_text = ""
+  if llm_request.contents:
+    last_content = llm_request.contents[-1]
+    if getattr(last_content, "role", "") == "user":
+      for part in getattr(last_content, "parts", []):
+        txt = getattr(part, "text", "")
+        if txt:
+          last_user_text = txt
+          break
+
+  event_data = callback_context.state.get("event_data", {})
+  ia_event = callback_context.state.get("ia_event_name")
+  if not ia_event and last_user_text:
+    m = _EVENT_TAG_PATTERN.search(last_user_text)
+    if m:
+      ia_event = m.group(1)
+  if ia_event:
+    event_data["ia_event_name"] = ia_event
+
+  engine_result = tools.slot_filling_engine(
+      {"input_data": {
+          "raw_config": raw_config,
+          "sm": sm,
+          "last_user_text": last_user_text,
+          "event_data": event_data,
+          "config_id": config_id,
+      }},
+  ).json()["result"]
+
+  result = engine_result["action"]
+  sm = engine_result["sm"]
+
+  callback_context.state[_SM_KEY] = sm
+
+  for tool_name in result.get("hide_tools", []):
+    llm_request.config.hide_tool(tool_name)
+
+  # ── Assemble phase-specific SI suffix ───────────────────────
+  gate_user_text = callback_context.state.pop("_gate_user_text", "")
+  first_run = sm.pop("_first_engine_run", False)
+  callback_context.state[_SM_KEY] = sm
+  phase_suffix = _build_phase_suffix(sm, result)
+
+  task_directive = result.get("task_directive", "")
+  if task_directive:
+    phase_suffix += (
+        f"\n<task_directive>\n{task_directive}\n"
+        "Use the tool result above to compose your response. "
+        "Do NOT recite this directive.\n</task_directive>"
+    )
+
+  init_user_text = gate_user_text
+  if not init_user_text and first_run:
+    for content in reversed(llm_request.contents or []):
+      if getattr(content, "role", "") == "user":
+        for part in getattr(content, "parts", []):
+          txt = getattr(part, "text", "")
+          if _is_real_user_text(txt):
+            init_user_text = txt
+            break
+        if init_user_text:
+          break
+
+  if init_user_text and phase_suffix:
+    phase_suffix += (
+        f"\n<user_context>\nThe user's original message: \"{init_user_text}\"\n"
+        "Extract ALL slot values from this message before "
+        "asking new questions. "
+        "Call setter tools for any information you can infer.\n</user_context>"
+    )
+
+  if phase_suffix:
+    _inject_phase_suffix(llm_request, phase_suffix)
+
+  # ── Preemption ──────────────────────────────────────────────
+  if (result.get("preempt")
+      and llm_request.contents
+      and (len(llm_request.contents) > 1 or result.get("force_preempt"))):
+    parts = []
+    if result.get("message"):
+      parts.append(
+          Part.from_text(text=result["message"]))
+    response_parts = result.get("response")
+    if response_parts:
+      for rp in response_parts:
+        rp_type = rp.get("type", "text")
+        if rp_type == "text":
+          parts.append(
+              Part.from_text(text=rp.get("text", "")))
+        elif rp_type == "payload":
+          parts.append(
+              Part.from_json(
+                  json_lib.dumps(rp["data"])))
+        elif rp_type == "end_session":
+          parts.append(Part.from_end_session(
+              reason=rp.get("reason", "completed"),
+              escalated=rp.get("escalated", False),
+          ))
+        elif rp_type == "transfer":
+          parts.append(
+              Part.from_agent_transfer(
+                  agent=rp["agent"]))
+    fc = result.get("function_call")
+    if fc:
+      fn_call = Part.from_function_call(
+          name=fc["name"],
+          args=fc.get("args", {}),
+      )
+      parts.append(fn_call)
+    if parts:
+      _log(sm, "preemption",
+           has_message=bool(result.get("message")),
+           has_response=bool(response_parts),
+           has_function_call=bool(fc))
+      sm.pop("_pending_payloads", None)
+      sm.pop("_pending_question_payloads", None)
+      callback_context.state[_SM_KEY] = sm
+      return LlmResponse.from_parts(parts=parts)
 
   return {"decision": "OK"}

--- a/examples/bella_notte/agents/Reservation_Agent/after_model_callbacks/after_model_callbacks_01/python_code.py
+++ b/examples/bella_notte/agents/Reservation_Agent/after_model_callbacks/after_model_callbacks_01/python_code.py
@@ -6,10 +6,35 @@ Only _SM_KEY differs between agents.
 """
 
 import json as json_lib
+import logging
 from typing import Optional
 
 
 _SM_KEY = "sm"
+
+_LEVEL_MAP = {"DEBUG": logging.DEBUG, "INFO": logging.INFO,
+              "WARN": logging.WARNING, "ERROR": logging.ERROR}
+_LEVEL_ORDER = {"DEBUG": 0, "INFO": 1, "WARN": 2, "ERROR": 3}
+_logger = logging.getLogger("slot_filling.after_model")
+
+
+def _log(sm, tag, level="INFO", **data):
+  """Emit structured log entry; append to sm["_log"].
+
+  Args:
+    sm: Session state machine dict (callback_context.state).
+    tag: Short label identifying the log event.
+    level: Severity — DEBUG, INFO, WARN, or ERROR.
+    **data: Arbitrary key-value payload for the log entry.
+  """
+  min_level = sm.get("_log_level", "INFO")
+  if _LEVEL_ORDER.get(level, 1) < _LEVEL_ORDER.get(min_level, 1):
+    return
+  entry = {"src": "after_model", "tag": tag, "level": level,
+           "data": {k: v for k, v in data.items() if v is not None}}
+  _logger.log(_LEVEL_MAP.get(level, logging.INFO),
+              json_lib.dumps(entry, default=str))
+  sm.setdefault("_log", []).append(entry)
 
 
 def _extract_response_parts(response_parts):
@@ -56,5 +81,9 @@ def after_model_callback(
   if not extra_parts:
     return None
 
+  _log(sm, "payloads_injected", "DEBUG",
+       n_announce=len(_extract_response_parts(announce)) if announce else 0,
+       n_question=len(_extract_response_parts(question.get("parts", []))) if question else 0)
+  callback_context.state[_SM_KEY] = sm
   combined = list(llm_response.content.parts) + extra_parts
   return LlmResponse.from_parts(parts=combined)

--- a/examples/bella_notte/agents/Reservation_Agent/after_tool_callbacks/after_tool_callbacks_01/python_code.py
+++ b/examples/bella_notte/agents/Reservation_Agent/after_tool_callbacks/after_tool_callbacks_01/python_code.py
@@ -6,10 +6,35 @@ Config-driven: reads bootstrap config from SM (stashed by before_model).
 """
 
 import json as json_lib
+import logging
 from typing import Any, Optional
 
 
 _SM_KEY = "sm"
+
+_LEVEL_MAP = {"DEBUG": logging.DEBUG, "INFO": logging.INFO,
+              "WARN": logging.WARNING, "ERROR": logging.ERROR}
+_LEVEL_ORDER = {"DEBUG": 0, "INFO": 1, "WARN": 2, "ERROR": 3}
+_logger = logging.getLogger("slot_filling.after_tool")
+
+
+def _log(sm, tag, level="INFO", **data):
+  """Emit structured log entry; append to sm["_log"].
+
+  Args:
+    sm: Session state machine dict (callback_context.state).
+    tag: Short label identifying the log event.
+    level: Severity — DEBUG, INFO, WARN, or ERROR.
+    **data: Arbitrary key-value payload for the log entry.
+  """
+  min_level = sm.get("_log_level", "INFO")
+  if _LEVEL_ORDER.get(level, 1) < _LEVEL_ORDER.get(min_level, 1):
+    return
+  entry = {"src": "after_tool", "tag": tag, "level": level,
+           "data": {k: v for k, v in data.items() if v is not None}}
+  _logger.log(_LEVEL_MAP.get(level, logging.INFO),
+              json_lib.dumps(entry, default=str))
+  sm.setdefault("_log", []).append(entry)
 
 
 def _get_current_agent_name(callback_context) -> str:
@@ -52,13 +77,15 @@ def after_tool_callback(
         sm["task_results"] = {}
         sm["pending"] = {}
       sm.setdefault("filled", {})[slot_name] = response_data["value"]
+      _log(sm, "bootstrap_stored",
+           tool=tool.name, slot=slot_name, value=response_data["value"])
       callback_context.state[_SM_KEY] = sm
 
-      # Dynamic routing: Only transfer if target is NOT the current agent (blocks self-loops!)
       target = response_data.get("target_agent")
       if target:
         current_agent = _get_current_agent_name(callback_context)
         if target != current_agent:
+          _log(sm, "bootstrap_transfer", tool=tool.name, target=target)
           callback_context.state["_pending_transfer"] = target
     return None
 
@@ -75,6 +102,9 @@ def after_tool_callback(
       for field_name, error_code in field_errors.items():
         mapped_slot = field_map.get(field_name)
         if mapped_slot:
+          _log(sm, "multi_setter_error", "WARN",
+               tool=tool.name, field=field_name,
+               slot=mapped_slot, code=error_code)
           sm.setdefault("_slot_errors", []).append(
               {"slot": mapped_slot, "code": error_code},
           )
@@ -86,6 +116,7 @@ def after_tool_callback(
         prereq_fail = False
         for req in slot_requires.get(mapped_slot, []):
           if req not in filled:
+            _log(sm, "prereq_not_met", "WARN", slot=mapped_slot, missing=req)
             sm.setdefault("_slot_errors", []).append(
                 {"slot": mapped_slot, "code": "prereq_not_met"},
             )
@@ -102,11 +133,16 @@ def after_tool_callback(
           against_raw = filled.get(validation["filled_slot"], "")
           valid_options = [t.strip() for t in against_raw.split(",")]
           if check_value not in valid_options:
+            _log(sm, "validation_failed", "WARN", slot=mapped_slot,
+                 code=validation.get("error_code", "invalid"))
             sm.setdefault("_slot_errors", []).append(
                 {"slot": mapped_slot,
                  "code": validation.get("error_code", "invalid")},
             )
             continue
+        _log(sm, "multi_setter_stored",
+             tool=tool.name, field=field_name,
+             slot=mapped_slot, value=value)
         sm.setdefault("pending", {})[mapped_slot] = value
       callback_context.state[_SM_KEY] = sm
       return None
@@ -119,7 +155,10 @@ def after_tool_callback(
       task_results_map[task_info["task_name"]] = response_data
 
       success_key = task_info.get("success_check", "success")
-      if response_data.get(success_key):
+      success = bool(response_data.get(success_key))
+      _log(sm, "task_completed", "INFO" if success else "WARN",
+           tool=tool.name, task=task_info["task_name"], success=success)
+      if success:
         outputs = task_info.get("outputs", {})
         if all(k in response_data for k in outputs):
           filled_map = sm.setdefault("filled", {})
@@ -134,6 +173,7 @@ def after_tool_callback(
 
   if response_data.get("error"):
     error_code = response_data.get("error_code", "unknown")
+    _log(sm, "setter_error", "WARN", tool=tool.name, slot=slot_name, code=error_code)
     sm.setdefault("_slot_errors", []).append(
         {"slot": slot_name, "code": error_code}
     )
@@ -145,6 +185,7 @@ def after_tool_callback(
     slot_requires = sm.get("_slot_requires", {})
     for req in slot_requires.get(slot_name, []):
       if req not in filled:
+        _log(sm, "prereq_not_met", slot=slot_name, missing=req)
         sm.setdefault("_slot_errors", []).append(
             {"slot": slot_name, "code": "prereq_not_met"}
         )
@@ -157,14 +198,19 @@ def after_tool_callback(
       against_raw = filled.get(validation["filled_slot"], "")
       valid_options = [t.strip() for t in against_raw.split(",")]
       if check_value not in valid_options:
+        _log(sm, "validation_failed", "WARN", slot=slot_name,
+             code=validation.get("error_code", "invalid"))
         sm.setdefault("_slot_errors", []).append(
             {"slot": slot_name, "code": validation.get("error_code", "invalid")}
         )
         return None
 
+    _log(sm, "setter_stored", tool=tool.name, slot=slot_name, value=value)
     sm.setdefault("pending", {})[slot_name] = value
 
     inferred = response_data.get("inferred", {})
+    if inferred:
+      _log(sm, "inferred_slots", source_slot=slot_name, inferred=inferred)
     for inf_slot, inf_value in inferred.items():
       if inf_slot not in sm.get("filled", {}):
         sm["pending"][inf_slot] = inf_value

--- a/examples/bella_notte/agents/Reservation_Agent/before_agent_callbacks/before_agent_callbacks_01/python_code.py
+++ b/examples/bella_notte/agents/Reservation_Agent/before_agent_callbacks/before_agent_callbacks_01/python_code.py
@@ -7,10 +7,36 @@ Prompt assembly has moved to before_model_callback.
 """
 
 import json as json_lib
+import logging
 from typing import Any, Optional
 
 
 _SM_KEY = "sm"
+
+_LEVEL_MAP = {"DEBUG": logging.DEBUG, "INFO": logging.INFO,
+              "WARN": logging.WARNING, "ERROR": logging.ERROR}
+_LEVEL_ORDER = {"DEBUG": 0, "INFO": 1, "WARN": 2, "ERROR": 3}
+_logger = logging.getLogger("slot_filling.before_agent")
+
+
+def _log(sm, tag, level="INFO", **data):
+  """Emit structured log entry; append to sm["_log"].
+
+  Args:
+    sm: Session state machine dict (callback_context.state).
+    tag: Short label identifying the log event.
+    level: Severity — DEBUG, INFO, WARN, or ERROR.
+    **data: Arbitrary key-value payload for the log entry.
+  """
+  min_level = sm.get("_log_level", "INFO")
+  if _LEVEL_ORDER.get(level, 1) < _LEVEL_ORDER.get(min_level, 1):
+    return
+  entry = {"src": "before_agent", "tag": tag, "level": level,
+           "data": {k: v for k, v in data.items() if v is not None}}
+  _logger.log(_LEVEL_MAP.get(level, logging.INFO),
+              json_lib.dumps(entry, default=str))
+  sm.setdefault("_log", []).append(entry)
+
 
 _SM_DEFAULTS = {
     "filled": {},
@@ -29,8 +55,14 @@ def _ensure_sm_initialized(sm: dict[str, Any]) -> None:
 
 
 def _resolve_config_id(callback_context):
-  """Derive config_id from the agent_config_map variable + transfer events."""
-  # 1. Scan events FIRST for any recent transfer event
+  """Derive config_id from the agent_config_map variable + transfer events.
+
+  Args:
+    callback_context: CES CallbackContext with state and events.
+
+  Returns:
+    Tuple of (config_id, source) where source describes how it was resolved.
+  """
   agent_name = None
   for event in reversed(callback_context.events):
     for part in (event.parts() or []):
@@ -52,14 +84,12 @@ def _resolve_config_id(callback_context):
     config_id = config_map.get(agent_name)
     if config_id:
       callback_context.state["_active_config_id"] = config_id
-      return config_id
+      return config_id, "transfer_event"
 
-  # 2. Fallback to cached config_id only if no new transfer was detected
   cached = callback_context.state.get("_active_config_id")
   if cached:
-    return cached
+    return cached, "cached"
 
-  # 3. Fallback to single entry map if size is 1
   raw_map = callback_context.state.get("agent_config_map", "{}")
   try:
     config_map = (
@@ -70,9 +100,9 @@ def _resolve_config_id(callback_context):
   if len(config_map) == 1:
     config_id = next(iter(config_map.values()))
     callback_context.state["_active_config_id"] = config_id
-    return config_id
+    return config_id, "single_entry_map"
 
-  return None
+  return None, None
 
 
 def before_agent_callback(
@@ -85,10 +115,11 @@ def before_agent_callback(
   sm = callback_context.state.get(_SM_KEY, {})
   _ensure_sm_initialized(sm)
 
-  config_id = _resolve_config_id(callback_context)
+  config_id, config_source = _resolve_config_id(callback_context)
 
   callback_context.state["_active_sm_key"] = _SM_KEY
   if config_id:
+    _log(sm, "config_resolved", config_id=config_id, source=config_source)
     callback_context.state["_active_config_id"] = config_id
 
   # ── Deferred rejection ───────────────────────────────────────
@@ -102,6 +133,7 @@ def before_agent_callback(
     for k in snapshot:
       pending.pop(k, None)
     sm["pending"] = pending
+    _log(sm, "rejection_applied", slots=list(snapshot.keys()))
 
   callback_context.state[_SM_KEY] = sm
 

--- a/examples/bella_notte/agents/Reservation_Agent/before_model_callbacks/before_model_callbacks_01/python_code.py
+++ b/examples/bella_notte/agents/Reservation_Agent/before_model_callbacks/before_model_callbacks_01/python_code.py
@@ -5,8 +5,8 @@ FRAMEWORK CODE — fully generic across all agents.
 Config-driven: reads config_id from state (set by before_agent),
 bootstrap/gate from {config_id}_dag (stashed in SM on first load).
 """
-
 import json as json_lib
+import logging
 import re
 from typing import Optional
 
@@ -14,12 +14,37 @@ from typing import Optional
 _SM_KEY = "sm"
 
 _RAW_CONFIGS = {}
+_CROSS_VALIDATED = False
 
 _FRAMEWORK_SENTINEL = "<!-- slot-framework -->"
 
 _EVENT_TAG_PATTERN = re.compile(r"<event>(.*?)</event>")
 
 _TRANSFER_MARKERS = ("transfer_to_agent", "<context>", "</context>")
+
+_LEVEL_MAP = {"DEBUG": logging.DEBUG, "INFO": logging.INFO,
+              "WARN": logging.WARNING, "ERROR": logging.ERROR}
+_LEVEL_ORDER = {"DEBUG": 0, "INFO": 1, "WARN": 2, "ERROR": 3}
+_logger = logging.getLogger("slot_filling.before_model")
+
+
+def _log(sm, tag, level="INFO", **data):
+  """Emit structured log entry; append to sm["_log"].
+
+  Args:
+    sm: Session state machine dict (callback_context.state).
+    tag: Short label identifying the log event.
+    level: Severity — DEBUG, INFO, WARN, or ERROR.
+    **data: Arbitrary key-value payload for the log entry.
+  """
+  min_level = sm.get("_log_level", "INFO")
+  if _LEVEL_ORDER.get(level, 1) < _LEVEL_ORDER.get(min_level, 1):
+    return
+  entry = {"src": "before_model", "tag": tag, "level": level,
+           "data": {k: v for k, v in data.items() if v is not None}}
+  _logger.log(_LEVEL_MAP.get(level, logging.INFO),
+              json_lib.dumps(entry, default=str))
+  sm.setdefault("_log", []).append(entry)
 
 
 def _is_real_user_text(txt):
@@ -33,36 +58,34 @@ def _is_real_user_text(txt):
   return True
 
 
-def _prefill_from_conversation(sm, contents, slots):
-  """Scan conversation history and pre-fill slots with scan_keywords."""
-  filled = sm.get("filled", {})
-  pending = sm.get("pending", {})
-  for slot_def in slots:
-    scan_kw = slot_def.get("scan_keywords")
-    if not scan_kw:
-      continue
-    slot_name = slot_def["name"]
-    if slot_name in filled or slot_name in pending:
-      continue
-    cond_str = slot_def.get("condition")
-    if cond_str:
-      try:
-        if not eval(cond_str)(filled):  # pylint: disable=eval-used
-          continue
-      except Exception:  # pylint: disable=broad-except
-        continue
-    for content in (contents or []):
-      if getattr(content, "role", "") != "user":
-        continue
-      for part in getattr(content, "parts", []):
-        txt = getattr(part, "text", "")
-        if not _is_real_user_text(txt):
-          continue
-        lower = txt.lower()
-        for keyword, value in scan_kw.items():
-          if keyword in lower:
-            sm.setdefault("pending", {})[slot_name] = value
-            return
+def _probe_available_tools(raw, tools):
+  """Probe the CES runtime to find which config-referenced tools exist.
+
+  CES's tools object supports hasattr/getattr but not dir(), so we
+  extract every tool name referenced in the DAG config (setters, task
+  tools, bootstrap tool) and check each one individually.
+
+  Args:
+    raw: The raw DAG config dict.
+    tools: CES runtime tools object.
+
+  Returns:
+    Tuple of (available, missing) — both sorted lists of tool name strings.
+  """
+  referenced = set()
+  for s in raw.get("slots", []):
+    if s.get("setter"):
+      referenced.add(s["setter"])
+  for t in raw.get("tasks", []):
+    if t.get("tool"):
+      referenced.add(t["tool"])
+  bstrap = raw.get("bootstrap", {})
+  if isinstance(bstrap, dict) and bstrap.get("tool"):
+    referenced.add(bstrap["tool"])
+  available = sorted(n for n in referenced if hasattr(tools, n))
+  missing = sorted(referenced - set(available))
+  return available, missing
+
 
 _READBACK_BLOCK = """\
 <readback_protocol>
@@ -88,7 +111,7 @@ def _make_collection_block(
       "   (Determine the correct setter from tool names and descriptions.)"
   )
   ordering = slot_ordering or "natural order"
-  prereq = f" {prereq_note}" if prereq_note else ""
+  prereq = prereq_note
   return f"""\
 <slot_filling_protocol>
 1. CALL TOOLS FIRST: After each user message, call ALL matching setter tools
@@ -106,7 +129,7 @@ def _make_collection_block(
 3. TOOL SELECTION:
 {ts}
 
-4. ORDERING: {ordering}. Accept info out of order.{prereq}
+4. ORDERING: {ordering}. Accept info out of order.{f' {prereq}' if prereq else ''}
 </slot_filling_protocol>"""
 
 
@@ -180,13 +203,15 @@ def before_model_callback(
   llm_request.config.hide_tool("slot_filling_engine")
   llm_request.config.hide_tool("transfer_to_agent")
 
+  sm = callback_context.state.get(_SM_KEY, {})
+
   agent = callback_context.state.pop("_pending_transfer", "")
   if agent:
+    _log(sm, "transfer_dispatched", agent=agent)
+    callback_context.state[_SM_KEY] = sm
     return LlmResponse.from_parts(
         parts=[Part.from_agent_transfer(agent=agent)],
     )
-
-  sm = callback_context.state.get(_SM_KEY, {})
 
   # ── Resolve config_id from state (set by before_agent) ──────
   config_id = callback_context.state.get("_active_config_id")
@@ -194,15 +219,47 @@ def before_model_callback(
     return {"decision": "OK"}
 
   llm_request.config.hide_tool(f"{config_id}_dag")
+  llm_request.config.hide_tool("validate_dag_config")
 
   # ── Load raw config (cached per config_id) ─────────────────
+  global _CROSS_VALIDATED  # pylint: disable=global-statement
   if config_id not in _RAW_CONFIGS:
     dag_tool = getattr(tools, f"{config_id}_dag")
     _RAW_CONFIGS[config_id] = dag_tool({}).json()["result"]
+    raw = _RAW_CONFIGS[config_id]
+    _log(sm, "config_loaded", config_id=config_id,
+         n_slots=len(raw.get("slots", [])),
+         n_tasks=len(raw.get("tasks", [])))
+    available, missing = _probe_available_tools(raw, tools)
+    if missing:
+      _log(sm, "missing_tools", "WARN", missing=missing)
+    v = tools.validate_dag_config(
+        {"input_data": {"raw_config": raw, "available_tools": available}},
+    ).json()["result"]
+    if not v["valid"]:
+      _log(sm, "config_validation_failed", "ERROR", errors=v["errors"])
+    if not _CROSS_VALIDATED:
+      try:
+        config_map = json_lib.loads(
+            callback_context.state.get("agent_config_map", "{}"))
+        all_ids = set(config_map.values())
+        if all_ids and all_ids <= set(_RAW_CONFIGS):
+          cross = tools.validate_dag_config(
+              {"input_data": {"all_configs": {
+                  cid: _RAW_CONFIGS[cid] for cid in all_ids
+              }}},
+          ).json()["result"]
+          if not cross.get("cross_config", {}).get("valid", True):
+            _log(sm, "cross_config_validation_failed", "ERROR",
+                 errors=cross["cross_config"]["errors"])
+          _CROSS_VALIDATED = True
+      except Exception:  # pylint: disable=broad-except
+        pass
   raw_config = _RAW_CONFIGS[config_id]
 
   if sm.get("_config_id") != config_id:
     sm["_config_id"] = config_id
+    sm["_first_engine_run"] = True
     sm["_bootstrap"] = raw_config.get("bootstrap")
     sm["_gate_slot"] = raw_config.get("gate_slot")
     setter_slots = {}
@@ -243,6 +300,7 @@ def before_model_callback(
   # ── Gate: skip engine until gate_slot is filled ─────────────
   gate_slot = raw_config.get("gate_slot")
   if gate_slot and not sm.get("filled", {}).get(gate_slot):
+    _log(sm, "gate_active", "DEBUG", config_id=config_id, gate_slot=gate_slot)
     if llm_request.contents:
       for content in reversed(llm_request.contents):
         if getattr(content, "role", "") == "user":
@@ -292,20 +350,14 @@ def before_model_callback(
           continue
       sm.setdefault("pending", {})[sn] = transfer_slots[sn]
       consumed.append(sn)
+    if consumed:
+      _log(sm, "transfer_slots_consumed", slots=consumed)
     for sn in consumed:
       transfer_slots.pop(sn, None)
     if not transfer_slots:
       callback_context.state.pop("_transfer_slots", None)
     else:
       callback_context.state["_transfer_slots"] = transfer_slots
-
-  # ── Fallback: pre-fill from conversation history ───────────
-  _prefill_from_conversation(
-      sm, llm_request.contents, raw_config.get("slots", []),
-  )
-  callback_context.state[_SM_KEY] = sm
-
-  debug = sm.get("_debug_mode", False)
 
   last_user_text = ""
   if llm_request.contents:
@@ -333,15 +385,11 @@ def before_model_callback(
           "last_user_text": last_user_text,
           "event_data": event_data,
           "config_id": config_id,
-          **({"debug": True} if debug else {}),
       }},
   ).json()["result"]
 
   result = engine_result["action"]
   sm = engine_result["sm"]
-
-  if debug:
-    sm["_debug_log"] = engine_result.get("_debug_log", [])
 
   callback_context.state[_SM_KEY] = sm
 
@@ -350,11 +398,33 @@ def before_model_callback(
 
   # ── Assemble phase-specific SI suffix ───────────────────────
   gate_user_text = callback_context.state.pop("_gate_user_text", "")
+  first_run = sm.pop("_first_engine_run", False)
+  callback_context.state[_SM_KEY] = sm
   phase_suffix = _build_phase_suffix(sm, result)
 
-  if gate_user_text and phase_suffix:
+  task_directive = result.get("task_directive", "")
+  if task_directive:
     phase_suffix += (
-        f"\n<user_context>\nThe user's original message: \"{gate_user_text}\"\n"
+        f"\n<task_directive>\n{task_directive}\n"
+        "Use the tool result above to compose your response. "
+        "Do NOT recite this directive.\n</task_directive>"
+    )
+
+  init_user_text = gate_user_text
+  if not init_user_text and first_run:
+    for content in reversed(llm_request.contents or []):
+      if getattr(content, "role", "") == "user":
+        for part in getattr(content, "parts", []):
+          txt = getattr(part, "text", "")
+          if _is_real_user_text(txt):
+            init_user_text = txt
+            break
+        if init_user_text:
+          break
+
+  if init_user_text and phase_suffix:
+    phase_suffix += (
+        f"\n<user_context>\nThe user's original message: \"{init_user_text}\"\n"
         "Extract ALL slot values from this message before "
         "asking new questions. "
         "Call setter tools for any information you can infer.\n</user_context>"
@@ -399,8 +469,13 @@ def before_model_callback(
       )
       parts.append(fn_call)
     if parts:
+      _log(sm, "preemption",
+           has_message=bool(result.get("message")),
+           has_response=bool(response_parts),
+           has_function_call=bool(fc))
       sm.pop("_pending_payloads", None)
       sm.pop("_pending_question_payloads", None)
+      callback_context.state[_SM_KEY] = sm
       return LlmResponse.from_parts(parts=parts)
 
   return {"decision": "OK"}

--- a/examples/bella_notte/agents/Takeout_Agent/after_model_callbacks/after_model_callbacks_01/python_code.py
+++ b/examples/bella_notte/agents/Takeout_Agent/after_model_callbacks/after_model_callbacks_01/python_code.py
@@ -6,10 +6,35 @@ Only _SM_KEY differs between agents.
 """
 
 import json as json_lib
+import logging
 from typing import Optional
 
 
 _SM_KEY = "sm"
+
+_LEVEL_MAP = {"DEBUG": logging.DEBUG, "INFO": logging.INFO,
+              "WARN": logging.WARNING, "ERROR": logging.ERROR}
+_LEVEL_ORDER = {"DEBUG": 0, "INFO": 1, "WARN": 2, "ERROR": 3}
+_logger = logging.getLogger("slot_filling.after_model")
+
+
+def _log(sm, tag, level="INFO", **data):
+  """Emit structured log entry; append to sm["_log"].
+
+  Args:
+    sm: Session state machine dict (callback_context.state).
+    tag: Short label identifying the log event.
+    level: Severity — DEBUG, INFO, WARN, or ERROR.
+    **data: Arbitrary key-value payload for the log entry.
+  """
+  min_level = sm.get("_log_level", "INFO")
+  if _LEVEL_ORDER.get(level, 1) < _LEVEL_ORDER.get(min_level, 1):
+    return
+  entry = {"src": "after_model", "tag": tag, "level": level,
+           "data": {k: v for k, v in data.items() if v is not None}}
+  _logger.log(_LEVEL_MAP.get(level, logging.INFO),
+              json_lib.dumps(entry, default=str))
+  sm.setdefault("_log", []).append(entry)
 
 
 def _extract_response_parts(response_parts):
@@ -56,5 +81,9 @@ def after_model_callback(
   if not extra_parts:
     return None
 
+  _log(sm, "payloads_injected", "DEBUG",
+       n_announce=len(_extract_response_parts(announce)) if announce else 0,
+       n_question=len(_extract_response_parts(question.get("parts", []))) if question else 0)
+  callback_context.state[_SM_KEY] = sm
   combined = list(llm_response.content.parts) + extra_parts
   return LlmResponse.from_parts(parts=combined)

--- a/examples/bella_notte/agents/Takeout_Agent/after_tool_callbacks/after_tool_callbacks_01/python_code.py
+++ b/examples/bella_notte/agents/Takeout_Agent/after_tool_callbacks/after_tool_callbacks_01/python_code.py
@@ -6,10 +6,35 @@ Config-driven: reads bootstrap config from SM (stashed by before_model).
 """
 
 import json as json_lib
+import logging
 from typing import Any, Optional
 
 
 _SM_KEY = "sm"
+
+_LEVEL_MAP = {"DEBUG": logging.DEBUG, "INFO": logging.INFO,
+              "WARN": logging.WARNING, "ERROR": logging.ERROR}
+_LEVEL_ORDER = {"DEBUG": 0, "INFO": 1, "WARN": 2, "ERROR": 3}
+_logger = logging.getLogger("slot_filling.after_tool")
+
+
+def _log(sm, tag, level="INFO", **data):
+  """Emit structured log entry; append to sm["_log"].
+
+  Args:
+    sm: Session state machine dict (callback_context.state).
+    tag: Short label identifying the log event.
+    level: Severity — DEBUG, INFO, WARN, or ERROR.
+    **data: Arbitrary key-value payload for the log entry.
+  """
+  min_level = sm.get("_log_level", "INFO")
+  if _LEVEL_ORDER.get(level, 1) < _LEVEL_ORDER.get(min_level, 1):
+    return
+  entry = {"src": "after_tool", "tag": tag, "level": level,
+           "data": {k: v for k, v in data.items() if v is not None}}
+  _logger.log(_LEVEL_MAP.get(level, logging.INFO),
+              json_lib.dumps(entry, default=str))
+  sm.setdefault("_log", []).append(entry)
 
 
 def _get_current_agent_name(callback_context) -> str:
@@ -52,13 +77,15 @@ def after_tool_callback(
         sm["task_results"] = {}
         sm["pending"] = {}
       sm.setdefault("filled", {})[slot_name] = response_data["value"]
+      _log(sm, "bootstrap_stored",
+           tool=tool.name, slot=slot_name, value=response_data["value"])
       callback_context.state[_SM_KEY] = sm
 
-      # Dynamic routing: Only transfer if target is NOT the current agent (blocks self-loops!)
       target = response_data.get("target_agent")
       if target:
         current_agent = _get_current_agent_name(callback_context)
         if target != current_agent:
+          _log(sm, "bootstrap_transfer", tool=tool.name, target=target)
           callback_context.state["_pending_transfer"] = target
     return None
 
@@ -75,6 +102,9 @@ def after_tool_callback(
       for field_name, error_code in field_errors.items():
         mapped_slot = field_map.get(field_name)
         if mapped_slot:
+          _log(sm, "multi_setter_error", "WARN",
+               tool=tool.name, field=field_name,
+               slot=mapped_slot, code=error_code)
           sm.setdefault("_slot_errors", []).append(
               {"slot": mapped_slot, "code": error_code},
           )
@@ -86,6 +116,7 @@ def after_tool_callback(
         prereq_fail = False
         for req in slot_requires.get(mapped_slot, []):
           if req not in filled:
+            _log(sm, "prereq_not_met", "WARN", slot=mapped_slot, missing=req)
             sm.setdefault("_slot_errors", []).append(
                 {"slot": mapped_slot, "code": "prereq_not_met"},
             )
@@ -102,11 +133,16 @@ def after_tool_callback(
           against_raw = filled.get(validation["filled_slot"], "")
           valid_options = [t.strip() for t in against_raw.split(",")]
           if check_value not in valid_options:
+            _log(sm, "validation_failed", "WARN", slot=mapped_slot,
+                 code=validation.get("error_code", "invalid"))
             sm.setdefault("_slot_errors", []).append(
                 {"slot": mapped_slot,
                  "code": validation.get("error_code", "invalid")},
             )
             continue
+        _log(sm, "multi_setter_stored",
+             tool=tool.name, field=field_name,
+             slot=mapped_slot, value=value)
         sm.setdefault("pending", {})[mapped_slot] = value
       callback_context.state[_SM_KEY] = sm
       return None
@@ -119,7 +155,10 @@ def after_tool_callback(
       task_results_map[task_info["task_name"]] = response_data
 
       success_key = task_info.get("success_check", "success")
-      if response_data.get(success_key):
+      success = bool(response_data.get(success_key))
+      _log(sm, "task_completed", "INFO" if success else "WARN",
+           tool=tool.name, task=task_info["task_name"], success=success)
+      if success:
         outputs = task_info.get("outputs", {})
         if all(k in response_data for k in outputs):
           filled_map = sm.setdefault("filled", {})
@@ -134,6 +173,7 @@ def after_tool_callback(
 
   if response_data.get("error"):
     error_code = response_data.get("error_code", "unknown")
+    _log(sm, "setter_error", "WARN", tool=tool.name, slot=slot_name, code=error_code)
     sm.setdefault("_slot_errors", []).append(
         {"slot": slot_name, "code": error_code}
     )
@@ -145,6 +185,7 @@ def after_tool_callback(
     slot_requires = sm.get("_slot_requires", {})
     for req in slot_requires.get(slot_name, []):
       if req not in filled:
+        _log(sm, "prereq_not_met", slot=slot_name, missing=req)
         sm.setdefault("_slot_errors", []).append(
             {"slot": slot_name, "code": "prereq_not_met"}
         )
@@ -157,14 +198,19 @@ def after_tool_callback(
       against_raw = filled.get(validation["filled_slot"], "")
       valid_options = [t.strip() for t in against_raw.split(",")]
       if check_value not in valid_options:
+        _log(sm, "validation_failed", "WARN", slot=slot_name,
+             code=validation.get("error_code", "invalid"))
         sm.setdefault("_slot_errors", []).append(
             {"slot": slot_name, "code": validation.get("error_code", "invalid")}
         )
         return None
 
+    _log(sm, "setter_stored", tool=tool.name, slot=slot_name, value=value)
     sm.setdefault("pending", {})[slot_name] = value
 
     inferred = response_data.get("inferred", {})
+    if inferred:
+      _log(sm, "inferred_slots", source_slot=slot_name, inferred=inferred)
     for inf_slot, inf_value in inferred.items():
       if inf_slot not in sm.get("filled", {}):
         sm["pending"][inf_slot] = inf_value

--- a/examples/bella_notte/agents/Takeout_Agent/before_agent_callbacks/before_agent_callbacks_01/python_code.py
+++ b/examples/bella_notte/agents/Takeout_Agent/before_agent_callbacks/before_agent_callbacks_01/python_code.py
@@ -7,10 +7,36 @@ Prompt assembly has moved to before_model_callback.
 """
 
 import json as json_lib
+import logging
 from typing import Any, Optional
 
 
 _SM_KEY = "sm"
+
+_LEVEL_MAP = {"DEBUG": logging.DEBUG, "INFO": logging.INFO,
+              "WARN": logging.WARNING, "ERROR": logging.ERROR}
+_LEVEL_ORDER = {"DEBUG": 0, "INFO": 1, "WARN": 2, "ERROR": 3}
+_logger = logging.getLogger("slot_filling.before_agent")
+
+
+def _log(sm, tag, level="INFO", **data):
+  """Emit structured log entry; append to sm["_log"].
+
+  Args:
+    sm: Session state machine dict (callback_context.state).
+    tag: Short label identifying the log event.
+    level: Severity — DEBUG, INFO, WARN, or ERROR.
+    **data: Arbitrary key-value payload for the log entry.
+  """
+  min_level = sm.get("_log_level", "INFO")
+  if _LEVEL_ORDER.get(level, 1) < _LEVEL_ORDER.get(min_level, 1):
+    return
+  entry = {"src": "before_agent", "tag": tag, "level": level,
+           "data": {k: v for k, v in data.items() if v is not None}}
+  _logger.log(_LEVEL_MAP.get(level, logging.INFO),
+              json_lib.dumps(entry, default=str))
+  sm.setdefault("_log", []).append(entry)
+
 
 _SM_DEFAULTS = {
     "filled": {},
@@ -29,8 +55,14 @@ def _ensure_sm_initialized(sm: dict[str, Any]) -> None:
 
 
 def _resolve_config_id(callback_context):
-  """Derive config_id from the agent_config_map variable + transfer events."""
-  # 1. Scan events FIRST for any recent transfer event
+  """Derive config_id from the agent_config_map variable + transfer events.
+
+  Args:
+    callback_context: CES CallbackContext with state and events.
+
+  Returns:
+    Tuple of (config_id, source) where source describes how it was resolved.
+  """
   agent_name = None
   for event in reversed(callback_context.events):
     for part in (event.parts() or []):
@@ -52,14 +84,12 @@ def _resolve_config_id(callback_context):
     config_id = config_map.get(agent_name)
     if config_id:
       callback_context.state["_active_config_id"] = config_id
-      return config_id
+      return config_id, "transfer_event"
 
-  # 2. Fallback to cached config_id only if no new transfer was detected
   cached = callback_context.state.get("_active_config_id")
   if cached:
-    return cached
+    return cached, "cached"
 
-  # 3. Fallback to single entry map if size is 1
   raw_map = callback_context.state.get("agent_config_map", "{}")
   try:
     config_map = (
@@ -70,9 +100,9 @@ def _resolve_config_id(callback_context):
   if len(config_map) == 1:
     config_id = next(iter(config_map.values()))
     callback_context.state["_active_config_id"] = config_id
-    return config_id
+    return config_id, "single_entry_map"
 
-  return None
+  return None, None
 
 
 def before_agent_callback(
@@ -85,10 +115,11 @@ def before_agent_callback(
   sm = callback_context.state.get(_SM_KEY, {})
   _ensure_sm_initialized(sm)
 
-  config_id = _resolve_config_id(callback_context)
+  config_id, config_source = _resolve_config_id(callback_context)
 
   callback_context.state["_active_sm_key"] = _SM_KEY
   if config_id:
+    _log(sm, "config_resolved", config_id=config_id, source=config_source)
     callback_context.state["_active_config_id"] = config_id
 
   # ── Deferred rejection ───────────────────────────────────────
@@ -102,6 +133,7 @@ def before_agent_callback(
     for k in snapshot:
       pending.pop(k, None)
     sm["pending"] = pending
+    _log(sm, "rejection_applied", slots=list(snapshot.keys()))
 
   callback_context.state[_SM_KEY] = sm
 

--- a/examples/bella_notte/agents/Takeout_Agent/before_model_callbacks/before_model_callbacks_01/python_code.py
+++ b/examples/bella_notte/agents/Takeout_Agent/before_model_callbacks/before_model_callbacks_01/python_code.py
@@ -5,8 +5,8 @@ FRAMEWORK CODE — fully generic across all agents.
 Config-driven: reads config_id from state (set by before_agent),
 bootstrap/gate from {config_id}_dag (stashed in SM on first load).
 """
-
 import json as json_lib
+import logging
 import re
 from typing import Optional
 
@@ -14,12 +14,37 @@ from typing import Optional
 _SM_KEY = "sm"
 
 _RAW_CONFIGS = {}
+_CROSS_VALIDATED = False
 
 _FRAMEWORK_SENTINEL = "<!-- slot-framework -->"
 
 _EVENT_TAG_PATTERN = re.compile(r"<event>(.*?)</event>")
 
 _TRANSFER_MARKERS = ("transfer_to_agent", "<context>", "</context>")
+
+_LEVEL_MAP = {"DEBUG": logging.DEBUG, "INFO": logging.INFO,
+              "WARN": logging.WARNING, "ERROR": logging.ERROR}
+_LEVEL_ORDER = {"DEBUG": 0, "INFO": 1, "WARN": 2, "ERROR": 3}
+_logger = logging.getLogger("slot_filling.before_model")
+
+
+def _log(sm, tag, level="INFO", **data):
+  """Emit structured log entry; append to sm["_log"].
+
+  Args:
+    sm: Session state machine dict (callback_context.state).
+    tag: Short label identifying the log event.
+    level: Severity — DEBUG, INFO, WARN, or ERROR.
+    **data: Arbitrary key-value payload for the log entry.
+  """
+  min_level = sm.get("_log_level", "INFO")
+  if _LEVEL_ORDER.get(level, 1) < _LEVEL_ORDER.get(min_level, 1):
+    return
+  entry = {"src": "before_model", "tag": tag, "level": level,
+           "data": {k: v for k, v in data.items() if v is not None}}
+  _logger.log(_LEVEL_MAP.get(level, logging.INFO),
+              json_lib.dumps(entry, default=str))
+  sm.setdefault("_log", []).append(entry)
 
 
 def _is_real_user_text(txt):
@@ -33,36 +58,34 @@ def _is_real_user_text(txt):
   return True
 
 
-def _prefill_from_conversation(sm, contents, slots):
-  """Scan conversation history and pre-fill slots with scan_keywords."""
-  filled = sm.get("filled", {})
-  pending = sm.get("pending", {})
-  for slot_def in slots:
-    scan_kw = slot_def.get("scan_keywords")
-    if not scan_kw:
-      continue
-    slot_name = slot_def["name"]
-    if slot_name in filled or slot_name in pending:
-      continue
-    cond_str = slot_def.get("condition")
-    if cond_str:
-      try:
-        if not eval(cond_str)(filled):  # pylint: disable=eval-used
-          continue
-      except Exception:  # pylint: disable=broad-except
-        continue
-    for content in (contents or []):
-      if getattr(content, "role", "") != "user":
-        continue
-      for part in getattr(content, "parts", []):
-        txt = getattr(part, "text", "")
-        if not _is_real_user_text(txt):
-          continue
-        lower = txt.lower()
-        for keyword, value in scan_kw.items():
-          if keyword in lower:
-            sm.setdefault("pending", {})[slot_name] = value
-            return
+def _probe_available_tools(raw, tools):
+  """Probe the CES runtime to find which config-referenced tools exist.
+
+  CES's tools object supports hasattr/getattr but not dir(), so we
+  extract every tool name referenced in the DAG config (setters, task
+  tools, bootstrap tool) and check each one individually.
+
+  Args:
+    raw: The raw DAG config dict.
+    tools: CES runtime tools object.
+
+  Returns:
+    Tuple of (available, missing) — both sorted lists of tool name strings.
+  """
+  referenced = set()
+  for s in raw.get("slots", []):
+    if s.get("setter"):
+      referenced.add(s["setter"])
+  for t in raw.get("tasks", []):
+    if t.get("tool"):
+      referenced.add(t["tool"])
+  bstrap = raw.get("bootstrap", {})
+  if isinstance(bstrap, dict) and bstrap.get("tool"):
+    referenced.add(bstrap["tool"])
+  available = sorted(n for n in referenced if hasattr(tools, n))
+  missing = sorted(referenced - set(available))
+  return available, missing
+
 
 _READBACK_BLOCK = """\
 <readback_protocol>
@@ -88,7 +111,7 @@ def _make_collection_block(
       "   (Determine the correct setter from tool names and descriptions.)"
   )
   ordering = slot_ordering or "natural order"
-  prereq = f" {prereq_note}" if prereq_note else ""
+  prereq = prereq_note
   return f"""\
 <slot_filling_protocol>
 1. CALL TOOLS FIRST: After each user message, call ALL matching setter tools
@@ -106,7 +129,7 @@ def _make_collection_block(
 3. TOOL SELECTION:
 {ts}
 
-4. ORDERING: {ordering}. Accept info out of order.{prereq}
+4. ORDERING: {ordering}. Accept info out of order.{f' {prereq}' if prereq else ''}
 </slot_filling_protocol>"""
 
 
@@ -180,13 +203,15 @@ def before_model_callback(
   llm_request.config.hide_tool("slot_filling_engine")
   llm_request.config.hide_tool("transfer_to_agent")
 
+  sm = callback_context.state.get(_SM_KEY, {})
+
   agent = callback_context.state.pop("_pending_transfer", "")
   if agent:
+    _log(sm, "transfer_dispatched", agent=agent)
+    callback_context.state[_SM_KEY] = sm
     return LlmResponse.from_parts(
         parts=[Part.from_agent_transfer(agent=agent)],
     )
-
-  sm = callback_context.state.get(_SM_KEY, {})
 
   # ── Resolve config_id from state (set by before_agent) ──────
   config_id = callback_context.state.get("_active_config_id")
@@ -194,15 +219,47 @@ def before_model_callback(
     return {"decision": "OK"}
 
   llm_request.config.hide_tool(f"{config_id}_dag")
+  llm_request.config.hide_tool("validate_dag_config")
 
   # ── Load raw config (cached per config_id) ─────────────────
+  global _CROSS_VALIDATED  # pylint: disable=global-statement
   if config_id not in _RAW_CONFIGS:
     dag_tool = getattr(tools, f"{config_id}_dag")
     _RAW_CONFIGS[config_id] = dag_tool({}).json()["result"]
+    raw = _RAW_CONFIGS[config_id]
+    _log(sm, "config_loaded", config_id=config_id,
+         n_slots=len(raw.get("slots", [])),
+         n_tasks=len(raw.get("tasks", [])))
+    available, missing = _probe_available_tools(raw, tools)
+    if missing:
+      _log(sm, "missing_tools", "WARN", missing=missing)
+    v = tools.validate_dag_config(
+        {"input_data": {"raw_config": raw, "available_tools": available}},
+    ).json()["result"]
+    if not v["valid"]:
+      _log(sm, "config_validation_failed", "ERROR", errors=v["errors"])
+    if not _CROSS_VALIDATED:
+      try:
+        config_map = json_lib.loads(
+            callback_context.state.get("agent_config_map", "{}"))
+        all_ids = set(config_map.values())
+        if all_ids and all_ids <= set(_RAW_CONFIGS):
+          cross = tools.validate_dag_config(
+              {"input_data": {"all_configs": {
+                  cid: _RAW_CONFIGS[cid] for cid in all_ids
+              }}},
+          ).json()["result"]
+          if not cross.get("cross_config", {}).get("valid", True):
+            _log(sm, "cross_config_validation_failed", "ERROR",
+                 errors=cross["cross_config"]["errors"])
+          _CROSS_VALIDATED = True
+      except Exception:  # pylint: disable=broad-except
+        pass
   raw_config = _RAW_CONFIGS[config_id]
 
   if sm.get("_config_id") != config_id:
     sm["_config_id"] = config_id
+    sm["_first_engine_run"] = True
     sm["_bootstrap"] = raw_config.get("bootstrap")
     sm["_gate_slot"] = raw_config.get("gate_slot")
     setter_slots = {}
@@ -243,6 +300,7 @@ def before_model_callback(
   # ── Gate: skip engine until gate_slot is filled ─────────────
   gate_slot = raw_config.get("gate_slot")
   if gate_slot and not sm.get("filled", {}).get(gate_slot):
+    _log(sm, "gate_active", "DEBUG", config_id=config_id, gate_slot=gate_slot)
     if llm_request.contents:
       for content in reversed(llm_request.contents):
         if getattr(content, "role", "") == "user":
@@ -292,20 +350,14 @@ def before_model_callback(
           continue
       sm.setdefault("pending", {})[sn] = transfer_slots[sn]
       consumed.append(sn)
+    if consumed:
+      _log(sm, "transfer_slots_consumed", slots=consumed)
     for sn in consumed:
       transfer_slots.pop(sn, None)
     if not transfer_slots:
       callback_context.state.pop("_transfer_slots", None)
     else:
       callback_context.state["_transfer_slots"] = transfer_slots
-
-  # ── Fallback: pre-fill from conversation history ───────────
-  _prefill_from_conversation(
-      sm, llm_request.contents, raw_config.get("slots", []),
-  )
-  callback_context.state[_SM_KEY] = sm
-
-  debug = sm.get("_debug_mode", False)
 
   last_user_text = ""
   if llm_request.contents:
@@ -333,15 +385,11 @@ def before_model_callback(
           "last_user_text": last_user_text,
           "event_data": event_data,
           "config_id": config_id,
-          **({"debug": True} if debug else {}),
       }},
   ).json()["result"]
 
   result = engine_result["action"]
   sm = engine_result["sm"]
-
-  if debug:
-    sm["_debug_log"] = engine_result.get("_debug_log", [])
 
   callback_context.state[_SM_KEY] = sm
 
@@ -350,11 +398,33 @@ def before_model_callback(
 
   # ── Assemble phase-specific SI suffix ───────────────────────
   gate_user_text = callback_context.state.pop("_gate_user_text", "")
+  first_run = sm.pop("_first_engine_run", False)
+  callback_context.state[_SM_KEY] = sm
   phase_suffix = _build_phase_suffix(sm, result)
 
-  if gate_user_text and phase_suffix:
+  task_directive = result.get("task_directive", "")
+  if task_directive:
     phase_suffix += (
-        f"\n<user_context>\nThe user's original message: \"{gate_user_text}\"\n"
+        f"\n<task_directive>\n{task_directive}\n"
+        "Use the tool result above to compose your response. "
+        "Do NOT recite this directive.\n</task_directive>"
+    )
+
+  init_user_text = gate_user_text
+  if not init_user_text and first_run:
+    for content in reversed(llm_request.contents or []):
+      if getattr(content, "role", "") == "user":
+        for part in getattr(content, "parts", []):
+          txt = getattr(part, "text", "")
+          if _is_real_user_text(txt):
+            init_user_text = txt
+            break
+        if init_user_text:
+          break
+
+  if init_user_text and phase_suffix:
+    phase_suffix += (
+        f"\n<user_context>\nThe user's original message: \"{init_user_text}\"\n"
         "Extract ALL slot values from this message before "
         "asking new questions. "
         "Call setter tools for any information you can infer.\n</user_context>"
@@ -399,8 +469,13 @@ def before_model_callback(
       )
       parts.append(fn_call)
     if parts:
+      _log(sm, "preemption",
+           has_message=bool(result.get("message")),
+           has_response=bool(response_parts),
+           has_function_call=bool(fc))
       sm.pop("_pending_payloads", None)
       sm.pop("_pending_question_payloads", None)
+      callback_context.state[_SM_KEY] = sm
       return LlmResponse.from_parts(parts=parts)
 
   return {"decision": "OK"}

--- a/examples/bella_notte/evaluations/Happy_Path_-_Linear_Reservation_Flow/Happy_Path_-_Linear_Reservation_Flow.json
+++ b/examples/bella_notte/evaluations/Happy_Path_-_Linear_Reservation_Flow/Happy_Path_-_Linear_Reservation_Flow.json
@@ -22,6 +22,14 @@
           },
           {
             "expectation": {
+              "note": "Check_Transfer_To_Reservation",
+              "agentTransfer": {
+                "targetAgent": "Reservation_Agent"
+              }
+            }
+          },
+          {
+            "expectation": {
               "note": "Check_SetPartySize_Called",
               "toolCall": {
                 "tool": "set_reservation_basics",

--- a/examples/bella_notte/evaluations/Happy_Path_-_Multi-Agent_Reservation/Happy_Path_-_Multi-Agent_Reservation.json
+++ b/examples/bella_notte/evaluations/Happy_Path_-_Multi-Agent_Reservation/Happy_Path_-_Multi-Agent_Reservation.json
@@ -29,6 +29,14 @@
                 }
               }
             }
+          },
+          {
+            "expectation": {
+              "note": "Check_Transfer_To_Reservation",
+              "agentTransfer": {
+                "targetAgent": "Reservation_Agent"
+              }
+            }
           }
         ]
       },

--- a/examples/bella_notte/evaluations/Happy_Path_-_Multi-Agent_Takeout/Happy_Path_-_Multi-Agent_Takeout.json
+++ b/examples/bella_notte/evaluations/Happy_Path_-_Multi-Agent_Takeout/Happy_Path_-_Multi-Agent_Takeout.json
@@ -29,6 +29,14 @@
                 }
               }
             }
+          },
+          {
+            "expectation": {
+              "note": "Check_Transfer_To_Takeout",
+              "agentTransfer": {
+                "targetAgent": "Takeout_Agent"
+              }
+            }
           }
         ]
       },

--- a/examples/bella_notte/tools/slot_filling_engine/python_function/python_code.py
+++ b/examples/bella_notte/tools/slot_filling_engine/python_function/python_code.py
@@ -1,3 +1,4 @@
+# pylint: disable=undefined-variable
 """Slot-filling DAG engine — reusable across projects.
 
 FRAMEWORK CODE — shared across all agents using the slot-filling engine.
@@ -15,6 +16,8 @@ Called from the before_model_callback via:
 
 import copy
 import datetime
+import json as json_lib
+import logging
 import random
 from typing import Any, Optional
 
@@ -210,8 +213,7 @@ _SAFE_EVAL_GLOBALS = {
 }
 
 _COMPILED_CONFIGS = {}
-_DEBUG = False
-_DEBUG_LOG = []
+_sm_ref = None
 
 
 def _compile_formatter(fmt):
@@ -266,110 +268,6 @@ def _compile_config(config: dict[str, Any]) -> dict[str, Any]:
   compiled["slots"] = compiled_slots
   compiled["tasks"] = compiled_tasks
   return compiled
-
-
-def _validate_config(config):
-  """Validate config structure and references."""
-  slots = config["slots"]
-  tasks = config["tasks"]
-  slot_map = {s["name"]: s for s in slots}
-
-  slot_names = [s["name"] for s in slots]
-  slot_set = set(slot_names)
-  task_names = {t["name"] for t in tasks}
-
-  if len(slot_names) != len(slot_set):
-    dupes = [n for n in slot_names if slot_names.count(n) > 1]
-    raise ValueError(f"Duplicate slot names: {set(dupes)}")
-
-  for task in tasks:
-    for inp in task["inputs"]:
-      if inp not in slot_set:
-        raise ValueError(
-            f"Task '{task['name']}' input '{inp}' not in slots"
-        )
-    for slot_name in task.get("outputs", {}).values():
-      if slot_name not in slot_set:
-        raise ValueError(
-            f"Task '{task['name']}' output '{slot_name}'"
-            " not in slots"
-        )
-    if not task.get("tool"):
-      raise ValueError(
-          f"Task '{task['name']}' has no 'tool' key"
-      )
-    for req in task.get("requires", []):
-      if req not in slot_set:
-        raise ValueError(
-            f"Task '{task['name']}' requires '{req}'"
-            " not in slots"
-        )
-    condition = task.get("condition")
-    if (condition is not None
-        and not callable(condition)
-        and not isinstance(condition, str)):
-      raise ValueError(
-          f"Task '{task['name']}' condition must be callable or"
-          f" string, got {type(condition)}"
-      )
-
-  for slot in slots:
-    sources = _normalize_sources(slot.get("source", "user"))
-    for source in sources:
-      if source.startswith("task:"):
-        src_task = source[5:]
-        if src_task not in task_names:
-          raise ValueError(
-              f"Slot '{slot['name']}' references unknown task"
-              f" '{src_task}'"
-          )
-    condition = slot.get("condition")
-    if (condition is not None
-        and not callable(condition)
-        and not isinstance(condition, str)):
-      raise ValueError(
-          f"Slot '{slot['name']}' condition must be callable or"
-          f" string, got {type(condition)}"
-      )
-    if "announce" in sources:
-      if not slot.get("message"):
-        raise ValueError(
-            f"Announce slot '{slot['name']}'"
-            " requires 'message'"
-        )
-      if slot.get("setter"):
-        raise ValueError(
-            f"Announce slot '{slot['name']}'"
-            " must not have 'setter'"
-        )
-    for req in slot.get("requires", []):
-      if req not in slot_set:
-        raise ValueError(
-            f"Slot '{slot['name']}' requires unknown"
-            f" '{req}'"
-        )
-
-  def _has_cycle(name, visited, stack):
-    visited.add(name)
-    stack.add(name)
-    slot_def = slot_map.get(name)
-    if slot_def:
-      for req in slot_def.get("requires", []):
-        if req not in visited:
-          if _has_cycle(req, visited, stack):
-            return True
-        elif req in stack:
-          return True
-    stack.discard(name)
-    return False
-
-  visited, stack = set(), set()
-  for name in slot_names:
-    if name not in visited:
-      if _has_cycle(name, visited, stack):
-        raise ValueError(
-            f"Circular requires involving '{name}'"
-        )
 
 
 # ═════════════════════════════════════════════════════════════════════
@@ -518,30 +416,37 @@ def _starts_affirmative(text: str) -> bool:
 # ═════════════════════════════════════════════════════════════════════
 
 
-def _log(tag, **data):
-  """Emit a structured log line."""
-  parts = " ".join(f"{k}={v!r}" for k, v in data.items())
-  line = f"[slot-filling:{tag}]" + (f" {parts}" if parts else "")
-  print(line)
-  if _DEBUG:
-    _DEBUG_LOG.append(line)
+_LEVEL_MAP = {"DEBUG": logging.DEBUG, "INFO": logging.INFO,
+              "WARN": logging.WARNING, "ERROR": logging.ERROR}
+_LEVEL_ORDER = {"DEBUG": 0, "INFO": 1, "WARN": 2, "ERROR": 3}
+_logger = logging.getLogger("slot_filling.engine")
+
+
+def _log(tag, level="INFO", **data):
+  """Emit structured log entry; append to sm["_log"]."""
+  min_level = _sm_ref.get("_log_level", "INFO") if _sm_ref else "INFO"
+  if _LEVEL_ORDER.get(level, 1) < _LEVEL_ORDER.get(min_level, 1):
+    return
+  entry = {"src": "engine", "tag": tag, "level": level,
+           "data": {k: v for k, v in data.items() if v is not None}}
+  _logger.log(_LEVEL_MAP.get(level, logging.INFO),
+              json_lib.dumps(entry, default=str))
+  if _sm_ref is not None:
+    _sm_ref.setdefault("_log", []).append(entry)
 
 
 def _log_progress(filled, pending, last_state):
-  """Log slot state changes since last turn."""
+  """Log state deltas — skip if nothing changed."""
   last_filled = last_state.get("filled", {})
   last_pending = last_state.get("pending", {})
   confirmed = sorted(
-      k for k in set(last_pending) if k in filled and k not in last_filled
-  )
+      k for k in set(last_pending) if k in filled and k not in last_filled)
   task_out = {
       k: filled[k]
-      for k in set(filled) - set(last_filled) - set(confirmed)
-  }
+      for k in set(filled) - set(last_filled) - set(confirmed)}
   new_pending = {k: pending[k] for k in set(pending) - set(last_pending)}
   rejected = sorted(
-      k for k in set(last_pending) if k not in pending and k not in filled
-  )
+      k for k in set(last_pending) if k not in pending and k not in filled)
   if not (confirmed or task_out or new_pending or rejected):
     return
   _log("progress",
@@ -554,8 +459,8 @@ def _log_progress(filled, pending, last_state):
 def _log_invoke(n, phase, filled, pending, fresh_pending, hidden, *,
                 asking=None, reading_back=None, fired=None, done=False,
                 preempted=None, deferred=None):
-  """Log a DAG invocation with current state."""
-  _log("invoke",
+  """Log invocation snapshot (DEBUG level)."""
+  _log("invoke", level="DEBUG",
        n=n, phase=phase,
        **({} if not filled else {"filled": sorted(filled)}),
        **({} if not pending else {"pending": sorted(pending)}),
@@ -643,11 +548,12 @@ def _deactivate_conditional_slots(
     deferred: dict[str, Any], retries: dict[str, Any],
 ) -> None:
   """Remove slots whose conditions are no longer met."""
+  merged_state = {**filled, **pending, **deferred}
   for slot_def in slots:
     if "condition" not in slot_def:
       continue
     name = slot_def["name"]
-    if not _is_slot_active(slot_def, filled):
+    if not _is_slot_active(slot_def, merged_state):
       if name in filled:
         filled.pop(name)
         retries.pop(f"slot:{name}", None)
@@ -806,7 +712,7 @@ def _handle_steer_back(
   # After a hard steer preemption, yield one turn to the LLM
   # so it can process the user's response to the forced question.
   if sm.pop("_hard_steer_yielded", False):
-    _log("steer_back_yield", turns=sm.get("_steer_back_turns", 0))
+    _log("steer_back_yield", "DEBUG", turns=sm.get("_steer_back_turns", 0))
     return None
 
   turns = sm.get("_steer_back_turns", 0) + 1
@@ -835,7 +741,7 @@ def _handle_steer_back(
     )
 
   if turns >= escalate_after:
-    _log("steer_back_escalate", turns=turns)
+    _log("steer_back_escalate", "WARN", turns=turns)
     exhaust = steer_back_cfg.get("on_exhaust", {})
     fc = _resolve_exhaust_action(exhaust, filled)
     if fc:
@@ -868,7 +774,7 @@ def _handle_steer_back(
       )
       msg = next_q.get("system_message", "")
     sm["_hard_steer_yielded"] = True
-    _log("steer_back_hard", turns=turns, msg=msg)
+    _log("steer_back_hard", "WARN", turns=turns, msg=msg)
     _log_invoke(inv_n, "steer_back_hard", filled, pending,
                 fresh_pending, hide_tools, preempted=msg,
                 deferred=deferred)
@@ -906,9 +812,13 @@ def _handle_post_executor(
     retries.pop(task_just, None)
     sub_context = {**filled, **result}
     task_msg = ""
+    task_directive = ""
     msg_template = task_def.get("then_say", "")
+    directive_template = task_def.get("then_directive", "")
     if msg_template:
       task_msg = msg_template.format(**sub_context)
+    if directive_template:
+      task_directive = directive_template.format(**sub_context)
     deferred_transition = sm.pop("_deferred_transition", False)
     if deferred_transition and task_msg and confirm_transition_prefix:
       task_msg = f"{confirm_transition_prefix} {task_msg}"
@@ -919,10 +829,19 @@ def _handle_post_executor(
           filled.pop(sn, None)
         task_results.clear()
         sm["status"] = "in_progress"
+        sm["_just_completed_task"] = task_just
         _log("on_complete", task=task_just,
              cleared=on_complete.get("clear_slots", []))
       else:
         sm["status"] = "complete"
+      if task_directive and not task_msg:
+        _log_invoke(inv_n, phase, filled, pending, fresh_pending,
+                    hide_tools, fired=task_just, deferred=deferred)
+        return {
+            "hide_tools": [],
+            "preempt": False,
+            "task_directive": task_directive,
+        }, "", None
       _log_invoke(inv_n, phase, filled, pending, fresh_pending,
                   hide_tools, fired=task_just, preempted=task_msg,
                   deferred=deferred)
@@ -938,9 +857,13 @@ def _handle_post_executor(
     task_resp = _resolve_response(
         task_def, "then_response", sub_context, channel,
     )
+    if task_directive and not task_msg:
+      return {
+          "task_directive": task_directive,
+      }, "", task_resp
     return None, task_msg, task_resp
 
-  _log("task", name=task_just, ok=False)
+  _log("task", "WARN", name=task_just, ok=False)
   on_failure = task_def.get("on_failure", {})
   max_retries = on_failure.get("max_retries", 0)
   retries[task_just] = retries.get(task_just, 0) + 1
@@ -951,7 +874,7 @@ def _handle_post_executor(
     fc = _resolve_exhaust_action(exhaust, filled)
     if fc:
       sm["status"] = "escalated"
-    _log("task_exhaust", name=task_just)
+    _log("task_exhaust", "ERROR", name=task_just)
     exhaust_msg = exhaust.get("say", "An error occurred.")
     _log_invoke(inv_n, phase, filled, pending, fresh_pending,
                 hide_tools, preempted=exhaust_msg, deferred=deferred)
@@ -983,12 +906,13 @@ def _build_readback_hint(
   """Build readback hint for system instruction."""
   if not fresh_pending or not pending:
     return ""
+  merged_state = {**filled, **pending}
   hint_parts = []
   for slot_def in slots:
     name = slot_def["name"]
     if name not in pending:
       continue
-    if not _is_slot_active(slot_def, filled):
+    if not _is_slot_active(slot_def, merged_state):
       continue
     formatter = _resolve_formatter(slot_def.get("readback_fmt"))
     val = formatter(pending[name]) if formatter else str(pending[name])
@@ -1010,12 +934,13 @@ def _build_readback_hint(
 
 def _build_readback(slots, pending, filled, config=None, channel=""):
   """Build readback confirmation prompt."""
+  merged_state = {**filled, **pending}
   fragments = []
   for slot_def in slots:
     name = slot_def["name"]
     if name not in pending:
       continue
-    if not _is_slot_active(slot_def, filled):
+    if not _is_slot_active(slot_def, merged_state):
       continue
     formatter = _resolve_formatter(slot_def.get("readback_fmt"))
     if formatter:
@@ -1044,9 +969,10 @@ def _find_next_question(
 ):
   """Find the next unfilled user slot to ask about."""
   deferred = deferred or {}
+  merged_state = {**filled, **pending, **deferred}
   for slot_def in slots:
     name = slot_def["name"]
-    if not _is_slot_active(slot_def, filled):
+    if not _is_slot_active(slot_def, merged_state):
       continue
     if name in filled or name in pending or name in deferred:
       continue
@@ -1055,7 +981,7 @@ def _find_next_question(
     requires = slot_def.get("requires", [])
     if not all(
         req in filled
-        or not _is_slot_active(slot_map[req], filled)
+        or not _is_slot_active(slot_map[req], merged_state)
         for req in requires
     ):
       continue
@@ -1099,9 +1025,10 @@ def _find_next_slot_action(
     'next_question', or 'all_done').
   """
   deferred = deferred or {}
+  merged_state = {**filled, **pending, **deferred}
   for slot_def in slots:
     name = slot_def["name"]
-    if not _is_slot_active(slot_def, filled):
+    if not _is_slot_active(slot_def, merged_state):
       continue
     if name in filled or name in pending or name in deferred:
       continue
@@ -1111,7 +1038,7 @@ def _find_next_slot_action(
     requires = slot_def.get("requires", [])
     if not all(
         req in filled
-        or not _is_slot_active(slot_map[req], filled)
+        or not _is_slot_active(slot_map[req], merged_state)
         for req in requires
     ):
       continue
@@ -1145,7 +1072,7 @@ def _find_next_slot_action(
 
 def _compute_dag_state(
     tasks, slots, filled, pending, task_results, slot_map,
-    deferred=None, channel="", config=None,
+    deferred=None, channel="", config=None, skip_task=None,
 ):
   """Evaluate the DAG to determine the next action.
 
@@ -1163,30 +1090,35 @@ def _compute_dag_state(
     deferred: Currently deferred slot values.
     channel: Channel identifier for channel-aware responses.
     config: Full compiled config (for readback_response).
+    skip_task: Task name to skip (just completed via on_complete).
 
   Returns:
     Action dict describing the next step (fire, next_question, etc.).
   """
+  deferred = deferred or {}
+  merged_state = {**filled, **pending, **deferred}
   for task in tasks:
     task_name = task["name"]
+    if task_name == skip_task:
+      continue
     success_key = task.get("success_check", "success")
 
     if (task_name in task_results
         and task_results[task_name].get(success_key)):
       continue
 
-    if not _is_task_active(task, filled):
+    if not _is_task_active(task, merged_state):
       continue
 
     active_inputs = [
         s for s in task["inputs"]
-        if _is_slot_active(slot_map[s], filled)
+        if _is_slot_active(slot_map[s], merged_state)
     ]
     if not all(s in filled for s in active_inputs):
       continue
     task_reqs = [
         r for r in task.get("requires", [])
-        if _is_slot_active(slot_map[r], filled)
+        if _is_slot_active(slot_map[r], merged_state)
     ]
     if not all(r in filled for r in task_reqs):
       continue
@@ -1243,7 +1175,7 @@ def _handle_slot_errors(sm, slots, channel=""):
     max_retries = validation.get("max_retries", 3)
 
     retries[retry_key] = retries.get(retry_key, 0) + 1
-    _log("slot_error", slot=slot_name,
+    _log("slot_error", "WARN", slot=slot_name,
          code=error_code, retries=retries[retry_key])
 
     if retries[retry_key] >= max_retries:
@@ -1259,7 +1191,7 @@ def _handle_slot_errors(sm, slots, channel=""):
       except KeyError:
         pass
       resp = _resolve_response(exhaust, "response", filled, channel)
-      _log("slot_error_exhaust", slot=slot_name)
+      _log("slot_error_exhaust", "ERROR", slot=slot_name)
       return msg, True, fc, resp
 
     error_messages = validation.get("errors", {})
@@ -1344,6 +1276,7 @@ def _check_deferred_groups(
     The names of slots promoted from deferred to pending.
   """
   promoted = []
+  merged_state = {**filled, **pending, **deferred}
   for task_def in tasks:
     if not task_def.get("readback_inputs"):
       continue
@@ -1359,7 +1292,7 @@ def _check_deferred_groups(
         continue
       if "user" not in _normalize_sources(sd.get("source", "user")):
         continue
-      if not _is_slot_active(sd, filled):
+      if not _is_slot_active(sd, merged_state):
         continue
       if inp in filled or inp in pending:
         continue
@@ -1377,9 +1310,11 @@ def _check_deferred_groups(
 
 def _compute_hidden_tools(
     slots, filled, pending, readback_tools, slot_map,
-    *, fresh_pending=False, executor_tools=None,
+    *, fresh_pending=False, executor_tools=None, deferred=None,
 ):
   """Determine which tools to hide from the LLM."""
+  deferred = deferred or {}
+  merged_state = {**filled, **pending, **deferred}
   hidden = []
   if pending:
     if fresh_pending:
@@ -1393,7 +1328,7 @@ def _compute_hidden_tools(
     if not setter:
       continue
     name = slot_def["name"]
-    if not _is_slot_active(slot_def, filled):
+    if not _is_slot_active(slot_def, merged_state):
       hidden.append(setter)
     elif name in filled:
       hidden.append(setter)
@@ -1401,7 +1336,7 @@ def _compute_hidden_tools(
       hidden.append(setter)
     elif not all(
         r in filled
-        or not _is_slot_active(slot_map[r], filled)
+        or not _is_slot_active(slot_map[r], merged_state)
         for r in slot_def.get("requires", [])
     ):
       hidden.append(setter)
@@ -1416,11 +1351,11 @@ def _compute_hidden_tools(
     for sd in slot_defs:
       name = sd["name"]
       if (name not in filled
-          and _is_slot_active(sd, filled)
+          and _is_slot_active(sd, merged_state)
           and not (name in pending and fresh_pending)
           and all(
               r in filled
-              or not _is_slot_active(slot_map[r], filled)
+              or not _is_slot_active(slot_map[r], merged_state)
               for r in sd.get("requires", [])
           )):
         while tool_name in hidden:
@@ -1473,7 +1408,8 @@ def _build_si_suffix(
         f"\n\n<confirmed_details>"
         f"\nThe user has already provided and confirmed the following details:"
         f"\n{confirmed_summary}"
-        f"\nDo NOT re-ask the user for these details, and do NOT call setter tools for them."
+        f"\nDo NOT re-ask the user for these details,"
+        f" and do NOT call setter tools for them."
         f"\n</confirmed_details>"
     )
 
@@ -1487,6 +1423,11 @@ def _build_si_suffix(
           f"\n\n<readback_scope>"
           f"\nYou MUST confirm ALL of the following values together"
           f" in a single readback — do NOT omit any:\n{readback_hint}"
+          f"\n\nNote: Some of these values (like name or phone number) may have been"
+          f" carried over or pre-filled from previous topics or orders. Do NOT"
+          f" ask for them again from scratch. Instead, confirm/validate them warmly"
+          f" (e.g., 'I see we have your name as John Smith, shall I put this under"
+          f" the same name?')."
           f"\n</readback_scope>"
       )
     else:
@@ -1502,7 +1443,6 @@ def _build_si_suffix(
         f"\n</deferred_collection>"
     )
   return si_suffix
-
 
 
 # ═════════════════════════════════════════════════════════════════════
@@ -1582,6 +1522,7 @@ def _run_slot_filling(
   hide_tools = _compute_hidden_tools(
       slots, filled, pending, readback_tools, slot_map,
       fresh_pending=fresh_pending, executor_tools=executor_tool_names,
+      deferred=deferred,
   )
   bootstrap_tool = config.get("bootstrap", {}).get("tool")
   if bootstrap_tool and bootstrap_tool in hide_tools:
@@ -1623,16 +1564,23 @@ def _run_slot_filling(
     return result
 
   # ── Announce slots (cascade through consecutive) ────────
+  _just_completed = sm.pop("_just_completed_task", None)
   announce_msgs = []
   announce_responses = []
   any_announce_preempt = False
   dag_result = _compute_dag_state(
       tasks, slots, filled, pending, task_results, slot_map,
       deferred=deferred, channel=channel, config=config,
+      skip_task=_just_completed,
   )
+  _announced = set()
   while dag_result["action"] == "announce":
     slot_def_a = dag_result["slot_def"]
     name_a = slot_def_a["name"]
+    if name_a in _announced:
+      _log("announce_cycle_break", "WARN", slot=name_a)
+      break
+    _announced.add(name_a)
     msg_a = slot_def_a["message"]
     try:
       msg_a = msg_a.format(**filled)
@@ -1649,52 +1597,59 @@ def _run_slot_filling(
     dag_result = _compute_dag_state(
         tasks, slots, filled, pending, task_results,
         slot_map, deferred=deferred, channel=channel, config=config,
+        skip_task=_just_completed,
     )
 
   # Skip task fire on inline confirm — the LLM needs to run first
   # to process the additional content in the user's message. The
   # task will fire on the next before_model_callback invocation
   # after the LLM calls setters for the new content.
+  _fired_this_call = set()
   if dag_result["action"] == "fire" and not inline_confirmed:
     task_def_f = dag_result["task_def"]
     task_name_f = task_def_f["name"]
-    tool_name = task_def_f["tool"]
-    active_inputs = [
-        s for s in task_def_f["inputs"]
-        if _is_slot_active(slot_map[s], filled)
-    ]
-    args = {k: filled[k] for k in active_inputs if k in filled}
-    for name in deferred_promoted:
-      if name in pending and name not in active_inputs:
-        deferred[name] = pending.pop(name)
-        _log("re_deferred", slot=name, task=task_name_f)
-    if readback_transition:
-      sm["_deferred_transition"] = True
-    sm["_last_state"] = {
-        "filled": dict(filled),
-        "pending": dict(pending),
-        "deferred": dict(deferred),
-    }
-    combined_msg = task_msg
-    if announce_msgs:
-      announce_text = " ".join(announce_msgs)
-      combined_msg = (
-          f"{announce_text} {task_msg}"
-          if task_msg else announce_text
-      )
-    _log_invoke(inv_n, phase, filled, pending, fresh_pending,
-                hide_tools, fired=task_name_f, deferred=deferred)
-    fire_hide = [t for t in hide_tools if t != tool_name]
-    fire_result = {
-        "hide_tools": fire_hide,
-        "preempt": True,
-        "force_preempt": any_announce_preempt,
-        "function_call": {"name": tool_name, "args": args},
-        "message": combined_msg,
-    }
-    if announce_responses:
-      fire_result["response"] = announce_responses
-    return fire_result
+    if task_name_f in _fired_this_call:
+      _log("task_refire_blocked", "WARN", task=task_name_f)
+    else:
+      _fired_this_call.add(task_name_f)
+      tool_name = task_def_f["tool"]
+      merged_state = {**filled, **pending, **deferred}
+      active_inputs = [
+          s for s in task_def_f["inputs"]
+          if _is_slot_active(slot_map[s], merged_state)
+      ]
+      args = {k: filled[k] for k in active_inputs if k in filled}
+      for name in deferred_promoted:
+        if name in pending and name not in active_inputs:
+          deferred[name] = pending.pop(name)
+          _log("re_deferred", slot=name, task=task_name_f)
+      if readback_transition:
+        sm["_deferred_transition"] = True
+      sm["_last_state"] = {
+          "filled": dict(filled),
+          "pending": dict(pending),
+          "deferred": dict(deferred),
+      }
+      combined_msg = task_msg
+      if announce_msgs:
+        announce_text = " ".join(announce_msgs)
+        combined_msg = (
+            f"{announce_text} {task_msg}"
+            if task_msg else announce_text
+        )
+      _log_invoke(inv_n, phase, filled, pending, fresh_pending,
+                  hide_tools, fired=task_name_f, deferred=deferred)
+      fire_hide = [t for t in hide_tools if t != tool_name]
+      fire_result = {
+          "hide_tools": fire_hide,
+          "preempt": True,
+          "force_preempt": any_announce_preempt,
+          "function_call": {"name": tool_name, "args": args},
+          "message": combined_msg,
+      }
+      if announce_responses:
+        fire_result["response"] = announce_responses
+      return fire_result
 
   dag_msg = dag_result.get("system_message", "")
   if task_msg and dag_msg:
@@ -1787,22 +1742,22 @@ def _run_slot_filling(
     unconditional = unconditional + dag_response
   if unconditional:
     sm["_pending_payloads"] = unconditional
-    _log("payload_route", path="stash_unconditional",
+    _log("payload_route", "DEBUG", path="stash_unconditional",
          n_parts=len(unconditional))
   if dag_response and not awaiting_rb:
     sm["_pending_question_payloads"] = {
         "slot": dag_result.get("slot_name"),
         "parts": dag_response,
     }
-    _log("payload_route", path="stash_question",
+    _log("payload_route", "DEBUG", path="stash_question",
          slot=dag_result.get("slot_name"),
          n_parts=len(dag_response))
   if not unconditional and not dag_response:
-    _log("payload_route", path="none")
+    _log("payload_route", "DEBUG", path="none")
 
   if preempt and combined_response:
     final["response"] = combined_response
-    _log("payload_route", path="preempt_dispatch",
+    _log("payload_route", "DEBUG", path="preempt_dispatch",
          n_parts=len(combined_response))
   return final
 
@@ -1829,20 +1784,17 @@ def slot_filling_engine(input_data: dict[str, Any]) -> dict[str, Any]:
     (the updated state machine).
   """
   # pylint: disable=global-variable-not-assigned
-  global _COMPILED_CONFIGS, _DEBUG, _DEBUG_LOG
-
-  _DEBUG = bool(input_data.get("debug"))
-  _DEBUG_LOG = []
+  global _COMPILED_CONFIGS, _sm_ref
 
   raw_config = input_data.get("raw_config", {})
   sm = input_data.get("sm", {})
+  _sm_ref = sm
   last_user_text = input_data.get("last_user_text", "")
   event_data = input_data.get("event_data") or {}
   config_id = input_data.get("config_id", "default")
 
   # ── Compile config (cached per config_id) ──────────────────
   if config_id not in _COMPILED_CONFIGS:
-    _validate_config(raw_config)
     _COMPILED_CONFIGS[config_id] = _compile_config(raw_config)
   config = _COMPILED_CONFIGS[config_id]
 
@@ -1912,6 +1864,9 @@ def slot_filling_engine(input_data: dict[str, Any]) -> dict[str, Any]:
 
   # ── Generate tool selection for before_agent_callback ───────
   filled_for_ts = sm.get("filled", {})
+  pending_for_ts = sm.get("pending", {})
+  deferred_for_ts = sm.get("deferred", {})
+  merged_for_ts = {**filled_for_ts, **pending_for_ts, **deferred_for_ts}
   ts_lines = []
   ordering_parts = []
   prereq_parts = []
@@ -1924,7 +1879,7 @@ def slot_filling_engine(input_data: dict[str, Any]) -> dict[str, Any]:
     setter = slot_def.get("setter", "")
     if name in filled_for_ts:
       continue
-    if hint and setter and _is_slot_active(slot_def, filled_for_ts):
+    if hint and setter and _is_slot_active(slot_def, merged_for_ts):
       ts_lines.append(f"   - {hint} → {setter}")
     if not slot_def.get("condition") and hint and setter:
       ordering_parts.append(name)
@@ -1956,7 +1911,5 @@ def slot_filling_engine(input_data: dict[str, Any]) -> dict[str, Any]:
   else:
     action["event_prefilled"] = False
 
-  result = {"action": action, "sm": sm}
-  if _DEBUG:
-    result["_debug_log"] = _DEBUG_LOG
-  return result
+  _sm_ref = None
+  return {"action": action, "sm": sm}

--- a/examples/bella_notte/tools/validate_dag_config/python_function/python_code.py
+++ b/examples/bella_notte/tools/validate_dag_config/python_function/python_code.py
@@ -1,0 +1,1606 @@
+# pylint: disable=invalid-name
+"""Slot filling DAG config validator — reusable across projects.
+
+FRAMEWORK CODE — shared across all agents using the slot-filling engine.
+Do not add agent-specific logic here; this validates DAG config structure
+and cross-config interactions generically.
+
+Validates structure and references in a DAG configuration dict.
+Catches misconfigurations (broken references, loop risks, missing
+fields) before the engine encounters them at runtime.
+
+Usable as a CES tool (via validate_dag_config()) or directly from
+pytest (via DagConfigValidator / CrossConfigValidator).
+"""
+
+import ast
+import dataclasses
+import string
+from typing import Any
+
+
+@dataclasses.dataclass
+class ValidationResult:
+  """Structured output from DAG config validation."""
+
+  valid: bool = True
+  errors: list[str] = dataclasses.field(default_factory=list)
+  warnings: list[str] = dataclasses.field(default_factory=list)
+
+
+_VALID_SOURCES = frozenset({"user", "announce", "event"})
+
+_VALID_READBACK_FMT_TYPES = frozenset({
+    "prefix", "plural", "none_sub", "date", "time",
+})
+
+_READBACK_FMT_REQUIRED_FIELDS = {
+    "prefix": ["text"],
+    "plural": ["one", "other"],
+    "none_sub": ["default"],
+}
+
+_VALID_RESPONSE_TYPES = frozenset({
+    "text", "payload", "end_session", "transfer",
+})
+
+_SAFE_EVAL_GLOBALS = {  # pylint: disable=unused-variable
+    "__builtins__": {
+        "int": int, "str": str, "len": len,
+        "float": float, "bool": bool,
+    },
+}
+
+
+def _normalize_sources(source) -> list[str]:
+  """Normalize slot source to a list."""
+  if isinstance(source, list):
+    return source
+  return [source] if source else ["user"]
+
+
+def _extract_format_fields(template: str) -> set[str]:
+  """Extract {field_name} placeholders from a format string."""
+  try:
+    return {
+        fname for _, fname, _, _
+        in string.Formatter().parse(template)
+        if fname is not None
+    }
+  except (ValueError, KeyError):
+    return set()
+
+
+def _extract_dict_keys_from_source(source: str) -> set[str] | None:
+  """Extract string keys from dict literals and subscript assignments.
+
+  Parses Python source and collects keys from:
+    - Dict literals: {"key": ...}
+    - Subscript assignments: result["key"] = ...
+    - values["key"] = ... (nested dict builds)
+
+  Args:
+    source: Python source code to parse.
+
+  Returns:
+    Tuple of (all_keys, nested_keys) or None if parsing fails.
+  """
+  try:
+    tree = ast.parse(source)
+  except SyntaxError:
+    return None
+  keys: set[str] = set()
+  nested_keys: dict[str, set[str]] = {}
+
+  for node in ast.walk(tree):
+    if isinstance(node, ast.Dict):
+      for k in node.keys:
+        if isinstance(k, ast.Constant) and isinstance(k.value, str):
+          keys.add(k.value)
+    if isinstance(node, ast.Assign):
+      for target in node.targets:
+        if (isinstance(target, ast.Subscript)
+            and isinstance(target.slice, ast.Constant)
+            and isinstance(target.slice.value, str)):
+          var_name = ""
+          if isinstance(target.value, ast.Name):
+            var_name = target.value.id
+          keys.add(target.slice.value)
+          if var_name:
+            nested_keys.setdefault(var_name, set()).add(
+                target.slice.value)
+
+  return keys, nested_keys
+
+
+def _extract_values_dict_keys(source: str) -> set[str] | None:
+  """Extract keys written into a 'values' dict in setter source.
+
+  For multi-setters that build: values = {}; values["field"] = x
+  or values = {"field": x}.
+
+  Args:
+    source: Python source code of the setter function.
+
+  Returns:
+    Set of keys from the values dict, or None if undetermined.
+  """
+  result = _extract_dict_keys_from_source(source)
+  if result is None:
+    return None
+  _, nested = result
+  if "values" in nested:
+    return nested["values"]
+  return None
+
+
+class DagConfigValidator:
+  """Validates a slot filling DAG configuration.
+
+  Usage:
+      result = DagConfigValidator(raw_config).validate()
+      if not result.valid:
+          print(result.errors)
+  """
+
+  def __init__(self, config: dict[str, Any],
+               available_tools: list[str] | None = None,
+               setter_sources: dict[str, str] | None = None,
+               task_tool_sources: dict[str, str] | None = None):
+    self._config = config
+    self._slots = config.get("slots", [])
+    self._tasks = config.get("tasks", [])
+    self._slot_map = {s["name"]: s for s in self._slots if "name" in s}
+    self._slot_names = [s["name"] for s in self._slots if "name" in s]
+    self._slot_set = set(self._slot_names)
+    self._task_map = {t["name"]: t for t in self._tasks if "name" in t}
+    self._task_names = {t["name"] for t in self._tasks if "name" in t}
+    self._available_tools = (
+        set(available_tools) if available_tools else None)
+    self._setter_sources = setter_sources or {}
+    self._task_tool_sources = task_tool_sources or {}
+    self._errors: list[str] = []
+    self._warnings: list[str] = []
+
+  def validate(self) -> ValidationResult:
+    """Run all checks and return results."""
+    self._check_top_level_structure()
+    self._check_duplicate_slots()
+    self._check_slot_names()
+    self._check_slot_references()
+    self._check_slot_sources()
+    self._check_slot_readback_fmt()
+    self._check_slot_validation_config()
+    self._check_slot_validate_against()
+    self._check_slot_conditions()
+    self._check_task_names()
+    self._check_task_references()
+    self._check_task_on_failure()
+    self._check_task_on_complete()
+    self._check_loop_risks()
+    self._check_circular_requires()
+    self._check_bootstrap()
+    self._check_gate_slot()
+    self._check_steer_back()
+    self._check_response_parts()
+    self._check_format_string_placeholders()
+    self._check_orphaned_slots()
+    self._check_reachability()
+    self._check_tool_availability()
+    self._check_setter_output_keys()
+    self._check_task_output_keys()
+    self._check_duplicate_setter_mappings()
+    self._check_clear_slots_subset()
+    self._check_announce_dead_config()
+    self._check_user_slot_fields()
+    self._check_terminal_task_feedback()
+    self._check_task_output_source_alignment()
+    self._check_exhaust_tool_exists()
+    self._check_options_from_ordering()
+    self._check_empty_strings()
+    self._check_ask_text_response_conflict()
+    return ValidationResult(
+        valid=len(self._errors) == 0,
+        errors=list(self._errors),
+        warnings=list(self._warnings),
+    )
+
+  # ── Helpers ──────────────────────────────────────────────
+
+  def _error(self, msg: str):
+    self._errors.append(msg)
+
+  def _warn(self, msg: str):
+    self._warnings.append(msg)
+
+  # ── Top-level structure ────────────────────────────────
+
+  def _check_top_level_structure(self):
+    """Check that config has slots and optionally tasks.
+
+    Without slots, the engine has nothing to collect and
+    _compile_config raises KeyError on config["slots"]. Tasks are
+    optional (warn-only) since a config could be announce-only.
+    """
+    if not self._slots and not self._tasks:
+      self._error("Config has no 'slots' and no 'tasks'")
+      return
+    if not self._slots:
+      self._error("Config has no 'slots'")
+    if not self._tasks:
+      self._warn("Config has no 'tasks'")
+
+  # ── Slot checks ────────────────────────────────────────
+
+  def _check_duplicate_slots(self):
+    """Check for duplicate slot names.
+
+    Two slots with the same name cause the second to shadow the
+    first in slot_map. The engine silently uses only the last
+    definition, losing the first slot's setter, validation, and
+    readback config.
+    """
+    if len(self._slot_names) != len(self._slot_set):
+      dupes = {
+          n for n in self._slot_names
+          if self._slot_names.count(n) > 1
+      }
+      self._error(f"Duplicate slot names: {dupes}")
+
+  def _check_slot_names(self):
+    """Check that every slot has a 'name' key.
+
+    Slots without 'name' cause KeyError in slot_map construction
+    and are invisible to every engine lookup.
+    """
+    for i, slot in enumerate(self._slots):
+      if "name" not in slot:
+        self._error(f"Slot at index {i} has no 'name'")
+
+  def _check_slot_references(self):
+    """Validate slot wiring for announce, requires, and options_from.
+
+    Catches: announce without 'message' (KeyError at announce time),
+    announce with 'setter' (conflicts with auto-fill), requires
+    referencing unknown slot (KeyError in _find_next_slot_action),
+    and options_from referencing unknown slot (empty chip lists).
+    """
+    for slot in self._slots:
+      name = slot.get("name", "<unnamed>")
+      sources = _normalize_sources(
+          slot.get("source", "user"))
+      if "announce" in sources:
+        if not slot.get("message"):
+          self._error(
+              f"Announce slot '{name}' requires 'message'")
+        if slot.get("setter"):
+          self._error(
+              f"Announce slot '{name}'"
+              " must not have 'setter'")
+      for req in slot.get("requires", []):
+        if req not in self._slot_set:
+          self._error(
+              f"Slot '{name}' requires unknown '{req}'")
+      options_from = self._find_options_from(slot)
+      if options_from and options_from not in self._slot_set:
+        self._error(
+            f"Slot '{name}' response has options_from"
+            f" '{options_from}' not in slots")
+
+  def _find_options_from(self, slot_or_task: dict[str, Any]) -> str | None:
+    """Recursively search response parts for options_from."""
+    for resp in slot_or_task.get("response", []):
+      found = self._search_options_from(resp)
+      if found:
+        return found
+    return None
+
+  def _search_options_from(self, obj) -> str | None:
+    """Recursively search a response part for options_from."""
+    if isinstance(obj, dict):
+      if "options_from" in obj:
+        return obj["options_from"]
+      for v in obj.values():
+        found = self._search_options_from(v)
+        if found:
+          return found
+    elif isinstance(obj, list):
+      for item in obj:
+        found = self._search_options_from(item)
+        if found:
+          return found
+    return None
+
+  def _check_slot_sources(self):
+    """Validate that slot sources are recognized and well-formed.
+
+    Valid sources: 'user', 'announce', 'event', 'task:TaskName'.
+    Also checks task:X references existing tasks, event source has
+    event_key, and setter_field has a parent setter.
+    """
+    for slot in self._slots:
+      name = slot.get("name", "<unnamed>")
+      sources = _normalize_sources(
+          slot.get("source", "user"))
+      for source in sources:
+        if source.startswith("task:"):
+          src_task = source[5:]
+          if src_task not in self._task_names:
+            self._error(
+                f"Slot '{name}' references unknown task"
+                f" '{src_task}'")
+        elif source not in _VALID_SOURCES:
+          self._error(
+              f"Slot '{name}' has unknown source"
+              f" '{source}'")
+      if "event" in sources and not slot.get("event_key"):
+        self._warn(
+            f"Slot '{name}' has 'event' source but no"
+            " 'event_key' — will default to slot name")
+      if slot.get("setter_field") and not slot.get("setter"):
+        self._error(
+            f"Slot '{name}' has 'setter_field' without"
+            " 'setter'")
+
+  def _check_slot_readback_fmt(self):
+    """Validate readback_fmt type, required fields, and value type.
+
+    readback_fmt can be a string shorthand, a dict with type+params,
+    or a callable. Checks for unknown types and missing required
+    fields (e.g. plural without "one"/"other").
+    """
+    for slot in self._slots:
+      name = slot.get("name", "<unnamed>")
+      fmt = slot.get("readback_fmt")
+      if fmt is None:
+        continue
+      if isinstance(fmt, str):
+        if fmt not in _VALID_READBACK_FMT_TYPES:
+          self._error(
+              f"Slot '{name}' readback_fmt string"
+              f" '{fmt}' not recognized — valid:"
+              f" {sorted(_VALID_READBACK_FMT_TYPES)}")
+        continue
+      if isinstance(fmt, dict):
+        fmt_type = fmt.get("type")
+        if not fmt_type:
+          self._error(
+              f"Slot '{name}' readback_fmt dict"
+              " missing 'type'")
+          continue
+        if fmt_type not in _VALID_READBACK_FMT_TYPES:
+          self._error(
+              f"Slot '{name}' readback_fmt type"
+              f" '{fmt_type}' not recognized — valid:"
+              f" {sorted(_VALID_READBACK_FMT_TYPES)}")
+          continue
+        required = _READBACK_FMT_REQUIRED_FIELDS.get(
+            fmt_type, [])
+        for field_name in required:
+          if field_name not in fmt:
+            self._error(
+                f"Slot '{name}' readback_fmt type"
+                f" '{fmt_type}' missing required"
+                f" field '{field_name}'")
+        continue
+      if not callable(fmt):
+        self._error(
+            f"Slot '{name}' readback_fmt must be"
+            " string, dict, or callable")
+
+  def _check_slot_validation_config(self):
+    """Validate the validation block on each slot.
+
+    Checks validation.errors is a dict, max_retries is a positive
+    int, and on_exhaust structure is valid. Wrong types cause silent
+    failures or TypeErrors at runtime.
+    """
+    for slot in self._slots:
+      name = slot.get("name", "<unnamed>")
+      validation = slot.get("validation")
+      if not validation:
+        continue
+      if not isinstance(validation, dict):
+        self._error(
+            f"Slot '{name}' validation must be a dict")
+        continue
+      errors = validation.get("errors")
+      if errors is not None and not isinstance(errors, dict):
+        self._error(
+            f"Slot '{name}' validation.errors"
+            " must be a dict")
+      max_retries = validation.get("max_retries")
+      if max_retries is not None:
+        if not isinstance(max_retries, int):
+          self._error(
+              f"Slot '{name}' validation.max_retries"
+              " must be an int")
+        elif max_retries < 1:
+          self._warn(
+              f"Slot '{name}' validation.max_retries"
+              f" is {max_retries} — effectively no retries")
+      on_exhaust = validation.get("on_exhaust")
+      if on_exhaust is not None:
+        self._check_on_exhaust(
+            on_exhaust,
+            f"Slot '{name}' validation.on_exhaust")
+
+  def _check_slot_validate_against(self):
+    """Validate cross-slot validate_against configuration.
+
+    Checks that response_field, filled_slot, and error_code are all
+    present, and that filled_slot references a known slot.
+    """
+    for slot in self._slots:
+      name = slot.get("name", "<unnamed>")
+      va = slot.get("validate_against")
+      if not va:
+        continue
+      if not isinstance(va, dict):
+        self._error(
+            f"Slot '{name}' validate_against"
+            " must be a dict")
+        continue
+      for required_field in ("response_field", "filled_slot",
+                             "error_code"):
+        if required_field not in va:
+          self._error(
+              f"Slot '{name}' validate_against"
+              f" missing '{required_field}'")
+      filled_slot = va.get("filled_slot")
+      if filled_slot and filled_slot not in self._slot_set:
+        self._error(
+            f"Slot '{name}' validate_against.filled_slot"
+            f" '{filled_slot}' not in slots")
+
+  def _check_slot_conditions(self):
+    """Validate that slot condition strings compile without errors.
+
+    Condition strings are eval'd at compile time by _compile_config.
+    Compiling early surfaces syntax errors with the slot name.
+    """
+    for slot in self._slots:
+      name = slot.get("name", "<unnamed>")
+      cond = slot.get("condition")
+      if cond is None or callable(cond):
+        continue
+      if isinstance(cond, str):
+        try:
+          compile(cond, f"<slot:{name}:condition>", "eval")
+        except SyntaxError as e:
+          self._error(
+              f"Slot '{name}' condition syntax error: {e}")
+      else:
+        self._error(
+            f"Slot '{name}' condition must be callable"
+            f" or string, got {type(cond).__name__}")
+
+  # ── Task checks ────────────────────────────────────────
+
+  def _check_task_names(self):
+    """Check that every task has a 'name' key.
+
+    Tasks without 'name' cause KeyError in task_results tracking
+    and cannot be referenced by task:X slot sources.
+    """
+    for i, task in enumerate(self._tasks):
+      if "name" not in task:
+        self._error(f"Task at index {i} has no 'name'")
+
+  def _check_task_references(self):
+    """Validate task tool, inputs, outputs, requires, and conditions.
+
+    Checks that tasks have a 'tool' key, inputs/outputs/requires
+    reference known slots, and condition strings compile.
+    """
+    for task in self._tasks:
+      name = task.get("name", "<unnamed>")
+      if not task.get("tool"):
+        self._error(f"Task '{name}' has no 'tool' key")
+      for inp in task.get("inputs", []):
+        if inp not in self._slot_set:
+          self._error(
+              f"Task '{name}' input '{inp}' not in slots")
+      for sn in task.get("outputs", {}).values():
+        if sn not in self._slot_set:
+          self._error(
+              f"Task '{name}' output '{sn}' not in slots")
+      for req in task.get("requires", []):
+        if req not in self._slot_set:
+          self._error(
+              f"Task '{name}' requires '{req}'"
+              " not in slots")
+      cond = task.get("condition")
+      if cond is not None:
+        if callable(cond):
+          pass
+        elif isinstance(cond, str):
+          try:
+            compile(cond, f"<task:{name}:condition>", "eval")
+          except SyntaxError as e:
+            self._error(
+                f"Task '{name}' condition syntax error: {e}")
+        else:
+          self._error(
+              f"Task '{name}' condition must be callable"
+              f" or string, got {type(cond).__name__}")
+
+  def _check_task_on_failure(self):
+    """Validate task on_failure clear_slots and on_exhaust.
+
+    clear_slots referencing unknown names silently no-ops, so
+    the intended retry flow never triggers. on_exhaust structure
+    is validated by _check_on_exhaust.
+    """
+    for task in self._tasks:
+      name = task.get("name", "<unnamed>")
+      on_failure = task.get("on_failure")
+      if not on_failure:
+        continue
+      if not isinstance(on_failure, dict):
+        self._error(
+            f"Task '{name}' on_failure must be a dict")
+        continue
+      for sn in on_failure.get("clear_slots", []):
+        if sn not in self._slot_set:
+          self._error(
+              f"Task '{name}' on_failure.clear_slots"
+              f" references unknown slot '{sn}'")
+      on_exhaust = on_failure.get("on_exhaust")
+      if on_exhaust is not None:
+        self._check_on_exhaust(
+            on_exhaust, f"Task '{name}' on_failure.on_exhaust")
+
+  def _check_task_on_complete(self):
+    """Validate task on_complete clear_slots references.
+
+    on_complete clear_slots remove filled values so the DAG can
+    loop. Unknown slot names silently no-op, so the intended
+    reset flow doesn't work properly.
+    """
+    for task in self._tasks:
+      name = task.get("name", "<unnamed>")
+      on_complete = task.get("on_complete")
+      if not on_complete:
+        continue
+      if not isinstance(on_complete, dict):
+        self._error(
+            f"Task '{name}' on_complete must be a dict")
+        continue
+      for sn in on_complete.get("clear_slots", []):
+        if sn not in self._slot_set:
+          self._error(
+              f"Task '{name}' on_complete.clear_slots"
+              f" references unknown slot '{sn}'")
+
+  # ── Loop risk checks ───────────────────────────────────
+
+  def _check_loop_risks(self):
+    """Detect task configurations that cause infinite loops.
+
+    Checks three patterns: task with no inputs and not terminal
+    (fires every call), on_failure without max_retries (unbounded
+    retries), and terminal on_complete that doesn't clear all
+    inputs (immediate re-fire after reset).
+    """
+    for task in self._tasks:
+      name = task.get("name", "<unnamed>")
+      if not task.get("inputs", []) and not task.get("terminal"):
+        self._error(
+            f"Task '{name}' has no inputs and is not"
+            " terminal — will fire immediately and may loop")
+      on_failure = task.get("on_failure", {})
+      if on_failure and "max_retries" not in on_failure:
+        self._error(
+            f"Task '{name}' has on_failure but no"
+            " max_retries — retries would be unbounded")
+      if task.get("terminal") and task.get("on_complete"):
+        cleared = set(
+            task["on_complete"].get("clear_slots", []))
+        inputs_s = set(task.get("inputs", []))
+        uncovered = inputs_s - cleared
+        if uncovered:
+          self._warn(
+              f"Task '{name}' on_complete doesn't clear"
+              f" inputs {uncovered} — may re-fire")
+
+  def _check_circular_requires(self):
+    """Detect circular requires chains that stall the flow.
+
+    If slot A requires B and B requires A, neither can ever
+    become eligible. Uses DFS cycle detection.
+    """
+    visited, stack = set(), set()
+
+    def has_cycle(name):
+      visited.add(name)
+      stack.add(name)
+      slot_def = self._slot_map.get(name)
+      if slot_def:
+        for req in slot_def.get("requires", []):
+          if req not in visited:
+            if has_cycle(req):
+              return True
+          elif req in stack:
+            return True
+      stack.discard(name)
+      return False
+
+    for name in self._slot_names:
+      if name not in visited:
+        if has_cycle(name):
+          self._error(
+              f"Circular requires involving '{name}'")
+
+  # ── Orphan / reachability / tool checks ─────────────────
+
+  def _check_orphaned_slots(self):
+    """Detect slots that have no mechanism to be filled."""
+    for slot in self._slots:
+      name = slot.get("name", "<unnamed>")
+      sources = _normalize_sources(slot.get("source", "user"))
+      if "user" in sources and not slot.get("setter"):
+        self._error(
+            f"Slot '{name}' has source 'user' but no setter"
+            " — cannot be filled by user input")
+      if "event" in sources and not slot.get("event_key"):
+        self._error(
+            f"Slot '{name}' has source 'event' but no"
+            " event_key")
+      for src in sources:
+        if src.startswith("task:"):
+          task_ref = src[5:]
+          if task_ref not in self._task_names:
+            self._error(
+                f"Slot '{name}' source references unknown"
+                f" task '{task_ref}'")
+
+  def _check_reachability(self):
+    """Graph walk from fillable roots to detect unreachable slots/tasks.
+
+    Fillable roots: slots with setter, announce source, event+event_key,
+    bootstrap.slot, bootstrap.welcome_slot, gate_slot. Fixed-point
+    iteration propagates through requires and task inputs/outputs.
+    """
+    bootstrap = self._config.get("bootstrap", {})
+    if not isinstance(bootstrap, dict):
+      bootstrap = {}
+    gate_slot = self._config.get("gate_slot")
+
+    fillable: set[str] = set()
+    for slot in self._slots:
+      name = slot.get("name", "<unnamed>")
+      sources = _normalize_sources(slot.get("source", "user"))
+      if slot.get("setter"):
+        fillable.add(name)
+      if "announce" in sources:
+        fillable.add(name)
+      if "event" in sources and slot.get("event_key"):
+        fillable.add(name)
+    if bootstrap.get("slot"):
+      fillable.add(bootstrap["slot"])
+    if bootstrap.get("welcome_slot"):
+      fillable.add(bootstrap["welcome_slot"])
+    if gate_slot:
+      fillable.add(gate_slot)
+
+    changed = True
+    reachable_tasks: set[str] = set()
+    while changed:
+      changed = False
+      for slot in self._slots:
+        name = slot.get("name", "<unnamed>")
+        if name in fillable:
+          continue
+        reqs = slot.get("requires", [])
+        if not reqs:
+          continue
+        if all(r in fillable for r in reqs):
+          sources = _normalize_sources(
+              slot.get("source", "user"))
+          has_fill_mechanism = (
+              slot.get("setter")
+              or "announce" in sources
+              or ("event" in sources and slot.get("event_key"))
+          )
+          if has_fill_mechanism:
+            fillable.add(name)
+            changed = True
+      for task in self._tasks:
+        tname = task.get("name", "<unnamed>")
+        if tname in reachable_tasks:
+          continue
+        inputs_ok = all(
+            s in fillable for s in task.get("inputs", []))
+        reqs_ok = all(
+            s in fillable for s in task.get("requires", []))
+        if inputs_ok and reqs_ok:
+          reachable_tasks.add(tname)
+          for slot_name in task.get("outputs", {}).values():
+            if slot_name not in fillable:
+              fillable.add(slot_name)
+              changed = True
+
+    for slot in self._slots:
+      name = slot.get("name", "<unnamed>")
+      if name not in fillable:
+        missing = [
+            r for r in slot.get("requires", [])
+            if r not in fillable]
+        if missing:
+          self._error(
+              f"Slot '{name}' is unreachable: requires"
+              f" unfillable {missing}")
+        else:
+          self._error(f"Slot '{name}' is unreachable")
+
+    for task in self._tasks:
+      tname = task.get("name", "<unnamed>")
+      if tname not in reachable_tasks:
+        missing_inputs = [
+            s for s in task.get("inputs", [])
+            if s not in fillable]
+        missing_reqs = [
+            s for s in task.get("requires", [])
+            if s not in fillable]
+        detail = []
+        if missing_inputs:
+          detail.append(f"unfillable inputs {missing_inputs}")
+        if missing_reqs:
+          detail.append(
+              f"unfillable requires {missing_reqs}")
+        suffix = ": " + ", ".join(detail) if detail else ""
+        self._error(
+            f"Task '{tname}' is unreachable{suffix}")
+
+  def _check_tool_availability(self):
+    """Check that setter/task tools exist in the agent's tool list."""
+    if self._available_tools is None:
+      return
+    for slot in self._slots:
+      setter = slot.get("setter")
+      if setter and setter not in self._available_tools:
+        self._error(
+            f"Slot '{slot.get('name', '<unnamed>')}' setter"
+            f" '{setter}' not in agent tool list")
+    for task in self._tasks:
+      tool = task.get("tool")
+      if tool and tool not in self._available_tools:
+        self._error(
+            f"Task '{task.get('name', '<unnamed>')}' tool"
+            f" '{tool}' not in agent tool list")
+    bootstrap = self._config.get("bootstrap", {})
+    if isinstance(bootstrap, dict):
+      bt = bootstrap.get("tool")
+      if bt and bt not in self._available_tools:
+        self._error(
+            f"Bootstrap tool '{bt}' not in agent tool list")
+
+  def _check_setter_output_keys(self):
+    """Check that setter source code returns the keys the config expects.
+
+    For multi-setters (setter_field), verifies the field name appears
+    as a key in the values dict. For simple setters, verifies "value"
+    appears in return dicts. Skips if setter source is unavailable or
+    unparseable.
+    """
+    if not self._setter_sources:
+      return
+    setter_fields: dict[str, list[str]] = {}
+    simple_setters: set[str] = set()
+    for slot in self._slots:
+      setter = slot.get("setter")
+      if not setter:
+        continue
+      field = slot.get("setter_field")
+      if field:
+        setter_fields.setdefault(setter, []).append(field)
+      else:
+        simple_setters.add(setter)
+
+    for setter_name, fields in setter_fields.items():
+      source = self._setter_sources.get(setter_name)
+      if not source:
+        continue
+      values_keys = _extract_values_dict_keys(source)
+      if values_keys is None:
+        continue
+      for field in fields:
+        if field not in values_keys:
+          self._error(
+              f"Setter '{setter_name}' config expects"
+              f" setter_field '{field}' but source code"
+              f" never writes values[\"{field}\"]")
+
+    for setter_name in simple_setters:
+      source = self._setter_sources.get(setter_name)
+      if not source:
+        continue
+      result = _extract_dict_keys_from_source(source)
+      if result is None:
+        continue
+      all_keys, _ = result
+      if "value" not in all_keys:
+        self._warn(
+            f"Setter '{setter_name}' may not return"
+            f" a 'value' key")
+
+  def _check_task_output_keys(self):
+    """Check that task tools return the keys declared in outputs.
+
+    Config declares outputs: {result_key: slot_name}. The engine
+    reads result[result_key] after the task fires. If the tool
+    never returns that key, the output slot is silently never filled.
+    """
+    if not self._task_tool_sources:
+      return
+    for task in self._tasks:
+      tool_name = task.get("tool")
+      outputs = task.get("outputs", {})
+      if not tool_name or not outputs:
+        continue
+      source = self._task_tool_sources.get(tool_name)
+      if not source:
+        continue
+      result = _extract_dict_keys_from_source(source)
+      if result is None:
+        continue
+      all_keys, _ = result
+      for result_key in outputs:
+        if result_key not in all_keys:
+          self._error(
+              f"Task '{task.get('name', '<unnamed>')}' expects"
+              f" output key '{result_key}' but tool"
+              f" '{tool_name}' never returns it")
+
+  def _check_duplicate_setter_mappings(self):
+    """Detect multiple slots mapped to the same setter without setter_field.
+
+    The after_tool_callback maps one slot per setter name. If two
+    slots point to the same setter without setter_field to
+    disambiguate, only the last one in _setter_slots wins.
+    """
+    simple_setter_users: dict[str, list[str]] = {}
+    for slot in self._slots:
+      setter = slot.get("setter")
+      if not setter:
+        continue
+      if slot.get("setter_field"):
+        continue
+      name = slot.get("name", "<unnamed>")
+      simple_setter_users.setdefault(setter, []).append(name)
+    for setter, slot_names in simple_setter_users.items():
+      if len(slot_names) > 1:
+        self._error(
+            f"Slots {slot_names} all map to setter"
+            f" '{setter}' without setter_field —"
+            f" only the last will receive values")
+
+  def _check_clear_slots_subset(self):
+    """Check that on_failure.clear_slots are inputs of the failing task.
+
+    Clearing a slot that isn't an input to the task doesn't help
+    retry it — the task still won't re-fire because its inputs
+    haven't changed. Likely a copy-paste error.
+    """
+    for task in self._tasks:
+      name = task.get("name", "<unnamed>")
+      on_failure = task.get("on_failure")
+      if not on_failure or not isinstance(on_failure, dict):
+        continue
+      clear_slots = set(on_failure.get("clear_slots", []))
+      if not clear_slots:
+        continue
+      inputs = set(task.get("inputs", []))
+      extra = clear_slots - inputs
+      if extra:
+        self._warn(
+            f"Task '{name}' on_failure.clear_slots"
+            f" {sorted(extra)} are not inputs of the task"
+            f" — clearing them won't trigger a retry")
+
+  def _check_announce_dead_config(self):
+    """Flag fields on announce slots that have no effect.
+
+    Announce slots auto-fill without user interaction, so ask,
+    readback_fmt, validation, and scan_keywords are dead config.
+    """
+    for slot in self._slots:
+      name = slot.get("name", "<unnamed>")
+      sources = _normalize_sources(slot.get("source", "user"))
+      if "announce" not in sources:
+        continue
+      if slot.get("ask"):
+        self._warn(
+            f"Announce slot '{name}' has 'ask' —"
+            " announce slots auto-fill, never prompt")
+      if slot.get("readback_fmt"):
+        self._warn(
+            f"Announce slot '{name}' has 'readback_fmt' —"
+            " announce slots are not confirmed by user")
+      if slot.get("validation"):
+        self._warn(
+            f"Announce slot '{name}' has 'validation' —"
+            " announce slots auto-fill, never validated")
+      if slot.get("scan_keywords"):
+        self._warn(
+            f"Announce slot '{name}' has 'scan_keywords' —"
+            " announce slots don't scan user messages")
+
+  def _check_user_slot_fields(self):
+    """Check that user-source slots have ask and hint."""
+    bootstrap = self._config.get("bootstrap", {})
+    if not isinstance(bootstrap, dict):
+      bootstrap = {}
+    gate_slot = self._config.get("gate_slot")
+    external_slots = set()
+    if bootstrap.get("slot"):
+      external_slots.add(bootstrap["slot"])
+    if gate_slot:
+      external_slots.add(gate_slot)
+
+    for slot in self._slots:
+      name = slot.get("name", "<unnamed>")
+      if name in external_slots:
+        continue
+      sources = _normalize_sources(slot.get("source", "user"))
+      if "user" not in sources:
+        continue
+      if not slot.get("setter"):
+        continue
+      if not slot.get("ask"):
+        self._warn(
+            f"Slot '{name}' has source 'user' but no 'ask'"
+            " — LLM gets no prompt hint for this slot")
+      if not slot.get("hint"):
+        self._warn(
+            f"Slot '{name}' has source 'user' but no 'hint'"
+            " — gate mode shows raw slot name in tool list")
+
+  def _check_terminal_task_feedback(self):
+    """Check that terminal tasks provide user feedback."""
+    for task in self._tasks:
+      name = task.get("name", "<unnamed>")
+      if not task.get("terminal"):
+        continue
+      has_then_say = bool(task.get("then_say"))
+      has_directive = bool(task.get("then_directive"))
+      has_response = bool(task.get("then_response"))
+      if not has_then_say and not has_directive and not has_response:
+        self._warn(
+            f"Terminal task '{name}' has no 'then_say',"
+            " 'then_directive', or 'then_response' —"
+            " flow ends with no user feedback")
+
+  def _check_task_output_source_alignment(self):
+    """Check that task outputs and slot sources agree.
+
+    If a task declares outputs: {key: slot_name}, that slot should
+    have source including 'task:TaskName'. Conversely, a slot with
+    source 'task:X' should appear in task X's outputs.
+    """
+    task_output_slots: dict[str, set[str]] = {}
+    for task in self._tasks:
+      tname = task.get("name", "<unnamed>")
+      for slot_name in task.get("outputs", {}).values():
+        task_output_slots.setdefault(tname, set()).add(slot_name)
+
+    for task in self._tasks:
+      tname = task.get("name", "<unnamed>")
+      for slot_name in task.get("outputs", {}).values():
+        if slot_name not in self._slot_map:
+          continue
+        slot_def = self._slot_map[slot_name]
+        sources = _normalize_sources(
+            slot_def.get("source", "user"))
+        expected = f"task:{tname}"
+        if expected not in sources:
+          self._warn(
+              f"Task '{tname}' outputs to slot"
+              f" '{slot_name}' but slot source"
+              f" {sources} doesn't include '{expected}'")
+
+    for slot in self._slots:
+      name = slot.get("name", "<unnamed>")
+      sources = _normalize_sources(slot.get("source", "user"))
+      for src in sources:
+        if not src.startswith("task:"):
+          continue
+        task_name = src[5:]
+        if task_name not in self._task_names:
+          continue
+        output_slots = task_output_slots.get(task_name, set())
+        if name not in output_slots:
+          self._warn(
+              f"Slot '{name}' declares source '{src}'"
+              f" but task '{task_name}' has no output"
+              f" pointing to '{name}'")
+
+  def _check_exhaust_tool_exists(self):
+    """Check that on_exhaust.then tool references exist."""
+    if self._available_tools is None:
+      return
+    known = self._available_tools | {
+        "end_session", "transfer_to_agent",
+    }
+
+    def _check_then(exhaust, context):
+      if not isinstance(exhaust, dict):
+        return
+      then = exhaust.get("then")
+      if isinstance(then, dict):
+        tool = then.get("tool")
+        if tool and tool not in known:
+          self._error(
+              f"{context}.then tool '{tool}'"
+              " not in agent tool list")
+
+    for slot in self._slots:
+      name = slot.get("name", "<unnamed>")
+      validation = slot.get("validation")
+      if isinstance(validation, dict):
+        on_exhaust = validation.get("on_exhaust")
+        if on_exhaust:
+          _check_then(
+              on_exhaust,
+              f"Slot '{name}' validation.on_exhaust")
+    for task in self._tasks:
+      name = task.get("name", "<unnamed>")
+      on_failure = task.get("on_failure")
+      if isinstance(on_failure, dict):
+        on_exhaust = on_failure.get("on_exhaust")
+        if on_exhaust:
+          _check_then(
+              on_exhaust,
+              f"Task '{name}' on_failure.on_exhaust")
+    sb = self._config.get("steer_back")
+    if isinstance(sb, dict):
+      on_exhaust = sb.get("on_exhaust")
+      if on_exhaust:
+        _check_then(on_exhaust, "steer_back.on_exhaust")
+
+  def _check_options_from_ordering(self):
+    """Warn if options_from references a slot filled after this one.
+
+    options_from reads a filled slot's value to build chip options.
+    If the source slot requires this slot (or is otherwise ordered
+    after it), the options will be empty when the prompt fires.
+    """
+    for slot in self._slots:
+      name = slot.get("name", "<unnamed>")
+      options_from = self._find_options_from(slot)
+      if not options_from or options_from not in self._slot_map:
+        continue
+      source_slot = self._slot_map[options_from]
+      source_reqs = source_slot.get("requires", [])
+      if name in source_reqs:
+        self._warn(
+            f"Slot '{name}' options_from '{options_from}'"
+            f" but '{options_from}' requires '{name}'"
+            " — options won't be filled yet")
+
+  def _check_empty_strings(self):
+    """Flag empty strings in user-facing fields."""
+    for slot in self._slots:
+      name = slot.get("name", "<unnamed>")
+      for field in ("ask", "message"):
+        val = slot.get(field)
+        if val is not None and isinstance(val, str) and not val.strip():
+          self._warn(
+              f"Slot '{name}' has empty '{field}' string")
+    for task in self._tasks:
+      name = task.get("name", "<unnamed>")
+      for field in ("then_say", "then_directive"):
+        val = task.get(field)
+        if val is not None and isinstance(val, str) and not val.strip():
+          self._warn(
+              f"Task '{name}' has empty '{field}' string")
+
+  def _check_ask_text_response_conflict(self):
+    """Flag slots that have both 'ask' and a text-type response part.
+
+    If a slot has 'ask', the engine uses it as the user prompt. A
+    text-type response part would also emit text, creating duplicate
+    or conflicting prompts. Use one or the other.
+    """
+    for slot in self._slots:
+      name = slot.get("name", "<unnamed>")
+      if not slot.get("ask"):
+        continue
+      for resp in slot.get("response", []):
+        if not isinstance(resp, dict):
+          continue
+        if resp.get("type") == "text":
+          self._warn(
+              f"Slot '{name}' has both 'ask' and a text-type"
+              " response — these are redundant; use one or"
+              " the other")
+          break
+
+  # ── Bootstrap / gate / top-level checks ────────────────
+
+  def _check_bootstrap(self):
+    """Validate bootstrap slot, welcome_slot, and tool references.
+
+    bootstrap.slot and gate_slot are often filled externally (by
+    the Root Agent) so missing from local slots is a warning.
+    welcome_slot should point to an announce slot.
+    """
+    bootstrap = self._config.get("bootstrap")
+    if not bootstrap:
+      return
+    if not isinstance(bootstrap, dict):
+      self._error("'bootstrap' must be a dict")
+      return
+    slot = bootstrap.get("slot")
+    if slot and slot not in self._slot_set:
+      self._warn(
+          f"bootstrap.slot '{slot}' not in slots"
+          " — may be filled externally")
+    welcome = bootstrap.get("welcome_slot")
+    if welcome and welcome not in self._slot_set:
+      self._warn(
+          f"bootstrap.welcome_slot '{welcome}'"
+          " not in slots")
+    if welcome and welcome in self._slot_map:
+      ws = self._slot_map[welcome]
+      sources = _normalize_sources(
+          ws.get("source", "user"))
+      if "announce" not in sources:
+        self._warn(
+            f"bootstrap.welcome_slot '{welcome}'"
+            " is not an announce slot")
+    if not bootstrap.get("tool"):
+      self._warn("bootstrap has no 'tool'")
+
+  def _check_gate_slot(self):
+    """Validate that gate_slot references a known slot if present.
+
+    gate_slot is typically filled by the Root Agent's bootstrap
+    tool, so it may not exist in this DAG's slots list (warn).
+    """
+    gate_slot = self._config.get("gate_slot")
+    if gate_slot and gate_slot not in self._slot_set:
+      self._warn(
+          f"gate_slot '{gate_slot}' not in slots"
+          " — may be filled externally")
+
+  def _check_steer_back(self):
+    """Validate steer_back thresholds and ordering.
+
+    Thresholds must be ordered (soft <= hard <= escalate) and
+    must be ints. Non-int values cause TypeError at runtime.
+    """
+    sb = self._config.get("steer_back")
+    if not sb:
+      return
+    if not isinstance(sb, dict):
+      self._error("'steer_back' must be a dict")
+      return
+    for key in ("soft_after", "hard_after", "escalate_after"):
+      val = sb.get(key)
+      if val is not None and not isinstance(val, int):
+        self._error(
+            f"steer_back.{key} must be an int")
+    soft = sb.get("soft_after", 2)
+    hard = sb.get("hard_after", 4)
+    escalate = sb.get("escalate_after", 6)
+    if (isinstance(soft, int) and isinstance(hard, int)
+        and isinstance(escalate, int)):
+      if not (soft <= hard <= escalate):
+        self._error(
+            "steer_back ordering violated:"
+            f" soft_after ({soft}) <= hard_after ({hard})"
+            f" <= escalate_after ({escalate})")
+    on_exhaust = sb.get("on_exhaust")
+    if on_exhaust is not None:
+      self._check_on_exhaust(
+          on_exhaust, "steer_back.on_exhaust")
+
+  # ── Shared helpers ─────────────────────────────────────
+
+  def _check_on_exhaust(self, exhaust, context):
+    """Validate on_exhaust structure and 'then' action.
+
+    Args:
+      exhaust: The on_exhaust config dict to validate.
+      context: Human-readable label for error messages.
+
+    'then' can be a string action name or a dict with tool+args.
+    A dict without 'tool' produces {"name": None} at runtime.
+    """
+    if not isinstance(exhaust, dict):
+      self._error(f"{context} must be a dict")
+      return
+    then = exhaust.get("then")
+    if then is not None:
+      if isinstance(then, str):
+        pass
+      elif isinstance(then, dict):
+        if not then.get("tool"):
+          self._error(
+              f"{context}.then dict missing 'tool'")
+      else:
+        self._error(
+            f"{context}.then must be string or dict")
+
+  def _check_response_parts(self):
+    """Validate response part types and required fields.
+
+    Each part must have a 'type' field. Payload parts need 'data'
+    to be a dict.
+    """
+    for slot in self._slots:
+      name = slot.get("name", "<unnamed>")
+      self._validate_response_list(
+          slot.get("response"), f"Slot '{name}'")
+    for task in self._tasks:
+      name = task.get("name", "<unnamed>")
+      self._validate_response_list(
+          task.get("then_response"), f"Task '{name}'")
+      on_failure = task.get("on_failure", {})
+      if isinstance(on_failure, dict):
+        self._validate_response_list(
+            on_failure.get("retry_response"),
+            f"Task '{name}' on_failure")
+
+  def _validate_response_list(
+      self, response: Any, context: str,
+  ):
+    """Validate a list of response parts."""
+    if response is None:
+      return
+    if not isinstance(response, list):
+      self._error(f"{context} response must be a list")
+      return
+    for i, part in enumerate(response):
+      if not isinstance(part, dict):
+        self._error(
+            f"{context} response[{i}] must be a dict")
+        continue
+      rp_type = part.get("type")
+      if not rp_type:
+        self._error(
+            f"{context} response[{i}] missing 'type'")
+      elif rp_type not in _VALID_RESPONSE_TYPES:
+        self._warn(
+            f"{context} response[{i}] type"
+            f" '{rp_type}' not standard")
+      if rp_type == "payload" and "data" in part:
+        if not isinstance(part["data"], dict):
+          self._error(
+              f"{context} response[{i}] payload"
+              " 'data' must be a dict")
+
+  def _check_format_string_placeholders(self):
+    """Warn on format string placeholders referencing unknown names.
+
+    Format strings like ask, message, and then_say use {slot_name}
+    placeholders. Warn-only since some come from task outputs.
+    """
+    all_known = self._slot_set | {"success", "error"}
+    for task in self._tasks:
+      for sn in task.get("outputs", {}).values():
+        all_known.add(sn)
+      for key in task.get("outputs", {}):
+        all_known.add(key)
+
+    for slot in self._slots:
+      name = slot.get("name", "<unnamed>")
+      for field_name in ("ask", "message"):
+        template = slot.get(field_name)
+        if not template or not isinstance(template, str):
+          continue
+        fields = _extract_format_fields(template)
+        for f in fields:
+          if f not in all_known:
+            self._warn(
+                f"Slot '{name}' {field_name} references"
+                f" unknown placeholder '{{{f}}}'")
+
+    for task in self._tasks:
+      name = task.get("name", "<unnamed>")
+      for field_name in ("then_say",):
+        template = task.get(field_name)
+        if not template or not isinstance(template, str):
+          continue
+        fields = _extract_format_fields(template)
+        for f in fields:
+          if f not in all_known:
+            self._warn(
+                f"Task '{name}' {field_name} references"
+                f" unknown placeholder '{{{f}}}'")
+
+
+class CrossConfigValidator:
+  """Validates interactions between multiple DAG configs sharing one SM.
+
+  Multiple DAG configs share a single state machine dict (sm) that
+  persists across agent transfers. This validator catches cross-config
+  failure modes that single-config validation cannot detect.
+
+  Usage:
+      configs = {"bella_notte": {...}, "takeout": {...}}
+      result = CrossConfigValidator(configs).validate()
+  """
+
+  def __init__(self, configs: dict[str, dict[str, Any]]):
+    self._configs = configs
+    self._errors: list[str] = []
+    self._warnings: list[str] = []
+
+  def validate(self) -> ValidationResult:
+    """Run all cross-config checks and return results."""
+    if len(self._configs) < 2:
+      return ValidationResult(valid=True)
+    self._check_status_contamination()
+    self._check_task_name_collision()
+    self._check_welcome_slot_shadow()
+    self._check_shared_slot_no_condition()
+    self._check_retry_counter_leakage()
+    self._check_steer_back_counter_carryover()
+    self._check_gate_slot_consistency()
+    self._check_bootstrap_tool_consistency()
+    return ValidationResult(
+        valid=len(self._errors) == 0,
+        errors=list(self._errors),
+        warnings=list(self._warnings),
+    )
+
+  def _error(self, msg: str):
+    self._errors.append(msg)
+
+  def _warn(self, msg: str):
+    self._warnings.append(msg)
+
+  def _check_status_contamination(self):
+    """Ensure configs with terminal tasks have reset_on_complete.
+
+    Terminal tasks set sm.status='complete'. Before_model_callback
+    checks status AFTER config_id switch but does NOT reset it,
+    so a subsequent config's engine never runs.
+    """
+    for config_id, config in self._configs.items():
+      has_terminal = any(
+          t.get("terminal") for t in config.get("tasks", [])
+      )
+      if not has_terminal:
+        continue
+      bootstrap = config.get("bootstrap", {})
+      if not isinstance(bootstrap, dict):
+        bootstrap = {}
+      if not bootstrap.get("reset_on_complete"):
+        others = [c for c in self._configs if c != config_id]
+        self._error(
+            f"Config '{config_id}' has terminal tasks but"
+            f" bootstrap.reset_on_complete is not True —"
+            f" after completion, configs {others} will see"
+            " status='complete' and their engine will not run")
+
+  def _check_task_name_collision(self):
+    """Detect task names shared across multiple configs.
+
+    task_results is a flat dict keyed by task name. Collisions
+    cause one config to see another's result as its own.
+    """
+    task_owners: dict[str, list[str]] = {}
+    for config_id, config in self._configs.items():
+      for task in config.get("tasks", []):
+        name = task.get("name")
+        if name:
+          task_owners.setdefault(name, []).append(config_id)
+    for task_name, owners in task_owners.items():
+      if len(owners) > 1:
+        self._error(
+            f"Task '{task_name}' defined in configs"
+            f" {owners} — task_results will be corrupted")
+
+  def _check_welcome_slot_shadow(self):
+    """Warn if announce slots with the same name exist in 2+ configs.
+
+    Announce slots auto-fill filled[name]=True. The second config
+    sees it as already filled and skips its announcement.
+    reset_on_complete does NOT clear filled.
+    """
+    slot_announce_owners: dict[str, list[str]] = {}
+    for config_id, config in self._configs.items():
+      for slot in config.get("slots", []):
+        name = slot.get("name")
+        sources = _normalize_sources(
+            slot.get("source", "user"))
+        if name and "announce" in sources:
+          slot_announce_owners.setdefault(
+              name, []).append(config_id)
+    for slot_name, owners in slot_announce_owners.items():
+      if len(owners) > 1:
+        self._warn(
+            f"Announce slot '{slot_name}' in configs {owners}"
+            " — second config's announcement will be skipped"
+            " because filled['{slot_name}'] persists")
+
+  def _check_shared_slot_no_condition(self):
+    """Warn if shared user slots lack scoping conditions.
+
+    User-source slots sharing a name across configs risk unintended
+    data reuse. A scoping condition prevents this.
+    """
+    slot_owners: dict[str, list[tuple[str, dict[str, Any]]]] = {}
+    for config_id, config in self._configs.items():
+      for slot in config.get("slots", []):
+        name = slot.get("name")
+        sources = _normalize_sources(
+            slot.get("source", "user"))
+        if name and "user" in sources:
+          slot_owners.setdefault(name, []).append(
+              (config_id, slot))
+    for slot_name, entries in slot_owners.items():
+      if len(entries) < 2:
+        continue
+      unconditioned = [
+          cid for cid, s in entries if not s.get("condition")
+      ]
+      if len(unconditioned) == len(entries):
+        configs = [cid for cid, _ in entries]
+        self._warn(
+            f"Slot '{slot_name}' shared by configs {configs}"
+            " without scoping conditions — data filled by"
+            " one config will be silently reused by the other")
+      elif unconditioned:
+        conditioned = [
+            cid for cid, s in entries if s.get("condition")
+        ]
+        self._warn(
+            f"Slot '{slot_name}' shared: {unconditioned} have"
+            f" no condition, {conditioned} do — asymmetric"
+            " scoping may cause unintended reuse")
+
+  def _check_retry_counter_leakage(self):
+    """Warn if shared slots both define max_retries.
+
+    _retries is keyed by 'slot:{name}' and persists across config
+    switches, so shared slots share retry budgets.
+    """
+    slot_retry_owners: dict[str, list[str]] = {}
+    for config_id, config in self._configs.items():
+      for slot in config.get("slots", []):
+        name = slot.get("name")
+        validation = slot.get("validation")
+        if (name and validation
+            and isinstance(validation, dict)
+            and validation.get("max_retries")):
+          slot_retry_owners.setdefault(
+              name, []).append(config_id)
+    for slot_name, owners in slot_retry_owners.items():
+      if len(owners) > 1:
+        self._warn(
+            f"Slot '{slot_name}' has validation.max_retries"
+            f" in configs {owners} — retry counter"
+            " 'slot:{slot_name}' carries over between them")
+
+  def _check_steer_back_counter_carryover(self):
+    """Warn if steer_back thresholds differ across configs.
+
+    _steer_back_turns persists across config switches, so
+    different thresholds can cause premature escalation.
+    """
+    steer_configs: dict[str, dict[str, Any]] = {}
+    for config_id, config in self._configs.items():
+      sb = config.get("steer_back")
+      if sb and isinstance(sb, dict):
+        steer_configs[config_id] = sb
+    if len(steer_configs) < 2:
+      return
+    thresholds = set()
+    for sb in steer_configs.values():
+      thresholds.add((
+          sb.get("soft_after", 2),
+          sb.get("hard_after", 4),
+          sb.get("escalate_after", 6),
+      ))
+    if len(thresholds) > 1:
+      self._warn(
+          "steer_back thresholds differ across configs"
+          f" {list(steer_configs.keys())} —"
+          " _steer_back_turns carries over and may trigger"
+          " premature escalation in the receiving config")
+
+  def _check_gate_slot_consistency(self):
+    """Warn if configs use different gate_slot names.
+
+    The Root Agent's bootstrap tool typically fills a single
+    gate slot name, so differing names may leave a gate unfilled.
+    """
+    gate_slots: dict[str, list[str]] = {}
+    for config_id, config in self._configs.items():
+      gs = config.get("gate_slot")
+      if gs:
+        gate_slots.setdefault(gs, []).append(config_id)
+    if len(gate_slots) > 1:
+      self._warn(
+          f"Different gate_slot names across configs:"
+          f" {dict(gate_slots)} — Root Agent's bootstrap"
+          " may only fill one of them")
+
+  def _check_bootstrap_tool_consistency(self):
+    """Warn if configs use different bootstrap tools.
+
+    The after_tool callback's tool.name==bootstrap['tool'] check
+    won't match for configs with a different bootstrap tool,
+    so reset_on_complete can't fire.
+    """
+    bootstrap_tools: dict[str, list[str]] = {}
+    for config_id, config in self._configs.items():
+      bootstrap = config.get("bootstrap", {})
+      if isinstance(bootstrap, dict):
+        tool = bootstrap.get("tool")
+        if tool:
+          bootstrap_tools.setdefault(
+              tool, []).append(config_id)
+    if len(bootstrap_tools) > 1:
+      self._warn(
+          f"Different bootstrap tools across configs:"
+          f" {dict(bootstrap_tools)} — reset_on_complete"
+          " may not fire for configs with a different"
+          " bootstrap tool than the one called by Root Agent")
+
+
+# ── CES tool entry point ──────────────────────────────────
+
+
+def validate_dag_config(
+    input_data: dict[str, Any],
+) -> dict[str, Any]:
+  """Validate DAG config(s) for structural and cross-config issues.
+
+  Args:
+    input_data: Dict with either 'raw_config' (single config) or
+      'all_configs' (dict of config_id to config for cross-config).
+
+  Returns:
+    Dict with 'valid', 'errors', 'warnings'. When all_configs is
+    provided, also includes 'per_config' and 'cross_config' dicts.
+  """
+  all_configs = input_data.get("all_configs")
+  available_tools = input_data.get("available_tools")
+  if all_configs:
+    per_config = {}
+    combined_errors: list[str] = []
+    combined_warnings: list[str] = []
+    for config_id, config in all_configs.items():
+      r = DagConfigValidator(
+          config, available_tools=available_tools,
+      ).validate()
+      per_config[config_id] = {
+          "valid": r.valid,
+          "errors": r.errors,
+          "warnings": r.warnings,
+      }
+      combined_errors.extend(
+          f"[{config_id}] {e}" for e in r.errors)
+      combined_warnings.extend(
+          f"[{config_id}] {w}" for w in r.warnings)
+    cross = CrossConfigValidator(all_configs).validate()
+    combined_errors.extend(cross.errors)
+    combined_warnings.extend(cross.warnings)
+    return {
+        "valid": len(combined_errors) == 0,
+        "errors": combined_errors,
+        "warnings": combined_warnings,
+        "per_config": per_config,
+        "cross_config": {
+            "valid": cross.valid,
+            "errors": cross.errors,
+            "warnings": cross.warnings,
+        },
+    }
+
+  raw_config = input_data.get("raw_config", {})
+  available_tools = input_data.get("available_tools")
+  result = DagConfigValidator(
+      raw_config, available_tools=available_tools,
+  ).validate()
+  return {
+      "valid": result.valid,
+      "errors": result.errors,
+      "warnings": result.warnings,
+  }

--- a/examples/bella_notte/tools/validate_dag_config/validate_dag_config.json
+++ b/examples/bella_notte/tools/validate_dag_config/validate_dag_config.json
@@ -1,0 +1,9 @@
+{
+  "name": "ebbd5777-b617-463c-8d73-7fe80f6f748b",
+  "pythonFunction": {
+    "name": "validate_dag_config",
+    "pythonCode": "tools/validate_dag_config/python_function/python_code.py",
+    "description": "Validates a slot filling DAG configuration. Returns errors and warnings."
+  },
+  "displayName": "validate_dag_config"
+}


### PR DESCRIPTION
…ive, engine hardening

Four areas of improvement to the slot-filling DAG framework:

1. Structured logging (all components): Added `_log(sm, tag, level, **data)` to all callbacks and the engine via stdlib `logging.getLogger()` per component. Each entry is a JSON dict accumulated in `sm["_log"]`.

2. Config validation expansion (`validate_dag_config`): Refactored to OOP `DagConfigValidator` class that collects all errors/warnings. Added `CrossConfigValidator` for multi-agent setups. 16 new validation checks including orphaned slots, reachability analysis, tool existence, setter/task output key mismatch (AST-based), and 8 cross-config checks.

3. `then_directive` (new engine feature): Injects a directive into the system instruction so the LLM composes its own response from tool results, unlike `then_say` which preempts with verbatim text.

4. Engine safety improvements: Task re-fire prevention, announce cycle break, and task refire blocking per `execute_dag_step` call.

Cleanup: Removed `_validate_config()` from engine, removed `_prefill_from_conversation()`, removed `_debug_mode`/`_DEBUG`/`_DEBUG_LOG` (replaced by structured logging).