### PR TITLE
feat: add native support for CES_API_ENDPOINT and CES_TRANSPORT

### DIFF
--- a/src/cxas_scrapi/core/common.py
+++ b/src/cxas_scrapi/core/common.py
@@ -33,7 +33,7 @@ GLOBAL_SCOPES = [
     "https://www.googleapis.com/auth/generative-language.retriever",
 ]
 
-DEFAULT_API_ENDPOINT = "ces.googleapis.com"
+DEFAULT_API_ENDPOINT = os.environ.get("CES_API_ENDPOINT", "ces.googleapis.com")
 
 
 class Common:
@@ -368,14 +368,23 @@ class Common:
         return separator.join(agent_texts)
 
     def get_grpc_transport(self, client_class: type):
-        """Creates a customer gRPC transport for CXAS SCRAPI calls."""
-        transport_class = client_class.get_transport_class("grpc")
+        """Creates a customer transport for CXAS SCRAPI calls."""
+        transport_type = os.environ.get("CES_TRANSPORT", "grpc").lower()
 
         host = DEFAULT_API_ENDPOINT
         client_opts = getattr(self, "client_options", None)
         if client_opts and "api_endpoint" in client_opts:
             host = self.client_options["api_endpoint"]
 
+        if transport_type == "rest":
+            transport_class = client_class.get_transport_class("rest")
+            return transport_class(
+                host=host,
+                credentials=self.creds,
+                client_info=self.client_info,
+            )
+
+        transport_class = client_class.get_transport_class("grpc")
         channel = transport_class.create_channel(
             host=host,
             credentials=self.creds,

--- a/src/cxas_scrapi/evals/runner.py
+++ b/src/cxas_scrapi/evals/runner.py
@@ -173,7 +173,14 @@ def run_all_evals(
                     cases = [
                         c
                         for c in cases
-                        if any(t in filter_tags for t in (c.get("tags", []) if isinstance(c, dict) else (getattr(c, "tags", None) or [])))
+                        if any(
+                            t in filter_tags
+                            for t in (
+                                c.get("tags", [])
+                                if isinstance(c, dict)
+                                else (getattr(c, "tags", None) or [])
+                            )
+                        )
                     ]
                 test_cases.extend(cases)
 

--- a/src/cxas_scrapi/evals/runner.py
+++ b/src/cxas_scrapi/evals/runner.py
@@ -173,7 +173,7 @@ def run_all_evals(
                     cases = [
                         c
                         for c in cases
-                        if any(t in filter_tags for t in c.get("tags", []))
+                        if any(t in filter_tags for t in (c.get("tags", []) if isinstance(c, dict) else (getattr(c, "tags", None) or [])))
                     ]
                 test_cases.extend(cases)
 

--- a/tests/cxas_scrapi/core/test_common.py
+++ b/tests/cxas_scrapi/core/test_common.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import subprocess
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -125,26 +126,30 @@ def test_parse_textproto():
 
 
 def test_ces_api_endpoint_override():
-    import subprocess
-    import sys
-    
     # Run a subprocess with CES_API_ENDPOINT set
     cmd = [
         sys.executable,
         "-c",
-        "from cxas_scrapi.core.common import DEFAULT_API_ENDPOINT; print(DEFAULT_API_ENDPOINT)"
+        (
+            "from cxas_scrapi.core.common import DEFAULT_API_ENDPOINT; "
+            "print(DEFAULT_API_ENDPOINT)"
+        ),
     ]
     env = os.environ.copy()
     env["CES_API_ENDPOINT"] = "custom.ces.googleapis.com"
-    
+
     # We need to make sure src is in python path for the subprocess
-    src_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../src"))
+    src_path = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "../../../src")
+    )
     if "PYTHONPATH" in env:
         env["PYTHONPATH"] = f"{src_path}:{env['PYTHONPATH']}"
     else:
         env["PYTHONPATH"] = src_path
-        
-    result = subprocess.run(cmd, env=env, capture_output=True, text=True, check=True)
+
+    result = subprocess.run(
+        cmd, env=env, capture_output=True, text=True, check=True
+    )
     assert result.stdout.strip() == "custom.ces.googleapis.com"
 
 

--- a/tests/cxas_scrapi/core/test_common.py
+++ b/tests/cxas_scrapi/core/test_common.py
@@ -124,6 +124,46 @@ def test_parse_textproto():
     assert res == {"key": "value", "nested": {"inner": "1"}}
 
 
+def test_ces_api_endpoint_override():
+    import subprocess
+    import sys
+    
+    # Run a subprocess with CES_API_ENDPOINT set
+    cmd = [
+        sys.executable,
+        "-c",
+        "from cxas_scrapi.core.common import DEFAULT_API_ENDPOINT; print(DEFAULT_API_ENDPOINT)"
+    ]
+    env = os.environ.copy()
+    env["CES_API_ENDPOINT"] = "custom.ces.googleapis.com"
+    
+    # We need to make sure src is in python path for the subprocess
+    src_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../src"))
+    if "PYTHONPATH" in env:
+        env["PYTHONPATH"] = f"{src_path}:{env['PYTHONPATH']}"
+    else:
+        env["PYTHONPATH"] = src_path
+        
+    result = subprocess.run(cmd, env=env, capture_output=True, text=True, check=True)
+    assert result.stdout.strip() == "custom.ces.googleapis.com"
+
+
+def test_ces_transport_override_grpc():
+    # Default should be grpc
+    common = Common(creds=MagicMock())
+    mock_client = MagicMock()
+    common.get_grpc_transport(mock_client)
+    mock_client.get_transport_class.assert_called_with("grpc")
+
+
+@patch.dict(os.environ, {"CES_TRANSPORT": "rest"})
+def test_ces_transport_override_rest():
+    common = Common(creds=MagicMock())
+    mock_client = MagicMock()
+    common.get_grpc_transport(mock_client)
+    mock_client.get_transport_class.assert_called_with("rest")
+
+
 if __name__ == "__main__":
     test_common_init()
     test_client_options()


### PR DESCRIPTION
- Override DEFAULT_API_ENDPOINT dynamically with CES_API_ENDPOINT env var.
- Support CES_TRANSPORT=rest in get_grpc_transport to switch to REST transport.
- Added unit tests for the overrides in test_common.py.
- Fixed type handling for test case tag filtering in runner.py.