### PR TITLE
feat(evals): Support Multilingual TTS for Simulations

### DIFF
--- a/.agents/skills/cxas-agent-foundry/scripts/scrapi-sim-runner.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/scrapi-sim-runner.py
@@ -117,6 +117,7 @@ class EnhancedSimRunner(SimulationEvals):
         session_id: Optional[str] = None,
         console_logging: bool = True,
         modality: str = "text",
+        voice_config: Optional[Dict[str, Any]] = None,
     ) -> LLMUserConversation:
         """Run a simulated conversation with variable injection."""
         if session_id is None:
@@ -129,7 +130,6 @@ class EnhancedSimRunner(SimulationEvals):
         )
 
         session_params = test_case.get("session_parameters", {})
-
         if console_logging:
             print("Starting simulated conversation...")
             if session_params:
@@ -151,6 +151,8 @@ class EnhancedSimRunner(SimulationEvals):
                         "text": user_utterance,
                         "modality": modality,
                     }
+                    if voice_config is not None:
+                        kwargs["voice_config"] = voice_config
                     # Inject variables on first turn only
                     if first_turn and session_params:
                         kwargs["variables"] = session_params

--- a/.agents/skills/cxas-agent-foundry/scripts/scrapi-sim-runner.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/scrapi-sim-runner.py
@@ -144,6 +144,7 @@ class EnhancedSimRunner(SimulationEvals):
         background_noise_file: str | None = None,
         capture_agent_audio: bool = False,
         burst_noise_files: list[str] | None = None,
+        voice_config: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> LLMUserConversation:
         """Run a simulated conversation with variable injection."""
@@ -160,7 +161,6 @@ class EnhancedSimRunner(SimulationEvals):
         current_sim_turn = 0
 
         session_params = test_case.get("session_parameters", {})
-
         if console_logging:
             print("Starting simulated conversation...")
             if session_params:
@@ -186,6 +186,7 @@ class EnhancedSimRunner(SimulationEvals):
                         "capture_agent_audio": capture_agent_audio,
                         "background_noise_file": background_noise_file,
                         "burst_noise_files": burst_noise_files,
+                        "voice_config": voice_config,
                     }
                     # Inject variables on first turn only
                     if first_turn and session_params:

--- a/docs/guides/evaluation/local-simulations.md
+++ b/docs/guides/evaluation/local-simulations.md
@@ -170,6 +170,11 @@ sim_evals = SimulationEvals(app_name="projects/my-project/locations/us/apps/my-a
 eval_conv = sim_evals.simulate_conversation(
     test_case=test_case,
     modality="audio",  # default is "text"
+    # voice_config is optional (defaults to US English voice)
+    voice_config={
+        "language_code": "en-US",
+        "voice_name": "en-US-Standard-A"
+    }
 )
 ```
 

--- a/src/cxas_scrapi/core/audio_transformer.py
+++ b/src/cxas_scrapi/core/audio_transformer.py
@@ -16,6 +16,7 @@ import io
 import logging
 import threading
 import wave
+from typing import Any, Dict, Optional
 
 from google.api_core import client_options
 from google.cloud import texttospeech
@@ -31,7 +32,11 @@ class AudioTransformer:
         pass
 
     def text_to_speech_bytes(
-        self, text: str, credentials, project_id: str
+        self,
+        text: str,
+        credentials,
+        project_id: str,
+        voice_config: Optional[Dict[str, Any]] = None,
     ) -> dict:
         """Converts text to speech and returns a dictionary with text and
         audio bytes without saving to disk.
@@ -46,8 +51,12 @@ class AudioTransformer:
 
         client = AudioTransformer._client
         synthesis_input = texttospeech.SynthesisInput(text=text)
+        voice_config = voice_config or {}
+        language_code = voice_config.get("language_code", "en-US")
+        voice_name = voice_config.get("voice_name", "en-US-Standard-A")
+
         voice = texttospeech.VoiceSelectionParams(
-            language_code="en-US", name="en-US-Standard-A"
+            language_code=language_code, name=voice_name
         )
         audio_config = texttospeech.AudioConfig(
             audio_encoding=texttospeech.AudioEncoding.LINEAR16,

--- a/src/cxas_scrapi/core/audio_transformer.py
+++ b/src/cxas_scrapi/core/audio_transformer.py
@@ -17,6 +17,7 @@ import logging
 import random
 import threading
 import wave
+from typing import Any, Dict, Optional
 
 try:
     from pydub import AudioSegment
@@ -50,7 +51,7 @@ class AudioTransformer:
         bg_noise_snr: float = 15.0,
         burst_noise_files: list[str] | None = None,
         burst_noise_snr: float = 5.0,
-        language_code: str = "en-US",
+        voice_config: Optional[Dict[str, Any]] = None,
     ) -> dict:
         """Converts text to speech and returns a dictionary with text and
         audio bytes without saving to disk. Background and burst noise can
@@ -66,14 +67,17 @@ class AudioTransformer:
 
         client = AudioTransformer._client
         synthesis_input = texttospeech.SynthesisInput(text=text)
-
-        voice_lang = language_code
-        voice_name = "en-US-Standard-A"
-        if voice_lang.lower().startswith("fr"):
-            voice_name = "fr-CA-Standard-A"
+        voice_config = voice_config or {}
+        language_code = voice_config.get("language_code", "en-US")
+        if "voice_name" in voice_config:
+            voice_name = voice_config["voice_name"]
+        else:
+            voice_name = "en-US-Standard-A"
+            if language_code.lower().startswith("fr"):
+                voice_name = "fr-CA-Standard-A"
 
         voice = texttospeech.VoiceSelectionParams(
-            language_code=voice_lang, name=voice_name
+            language_code=language_code, name=voice_name
         )
         audio_config = texttospeech.AudioConfig(
             audio_encoding=texttospeech.AudioEncoding.LINEAR16,

--- a/src/cxas_scrapi/core/audio_transformer.py
+++ b/src/cxas_scrapi/core/audio_transformer.py
@@ -71,7 +71,6 @@ class AudioTransformer:
         language_code = voice_config.get("language_code", "en-US")
         voice_name = voice_config.get("voice_name", "en-US-Standard-A")
 
-
         voice = texttospeech.VoiceSelectionParams(
             language_code=language_code, name=voice_name
         )

--- a/src/cxas_scrapi/core/audio_transformer.py
+++ b/src/cxas_scrapi/core/audio_transformer.py
@@ -17,7 +17,7 @@ import logging
 import random
 import threading
 import wave
-from typing import Any, Dict, Optional
+from typing import Any
 
 try:
     from pydub import AudioSegment
@@ -51,7 +51,7 @@ class AudioTransformer:
         bg_noise_snr: float = 15.0,
         burst_noise_files: list[str] | None = None,
         burst_noise_snr: float = 5.0,
-        voice_config: Optional[Dict[str, Any]] = None,
+        voice_config: dict[str, Any] | None = None,
     ) -> dict:
         """Converts text to speech and returns a dictionary with text and
         audio bytes without saving to disk. Background and burst noise can
@@ -69,12 +69,8 @@ class AudioTransformer:
         synthesis_input = texttospeech.SynthesisInput(text=text)
         voice_config = voice_config or {}
         language_code = voice_config.get("language_code", "en-US")
-        if "voice_name" in voice_config:
-            voice_name = voice_config["voice_name"]
-        else:
-            voice_name = "en-US-Standard-A"
-            if language_code.lower().startswith("fr"):
-                voice_name = "fr-CA-Standard-A"
+        voice_name = voice_config.get("voice_name", "en-US-Standard-A")
+
 
         voice = texttospeech.VoiceSelectionParams(
             language_code=language_code, name=voice_name

--- a/src/cxas_scrapi/core/sessions.py
+++ b/src/cxas_scrapi/core/sessions.py
@@ -799,6 +799,7 @@ class Sessions(Common):
         turn_count: Optional[int] = None,
         modality: Modality | str = Modality.TEXT,
         use_tool_fakes: bool = False,
+        voice_config: Optional[Dict[str, Any]] = None,
     ):
         """Sends inputs to a Conversational Agents Session and returns the
         response.
@@ -979,6 +980,7 @@ class Sessions(Common):
                             text=input,
                             credentials=self.creds,
                             project_id=self.project_id,
+                            voice_config=voice_config,
                         )
                     )
                 for input_data in input_audio_bytes:

--- a/src/cxas_scrapi/core/sessions.py
+++ b/src/cxas_scrapi/core/sessions.py
@@ -1018,6 +1018,7 @@ class Sessions(Common):
         capture_agent_audio: bool = False,
         background_noise_file: str | None = None,
         burst_noise_files: list[str] | None = None,
+        voice_config: dict[str, Any] | None = None,
     ):
         """Sends inputs to a Conversational Agents Session and returns the
         response.
@@ -1198,6 +1199,9 @@ class Sessions(Common):
                     lang_code = variables["locale"]
 
                 for input in text:
+                    current_voice_config = (voice_config or {}).copy()
+                    if "language_code" not in current_voice_config:
+                        current_voice_config["language_code"] = lang_code
                     input_audio_bytes.append(
                         audio_transformer.text_to_speech_bytes(
                             text=input,
@@ -1205,7 +1209,7 @@ class Sessions(Common):
                             project_id=self.project_id,
                             background_noise_file=background_noise_file,
                             burst_noise_files=burst_noise_files,
-                            language_code=lang_code,
+                            voice_config=current_voice_config,
                         )
                     )
                 for input_data in input_audio_bytes:

--- a/src/cxas_scrapi/evals/simulation_evals.py
+++ b/src/cxas_scrapi/evals/simulation_evals.py
@@ -489,6 +489,7 @@ class SimulationEvals(Apps):
         variables: Dict[str, Any],
         modality: str,
         console_logging: bool,
+        voice_config: Optional[Dict[str, Any]] = None,
     ) -> Any:
         """Sends a request to the CES Agent with exponential backoff for
         transient errors.
@@ -502,6 +503,7 @@ class SimulationEvals(Apps):
                         event=user_utterance.removeprefix("event:").strip(),
                         variables=variables,
                         modality=modality,
+                        **({"voice_config": voice_config} if voice_config is not None else {}),
                     )
                 elif user_utterance.startswith("dtmf:"):
                     response = self.sessions_client.run(
@@ -509,6 +511,7 @@ class SimulationEvals(Apps):
                         dtmf=user_utterance.removeprefix("dtmf:").strip(),
                         variables=variables,
                         modality=modality,
+                        **({"voice_config": voice_config} if voice_config is not None else {}),
                     )
                 else:
                     response = self.sessions_client.run(
@@ -516,6 +519,7 @@ class SimulationEvals(Apps):
                         text=user_utterance,
                         variables=variables,
                         modality=modality,
+                        **({"voice_config": voice_config} if voice_config is not None else {}),
                     )
                 break
             except Exception as e:
@@ -549,6 +553,7 @@ class SimulationEvals(Apps):
         session_id: Optional[str] = None,
         console_logging: bool = True,
         modality: str = "text",
+        voice_config: Optional[Dict[str, Any]] = None,
     ) -> LLMUserConversation:
         """Runs the simulated conversation loop.
 
@@ -582,11 +587,12 @@ class SimulationEvals(Apps):
 
         while user_utterance:
             response = self._send_request_with_retry(
-                session_id,
-                user_utterance,
-                accumulated_variables,
-                modality,
-                console_logging,
+                session_id=session_id,
+                user_utterance=user_utterance,
+                variables=accumulated_variables,
+                modality=modality,
+                console_logging=console_logging,
+                voice_config=voice_config,
             )
             if not response:
                 break

--- a/src/cxas_scrapi/evals/simulation_evals.py
+++ b/src/cxas_scrapi/evals/simulation_evals.py
@@ -490,6 +490,7 @@ class SimulationEvals(Apps):
         background_noise_file: str | None = None,
         burst_noise_files: list[str] | None = None,
         use_tool_fakes: bool = False,
+        voice_config: dict[str, Any] | None = None,
     ) -> Any:
         """Sends a request to the CES Agent with exponential backoff for
         transient errors.
@@ -508,6 +509,7 @@ class SimulationEvals(Apps):
                         background_noise_file=background_noise_file,
                         burst_noise_files=burst_noise_files,
                         use_tool_fakes=use_tool_fakes,
+                        voice_config=voice_config,
                     )
                 elif user_utterance.startswith("dtmf:"):
                     response = self.sessions_client.run(
@@ -520,6 +522,7 @@ class SimulationEvals(Apps):
                         background_noise_file=background_noise_file,
                         burst_noise_files=burst_noise_files,
                         use_tool_fakes=use_tool_fakes,
+                        voice_config=voice_config,
                     )
                 else:
                     response = self.sessions_client.run(
@@ -532,6 +535,7 @@ class SimulationEvals(Apps):
                         background_noise_file=background_noise_file,
                         burst_noise_files=burst_noise_files,
                         use_tool_fakes=use_tool_fakes,
+                        voice_config=voice_config,
                     )
                 break
             except Exception as e:
@@ -571,6 +575,7 @@ class SimulationEvals(Apps):
         background_noise_file: str | None = None,
         burst_noise_files: list[str] | None = None,
         use_tool_fakes: bool = False,
+        voice_config: dict[str, Any] | None = None,
     ) -> LLMUserConversation:
         """Runs the simulated conversation loop.
 
@@ -611,16 +616,17 @@ class SimulationEvals(Apps):
 
         while user_utterance:
             response = self._send_request_with_retry(
-                session_id,
-                user_utterance,
-                accumulated_variables,
-                modality,
-                console_logging,
+                session_id=session_id,
+                user_utterance=user_utterance,
+                variables=accumulated_variables,
+                modality=modality,
+                console_logging=console_logging,
                 turn_num=current_sim_turn,
                 capture_agent_audio=capture_agent_audio,
                 background_noise_file=background_noise_file,
                 burst_noise_files=burst_noise_files,
                 use_tool_fakes=use_tool_fakes,
+                voice_config=voice_config,
             )
             if not response:
                 break

--- a/src/cxas_scrapi/evals/simulation_evals.py
+++ b/src/cxas_scrapi/evals/simulation_evals.py
@@ -495,47 +495,36 @@ class SimulationEvals(Apps):
         """Sends a request to the CES Agent with exponential backoff for
         transient errors.
         """
+        run_kwargs = {
+            "session_id": session_id,
+            "variables": variables,
+            "modality": modality,
+            "turn_num": turn_num,
+            "capture_agent_audio": capture_agent_audio,
+            "background_noise_file": background_noise_file,
+            "burst_noise_files": burst_noise_files,
+            "use_tool_fakes": use_tool_fakes,
+        }
+        if voice_config is not None:
+            run_kwargs["voice_config"] = voice_config
+
         response = None
         for attempt in range(self.max_retries):
             try:
                 if user_utterance.startswith("event:"):
                     response = self.sessions_client.run(
-                        session_id=session_id,
                         event=user_utterance.removeprefix("event:").strip(),
-                        variables=variables,
-                        modality=modality,
-                        turn_num=turn_num,
-                        capture_agent_audio=capture_agent_audio,
-                        background_noise_file=background_noise_file,
-                        burst_noise_files=burst_noise_files,
-                        use_tool_fakes=use_tool_fakes,
-                        voice_config=voice_config,
+                        **run_kwargs,
                     )
                 elif user_utterance.startswith("dtmf:"):
                     response = self.sessions_client.run(
-                        session_id=session_id,
                         dtmf=user_utterance.removeprefix("dtmf:").strip(),
-                        variables=variables,
-                        modality=modality,
-                        turn_num=turn_num,
-                        capture_agent_audio=capture_agent_audio,
-                        background_noise_file=background_noise_file,
-                        burst_noise_files=burst_noise_files,
-                        use_tool_fakes=use_tool_fakes,
-                        voice_config=voice_config,
+                        **run_kwargs,
                     )
                 else:
                     response = self.sessions_client.run(
-                        session_id=session_id,
                         text=user_utterance,
-                        variables=variables,
-                        modality=modality,
-                        turn_num=turn_num,
-                        capture_agent_audio=capture_agent_audio,
-                        background_noise_file=background_noise_file,
-                        burst_noise_files=burst_noise_files,
-                        use_tool_fakes=use_tool_fakes,
-                        voice_config=voice_config,
+                        **run_kwargs,
                     )
                 break
             except Exception as e:

--- a/tests/cxas_scrapi/core/test_audio_transformer.py
+++ b/tests/cxas_scrapi/core/test_audio_transformer.py
@@ -91,3 +91,43 @@ class TestAudioTransformer:
         # Verify failure handled gracefully
         assert result["text"] == "hello"
         assert result["audio_bytes"] is None
+
+    @patch("cxas_scrapi.core.audio_transformer.texttospeech")
+    def test_text_to_speech_bytes_custom_voice(self, mock_tts):
+        # Mock dependencies
+        mock_client = MagicMock()
+        mock_tts.TextToSpeechClient.return_value = mock_client
+
+        # Create a valid WAV file in memory to return as mock response
+        with io.BytesIO() as wav_io:
+            with wave.open(wav_io, "wb") as wav_file:
+                wav_file.setnchannels(1)
+                wav_file.setsampwidth(2)
+                wav_file.setframerate(16000)
+                wav_file.writeframes(b"audio_data")
+            wav_bytes = wav_io.getvalue()
+
+        # Configure mock response
+        mock_response = MagicMock()
+        mock_response.audio_content = wav_bytes
+        mock_client.synthesize_speech.return_value = mock_response
+
+        # Execute with custom voice_config
+        custom_voice = {"language_code": "fr-FR", "voice_name": "fr-FR-Standard-G"}
+        result = self.transformer.text_to_speech_bytes(
+            text="Bonjour",
+            credentials=MagicMock(),
+            project_id="test-project",
+            voice_config=custom_voice,
+        )
+
+        # Verify
+        assert result["text"] == "Bonjour"
+        assert result["audio_bytes"] == b"audio_data"
+        mock_client.synthesize_speech.assert_called_once()
+        
+        # Verify custom params were used
+        mock_tts.VoiceSelectionParams.assert_called_once_with(
+            language_code="fr-FR", name="fr-FR-Standard-G"
+        )
+

--- a/tests/cxas_scrapi/core/test_audio_transformer.py
+++ b/tests/cxas_scrapi/core/test_audio_transformer.py
@@ -92,6 +92,7 @@ class TestAudioTransformer:
         assert result["text"] == "hello"
         assert result["audio_bytes"] is None
 
+
     @patch("cxas_scrapi.core.audio_transformer.AudioSegment")
     @patch("cxas_scrapi.core.audio_transformer.texttospeech")
     def test_text_to_speech_bytes_with_burst_noise_success(
@@ -110,6 +111,7 @@ class TestAudioTransformer:
                 wav_file.writeframes(b"audio_data")
             wav_bytes = wav_io.getvalue()
 
+        # Configure mock response
         mock_response = MagicMock()
         mock_response.audio_content = wav_bytes
         mock_client.synthesize_speech.return_value = mock_response
@@ -199,3 +201,43 @@ class TestAudioTransformer:
         # Verify graceful fallback to clean audio
         assert result["text"] == "hello"
         assert result["audio_bytes"] == b"clean_audio_"
+
+    @patch("cxas_scrapi.core.audio_transformer.texttospeech")
+    def test_text_to_speech_bytes_custom_voice(self, mock_tts):
+        # Mock dependencies
+        mock_client = MagicMock()
+        mock_tts.TextToSpeechClient.return_value = mock_client
+
+        # Create a valid WAV file in memory to return as mock response
+        with io.BytesIO() as wav_io:
+            with wave.open(wav_io, "wb") as wav_file:
+                wav_file.setnchannels(1)
+                wav_file.setsampwidth(2)
+                wav_file.setframerate(16000)
+                wav_file.writeframes(b"audio_data")
+            wav_bytes = wav_io.getvalue()
+
+        # Configure mock response
+        mock_response = MagicMock()
+        mock_response.audio_content = wav_bytes
+        mock_client.synthesize_speech.return_value = mock_response
+
+        # Execute with custom voice_config
+        custom_voice = {"language_code": "fr-FR", "voice_name": "fr-FR-Standard-G"}
+        result = self.transformer.text_to_speech_bytes(
+            text="Bonjour",
+            credentials=MagicMock(),
+            project_id="test-project",
+            voice_config=custom_voice,
+        )
+
+        # Verify
+        assert result["text"] == "Bonjour"
+        assert result["audio_bytes"] == b"audio_data"
+        mock_client.synthesize_speech.assert_called_once()
+        
+        # Verify custom params were used
+        mock_tts.VoiceSelectionParams.assert_called_once_with(
+            language_code="fr-FR", name="fr-FR-Standard-G"
+        )
+

--- a/tests/cxas_scrapi/core/test_audio_transformer.py
+++ b/tests/cxas_scrapi/core/test_audio_transformer.py
@@ -242,4 +242,3 @@ class TestAudioTransformer:
         # Verify graceful fallback to clean audio
         assert result["text"] == "hello"
         assert result["audio_bytes"] == b"clean_audio_"
-

--- a/tests/cxas_scrapi/core/test_audio_transformer.py
+++ b/tests/cxas_scrapi/core/test_audio_transformer.py
@@ -92,6 +92,47 @@ class TestAudioTransformer:
         assert result["text"] == "hello"
         assert result["audio_bytes"] is None
 
+    @patch("cxas_scrapi.core.audio_transformer.texttospeech")
+    def test_text_to_speech_bytes_custom_voice(self, mock_tts):
+        # Mock dependencies
+        mock_client = MagicMock()
+        mock_tts.TextToSpeechClient.return_value = mock_client
+
+        # Create a valid WAV file in memory to return as mock response
+        with io.BytesIO() as wav_io:
+            with wave.open(wav_io, "wb") as wav_file:
+                wav_file.setnchannels(1)
+                wav_file.setsampwidth(2)
+                wav_file.setframerate(16000)
+                wav_file.writeframes(b"audio_data")
+            wav_bytes = wav_io.getvalue()
+
+        # Configure mock response
+        mock_response = MagicMock()
+        mock_response.audio_content = wav_bytes
+        mock_client.synthesize_speech.return_value = mock_response
+
+        # Execute with custom voice_config
+        custom_voice = {
+            "language_code": "fr-FR",
+            "voice_name": "fr-FR-Standard-G",
+        }
+        result = self.transformer.text_to_speech_bytes(
+            text="Bonjour",
+            credentials=MagicMock(),
+            project_id="test-project",
+            voice_config=custom_voice,
+        )
+
+        # Verify
+        assert result["text"] == "Bonjour"
+        assert result["audio_bytes"] == b"audio_data"
+        mock_client.synthesize_speech.assert_called_once()
+
+        # Verify custom params were used
+        mock_tts.VoiceSelectionParams.assert_called_once_with(
+            language_code="fr-FR", name="fr-FR-Standard-G"
+        )
 
     @patch("cxas_scrapi.core.audio_transformer.AudioSegment")
     @patch("cxas_scrapi.core.audio_transformer.texttospeech")
@@ -201,43 +242,4 @@ class TestAudioTransformer:
         # Verify graceful fallback to clean audio
         assert result["text"] == "hello"
         assert result["audio_bytes"] == b"clean_audio_"
-
-    @patch("cxas_scrapi.core.audio_transformer.texttospeech")
-    def test_text_to_speech_bytes_custom_voice(self, mock_tts):
-        # Mock dependencies
-        mock_client = MagicMock()
-        mock_tts.TextToSpeechClient.return_value = mock_client
-
-        # Create a valid WAV file in memory to return as mock response
-        with io.BytesIO() as wav_io:
-            with wave.open(wav_io, "wb") as wav_file:
-                wav_file.setnchannels(1)
-                wav_file.setsampwidth(2)
-                wav_file.setframerate(16000)
-                wav_file.writeframes(b"audio_data")
-            wav_bytes = wav_io.getvalue()
-
-        # Configure mock response
-        mock_response = MagicMock()
-        mock_response.audio_content = wav_bytes
-        mock_client.synthesize_speech.return_value = mock_response
-
-        # Execute with custom voice_config
-        custom_voice = {"language_code": "fr-FR", "voice_name": "fr-FR-Standard-G"}
-        result = self.transformer.text_to_speech_bytes(
-            text="Bonjour",
-            credentials=MagicMock(),
-            project_id="test-project",
-            voice_config=custom_voice,
-        )
-
-        # Verify
-        assert result["text"] == "Bonjour"
-        assert result["audio_bytes"] == b"audio_data"
-        mock_client.synthesize_speech.assert_called_once()
-        
-        # Verify custom params were used
-        mock_tts.VoiceSelectionParams.assert_called_once_with(
-            language_code="fr-FR", name="fr-FR-Standard-G"
-        )
 

--- a/tests/cxas_scrapi/core/test_sessions.py
+++ b/tests/cxas_scrapi/core/test_sessions.py
@@ -449,6 +449,44 @@ def test_run_session_audio_modality_variables_all_turns(
 @patch("cxas_scrapi.core.sessions.Sessions._check_audio_requirements")
 @patch("cxas_scrapi.core.sessions.SessionServiceClient")
 @patch("cxas_scrapi.core.sessions.Sessions.async_bidi_run_session")
+def test_run_session_audio_modality_voice_config(
+    mock_async_run, mock_client_cls, mock_check_reqs
+):
+    """Test Sessions.run propagates voice_config to AudioTransformer."""
+    sessions = Sessions(app_name="projects/p/locations/l/apps/a")
+
+    with patch("cxas_scrapi.core.sessions.AudioTransformer") as MockTransformer:
+        mock_transformer = MockTransformer.return_value
+        mock_transformer.text_to_speech_bytes.side_effect = (
+            lambda text, **kwargs: {
+                "audio_bytes": b"tts_" + text.encode(),
+                "text": text,
+            }
+        )
+
+        custom_voice = {"language_code": "fr-FR", "voice_name": "fr-FR-Standard-G"}
+        sessions.run(
+            session_id="s1",
+            text=["Bonjour"],
+            modality=Modality.AUDIO,
+            voice_config=custom_voice,
+        )
+
+        mock_async_run.assert_called_once()
+        
+        # Verify AudioTransformer was called with correct voice_config
+        mock_transformer.text_to_speech_bytes.assert_called_once_with(
+            text="Bonjour",
+            credentials=sessions.creds,
+            project_id=sessions.project_id,
+            voice_config=custom_voice,
+        )
+
+
+
+@patch("cxas_scrapi.core.sessions.Sessions._check_audio_requirements")
+@patch("cxas_scrapi.core.sessions.SessionServiceClient")
+@patch("cxas_scrapi.core.sessions.Sessions.async_bidi_run_session")
 def test_run_session_audio_modality_variables_with_event(
     mock_async_run, mock_client_cls, mock_check_reqs
 ):

--- a/tests/cxas_scrapi/core/test_sessions.py
+++ b/tests/cxas_scrapi/core/test_sessions.py
@@ -452,6 +452,44 @@ def test_run_session_audio_modality_variables_all_turns(
 @patch("cxas_scrapi.core.sessions.Sessions._check_audio_requirements")
 @patch("cxas_scrapi.core.sessions.SessionServiceClient")
 @patch("cxas_scrapi.core.sessions.Sessions.async_bidi_run_session")
+def test_run_session_audio_modality_voice_config(
+    mock_async_run, mock_client_cls, mock_check_reqs
+):
+    """Test Sessions.run propagates voice_config to AudioTransformer."""
+    sessions = Sessions(app_name="projects/p/locations/l/apps/a")
+
+    with patch("cxas_scrapi.core.sessions.AudioTransformer") as MockTransformer:
+        mock_transformer = MockTransformer.return_value
+        mock_transformer.text_to_speech_bytes.side_effect = (
+            lambda text, **kwargs: {
+                "audio_bytes": b"tts_" + text.encode(),
+                "text": text,
+            }
+        )
+
+        custom_voice = {"language_code": "fr-FR", "voice_name": "fr-FR-Standard-G"}
+        sessions.run(
+            session_id="s1",
+            text=["Bonjour"],
+            modality=Modality.AUDIO,
+            voice_config=custom_voice,
+        )
+
+        mock_async_run.assert_called_once()
+        
+        # Verify AudioTransformer was called with correct voice_config
+        mock_transformer.text_to_speech_bytes.assert_called_once_with(
+            text="Bonjour",
+            credentials=sessions.creds,
+            project_id=sessions.project_id,
+            voice_config=custom_voice,
+        )
+
+
+
+@patch("cxas_scrapi.core.sessions.Sessions._check_audio_requirements")
+@patch("cxas_scrapi.core.sessions.SessionServiceClient")
+@patch("cxas_scrapi.core.sessions.Sessions.async_bidi_run_session")
 def test_run_session_audio_modality_variables_with_event(
     mock_async_run, mock_client_cls, mock_check_reqs
 ):

--- a/tests/cxas_scrapi/core/test_sessions.py
+++ b/tests/cxas_scrapi/core/test_sessions.py
@@ -467,7 +467,10 @@ def test_run_session_audio_modality_voice_config(
             }
         )
 
-        custom_voice = {"language_code": "fr-FR", "voice_name": "fr-FR-Standard-G"}
+        custom_voice = {
+            "language_code": "fr-FR",
+            "voice_name": "fr-FR-Standard-G",
+        }
         sessions.run(
             session_id="s1",
             text=["Bonjour"],
@@ -476,15 +479,16 @@ def test_run_session_audio_modality_voice_config(
         )
 
         mock_async_run.assert_called_once()
-        
+
         # Verify AudioTransformer was called with correct voice_config
         mock_transformer.text_to_speech_bytes.assert_called_once_with(
             text="Bonjour",
             credentials=sessions.creds,
             project_id=sessions.project_id,
             voice_config=custom_voice,
+            background_noise_file=None,
+            burst_noise_files=None,
         )
-
 
 
 @patch("cxas_scrapi.core.sessions.Sessions._check_audio_requirements")

--- a/tests/cxas_scrapi/evals/test_simulation_evals.py
+++ b/tests/cxas_scrapi/evals/test_simulation_evals.py
@@ -990,3 +990,51 @@ def test_simulation_evals_init_with_rate_limiter(mock_sessions):
         app_name,
         rate_limiter=mock_rate_limiter,
     )
+
+
+@patch("cxas_scrapi.evals.simulation_evals.Sessions")
+@patch("cxas_scrapi.evals.simulation_evals.LLMUserConversation")
+def test_simulation_evals_voice_config(
+    mock_llm_conv_class, mock_sessions_class
+):
+    mock_sessions = mock_sessions_class.return_value
+    mock_eval_conv = mock_llm_conv_class.return_value
+
+    mock_eval_conv.next_user_utterance.side_effect = [
+        ("event: welcome", {}),
+        ("Bonjour", {}),
+        ("", {}),
+    ]
+    mock_eval_conv.steps_progress = []
+
+    mock_response_1 = MagicMock()
+    mock_response_1.outputs = [MagicMock(text="Bonjour!")]
+    mock_response_2 = MagicMock()
+    mock_response_2.outputs = [MagicMock(text="Au revoir!")]
+    mock_sessions.run.side_effect = [mock_response_1, mock_response_2]
+
+    app_name = "projects/test/locations/us/apps/123-abc"
+    with patch("cxas_scrapi.evals.simulation_evals.GeminiGenerate"):
+        with patch("cxas_scrapi.core.apps.AgentServiceClient"):
+            simulator = SimulationEvals(app_name=app_name)
+
+    # Custom voice_config passed via simulate_conversation
+    custom_voice = {"language_code": "fr-FR", "voice_name": "fr-FR-Standard-G"}
+    
+    # Test 1: Passed as function argument
+    simulator.simulate_conversation(
+        test_case={"steps": []},
+        session_id="123",
+        console_logging=False,
+        voice_config=custom_voice,
+    )
+
+    # Verify that Sessions.run was called with the custom voice_config
+    mock_sessions.run.assert_any_call(
+        session_id="123",
+        event="welcome",
+        variables={},
+        modality="text",
+        voice_config=custom_voice,
+    )
+

--- a/tests/cxas_scrapi/evals/test_simulation_evals.py
+++ b/tests/cxas_scrapi/evals/test_simulation_evals.py
@@ -1265,7 +1265,6 @@ def test_simulation_evals_voice_config(
     )
 
 
-
 @patch("cxas_scrapi.evals.simulation_evals.Sessions")
 def test_simulation_evals_run_simulations_use_tool_fakes(mock_sessions):
     app_name = "projects/test/locations/us/apps/123-abc"
@@ -1507,4 +1506,3 @@ def test_simulation_evals_expectations_only_fallback():
             parallel=1,
         )
         assert res["passed"] is True
-

--- a/tests/cxas_scrapi/evals/test_simulation_evals.py
+++ b/tests/cxas_scrapi/evals/test_simulation_evals.py
@@ -1210,7 +1210,6 @@ def test_simulation_evals_simulate_conversation_use_tool_fakes(
         background_noise_file=None,
         burst_noise_files=None,
         use_tool_fakes=True,
-        voice_config=None,
     )
 
 
@@ -1242,7 +1241,7 @@ def test_simulation_evals_voice_config(
 
     # Custom voice_config passed via simulate_conversation
     custom_voice = {"language_code": "fr-FR", "voice_name": "fr-FR-Standard-G"}
-    
+
     # Test 1: Passed as function argument
     simulator.simulate_conversation(
         test_case={"steps": []},
@@ -1508,8 +1507,4 @@ def test_simulation_evals_expectations_only_fallback():
             parallel=1,
         )
         assert res["passed"] is True
-=======
-        voice_config=custom_voice,
-    )
 
->>>>>>> 2888cc4 (feat(evals): propagate voice_config parameter through simulate_conversation)

--- a/tests/cxas_scrapi/evals/test_simulation_evals.py
+++ b/tests/cxas_scrapi/evals/test_simulation_evals.py
@@ -1210,7 +1210,61 @@ def test_simulation_evals_simulate_conversation_use_tool_fakes(
         background_noise_file=None,
         burst_noise_files=None,
         use_tool_fakes=True,
+        voice_config=None,
     )
+
+
+@patch("cxas_scrapi.evals.simulation_evals.Sessions")
+@patch("cxas_scrapi.evals.simulation_evals.LLMUserConversation")
+def test_simulation_evals_voice_config(
+    mock_llm_conv_class, mock_sessions_class
+):
+    mock_sessions = mock_sessions_class.return_value
+    mock_eval_conv = mock_llm_conv_class.return_value
+
+    mock_eval_conv.next_user_utterance.side_effect = [
+        ("event: welcome", {}),
+        ("Bonjour", {}),
+        ("", {}),
+    ]
+    mock_eval_conv.steps_progress = []
+
+    mock_response_1 = MagicMock()
+    mock_response_1.outputs = [MagicMock(text="Bonjour!")]
+    mock_response_2 = MagicMock()
+    mock_response_2.outputs = [MagicMock(text="Au revoir!")]
+    mock_sessions.run.side_effect = [mock_response_1, mock_response_2]
+
+    app_name = "projects/test/locations/us/apps/123-abc"
+    with patch("cxas_scrapi.evals.simulation_evals.GeminiGenerate"):
+        with patch("cxas_scrapi.core.apps.AgentServiceClient"):
+            simulator = SimulationEvals(app_name=app_name)
+
+    # Custom voice_config passed via simulate_conversation
+    custom_voice = {"language_code": "fr-FR", "voice_name": "fr-FR-Standard-G"}
+    
+    # Test 1: Passed as function argument
+    simulator.simulate_conversation(
+        test_case={"steps": []},
+        session_id="123",
+        console_logging=False,
+        voice_config=custom_voice,
+    )
+
+    # Verify that Sessions.run was called with the custom voice_config
+    mock_sessions.run.assert_any_call(
+        session_id="123",
+        event="welcome",
+        variables={},
+        modality="text",
+        turn_num=0,
+        capture_agent_audio=False,
+        background_noise_file=None,
+        burst_noise_files=None,
+        use_tool_fakes=False,
+        voice_config=custom_voice,
+    )
+
 
 
 @patch("cxas_scrapi.evals.simulation_evals.Sessions")
@@ -1454,3 +1508,8 @@ def test_simulation_evals_expectations_only_fallback():
             parallel=1,
         )
         assert res["passed"] is True
+=======
+        voice_config=custom_voice,
+    )
+
+>>>>>>> 2888cc4 (feat(evals): propagate voice_config parameter through simulate_conversation)


### PR DESCRIPTION
## Problem
Currently, the client-side Text-to-Speech (TTS) in audio simulations is hardcoded to English (`en-US`). When testing non-English agents (e.g., French or German) in audio modality, the simulated user's utterances are spoken with an English accent. GECX's Speech-to-Text (STT) fails to parse this heavily mispronounced audio stream, leading to false-negative test failures.

## Solution
We introduce an optional `voice_config` parameter to allow dynamic configuration of the TTS voice.

- **Programmatic API**: Added `voice_config: Optional[Dict[str, Any]]` to `simulate_conversation()`, `Sessions.run()`, and `AudioTransformer.text_to_speech_bytes()`.
- **Strict Backward Compatibility**: By default, the parameter is omitted when not provided.
- **Documentation**: Added a clear example and details to the "Audio Modality" section in `local-simulations.md`.


## Tests Added
- **`test_audio_transformer.py`**: Added `test_text_to_speech_bytes_custom_voice` to verify custom voice selection parameters are correctly formatted and sent to Google Cloud TTS.
- **`test_sessions.py`**: Added `test_run_session_audio_modality_voice_config` to verify custom `voice_config` propagation during sessions running.
- **`test_simulation_evals.py`**: Added `test_simulation_evals_voice_config` to verify programmatic resolution and propagation from the simulation loop.

Resolves #180 