### PR TITLE
fix: InquirerPy TUI event loop crash in grouping review

### DIFF
--- a/src/cxas_scrapi/migration/grouping_review.py
+++ b/src/cxas_scrapi/migration/grouping_review.py
@@ -145,7 +145,7 @@ def render_diff(
 # ---------------------------------------------------------------------------
 
 
-def _merge_groups(groupings: dict, console: Console) -> dict:
+async def _merge_groups(groupings: dict, console: Console) -> dict:
     names = list(groupings.keys())
     choices = [
         Choice(
@@ -154,19 +154,19 @@ def _merge_groups(groupings: dict, console: Console) -> dict:
         )
         for i, n in enumerate(names)
     ]
-    selected = inquirer.checkbox(
+    selected = await inquirer.checkbox(
         message=(
             "Pick groups to merge (Space to toggle, Enter to confirm; need ≥2):"
         ),
         choices=choices,
         validate=lambda r: len(r) >= 2 or "Pick at least 2 groups",
-    ).execute()
+    ).execute_async()
     targets = [names[i] for i in selected]
-    new_name = inquirer.text(
+    new_name = await inquirer.text(
         message="New group name:",
         default=targets[0],
         validate=lambda v: bool(GROUP_NAME_RE.match(v)) or "Invalid name",
-    ).execute()
+    ).execute_async()
 
     merged_agents: list[str] = []
     rationales: list[str] = []
@@ -189,9 +189,11 @@ def _merge_groups(groupings: dict, console: Console) -> dict:
     return new_groupings
 
 
-def _split_group(ir: MigrationIR, groupings: dict, console: Console) -> dict:
+async def _split_group(
+    ir: MigrationIR, groupings: dict, console: Console
+) -> dict:
     names = list(groupings.keys())
-    target = inquirer.select(
+    target = await inquirer.select(
         message="Group to split:",
         choices=[
             Choice(
@@ -200,7 +202,7 @@ def _split_group(ir: MigrationIR, groupings: dict, console: Console) -> dict:
             )
             for n in names
         ],
-    ).execute()
+    ).execute_async()
     members = groupings[target].get("agents", [])
     if len(members) < 2:
         console.print(
@@ -211,18 +213,18 @@ def _split_group(ir: MigrationIR, groupings: dict, console: Console) -> dict:
         Choice(value=m, name=f"{m} ('{ir.agents[m].display_name}')")
         for m in members
     ]
-    moving = inquirer.checkbox(
+    moving = await inquirer.checkbox(
         message="Members to MOVE to a new group:",
         choices=moving_choices,
         validate=lambda r: 0 < len(r) < len(members) or "Pick a strict subset",
-    ).execute()
-    new_name = inquirer.text(
+    ).execute_async()
+    new_name = await inquirer.text(
         message="Name for new group:",
         validate=lambda v: (
             (bool(GROUP_NAME_RE.match(v)) and v not in groupings)
             or "Invalid or duplicate name"
         ),
-    ).execute()
+    ).execute_async()
 
     new_groupings = {k: dict(v) for k, v in groupings.items()}
     new_groupings[target]["agents"] = [m for m in members if m not in moving]
@@ -235,19 +237,19 @@ def _split_group(ir: MigrationIR, groupings: dict, console: Console) -> dict:
     return new_groupings
 
 
-def _rename_group(groupings: dict, console: Console) -> dict:
+async def _rename_group(groupings: dict, console: Console) -> dict:
     names = list(groupings.keys())
-    old = inquirer.select(
+    old = await inquirer.select(
         message="Group to rename:",
         choices=names,
-    ).execute()
-    new_name = inquirer.text(
+    ).execute_async()
+    new_name = await inquirer.text(
         message="New name:",
         validate=lambda v: (
             (bool(GROUP_NAME_RE.match(v)) and v not in groupings)
             or "Invalid or duplicate name"
         ),
-    ).execute()
+    ).execute_async()
     return {(new_name if k == old else k): v for k, v in groupings.items()}
 
 
@@ -304,7 +306,7 @@ async def interactive_review(
             console,
         )
 
-        action = inquirer.select(
+        action = await inquirer.select(
             message="Action:",
             choices=[
                 Choice(value="accept", name="[a]ccept"),
@@ -315,16 +317,16 @@ async def interactive_review(
                 Choice(value="quit", name="[q]uit"),
             ],
             default="accept",
-        ).execute()
+        ).execute_async()
 
         if action == "accept":
             return groupings
         if action == "quit":
             return None
         if action == "repropose":
-            feedback = inquirer.text(
+            feedback = await inquirer.text(
                 message="Feedback for re-proposal:",
-            ).execute()
+            ).execute_async()
             try:
                 groupings = await consolidator.propose_groupings(
                     root_key, dep_summary, feedback
@@ -332,8 +334,8 @@ async def interactive_review(
             except Exception as exc:  # noqa: BLE001
                 console.print(f"[red]Re-proposal failed: {exc}[/]")
         elif action == "merge":
-            groupings = _merge_groups(groupings, console)
+            groupings = await _merge_groups(groupings, console)
         elif action == "split":
-            groupings = _split_group(ir, groupings, console)
+            groupings = await _split_group(ir, groupings, console)
         elif action == "rename":
-            groupings = _rename_group(groupings, console)
+            groupings = await _rename_group(groupings, console)

--- a/tests/cxas_scrapi/migration/test_grouping_review.py
+++ b/tests/cxas_scrapi/migration/test_grouping_review.py
@@ -17,9 +17,11 @@ the structure of the rendered Rich trees, and the return contract
 from __future__ import annotations
 
 from io import StringIO
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 
 import pytest
+from InquirerPy.prompts.input import InputPrompt
+from InquirerPy.prompts.list import ListPrompt
 from rich.console import Console as RichConsole
 
 from cxas_scrapi.migration import grouping_review
@@ -119,13 +121,16 @@ async def test_interactive_review_accept_returns_groupings_unchanged():
     consolidator = _make_consolidator()
 
     # Stub InquirerPy: render_diff doesn't matter; the select returns "accept".
-    fake_select = MagicMock()
-    fake_select.execute = MagicMock(return_value="accept")
+    fake_select = create_autospec(ListPrompt, instance=True)
+    fake_select.execute_async.return_value = "accept"
 
     with (
         patch.object(grouping_review, "render_diff"),
         patch.object(
-            grouping_review.inquirer, "select", return_value=fake_select
+            grouping_review.inquirer,
+            "select",
+            autospec=True,
+            return_value=fake_select,
         ),
     ):
         result = await grouping_review.interactive_review(
@@ -143,13 +148,16 @@ async def test_interactive_review_quit_returns_none():
     groupings = {"RootGroup": {"agents": ["RootAgent"], "is_root": True}}
     consolidator = _make_consolidator()
 
-    fake_select = MagicMock()
-    fake_select.execute = MagicMock(return_value="quit")
+    fake_select = create_autospec(ListPrompt, instance=True)
+    fake_select.execute_async.return_value = "quit"
 
     with (
         patch.object(grouping_review, "render_diff"),
         patch.object(
-            grouping_review.inquirer, "select", return_value=fake_select
+            grouping_review.inquirer,
+            "select",
+            autospec=True,
+            return_value=fake_select,
         ),
     ):
         result = await grouping_review.interactive_review(
@@ -189,17 +197,25 @@ async def test_interactive_review_repropose_then_accept():
 
     # First iteration: select repropose → text prompt for feedback → next
     # iteration: select accept.
-    fake_select = MagicMock()
-    fake_select.execute = MagicMock(side_effect=["repropose", "accept"])
-    fake_text = MagicMock()
-    fake_text.execute = MagicMock(return_value="please split G1")
+    fake_select = create_autospec(ListPrompt, instance=True)
+    fake_select.execute_async.side_effect = ["repropose", "accept"]
+    fake_text = create_autospec(InputPrompt, instance=True)
+    fake_text.execute_async.return_value = "please split G1"
 
     with (
         patch.object(grouping_review, "render_diff"),
         patch.object(
-            grouping_review.inquirer, "select", return_value=fake_select
+            grouping_review.inquirer,
+            "select",
+            autospec=True,
+            return_value=fake_select,
         ),
-        patch.object(grouping_review.inquirer, "text", return_value=fake_text),
+        patch.object(
+            grouping_review.inquirer,
+            "text",
+            autospec=True,
+            return_value=fake_text,
+        ),
     ):
         result = await grouping_review.interactive_review(
             ir,

--- a/uv.lock
+++ b/uv.lock
@@ -555,6 +555,7 @@ dependencies = [
     { name = "graphviz" },
     { name = "gspread" },
     { name = "gspread-dataframe" },
+    { name = "inquirerpy" },
     { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "ipython", version = "9.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "jinja2" },
@@ -607,6 +608,7 @@ requires-dist = [
     { name = "graphviz" },
     { name = "gspread" },
     { name = "gspread-dataframe" },
+    { name = "inquirerpy" },
     { name = "ipython" },
     { name = "jinja2" },
     { name = "json5" },
@@ -1303,6 +1305,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "inquirerpy"
+version = "0.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pfzy" },
+    { name = "prompt-toolkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/73/7570847b9da026e07053da3bbe2ac7ea6cde6bb2cbd3c7a5a950fa0ae40b/InquirerPy-0.3.4.tar.gz", hash = "sha256:89d2ada0111f337483cb41ae31073108b2ec1e618a49d7110b0d7ade89fc197e", size = 44431, upload-time = "2022-06-27T23:11:20.598Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/ff/3b59672c47c6284e8005b42e84ceba13864aa0f39f067c973d1af02f5d91/InquirerPy-0.3.4-py3-none-any.whl", hash = "sha256:c65fdfbac1fa00e3ee4fb10679f4d3ed7a012abf4833910e63c295827fe2a7d4", size = 67677, upload-time = "2022-06-27T23:11:17.723Z" },
 ]
 
 [[package]]
@@ -2249,6 +2264,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
+]
+
+[[package]]
+name = "pfzy"
+version = "0.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/5a/32b50c077c86bfccc7bed4881c5a2b823518f5450a30e639db5d3711952e/pfzy-0.3.4.tar.gz", hash = "sha256:717ea765dd10b63618e7298b2d98efd819e0b30cd5905c9707223dceeb94b3f1", size = 8396, upload-time = "2022-01-28T02:26:17.946Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/d7/8ff98376b1acc4503253b685ea09981697385ce344d4e3935c2af49e044d/pfzy-0.3.4-py3-none-any.whl", hash = "sha256:5f50d5b2b3207fa72e7ec0ef08372ef652685470974a107d0d4999fc5a903a96", size = 8537, upload-time = "2022-01-28T02:26:16.047Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Problem:
The Stage 1 migration script (`stage1.py`) crashes with `RuntimeError: asyncio.run() cannot be called from a running event loop` when attempting to launch the interactive grouping review TUI.

Root Cause:
The script is running inside an active `asyncio` event loop (`asyncio.run(_run(args))`). When it invokes `grouping_review.interactive_review` (which is called asynchronously), the TUI attempts to render InquirerPy prompts using the synchronous `.execute()` method. Under the hood, `.execute()` calls `asyncio.run()$, which strictly prohibits nesting within an already running event loop.

Solution:
Patched `grouping_review.py` and its prompt helper functions (`_merge_groups`, `_split_group`, `_rename_group`) to be asynchronous (`async def`) and use the native `await ...execute_async()` method instead. This allows InquirerPy to yield execution back to the existing active event loop instead of trying to spawn a nested one.