### PR TITLE
chore: refactor ui styles for interactive prompts

### DIFF
--- a/.agents/skills/cxas-agent-foundry/scripts/configure.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/configure.py
@@ -43,27 +43,7 @@ USER_AGENT_EXTENSION = "skill/cxas-agent-foundry/configure"
 
 console = Console()
 
-# Keybinding: map Escape to skip/cancel so fuzzy prompts can be aborted.
-ESCAPE_KEYBINDINGS = {"skip": [{"key": "escape"}]}
-
-# Style with a contrasting background for the highlighted row.
-# Uses a steel-blue background with white text for the pointer/selected row,
-# and magenta for fuzzy-matched characters so they pop against both
-# light and dark terminal themes.
-PROMPT_STYLE = get_style(
-    {
-        "pointer": "#ffffff bg:#4a6fa5",
-        "fuzzy_match": "#ff79c6 bold",
-        "fuzzy_prompt": "#6c99bb",
-        "fuzzy_info": "#888888",
-        "fuzzy_border": "#4a6fa5",
-        "questionmark": "#6c99bb bold",
-        "answer": "#61afef",
-        "input": "#98c379",
-        "marker": "#e5c07b",
-    },
-    style_override=False,
-)
+from cxas_scrapi.utils.ui_styles import ESCAPE_KEYBINDINGS, PROMPT_STYLE
 
 def _resolve_config_dir():
     """Return the directory where gecx-config.json and cxas_app/ should live.

--- a/.agents/skills/cxas-dfcx-migration/scripts/_prompts.py
+++ b/.agents/skills/cxas-dfcx-migration/scripts/_prompts.py
@@ -20,32 +20,15 @@ from typing import Any
 
 from InquirerPy import inquirer
 from InquirerPy.base.control import Choice
-from InquirerPy.utils import get_style
 from InquirerPy.validator import EmptyInputValidator
 
 from cxas_scrapi.core.apps import Apps
+from cxas_scrapi.utils.ui_styles import ESCAPE_KEYBINDINGS, PROMPT_STYLE
 
 logger = logging.getLogger(__name__)
 
 LOCATIONS = ["us", "eu", "global"]
 DEFAULT_LOCATION = "us"
-
-ESCAPE_KEYBINDINGS = {"skip": [{"key": "escape"}]}
-
-PROMPT_STYLE = get_style(
-    {
-        "pointer": "#ffffff bg:#4a6fa5",
-        "fuzzy_match": "#ff79c6 bold",
-        "fuzzy_prompt": "#6c99bb",
-        "fuzzy_info": "#888888",
-        "fuzzy_border": "#4a6fa5",
-        "questionmark": "#6c99bb bold",
-        "answer": "#61afef",
-        "input": "#98c379",
-        "marker": "#e5c07b",
-    },
-    style_override=False,
-)
 
 
 def is_interactive() -> bool:

--- a/src/cxas_scrapi/utils/ui_styles.py
+++ b/src/cxas_scrapi/utils/ui_styles.py
@@ -1,0 +1,43 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Common User Interface (UI) styling catalog.
+
+Consolidates shared styles, color schemes, and keybindings for CLI,
+Terminal User Interfaces (TUI), and notebook environments.
+"""
+
+from InquirerPy.utils import get_style
+
+# Keybinding: map Escape to skip/cancel so fuzzy prompts can be aborted.
+ESCAPE_KEYBINDINGS = {"skip": [{"key": "escape"}]}
+
+# Style with a contrasting background for the highlighted row.
+# Uses a steel-blue background with white text for the pointer/selected row,
+# and magenta for fuzzy-matched characters so they pop against both
+# light and dark terminal themes.
+PROMPT_STYLE = get_style(
+    {
+        "pointer": "#ffffff bg:#4a6fa5",
+        "fuzzy_match": "#ff79c6 bold",
+        "fuzzy_prompt": "#6c99bb",
+        "fuzzy_info": "#888888",
+        "fuzzy_border": "#4a6fa5",
+        "questionmark": "#6c99bb bold",
+        "answer": "#61afef",
+        "input": "#98c379",
+        "marker": "#e5c07b",
+    },
+    style_override=False,
+)


### PR DESCRIPTION
# Summary
Consolidated duplicate visual styling variables across the specialized agent skills into a single generic core catalog `ui_styles.py` in the SDK.
# Changes
- Created `src/cxas_scrapi/utils/ui_styles.py` containing shared color schemes (`PROMPT_STYLE`) and Escape bindings (`ESCAPE_KEYBINDINGS`) for CLI, TUI, and notebooks.
- Refactored `configure.py` and `_prompts.py` in the skills folders to import from `ui_styles.py` and deleted their duplicate local declarations.
# Verification
- All unit tests passed successfully (883/883 passed).
- Linter passed.