### PR TITLE
fix: app_name propagation in cxas create

### DIFF
--- a/src/cxas_scrapi/cli/app.py
+++ b/src/cxas_scrapi/cli/app.py
@@ -278,7 +278,7 @@ def app_create(args: argparse.Namespace) -> None:
     apps_client = Apps(project_id=args.project_id, location=args.location)
     try:
         app = apps_client.create_app(
-            app_id=getattr(args, "app_id", None),
+            app_id=args.app_id,
             display_name=args.name,
             description=args.description,
         )

--- a/src/cxas_scrapi/cli/main.py
+++ b/src/cxas_scrapi/cli/main.py
@@ -1684,7 +1684,7 @@ def get_parser() -> argparse.ArgumentParser:
         "--description", help="Description for the new app."
     )
     parser_create.add_argument(
-        "--app-name", help="Optional specific app_name to use."
+        "--app-id", help="Optional specific app_id to use."
     )
     _add_project_location_args(parser_create)
     parser_create.set_defaults(func=app_create)

--- a/tests/cxas_scrapi/cli/test_app.py
+++ b/tests/cxas_scrapi/cli/test_app.py
@@ -77,6 +77,30 @@ def test_app_create(
     )
 
 
+def test_app_create_with_app_id(
+    mock_apps_client, mock_common_get_project_id, mock_common_get_location
+):
+    args = argparse.Namespace(
+        name="Test App",
+        description="A test app",
+        app_id="my-custom-id",
+        project_id="test-project",
+        location="us",
+    )
+
+    mock_app_response = mock.MagicMock()
+    mock_app_response.name = (
+        "projects/test-project/locations/us/apps/my-custom-id"
+    )
+    mock_apps_client.create_app.return_value = mock_app_response
+
+    cli_app.app_create(args)
+
+    mock_apps_client.create_app.assert_called_once_with(
+        app_id="my-custom-id", display_name="Test App", description="A test app"
+    )
+
+
 def test_apps_list(mock_apps_client, capsys):
     args = argparse.Namespace(project_id="test-project", location="us")
 


### PR DESCRIPTION
This command was failing due to app-name not being read properly in the cli
`cxas create --app-name 496cffd9-3636-49c4-93aa-7443eab54e10 --project-id infobot-wat --location us delete_me_eval`

Confirm this new command works as expected after the fix