### PR TITLE
fix: fix .gitignore to prevent packaging issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,6 @@ bin/
 .agents/**/*.pyc
 
 # Local evaluation results, scratch notebooks/scripts and temp configurations
-evals/
-scratch/
-temp_sims/
+/evals/
+/scratch/
+/temp_sims/

--- a/src/cxas_scrapi/evals/guardrail_evals.py
+++ b/src/cxas_scrapi/evals/guardrail_evals.py
@@ -18,17 +18,16 @@ import datetime
 import json
 import logging
 import time
-from typing import Annotated, Any, Dict, List, NamedTuple, Optional
+from typing import Annotated, Any, Dict, NamedTuple, Optional
 
 import pandas as pd
-from google.protobuf.json_format import MessageToDict
 from pydantic import BaseModel, BeforeValidator, Field
 from rich.progress import track
 
 from cxas_scrapi.core.agents import Agents
 from cxas_scrapi.core.apps import Apps
-from cxas_scrapi.core.sessions import Sessions
 from cxas_scrapi.core.response_parser import ParsedSessionResponse
+from cxas_scrapi.core.sessions import Sessions
 from cxas_scrapi.utils.eval_utils import EvalUtils
 
 logger = logging.getLogger(__name__)
@@ -101,8 +100,6 @@ class GuardrailEvals:
             return name.split("/")[3]
         except IndexError as e:
             raise ValueError(f"Invalid resource name format: {name}") from e
-
-
 
     def run_guardrail_tests(
         self,

--- a/src/cxas_scrapi/evals/simulation_evals.py
+++ b/src/cxas_scrapi/evals/simulation_evals.py
@@ -29,9 +29,9 @@ from rich.progress import Progress
 
 from cxas_scrapi.core.apps import Apps
 from cxas_scrapi.core.conversation_history import ConversationHistory
+from cxas_scrapi.core.response_parser import ParsedSessionResponse
 from cxas_scrapi.core.sessions import Sessions
 from cxas_scrapi.core.tools import Tools
-from cxas_scrapi.core.response_parser import ParsedSessionResponse
 from cxas_scrapi.prompts import llm_user_prompts
 from cxas_scrapi.utils.eval_utils import (
     Conversation as GoldenConversation,
@@ -369,7 +369,11 @@ class SimulationEvals(Apps):
             A tuple of (agent_text, trace_chunks, session_ended)
         """
         parsed = ParsedSessionResponse(response, tools_map=self.tools_map)
-        return parsed.consolidated_agent_text, parsed.detailed_trace, parsed.session_ended
+        return (
+            parsed.consolidated_agent_text,
+            parsed.detailed_trace,
+            parsed.session_ended,
+        )
 
     def _evaluate_expectations(
         self,


### PR DESCRIPTION
The recently added `.gitignore` patterns for local temporary directories (`evals/`, `scratch/`, `temp_sims/`) were unanchored. This caused the build system to globally ignore any matching directories during packaging. For example, `src/cxas_scrapi/evals/` was being excluded, causing `ModuleNotFoundError: No module named 'cxas_scrapi.evals'`. 