### PR TITLE
docs(agent-foundry): add eval execution strategy — smoke test first, iterate targeted

### DIFF
--- a/.agents/skills/cxas-agent-foundry/references/debug.md
+++ b/.agents/skills/cxas-agent-foundry/references/debug.md
@@ -85,7 +85,7 @@ Initialize your `todo.md` with the following. Items start unchecked; check only 
 
 1. [ ] Verify prerequisites (above)
 2. [ ] Lint (`agents/lint-fixer.md`) + `cxas push` agent code
-3. [ ] Run evals: `python scripts/run-and-report.py --runs 5 --auto-revert --json-summary <path> --message "<describe change>" > <project>/eval-reports/last-run.log 2>&1`, then read `<path>`. If the script errors (non-zero exit, or `status: "errored"` in the summary), read `<project>/eval-reports/last-run.log` for the underlying stack — no re-run needed.
+3. [ ] Run evals — **target first, then broaden** (see `references/run.md` → "Eval Execution Strategy"). When fixing a specific failure, run only the eval(s) where the problem surfaces until they pass, then run the full suite for regressions. Full-suite command: `python scripts/run-and-report.py --runs 5 --auto-revert --json-summary <path> --message "<describe change>" > <project>/eval-reports/last-run.log 2>&1`, then read `<path>`. If the script errors (non-zero exit, or `status: "errored"` in the summary), read `<project>/eval-reports/last-run.log` for the underlying stack — no re-run needed.
 4. [ ] Read `failure_clusters` from the JSON summary. Pick the top 5 clusters by `priority_score` and dispatch `agents/triage-failure.md` once per cluster, in parallel. Aggregate the returned diagnoses (a cluster may return one shared diagnosis covering N evals, or split into per-eval diagnoses with `cluster_split: true`).
 5. [ ] Plan fix from the aggregated diagnoses + `<project>/experiment_log.md`
 6. [ ] Apply fix; back to step 2 until adjusted pass rate ≥ target

--- a/.agents/skills/cxas-agent-foundry/references/run.md
+++ b/.agents/skills/cxas-agent-foundry/references/run.md
@@ -5,6 +5,7 @@ Run evals, triage failures, and generate reports for GECX conversational agents.
 ## Table of Contents
 
 - [Before Starting](#before-starting)
+- [Eval Execution Strategy](#eval-execution-strategy)
 - [Four Eval Types](#four-eval-types)
 - [Run Everything](#run-everything)
 - [Choosing Golden vs Sim](#choosing-golden-vs-sim)
@@ -32,6 +33,20 @@ Check memory for project-specific context (app ID, variable handling rules, know
 
 **CRITICAL: Evaluation Channel Enforcement**
 If the app's `gecx-config.json` specifies `"modality": "audio"`, you MUST NOT run evaluations in text mode. The runner scripts will now throw a fatal error if you attempt to bypass this. When running eval scripts, either omit the `--channel` flag to rely on the default config, or explicitly pass `--channel audio`. Never pass `--channel text` for an audio agent.
+
+## Eval Execution Strategy
+
+Prefer tight feedback loops over casting a wide net. Running the full eval suite on every iteration is slow and buries the signal you care about in noise from unrelated tests.
+
+**After building or pushing a new agent:**
+1. Run 2–3 smoke-test evals first (e.g., one happy path, one edge case) and confirm they pass.
+2. Only then run the full battery. If smoke tests fail, fix them before wasting time on the full suite.
+
+**When fixing a specific problem:**
+1. Run only the eval(s) where the problem surfaces. Iterate until they pass.
+2. Once the targeted evals pass, run the full suite to check for regressions.
+
+The goal is to minimize the time between "make a change" and "see whether it worked." A 2-minute targeted run that tells you exactly what broke is worth more than a 15-minute full run where you have to hunt for the relevant result.
 
 ## Four Eval Types
 


### PR DESCRIPTION
Adds guidance to run.md and debug.md: run 2-3 smoke tests before the full suite after building, and when fixing a specific problem, run only the affected evals until they pass before broadening to the full battery. Tight feedback loops over wide nets.