### PR TITLE
fix(skills): pass resource name instead of display name in sync-callb…

### DIFF
--- a/.agents/skills/cxas-agent-foundry/scripts/sync-callbacks.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/sync-callbacks.py
@@ -65,7 +65,9 @@ def derive_callback_name(field_name):
     return field_name
 
 
-def sync_agent_callbacks(app_name, agent_name, dry_run=False):
+def sync_agent_callbacks(
+    app_name, agent_name, agent_resource_name, dry_run=False
+):
     """Sync callbacks for a single agent.
 
     Returns (synced, tests_found, tests_missing).
@@ -76,7 +78,7 @@ def sync_agent_callbacks(app_name, agent_name, dry_run=False):
         app_name=app_name, user_agent_extension=USER_AGENT_EXTENSION
     )
     try:
-        cb_map = callbacks_client.list_callbacks(agent_name)
+        cb_map = callbacks_client.list_callbacks(agent_resource_name)
     except Exception as e:
         print(f"  Error: Failed to list callbacks for '{agent_name}': {e}")
         return 0, 0, 0
@@ -385,7 +387,7 @@ def main():
         print(f"\n--- {agent_name} ---")
 
         s, tf, tm = sync_agent_callbacks(
-            app_name, agent_name, dry_run=args.dry_run
+            app_name, agent_name, agent.name, dry_run=args.dry_run
         )
         total_synced += s
         total_tests_found += tf

--- a/.agents/skills/cxas-agent-foundry/scripts/sync-callbacks.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/sync-callbacks.py
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Sync callback code into evals/callback_tests/agents/ and create test.py symlinks.
+"""Sync callback code into evals/callback_tests/agents/.
+
+Also creates test.py symlinks.
 
 Two modes:
   - Default (post-push): pull each agent's callbacks from the GECX platform.
@@ -28,22 +30,22 @@ test_all_callbacks_in_app_dir requires test.py and python_code.py in the same
 directory — without the symlink, tests are silently skipped.
 
 Usage:
-  python scripts/sync-callbacks.py                              # Pull all callbacks from platform
-  python scripts/sync-callbacks.py --agent root_agent           # Pull only one agent from platform
-  python scripts/sync-callbacks.py --from-local <app_dir>       # Copy from local app dir (pre-push)
-  python scripts/sync-callbacks.py --dry-run                    # Show what would be synced
+  # Pull all callbacks from platform:
+  python scripts/sync-callbacks.py
+  # Pull only one agent from platform:
+  python scripts/sync-callbacks.py --agent root_agent
+  # Copy from local app dir (pre-push):
+  python scripts/sync-callbacks.py --from-local <app_dir>
+  # Show what would be synced:
+  python scripts/sync-callbacks.py --dry-run
 """
 
 import argparse
-import glob
-import json
 import os
-import re
 import shutil
 import sys
-import yaml
 
-from config import load_app_name, get_project_path
+from config import get_project_path, load_app_name
 
 USER_AGENT_EXTENSION = "skill/cxas-agent-foundry/sync-callbacks"
 
@@ -64,10 +66,15 @@ def derive_callback_name(field_name):
 
 
 def sync_agent_callbacks(app_name, agent_name, dry_run=False):
-    """Sync callbacks for a single agent. Returns (synced, tests_found, tests_missing)."""
-    from cxas_scrapi.core.callbacks import Callbacks
+    """Sync callbacks for a single agent.
 
-    callbacks_client = Callbacks(app_name=app_name, user_agent_extension=USER_AGENT_EXTENSION)
+    Returns (synced, tests_found, tests_missing).
+    """
+    from cxas_scrapi.core.callbacks import Callbacks  # noqa: PLC0415
+
+    callbacks_client = Callbacks(
+        app_name=app_name, user_agent_extension=USER_AGENT_EXTENSION
+    )
     try:
         cb_map = callbacks_client.list_callbacks(agent_name)
     except Exception as e:
@@ -102,17 +109,21 @@ def sync_agent_callbacks(app_name, agent_name, dry_run=False):
                 callback_name = base_name
 
             # Build paths
-            agent_cb_dir = os.path.join(AGENTS_DIR, agent_name, callback_type, callback_name)
+            agent_cb_dir = os.path.join(
+                AGENTS_DIR, agent_name, callback_type, callback_name
+            )
             code_path = os.path.join(agent_cb_dir, "python_code.py")
-            test_src = os.path.join(TESTS_DIR, agent_name, callback_type, callback_name, "test.py")
+            test_src = os.path.join(
+                TESTS_DIR, agent_name, callback_type, callback_name, "test.py"
+            )
             symlink_path = os.path.join(agent_cb_dir, "test.py")
 
             disabled = getattr(cb, "disabled", False)
-            description = getattr(cb, "description", "")
             status = " (disabled)" if disabled else ""
 
             if dry_run:
-                print(f"  [dry-run] Would write: {os.path.relpath(code_path)}{status}")
+                rel_path = os.path.relpath(code_path)
+                print(f"  [dry-run] Would write: {rel_path}{status}")
             else:
                 os.makedirs(agent_cb_dir, exist_ok=True)
                 with open(code_path, "w") as f:
@@ -125,26 +136,35 @@ def sync_agent_callbacks(app_name, agent_name, dry_run=False):
             if os.path.exists(test_src):
                 tests_found += 1
                 if dry_run:
-                    print(f"  [dry-run] Would link: test.py -> {os.path.relpath(test_src)}")
-                else:
-                    # Create or update symlink
-                    if os.path.islink(symlink_path):
-                        current_target = os.readlink(symlink_path)
-                        if current_target == test_src:
-                            pass  # Already correct
-                        else:
-                            os.remove(symlink_path)
-                            os.symlink(test_src, symlink_path)
-                            print(f"  Updated symlink: test.py -> {os.path.relpath(test_src)}")
-                    elif os.path.exists(symlink_path):
-                        # Regular file exists where symlink should be -- skip
-                        print(f"  WARNING: {os.path.relpath(symlink_path)} exists as a regular file, skipping symlink")
+                    rel_test = os.path.relpath(test_src)
+                    print(f"  [dry-run] Would link: test.py -> {rel_test}")
+                # Create or update symlink
+                elif os.path.islink(symlink_path):
+                    current_target = os.readlink(symlink_path)
+                    if current_target == test_src:
+                        pass  # Already correct
                     else:
+                        os.remove(symlink_path)
                         os.symlink(test_src, symlink_path)
-                        print(f"  Linked: test.py -> {os.path.relpath(test_src)}")
+                        rel_test = os.path.relpath(test_src)
+                        print(f"  Updated symlink: test.py -> {rel_test}")
+                elif os.path.exists(symlink_path):
+                    # Regular file exists where symlink should be -- skip
+                    rel_link = os.path.relpath(symlink_path)
+                    print(
+                        f"  WARNING: {rel_link} exists as a regular file, "
+                        "skipping symlink"
+                    )
+                else:
+                    os.symlink(test_src, symlink_path)
+                    print(
+                        f"  Linked: test.py -> {os.path.relpath(test_src)}"
+                    )
             else:
                 tests_missing += 1
-                print(f"  WARNING: No test found at {os.path.relpath(test_src)}")
+                print(
+                    f"  WARNING: No test found at {os.path.relpath(test_src)}"
+                )
 
     return synced, tests_found, tests_missing
 
@@ -174,7 +194,11 @@ def _ensure_symlink(test_src, symlink_path, dry_run=False):
         os.symlink(test_src, symlink_path)
         print(f"  Updated symlink: test.py -> {os.path.relpath(test_src)}")
     elif os.path.exists(symlink_path):
-        print(f"  WARNING: {os.path.relpath(symlink_path)} exists as a regular file, skipping symlink")
+        rel_link = os.path.relpath(symlink_path)
+        print(
+            f"  WARNING: {rel_link} exists as a regular file, "
+            "skipping symlink"
+        )
     else:
         os.symlink(test_src, symlink_path)
         print(f"  Linked: test.py -> {os.path.relpath(test_src)}")
@@ -182,8 +206,9 @@ def _ensure_symlink(test_src, symlink_path, dry_run=False):
 
 
 def sync_from_local(app_dir, agent_filter=None, dry_run=False):
-    """Copy callback python_code.py files from a local app dir into evals/callback_tests/agents/.
+    """Copy callback python_code.py files from a local app dir.
 
+    Saves into evals/callback_tests/agents/.
     Mirrors the directory naming used by sync_agent_callbacks (platform mode):
       <type>_callbacks → strip _callbacks → base; append _<idx> if multiple.
     """
@@ -206,7 +231,8 @@ def sync_from_local(app_dir, agent_filter=None, dry_run=False):
             continue
         if agent_filter and agent_name != agent_filter:
             continue
-        # Collect callbacks grouped by type so we can index multiples consistently.
+        # Collect callbacks grouped by type so we can index multiples
+        # consistently.
         per_type = {}
         for cb_type in CALLBACK_TYPES:
             type_dir = os.path.join(agent_path, cb_type)
@@ -225,67 +251,105 @@ def sync_from_local(app_dir, agent_filter=None, dry_run=False):
 
         print(f"\n--- {agent_name} ---")
         for cb_type, entries in per_type.items():
-            base = cb_type[: -len("_callbacks")] if cb_type.endswith("_callbacks") else cb_type
+            base = (
+                cb_type[: -len("_callbacks")]
+                if cb_type.endswith("_callbacks")
+                else cb_type
+            )
             use_index = len(entries) > 1
-            for idx, (local_subdir, code_src) in enumerate(entries):
+            for idx, (_, code_src) in enumerate(entries):
                 base_name = f"{base}_{idx}" if use_index else base
-                agent_cb_dir = os.path.join(AGENTS_DIR, agent_name, cb_type, base_name)
+                agent_cb_dir = os.path.join(
+                    AGENTS_DIR, agent_name, cb_type, base_name
+                )
                 code_dst = os.path.join(agent_cb_dir, "python_code.py")
-                test_src = os.path.join(TESTS_DIR, agent_name, cb_type, base_name, "test.py")
+                test_src = os.path.join(
+                    TESTS_DIR, agent_name, cb_type, base_name, "test.py"
+                )
                 symlink_path = os.path.join(agent_cb_dir, "test.py")
 
                 if dry_run:
-                    print(f"  [dry-run] Would copy: {os.path.relpath(code_src)} -> {os.path.relpath(code_dst)}")
+                    rel_src = os.path.relpath(code_src)
+                    rel_dst = os.path.relpath(code_dst)
+                    print(f"  [dry-run] Would copy: {rel_src} -> {rel_dst}")
                 else:
                     os.makedirs(agent_cb_dir, exist_ok=True)
                     shutil.copyfile(code_src, code_dst)
-                    print(f"  Copied: {os.path.relpath(code_dst)} (from {os.path.relpath(code_src)})")
+                    rel_src = os.path.relpath(code_src)
+                    rel_dst = os.path.relpath(code_dst)
+                    print(f"  Copied: {rel_dst} (from {rel_src})")
                 total_synced += 1
 
-                tf, tm = _ensure_symlink(test_src, symlink_path, dry_run=dry_run)
+                tf, tm = _ensure_symlink(
+                    test_src, symlink_path, dry_run=dry_run
+                )
                 total_tests_found += int(tf)
                 total_tests_missing += int(tm)
 
     print(f"\n{'=' * 50}")
     prefix = "[dry-run] " if dry_run else ""
-    print(f"{prefix}{total_synced} callbacks synced from {app_dir}, "
-          f"{total_tests_found} tests found, "
-          f"{total_tests_missing} tests missing")
+    print(
+        f"{prefix}{total_synced} callbacks synced from {app_dir}, "
+        f"{total_tests_found} tests found, "
+        f"{total_tests_missing} tests missing"
+    )
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Sync callback code into evals/callback_tests/agents/ and create test.py symlinks."
+        description=(
+            "Sync callback code into evals/callback_tests/agents/ "
+            "and create test.py symlinks."
+        )
     )
     parser.add_argument(
-        "--agent", default=None,
-        help="Sync only this agent (by display_name in platform mode, by directory name in --from-local mode)"
+        "--agent",
+        default=None,
+        help=(
+            "Sync only this agent (by display_name in platform mode, "
+            "by directory name in --from-local mode)"
+        ),
     )
     parser.add_argument(
-        "--from-local", default=None, metavar="APP_DIR",
-        help="Copy callback code from a local app dir (e.g., <project>/cxas_app/<App>) instead of pulling from the platform. Use during initial build, pre-push."
+        "--from-local",
+        default=None,
+        metavar="APP_DIR",
+        help=(
+            "Copy callback code from a local app dir (e.g., "
+            "<project>/cxas_app/<App>) instead of pulling from "
+            "the platform. Use during initial build, pre-push."
+        ),
     )
     parser.add_argument(
-        "--dry-run", action="store_true",
-        help="Show what would be synced without writing files"
+        "--dry-run",
+        action="store_true",
+        help="Show what would be synced without writing files",
     )
     args = parser.parse_args()
 
     if args.from_local:
-        sync_from_local(args.from_local, agent_filter=args.agent, dry_run=args.dry_run)
+        sync_from_local(
+            args.from_local, agent_filter=args.agent, dry_run=args.dry_run
+        )
         return
 
     try:
-        import cxas_scrapi  # noqa: F401
+        import cxas_scrapi  # noqa: F401, PLC0415
     except ImportError:
-        print("Error: cxas-scrapi not installed. Activate venv (source .venv/bin/activate) and install cxas-scrapi first.")
+        print(
+            "Error: cxas-scrapi not installed. Activate venv (source "
+            ".venv/bin/activate) and install cxas-scrapi first."
+        )
         sys.exit(1)
 
     app_name = load_app_name()
 
     # List agents
-    from cxas_scrapi.core.agents import Agents
-    agents_client = Agents(app_name=app_name, user_agent_extension=USER_AGENT_EXTENSION)
+    from cxas_scrapi.core.agents import Agents  # noqa: PLC0415
+
+    agents_client = Agents(
+        app_name=app_name, user_agent_extension=USER_AGENT_EXTENSION
+    )
     try:
         agent_list = agents_client.list_agents()
     except Exception as e:
@@ -298,7 +362,11 @@ def main():
 
     # Filter to a single agent if requested
     if args.agent:
-        agent_list = [a for a in agent_list if getattr(a, "display_name", None) == args.agent]
+        agent_list = [
+            a
+            for a in agent_list
+            if getattr(a, "display_name", None) == args.agent
+        ]
         if not agent_list:
             print(f"Agent '{args.agent}' not found. Available agents:")
             all_agents = agents_client.list_agents()
@@ -311,10 +379,14 @@ def main():
     total_tests_missing = 0
 
     for agent in agent_list:
-        agent_name = getattr(agent, "display_name", None) or getattr(agent, "name", "unknown")
+        agent_name = getattr(agent, "display_name", None) or getattr(
+            agent, "name", "unknown"
+        )
         print(f"\n--- {agent_name} ---")
 
-        s, tf, tm = sync_agent_callbacks(app_name, agent_name, dry_run=args.dry_run)
+        s, tf, tm = sync_agent_callbacks(
+            app_name, agent_name, dry_run=args.dry_run
+        )
         total_synced += s
         total_tests_found += tf
         total_tests_missing += tm
@@ -322,9 +394,11 @@ def main():
     # Summary
     print(f"\n{'=' * 50}")
     prefix = "[dry-run] " if args.dry_run else ""
-    print(f"{prefix}{total_synced} callbacks synced, "
-          f"{total_tests_found} tests found, "
-          f"{total_tests_missing} tests missing")
+    print(
+        f"{prefix}{total_synced} callbacks synced, "
+        f"{total_tests_found} tests found, "
+        f"{total_tests_missing} tests missing"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/cxas_scrapi/cli/test_sync_callbacks.py
+++ b/tests/cxas_scrapi/cli/test_sync_callbacks.py
@@ -1,0 +1,83 @@
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+# Append scripts directory to sys.path so config can be resolved
+scripts_dir = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "../../../.agents/skills/cxas-agent-foundry/scripts",
+    )
+)
+if scripts_dir not in sys.path:
+    sys.path.insert(0, scripts_dir)
+
+# We need to mock config.get_project_path before importing sync-callbacks
+# because it calls it at module level.
+import config  # noqa: E402
+
+with patch.object(
+    config, "get_project_path", return_value="/tmp/mock_project_path"
+):
+    # Dynamic import of sync-callbacks.py due to hyphen in filename
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "sync_callbacks", os.path.join(scripts_dir, "sync-callbacks.py")
+    )
+    sync_callbacks = importlib.util.module_from_spec(spec)
+    sys.modules["sync_callbacks"] = sync_callbacks
+    spec.loader.exec_module(sync_callbacks)
+
+
+def test_sync_agent_callbacks_passes_resource_name():
+
+    with patch("cxas_scrapi.core.callbacks.Callbacks") as mock_callbacks_class:
+        mock_callbacks_client = MagicMock()
+        mock_callbacks_class.return_value = mock_callbacks_client
+        mock_callbacks_client.list_callbacks.return_value = {}
+
+        sync_callbacks.sync_agent_callbacks(
+            app_name="projects/P/locations/L/apps/A",
+            agent_name="Technical Support",
+            agent_resource_name="projects/P/locations/L/apps/A/agents/123",
+            dry_run=False,
+        )
+
+        mock_callbacks_client.list_callbacks.assert_called_once_with(
+            "projects/P/locations/L/apps/A/agents/123"
+        )
+
+
+@patch("sync_callbacks.load_app_name")
+@patch("sync_callbacks.sync_agent_callbacks")
+def test_main_loop_passes_resource_name(
+    mock_sync_agent_callbacks, mock_load_app_name
+):
+    mock_load_app_name.return_value = "projects/P/locations/L/apps/A"
+    mock_sync_agent_callbacks.return_value = (0, 0, 0)
+
+    with patch("cxas_scrapi.core.agents.Agents") as mock_agents_class:
+        mock_agents_client = MagicMock()
+        mock_agents_class.return_value = mock_agents_client
+
+        mock_agent = MagicMock()
+        mock_agent.display_name = "Technical Support"
+        mock_agent.name = "projects/P/locations/L/apps/A/agents/123"
+        mock_agents_client.list_agents.return_value = [mock_agent]
+
+        mock_args = MagicMock()
+        mock_args.agent = None
+        mock_args.from_local = None
+        mock_args.dry_run = False
+
+        with patch("argparse.ArgumentParser.parse_args") as mock_parse_args:
+            mock_parse_args.return_value = mock_args
+            sync_callbacks.main()
+
+            mock_sync_agent_callbacks.assert_called_once_with(
+                "projects/P/locations/L/apps/A",
+                "Technical Support",
+                "projects/P/locations/L/apps/A/agents/123",
+                dry_run=False,
+            )


### PR DESCRIPTION
…acks

- In sync-callbacks.py, passing the display name to list_callbacks caused a 404 error.
- Fixed by updating sync_agent_callbacks to accept and use the agent resource name (agent.name) for the API call.
- Retained the display name for generating local directory and file paths.
- Added robust automated unit tests in tests/cxas_scrapi/cli/test_sync_callbacks.py to verify the overrides.

