### PR TITLE
fix(lint): update I014 to check for {current_date} instead of ${current_date}

### DIFF
--- a/src/cxas_scrapi/utils/lint_rules/instructions.py
+++ b/src/cxas_scrapi/utils/lint_rules/instructions.py
@@ -574,12 +574,12 @@ class MissingCurrentDate(Rule):
     id = "I014"
     name = "missing-current-date"
     description = (
-        "Instruction should reference ${current_date} so the"
+        "Instruction should reference {current_date} so the"
         " agent knows today's date"
     )
     default_severity = Severity.WARNING
 
-    VALID_PATTERNS = re.compile(r"\$\{current_date\}|\$\{\{current_date\}\}")
+    VALID_PATTERNS = re.compile(r"\{current_date\}|\{\{current_date\}\}")
 
     _APPLICABLE_FILES = {"instruction.txt", "global_instruction.txt"}
 
@@ -628,8 +628,8 @@ class MissingCurrentDate(Rule):
                     " not know today's date"
                 ),
                 fix=(
-                    "Add ${current_date} or"
-                    " ${{current_date}} to the"
+                    "Add {current_date} or"
+                    " {{current_date}} to the"
                     " instruction or global"
                     " instruction"
                 ),

--- a/tests/cxas_scrapi/utils/test_lint_rules.py
+++ b/tests/cxas_scrapi/utils/test_lint_rules.py
@@ -193,9 +193,7 @@ def test_i014_in_global_only(tmp_path, context):
     from cxas_scrapi.utils.lint_rules.instructions import MissingCurrentDate  # noqa: PLC0415,I001
 
     rule = MissingCurrentDate()
-    (tmp_path / "global_instruction.txt").write_text(
-        "Today is {current_date}."
-    )
+    (tmp_path / "global_instruction.txt").write_text("Today is {current_date}.")
     f = tmp_path / "instruction.txt"
     f.write_text("No date here.")
 
@@ -208,9 +206,7 @@ def test_i014_in_global_and_agent(tmp_path, context):
     from cxas_scrapi.utils.lint_rules.instructions import MissingCurrentDate  # noqa: PLC0415,I001
 
     rule = MissingCurrentDate()
-    (tmp_path / "global_instruction.txt").write_text(
-        "Today is {current_date}."
-    )
+    (tmp_path / "global_instruction.txt").write_text("Today is {current_date}.")
     f = tmp_path / "instruction.txt"
     f.write_text("Date: {current_date}.")
 

--- a/tests/cxas_scrapi/utils/test_lint_rules.py
+++ b/tests/cxas_scrapi/utils/test_lint_rules.py
@@ -194,7 +194,7 @@ def test_i014_in_global_only(tmp_path, context):
 
     rule = MissingCurrentDate()
     (tmp_path / "global_instruction.txt").write_text(
-        "Today is ${current_date}."
+        "Today is {current_date}."
     )
     f = tmp_path / "instruction.txt"
     f.write_text("No date here.")
@@ -209,10 +209,10 @@ def test_i014_in_global_and_agent(tmp_path, context):
 
     rule = MissingCurrentDate()
     (tmp_path / "global_instruction.txt").write_text(
-        "Today is ${current_date}."
+        "Today is {current_date}."
     )
     f = tmp_path / "instruction.txt"
-    f.write_text("Date: ${current_date}.")
+    f.write_text("Date: {current_date}.")
 
     results = rule.check(f, f.read_text(), context)
     assert len(results) == 0
@@ -227,7 +227,7 @@ def test_i014_in_all_agents_not_global(tmp_path, context):
     for name in ("agent_a", "agent_b"):
         d = tmp_path / "agents" / name
         d.mkdir(parents=True)
-        (d / "instruction.txt").write_text("Date: ${current_date}.")
+        (d / "instruction.txt").write_text("Date: {current_date}.")
     # Global does not have it
     gi = tmp_path / "global_instruction.txt"
     gi.write_text("No date here.")
@@ -244,7 +244,7 @@ def test_i014_in_some_agents_not_global(tmp_path, context):
     # agent_a has it, agent_b does not
     a = tmp_path / "agents" / "agent_a"
     a.mkdir(parents=True)
-    (a / "instruction.txt").write_text("Date: ${current_date}.")
+    (a / "instruction.txt").write_text("Date: {current_date}.")
     b = tmp_path / "agents" / "agent_b"
     b.mkdir(parents=True)
     (b / "instruction.txt").write_text("No date here.")
@@ -268,12 +268,12 @@ def test_i014_in_some_agents_not_global(tmp_path, context):
 
 
 def test_i014_accepts_double_brace_syntax(tmp_path, context):
-    """${{current_date}} syntax is also valid."""
+    """{{current_date}} syntax is also valid."""
     from cxas_scrapi.utils.lint_rules.instructions import MissingCurrentDate  # noqa: PLC0415,I001
 
     rule = MissingCurrentDate()
     f = tmp_path / "global_instruction.txt"
-    f.write_text("Today is ${{current_date}}.")
+    f.write_text("Today is {{current_date}}.")
 
     results = rule.check(f, f.read_text(), context)
     assert len(results) == 0


### PR DESCRIPTION
Updated I014 rule to check for {current_date} instead of ${current_date} since it's not necessary to add the dollar sign when we reference the variable . Also updated corresponding tests.