### PR TITLE
chore: remove legacy AGENTS.md and GEMINI.md generation from init

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,8 +90,6 @@ cxas = "cxas_scrapi.cli.main:main"
 ".agents" = "share/cxas-scrapi/skills/.agents"
 ".claude" = "share/cxas-scrapi/skills/.claude"
 ".gemini" = "share/cxas-scrapi/skills/.gemini"
-"AGENTS.md" = "share/cxas-scrapi/skills/AGENTS.md"
-"GEMINI.md" = "share/cxas-scrapi/skills/GEMINI.md"
 "examples/cxaslint.yaml" = "share/cxas-scrapi/skills/examples/cxaslint.yaml"
 
 [tool.hatch.build.targets.wheel]

--- a/src/cxas_scrapi/cli/main.py
+++ b/src/cxas_scrapi/cli/main.py
@@ -1902,7 +1902,7 @@ def get_parser() -> argparse.ArgumentParser:
     parser_init = subparsers.add_parser(
         "init",
         help="Initialize a project with CXAS agent development skills "
-        "(.agents, .claude, .gemini, AGENTS.md, etc.).",
+        "(.agents, .claude, .gemini, etc.).",
     )
     parser_init.add_argument(
         "--target-dir",


### PR DESCRIPTION
Removes the legacy 'AGENTS.md' and 'GEMINI.md' mapping from the wheel build shared-data and updates the init parser help description. These files were temporary workarounds for deprecated Gemini CLI setups and can pollute LLM rule contexts or degrade Jetski reasoning in active customer workspaces.