### PR TITLE
fix(trace): correct GECX/CES Console URL query parameter route

### DIFF
--- a/src/cxas_scrapi/cli/trace_cli.py
+++ b/src/cxas_scrapi/cli/trace_cli.py
@@ -424,7 +424,9 @@ def trace_bug_report(args: argparse.Namespace) -> None:
 def trace_open(args: argparse.Namespace) -> None:
     try:
         traces = _build_traces(args)
-        url = traces.console_url(args.conversation_id)
+        normalized = traces.get_normalized(args.conversation_id)
+        source_str = normalized.get("source")
+        url = traces.console_url(args.conversation_id, source=source_str)
     except Exception as e:
         print(f"Open failed: {e}", file=sys.stderr)
         sys.exit(1)

--- a/src/cxas_scrapi/core/traces.py
+++ b/src/cxas_scrapi/core/traces.py
@@ -33,6 +33,7 @@ import json
 import logging
 import os
 import subprocess
+import urllib.parse
 import zipfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from statistics import median
@@ -133,15 +134,18 @@ class Traces(Common):
             )
             if channel_filter and normalized_channel != channel_filter.upper():
                 continue
+            source_str = _enum_name(getattr(c, "source", None))
             rows.append(
                 {
                     "id": c.name.split("/")[-1],
                     "name": c.name,
-                    "source": _enum_name(getattr(c, "source", None)),
+                    "source": source_str,
                     "channel": normalized_channel,
                     "start_time": _ts_iso(getattr(c, "start_time", None)),
                     "end_time": _ts_iso(getattr(c, "end_time", None)),
-                    "ces_url": self.console_url(c.name.split("/")[-1]),
+                    "ces_url": self.console_url(
+                        c.name.split("/")[-1], source=source_str
+                    ),
                 }
             )
             if limit and len(rows) >= limit:
@@ -200,7 +204,8 @@ class Traces(Common):
                 conversation_id, normalized=normalized
             )
 
-        url = self.console_url(conversation_id)
+        source_str = normalized.get("source")
+        url = self.console_url(conversation_id, source=source_str)
         if fmt == "json":
             return trace_report.to_json(normalized, extras=extras)
         if fmt in ("md", "markdown"):
@@ -640,6 +645,7 @@ class Traces(Common):
             else None
         )
 
+        source_str = normalized.get("source")
         with zipfile.ZipFile(out_path, "w", zipfile.ZIP_DEFLATED) as z:
             z.writestr(
                 "transcript.json",
@@ -648,14 +654,19 @@ class Traces(Common):
             z.writestr(
                 "transcript.md",
                 trace_report.to_markdown(
-                    normalized, console_url=self.console_url(conversation_id)
+                    normalized,
+                    console_url=self.console_url(
+                        conversation_id, source=source_str
+                    ),
                 ),
             )
             z.writestr(
                 "report.html",
                 trace_report.to_html(
                     normalized,
-                    console_url=self.console_url(conversation_id),
+                    console_url=self.console_url(
+                        conversation_id, source=source_str
+                    ),
                     audio_path=(
                         os.path.basename(audio_path) if audio_path else None
                     ),
@@ -721,7 +732,9 @@ class Traces(Common):
                 f"{base_uri}transcript.md",
                 trace_report.to_markdown(
                     normalized,
-                    console_url=self.console_url(conversation_id),
+                    console_url=self.console_url(
+                        conversation_id, source=normalized.get("source")
+                    ),
                 ),
                 content_type="text/markdown",
             )
@@ -789,12 +802,22 @@ class Traces(Common):
 
     # ---------------------------- ui / helpers ------------------------------
 
-    def console_url(self, conversation_id: str) -> str:
+    def console_url(
+        self, conversation_id: str, source: str | None = None
+    ) -> str:
+        """Builds the GECX/CES Console URL for a conversation."""
         base = self.trace_config.ui.ces_console_base.rstrip("/")
+        app_id = (self.app_name or "").split("/")[-1]
+        params = {
+            "panel": "conversation_list",
+            "id": conversation_id,
+        }
+        if source:
+            params["source"] = source
+        qs = urllib.parse.urlencode(params)
         return (
             f"{base}/projects/{self.project_id}/locations/{self.location}"
-            f"/apps/{(self.app_name or '').split('/')[-1]}/conversations/"
-            f"{conversation_id}"
+            f"/apps/{app_id}?{qs}"
         )
 
     def _metadata(self) -> dict[str, Any]:

--- a/tests/cxas_scrapi/cli/test_trace_cli.py
+++ b/tests/cxas_scrapi/cli/test_trace_cli.py
@@ -441,6 +441,7 @@ def test_trace_bug_report_failure(fake_traces):
 
 
 def test_trace_open_prints_and_runs_open(fake_traces, capsys, monkeypatch):
+    fake_traces.get_normalized.return_value = {"source": "LIVE"}
     fake_traces.console_url.return_value = "https://x/y"
     monkeypatch.setattr(trace_cli.platform, "system", lambda: "Darwin")
     fake_run = MagicMock()
@@ -448,24 +449,30 @@ def test_trace_open_prints_and_runs_open(fake_traces, capsys, monkeypatch):
     trace_cli.trace_open(_ns(conversation_id="c1"))
     assert "https://x/y" in capsys.readouterr().out
     fake_run.assert_called_once()
+    fake_traces.get_normalized.assert_called_once_with("c1")
+    fake_traces.console_url.assert_called_once_with("c1", source="LIVE")
 
 
 def test_trace_open_non_darwin(fake_traces, capsys, monkeypatch):
+    fake_traces.get_normalized.return_value = {"source": "LIVE"}
     fake_traces.console_url.return_value = "https://x/y"
     monkeypatch.setattr(trace_cli.platform, "system", lambda: "Linux")
     fake_run = MagicMock()
     monkeypatch.setattr(trace_cli.subprocess, "run", fake_run)
     trace_cli.trace_open(_ns(conversation_id="c1"))
     fake_run.assert_not_called()
+    fake_traces.get_normalized.assert_called_once_with("c1")
+    fake_traces.console_url.assert_called_once_with("c1", source="LIVE")
 
 
 def test_trace_open_failure(fake_traces):
-    fake_traces.console_url.side_effect = RuntimeError("boom")
+    fake_traces.get_normalized.side_effect = RuntimeError("boom")
     with pytest.raises(SystemExit):
         trace_cli.trace_open(_ns(conversation_id="c1"))
 
 
 def test_trace_open_subprocess_failure_silent(fake_traces, monkeypatch, capsys):
+    fake_traces.get_normalized.return_value = {"source": "LIVE"}
     fake_traces.console_url.return_value = "https://x/y"
     monkeypatch.setattr(trace_cli.platform, "system", lambda: "Darwin")
 
@@ -475,6 +482,8 @@ def test_trace_open_subprocess_failure_silent(fake_traces, monkeypatch, capsys):
     monkeypatch.setattr(trace_cli.subprocess, "run", boom)
     trace_cli.trace_open(_ns(conversation_id="c1"))
     assert "https://x/y" in capsys.readouterr().out
+    fake_traces.get_normalized.assert_called_once_with("c1")
+    fake_traces.console_url.assert_called_once_with("c1", source="LIVE")
 
 
 @patch("cxas_scrapi.cli.trace_cli.Traces")

--- a/tests/cxas_scrapi/core/test_traces.py
+++ b/tests/cxas_scrapi/core/test_traces.py
@@ -808,10 +808,18 @@ def test_report_bug_skips_failing_artifacts(traces_obj, monkeypatch):
 
 
 def test_console_url_format(traces_obj):
+    # 1. Without source
     url = traces_obj.console_url("conv-1")
     assert url == (
-        "https://ces.cloud.google.com/projects/p/locations/l/apps/a/"
-        "conversations/conv-1"
+        "https://ces.cloud.google.com/projects/p/locations/l/apps/a"
+        "?panel=conversation_list&id=conv-1"
+    )
+
+    # 2. With source
+    url_with_source = traces_obj.console_url("conv-1", source="LIVE")
+    assert url_with_source == (
+        "https://ces.cloud.google.com/projects/p/locations/l/apps/a"
+        "?panel=conversation_list&id=conv-1&source=LIVE"
     )
 
 


### PR DESCRIPTION
This PR corrects the GECX/CES Console URL routing constructed by Traces.console_url() to follow the query-parameter based format (?panel=conversation_list&id=<convId>&source=<source>), resolving 404/route errors when viewing conversations. All internal and CLI call-sites are updated to retrieve and pass the conversation source parameter.

Fixes #189 