### PR TITLE
chore(evals): migrate default model to gemini-3.1-flash-lite

### DIFF
--- a/.agents/skills/cxas-agent-foundry/scripts/scrapi-sim-runner.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/scrapi-sim-runner.py
@@ -58,7 +58,7 @@ EVALS_YAML = get_project_path("evals", "scenarios", "scenarios.yaml")
 SIM_EVALS_YAML = get_project_path("evals", "simulations", "simulations.yaml")
 REPORTS_DIR = get_project_path("eval-reports")
 
-_DEFAULT_MODEL = "gemini-3.1-flash-lite-preview"
+_DEFAULT_MODEL = "gemini-3.1-flash-lite"
 
 
 def load_yaml():

--- a/src/cxas_scrapi/evals/simulation_evals.py
+++ b/src/cxas_scrapi/evals/simulation_evals.py
@@ -50,7 +50,7 @@ from cxas_scrapi.utils.rate_limiter import RateLimiter
 
 _FIRST_UTTERANCE = "event: welcome"
 _MAX_TURNS = 30
-_DEFAULT_GEMINI_MODEL = "gemini-3.1-flash-lite-preview"
+_DEFAULT_GEMINI_MODEL = "gemini-3.1-flash-lite"
 
 
 class Step(pydantic.BaseModel):

--- a/src/cxas_scrapi/evals/turn_evals.py
+++ b/src/cxas_scrapi/evals/turn_evals.py
@@ -622,7 +622,7 @@ class TurnEvals:
                 trace_chunks.append(f"Agent Transfer: {target_agent}")
 
             model_name = test_case.config.get(
-                "gemini_model", "gemini-3.1-flash-lite-preview"
+                "gemini_model", "gemini-3.1-flash-lite"
             )
 
             llm_results = evaluate_expectations(
@@ -868,7 +868,7 @@ class TurnEvals:
                             )
 
                             model_name = case.config.get(
-                                "gemini_model", "gemini-3.1-flash-lite-preview"
+                                "gemini_model", "gemini-3.1-flash-lite"
                             )
 
                             llm_results = evaluate_expectations(


### PR DESCRIPTION
Migrate from gemini-3.1-flash-lite-preview to gemini-3.1-flash-lite

Deprecated as per http://ai.google.dev/gemini-api/docs/models/gemini-3.1-flash-lite-preview

Migrate the default model used in simulation and turn evaluations, as well as the scrapi-sim-runner script, from the deprecated preview version to the GA version.
