### PR TITLE
feat(chat): interactive chat CLI/TUI, programmatic driver, and slot inspection

### DIFF
--- a/.agents/skills/cxas-agent-foundry/SKILL.md
+++ b/.agents/skills/cxas-agent-foundry/SKILL.md
@@ -41,6 +41,16 @@ python .agents/skills/cxas-agent-foundry/scripts/triage-results.py --last 3
 # Run all 6 build-verification gates against the deployed app
 python .agents/skills/cxas-agent-foundry/scripts/gate-check.py
 
+# Debug a conversation (step through turns, inspect SM state)
+cxas chat-step --app-name <full_resource_name> \
+  -m "user message" --session-file /tmp/cxas-debug.json \
+  --with-log --with-slots --with-flow-context
+
+# Inspect existing session (no message sent)
+cxas chat-step --app-name <full_resource_name> \
+  --session-file /tmp/cxas-debug.json \
+  --inspect-only --with-log debug --with-slots
+
 # Tune scoring thresholds (similarity, hallucination, extra-tools)
 python .agents/skills/cxas-agent-foundry/scripts/app-thresholds.py show
 
@@ -105,6 +115,9 @@ Read what the user wants and load the appropriate sub-skill:
 | "Why is this eval failing", "get to 90%" | Debug | `references/debug.md` |
 | "Fix the failing evals", "debug the agent" | Debug | `references/debug.md` |
 | "Tool test is failing", "callback test broke" | Debug | `references/debug.md` |
+| "Why did the agent say X?", "reproduce this issue", "step through the conversation" | Chat Debug | `references/chat-debug.md` |
+| "Slots are getting lost", "preempt is stuck", "flow switch drops data" | Chat Debug | `references/chat-debug.md` |
+| "Inspect the SM log", "debug this conversation", "what happened in this turn" | Chat Debug | `references/chat-debug.md` |
 | **"Edit the agent's instructions", "tweak the auth tool", "fix the greeting", "update this callback"** | **Build** (Edit cycle) | **`references/build.md` → "Editing an Existing Agent"** |
 
 **Any phrasing that implies creating, building, or setting up an agent/app routes to `references/build.md` — even if it sounds like "just create the app shell."** "Create a new cxas app" is NOT a shortcut to scaffolding; it triggers the full build flow (todo.md → interview/PRD → TDD + approval → scaffold → lint → evals → push). Skipping the interview / TDD because the user said "create" instead of "build" is a routing failure.

--- a/.agents/skills/cxas-agent-foundry/references/chat-debug.md
+++ b/.agents/skills/cxas-agent-foundry/references/chat-debug.md
@@ -1,0 +1,274 @@
+# Chat Debugger
+
+Programmatic conversation debugging using `cxas chat-step`. Reproduce issues, step through turns, inspect slot machine state, and diagnose behavioral bugs.
+
+**When to use this** instead of `debug.md`: Use `debug.md` for eval failure triage (pass rates, categories, scoring). Use this for **live conversation debugging** — "why did the agent say X?", "slots are getting lost", "preempt seems stuck", "the flow switch drops data".
+
+## Quick Reference
+
+```bash
+# Resolve app name
+cxas apps list --project-id <project_id> --location <location>
+
+# Start a new debug session (turn 1)
+cxas chat-step --app-name <full_resource_name> \
+  -m "I'd like to book a table for 4" \
+  --session-file /tmp/cxas-debug.json \
+  --with-log --with-slots --with-flow-context
+
+# Continue the conversation (turn 2+)
+cxas chat-step --app-name <full_resource_name> \
+  -m "Friday evening" \
+  --session-file /tmp/cxas-debug.json \
+  --with-log --with-slots
+
+# Inspect without advancing (no message sent)
+cxas chat-step --app-name <full_resource_name> \
+  --session-file /tmp/cxas-debug.json \
+  --inspect-only --with-log debug --with-slots --with-flow-context
+
+# Get formatted trace
+cxas chat-step --app-name <full_resource_name> \
+  --session-file /tmp/cxas-debug.json \
+  --inspect-only --with-trace-report text
+
+# Get full conversation history
+cxas chat-step --app-name <full_resource_name> \
+  --session-file /tmp/cxas-debug.json \
+  --inspect-only --with-turns
+
+# File a bug report
+cxas chat-step --app-name <full_resource_name> \
+  --session-file /tmp/cxas-debug.json \
+  --bug "Agent echoes verbatim instead of rephrasing on readback"
+```
+
+> **CLI note:** If `cxas` binary fails with import errors, use `.venv/bin/python3 -m cxas_scrapi.cli.main chat-step ...` instead.
+
+## Workflow
+
+### Step 1: Set Up
+
+1. Get the full app resource name from memory, `gecx-config.json`, or `cxas apps list`
+2. Create a session file path: `/tmp/cxas-debug-<issue>.json`
+3. Decide channel if the app uses channel-specific behavior: `--channel web` or `--channel audio`
+
+### Step 2: Reproduce
+
+Send the user's reported message sequence one turn at a time. After each turn, examine the output:
+
+```bash
+# Turn 1
+cxas chat-step --app-name $APP -m "first message" \
+  --session-file /tmp/debug.json --with-log --with-slots --with-flow-context
+
+# Read the JSON output. Check:
+# - agent_text: what the agent said
+# - state.filled_slots: what slots are filled
+# - state.active_agent: which agent is handling
+# - sm_log: SM events for this turn
+# - slot_inspection: deep slot state
+# - flow_context: active flow, suspended flows
+
+# Turn 2
+cxas chat-step --app-name $APP -m "second message" \
+  --session-file /tmp/debug.json --with-log --with-slots
+```
+
+### Step 3: Inspect
+
+When something looks wrong, use `--inspect-only` with deeper inspection:
+
+```bash
+# Full debug-level log (shows all internal engine events)
+cxas chat-step --app-name $APP --session-file /tmp/debug.json \
+  --inspect-only --with-log debug --with-slots --with-flow-context
+
+# Get the trace for latency/timing analysis
+cxas chat-step --app-name $APP --session-file /tmp/debug.json \
+  --inspect-only --with-trace-report text
+```
+
+### Step 4: Diagnose
+
+Match what you see to the diagnostic patterns below. For SM event details, see `references/sm-events.md`.
+
+### Step 5: Report
+
+Either file a bug or report findings to the user:
+
+```bash
+# File a bug with evidence
+cxas chat-step --app-name $APP --session-file /tmp/debug.json \
+  --bug "Slots lost on flow switch: party_size and date not transferred"
+```
+
+## Reading the Output
+
+The JSON output from `chat-step` has these key sections:
+
+| Field | What to look for |
+|-------|-----------------|
+| `agent_text` | What the agent actually said — compare to expected behavior |
+| `tool_calls` | Which tools were called and with what args |
+| `tool_responses` | What tools returned — look for error codes |
+| `agent_transfer` | If/where the agent transferred |
+| `state.filled_slots` | Currently filled slot values |
+| `state.slot_machine` | Raw SM state — check `pending`, `phase`, `status` |
+| `state.active_agent` | Which agent is currently handling the conversation |
+| `sm_log` | SM event timeline — **primary diagnostic source** |
+| `slot_inspection` | Deep slot state: categories, DAG, configuration |
+| `flow_context` | Active flow, agent-to-config mapping, suspended flows |
+
+### SM Log: What to Look For
+
+The `sm_log` is a list of events ordered chronologically within a turn. Key patterns:
+
+- **Normal turn**: `invoke` → `progress` → `setter_stored` (×N) → `auto_confirm` or `announce` → `progress`
+- **Task firing**: ... → `task_completed` → `on_complete` (if flow done)
+- **Transfer**: `bootstrap_transfer` → `transfer_dispatched` → `config_loaded` (on receiving agent)
+- **Error**: `slot_error` → (retry) → `slot_error_exhaust`
+- **Preemption**: `preemption` — LLM was bypassed, response is deterministic
+
+## Diagnostic Patterns
+
+### Agent echoes user text verbatim (no rephrasing)
+
+**Symptom**: Agent says exactly what the user said instead of naturally incorporating it.
+
+**Check**: Look for `preemption` in `sm_log`. If present, the LLM was bypassed — a callback returned a hardcoded `LlmResponse`.
+
+**Root cause**: Usually `readback_transition` + unconditional `preempt = True` in the engine. When the user confirms + provides new data, inline-confirm fires and sets a readback_transition prefix. If the engine also preempts, the prefix gets prepended to the user's text and returned as-is.
+
+**Fix**: Make preemption conditional — only preempt when there's no fresh readback pending (no new slots need confirmation via LLM).
+
+### Slots lost on agent transfer / flow switch
+
+**Symptom**: User provides slot data (e.g., "table for 4 on Friday") during a transfer, but the receiving agent doesn't see it.
+
+**Check**:
+1. Look for `bootstrap_transfer` — was the transfer triggered?
+2. Look for `transfer_slots_consumed` — did the receiving agent consume the slots?
+3. Look for `flow_state_saved` / `flow_state_restored` — was flow context preserved?
+4. Check `_gate_user_text` in `state.slot_machine` — was the user's message captured?
+
+**Root cause options**:
+- `_gate_user_text` not captured during the early return path (status=complete or gate_active)
+- `pass_through_on_transfer` not enabled (structured bootstrap disabled)
+- Flow context not saved before switching
+
+**Fix**: Ensure `_gate_user_text` is captured in ALL early return paths of `before_model_callback`, not just the gate path.
+
+### Agent not progressing (stuck in loop)
+
+**Symptom**: Agent keeps asking the same question or doesn't move forward.
+
+**Check**:
+1. `steer_back_*` events — is the engine detecting off-topic input?
+2. `slot_error` / `slot_error_exhaust` — is a slot repeatedly failing validation?
+3. `task_exhaust` — did a task fail all retries?
+4. `announce_cycle_break` — is readback stuck in a loop?
+
+**Root cause options**:
+- Steer-back counter incremented incorrectly (user's on-topic message misclassified)
+- Slot validation too strict (rejecting valid input)
+- Task dependency not met (prereq slot missing)
+
+### Wrong slot value stored
+
+**Symptom**: A slot has the wrong value (e.g., "2" instead of "4" for party_size).
+
+**Check**:
+1. Find `setter_stored` or `multi_setter_stored` events for that slot — what value was stored?
+2. Check `correction_applied` — was a correction attempted?
+3. Check `slot_correction_pending` / `slot_correction_overwrite` — was a correction queued?
+4. Look at `tool_calls` — which setter tool was called and with what args?
+
+**Root cause options**:
+- LLM extracted wrong value from user message
+- Multi-setter mapped value to wrong slot
+- Correction tool overwrote the value
+
+### Readback / confirmation wrong
+
+**Symptom**: Agent confirms wrong values or skips confirmation entirely.
+
+**Check**:
+1. `auto_confirm` — was an automatic confirm triggered? What was the user message?
+2. `auto_confirm_inline` — which slots were committed?
+3. Check `state.slot_machine.pending` — are there uncommitted slots?
+4. Check `state.slot_machine.phase` — is it `awaiting_readback` or `awaiting_confirmation`?
+
+**Root cause options**:
+- `_starts_affirmative()` matching too broadly (user didn't mean "yes")
+- Inline confirm committing slots before readback
+- Pending slots not populated correctly
+
+### Task not firing
+
+**Symptom**: All prerequisite slots are filled but the task doesn't execute.
+
+**Check**:
+1. Look at `slot_inspection` → DAG section — are all prereqs shown as filled?
+2. Check for `task_refire_blocked` — task already succeeded and is locked
+3. Check `progress` events — what `action` does the engine report?
+4. Verify the task tool is available (`missing_tools` event)
+
+**Root cause options**:
+- Prereq slot is in `pending`, not `filled` (needs confirmation first)
+- Task already succeeded — status is locked
+- Task tool name doesn't match the tool available on the agent
+
+### Flow doesn't start (gate not opening)
+
+**Symptom**: Agent responds but doesn't enter the slot filling flow.
+
+**Check**:
+1. `gate_active` — is the gate slot check firing?
+2. `config_loaded` — was the config loaded at all?
+3. Check `flow_context.active_config_id` — is a config active?
+4. `config_validation_failed` — did the config fail validation?
+
+**Root cause options**:
+- Gate slot not filled (user hasn't triggered the flow entry condition)
+- Config not registered in `before_model_callback`
+- Config validation errors blocking load
+
+## Session File Management
+
+Session files persist conversation state between `chat-step` invocations:
+
+```json
+{
+  "session_id": "abc-123",
+  "turn_count": 3,
+  "app_name": "projects/.../apps/...",
+  "variable_state": {
+    "sm": { "filled": {...}, "_log": [...] },
+    "_active_config_id": "reservation",
+    "agent_config_map": "{...}"
+  }
+}
+```
+
+- **New session**: omit `--session-file` or point to a non-existent path
+- **Resume session**: point to an existing session file
+- **Inspect without advancing**: use `--inspect-only` with existing session file
+- **Compare sessions**: run the same message sequence with different agent code, save to different session files, compare the JSON output
+
+### Cleanup
+
+```bash
+rm /tmp/cxas-debug-*.json
+```
+
+## Combining with Eval Debugging
+
+When an eval fails and you need to understand why:
+
+1. Read the eval's turn sequence from the golden/sim YAML
+2. Replay the sequence with `chat-step`, inspecting after each turn
+3. Compare the `chat-step` output against the eval's expected behavior
+4. Use `--with-log debug` at the turn where behavior diverges
+
+This bridges the gap between `debug.md` (which tells you WHAT failed) and understanding WHY it failed at the SM level.

--- a/.agents/skills/cxas-agent-foundry/references/debug.md
+++ b/.agents/skills/cxas-agent-foundry/references/debug.md
@@ -38,6 +38,8 @@ Methodology for systematically debugging eval failures and improving agent behav
 - **Eval YAML formats**: `references/eval-templates.md` -- load when fixing eval configuration
 - **Report interpretation**: `references/generating-reports.md` -- load when interpreting triage results or understanding triage categories
 - **SCRAPI API calls**: `references/api-reference.md`
+- **Live conversation debugging**: `references/chat-debug.md` -- load when reproducing issues with `chat-step` or inspecting SM state turn-by-turn
+- **SM event tag reference**: `references/sm-events.md` -- load when interpreting `--with-log` output from `chat-step`
 
 ## Prerequisites
 
@@ -85,7 +87,7 @@ Initialize your `todo.md` with the following. Items start unchecked; check only 
 
 1. [ ] Verify prerequisites (above)
 2. [ ] Lint (`agents/lint-fixer.md`) + `cxas push` agent code
-3. [ ] Run evals: `python scripts/run-and-report.py --runs 5 --auto-revert --json-summary <path> --message "<describe change>" > <project>/eval-reports/last-run.log 2>&1`, then read `<path>`. If the script errors (non-zero exit, or `status: "errored"` in the summary), read `<project>/eval-reports/last-run.log` for the underlying stack — no re-run needed.
+3. [ ] Run evals — **target first, then broaden** (see `references/run.md` → "Eval Execution Strategy"). When fixing a specific failure, run only the eval(s) where the problem surfaces until they pass, then run the full suite for regressions. Full-suite command: `python scripts/run-and-report.py --runs 5 --auto-revert --json-summary <path> --message "<describe change>" > <project>/eval-reports/last-run.log 2>&1`, then read `<path>`. If the script errors (non-zero exit, or `status: "errored"` in the summary), read `<project>/eval-reports/last-run.log` for the underlying stack — no re-run needed.
 4. [ ] Read `failure_clusters` from the JSON summary. Pick the top 5 clusters by `priority_score` and dispatch `agents/triage-failure.md` once per cluster, in parallel. Aggregate the returned diagnoses (a cluster may return one shared diagnosis covering N evals, or split into per-eval diagnoses with `cluster_split: true`).
 5. [ ] Plan fix from the aggregated diagnoses + `<project>/experiment_log.md`
 6. [ ] Apply fix; back to step 2 until adjusted pass rate ≥ target

--- a/.agents/skills/cxas-agent-foundry/references/run.md
+++ b/.agents/skills/cxas-agent-foundry/references/run.md
@@ -5,6 +5,7 @@ Run evals, triage failures, and generate reports for GECX conversational agents.
 ## Table of Contents
 
 - [Before Starting](#before-starting)
+- [Eval Execution Strategy](#eval-execution-strategy)
 - [Four Eval Types](#four-eval-types)
 - [Run Everything](#run-everything)
 - [Choosing Golden vs Sim](#choosing-golden-vs-sim)
@@ -32,6 +33,20 @@ Check memory for project-specific context (app ID, variable handling rules, know
 
 **CRITICAL: Evaluation Channel Enforcement**
 If the app's `gecx-config.json` specifies `"modality": "audio"`, you MUST NOT run evaluations in text mode. The runner scripts will now throw a fatal error if you attempt to bypass this. When running eval scripts, either omit the `--channel` flag to rely on the default config, or explicitly pass `--channel audio`. Never pass `--channel text` for an audio agent.
+
+## Eval Execution Strategy
+
+Prefer tight feedback loops over casting a wide net. Running the full eval suite on every iteration is slow and buries the signal you care about in noise from unrelated tests.
+
+**After building or pushing a new agent:**
+1. Run 2–3 smoke-test evals first (e.g., one happy path, one edge case) and confirm they pass.
+2. Only then run the full battery. If smoke tests fail, fix them before wasting time on the full suite.
+
+**When fixing a specific problem:**
+1. Run only the eval(s) where the problem surfaces. Iterate until they pass.
+2. Once the targeted evals pass, run the full suite to check for regressions.
+
+The goal is to minimize the time between "make a change" and "see whether it worked." A 2-minute targeted run that tells you exactly what broke is worth more than a 15-minute full run where you have to hunt for the relevant result.
 
 ## Four Eval Types
 

--- a/.agents/skills/cxas-agent-foundry/references/sm-events.md
+++ b/.agents/skills/cxas-agent-foundry/references/sm-events.md
@@ -1,0 +1,103 @@
+# SM Event Tag Reference
+
+Complete reference for slot machine `_log` entries. Use with `cxas chat-step --with-log` output.
+
+Each entry in `sm["_log"]` is a dict: `{"src": "engine"|"callback"|"after_tool", "tag": "<tag>", "level": "DEBUG"|"INFO"|"WARN"|"ERROR", ...data}`.
+
+## Flow Lifecycle
+
+| Tag | Level | Source | Key Fields | Meaning |
+|-----|-------|--------|------------|---------|
+| `config_loaded` | INFO | callback | `config_id`, `n_slots`, `n_tasks` | Slot filling config loaded into SM — flow is starting |
+| `config_resolved` | INFO | callback | `config_id` | Config selected for this agent (multi-config resolution) |
+| `config_validation_failed` | ERROR | callback | `errors` | Config has structural errors — flow won't work |
+| `cross_config_validation_failed` | ERROR | callback | `config_a`, `config_b`, `errors` | Two configs have conflicting declarations |
+| `gate_active` | DEBUG | callback | `config_id`, `gate_slot` | Flow gated — waiting for gate slot before proceeding |
+| `missing_tools` | WARN | callback | `missing` | Config references tools not available on this agent |
+| `cancel_preempt` | INFO | callback | `config_id` | Cancelled a pending preemption (flow switching) |
+| `cancel_flow_called` | INFO | after_tool | `reason` | User/agent explicitly cancelled the current flow |
+| `terminal_fallback` | WARN | callback | | Engine hit a terminal state — fallback behavior triggered |
+
+## Flow Context Switching
+
+| Tag | Level | Source | Key Fields | Meaning |
+|-----|-------|--------|------------|---------|
+| `flow_state_saved` | INFO | after_tool | `flow`, `n_slots` | Flow paused — slots saved for later restoration |
+| `flow_state_restored` | INFO | after_tool | `flow`, `n_slots` | Flow resumed — saved slots restored into SM |
+| `bootstrap_stored` | INFO | after_tool | `slot`, `value` | Slot value pre-filled from bootstrap/transfer data |
+| `bootstrap_transfer` | INFO | after_tool | `tool`, `target` | Agent transfer triggered with slot bootstrap |
+| `bootstrap_reentry` | DEBUG | after_tool | `tool`, `target` | Re-entering same agent after bootstrap (no transfer needed) |
+| `transfer_dispatched` | INFO | callback | `agent` | Transfer to another agent initiated |
+| `transfer_slots_consumed` | INFO | callback | `slots` | Transferred slot values consumed by receiving agent |
+
+## Slot Filling
+
+| Tag | Level | Source | Key Fields | Meaning |
+|-----|-------|--------|------------|---------|
+| `setter_stored` | INFO | after_tool | `tool`, `slot`, `value` | Single-slot setter stored a value |
+| `multi_setter_stored` | INFO | after_tool | `tool`, `slots` | Multi-slot setter stored values |
+| `multi_setter_error` | WARN | after_tool | `tool`, `error` | Multi-setter failed for some slots |
+| `setter_error` | WARN | after_tool | `tool`, `slot`, `code` | Single setter failed validation |
+| `fill_slots` | DEBUG | engine | `slot`, `value` | Internal: slot value committed to filled dict |
+| `slot_deactivated` | DEBUG | engine | `slot`, `source` | Slot removed from active tracking (`source`: filled/pending/deferred) |
+| `inferred_slots` | INFO | after_tool | `slots` | Slots inferred from other slot values |
+| `prereq_not_met` | WARN | after_tool | `slot`, `missing` | Slot can't be filled — prerequisite slot not yet filled |
+| `validation_failed` | WARN | after_tool | `slot`, `code` | Slot value failed validation rule |
+
+## Confirmation & Readback
+
+| Tag | Level | Source | Key Fields | Meaning |
+|-----|-------|--------|------------|---------|
+| `auto_confirm` | INFO | engine | `user_msg` | User confirmed — pending slots committed |
+| `auto_confirm_inline` | INFO | engine | `committed` | Inline confirm: user said yes + provided new data in same message |
+| `announce` | DEBUG | engine | `slot` | Slot announced to user (readback) |
+| `announce_cycle_break` | WARN | engine | `slot` | Announce cycle broken to prevent infinite readback loop |
+
+## Corrections
+
+| Tag | Level | Source | Key Fields | Meaning |
+|-----|-------|--------|------------|---------|
+| `correction_applied` | INFO | engine | `slot`, `value`, `old` | Slot value corrected (old → new) |
+| `slot_correction_pending` | INFO | after_tool | `tool`, `slot`, `value` | Correction queued — awaiting confirmation |
+| `slot_correction_overwrite` | INFO | after_tool | `tool`, `slot`, `value` | Correction overwrote existing value directly |
+| `correction_not_found` | WARN | after_tool | `tool`, `slot` | Correction requested but target slot not found |
+| `rejection_applied` | INFO | engine | `slot` | User rejected a readback value |
+
+## Tasks
+
+| Tag | Level | Source | Key Fields | Meaning |
+|-----|-------|--------|------------|---------|
+| `task` | INFO/WARN | engine | `name`, `ok` | Task completed (ok=True) or failed (ok=False) |
+| `task_completed` | INFO/WARN | after_tool | `name`, `success` | Task tool returned result |
+| `task_exhaust` | ERROR | engine | `name` | Task failed all retry attempts |
+| `task_refire_blocked` | WARN | engine | `task` | Task would fire again but is blocked (already succeeded) |
+| `on_complete` | INFO | engine | `task`, `action` | Flow completed — running on_complete action |
+| `on_complete_auto_resume` | INFO | engine | `task`, `flow` | Flow completed — auto-resuming a suspended flow |
+
+## Slot Errors
+
+| Tag | Level | Source | Key Fields | Meaning |
+|-----|-------|--------|------------|---------|
+| `slot_error` | WARN | engine | `slot`, `code`, `retries` | Slot validation error with retry count |
+| `slot_error_exhaust` | ERROR | engine | `slot` | Slot exhausted all retries — giving up |
+
+## Steering (Off-Topic Detection)
+
+| Tag | Level | Source | Key Fields | Meaning |
+|-----|-------|--------|------------|---------|
+| `steer_back_soft` | INFO | engine | `turns`, `directive` | Soft redirect — gentle nudge back to flow |
+| `steer_back_hard` | WARN | engine | `turns`, `msg` | Hard redirect — explicit instruction to stay on topic |
+| `steer_back_escalate` | WARN | engine | `turns` | Escalation — too many off-topic turns, transferring out |
+| `steer_back_correction_yield` | DEBUG | engine | | Steer-back yielded to a pending correction |
+| `steer_back_correction_grace` | DEBUG | engine | | Steer-back gave grace period for correction to complete |
+
+## Engine Internals
+
+| Tag | Level | Source | Key Fields | Meaning |
+|-----|-------|--------|------------|---------|
+| `invoke` | DEBUG | engine | | Engine invoked for this turn |
+| `progress` | DEBUG | engine | `phase`, `action`, `slots_*` | Engine progress snapshot (phase, DAG state) |
+| `preemption` | INFO | callback | `config_id`, `msg` | LLM bypassed — deterministic response injected |
+| `payload_route` | DEBUG | engine | `path` | Internal routing decision for preempt/stash/question |
+| `payloads_injected` | DEBUG | callback | | Stashed payloads injected into conversation |
+| `re_deferred` | DEBUG | engine | `slot`, `task` | Slot re-deferred after partial task completion |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ dependencies = [
   # subcommands do NOT pull it in.
   "InquirerPy",
   "ratelimit",
+  "textual>=1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/cxas_scrapi/__init__.py
+++ b/src/cxas_scrapi/__init__.py
@@ -17,6 +17,7 @@ from cxas_scrapi.core.apps import Apps
 from cxas_scrapi.core.callbacks import Callbacks
 from cxas_scrapi.core.changelogs import Changelogs
 from cxas_scrapi.core.common import Common
+from cxas_scrapi.core.programmatic_chat import ProgrammaticChatDriver
 from cxas_scrapi.core.conversation_history import ConversationHistory
 from cxas_scrapi.core.deployments import Deployments
 from cxas_scrapi.core.evaluations import Evaluations
@@ -57,6 +58,7 @@ from cxas_scrapi.utils.secret_manager_utils import SecretManagerUtils
 
 __all__ = [
     "Common",
+    "ProgrammaticChatDriver",
     "Apps",
     "Agents",
     "Sessions",

--- a/src/cxas_scrapi/cli/chat_cli.py
+++ b/src/cxas_scrapi/cli/chat_cli.py
@@ -1,0 +1,530 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Argparse subcommand handlers for `cxas chat`.
+
+Provides an interactive REPL for chatting with a CES agent, with
+integrated trace analysis, slash commands, and rich terminal output.
+"""
+
+import argparse
+import atexit
+import json
+import logging
+import os
+import readline
+import shutil
+import subprocess
+import sys
+import warnings
+
+from cxas_scrapi.core.chat_session import ChatSession, SessionEndedError
+from cxas_scrapi.core.traces import Traces
+from cxas_scrapi.utils.chat_renderer import ChatRenderer
+from cxas_scrapi.utils.tracing.trace_config import TraceConfig
+
+logger = logging.getLogger(__name__)
+
+SLASH_COMMANDS = {
+    "/help": "Show available commands",
+    "/trace": "Fetch and display the trace for this session",
+    "/state": "Show current variable/slot state",
+    "/slots": "Deep slot machine inspection (phase, DAG, all fields)",
+    "/slots <category>": "Show one category (e.g., core_data, configuration)",
+    "/slots flows": "List all flows with status (active/suspended/idle)",
+    "/slots flow:<name>": "Inspect saved slots in a suspended flow",
+    "/log": "Show slot machine lifecycle timeline (INFO+)",
+    "/log <level>": "Filter timeline (debug, info, warn, error)",
+    "/bug <reason>": "Bundle this conversation as a bug report",
+    "/save <path>": "Export the conversation to a file",
+    "/clear": "Clear the terminal",
+    "/quit": "End the session",
+}
+
+
+def _resolve_app_name(args: argparse.Namespace) -> tuple[str, str, str]:
+    """Resolve --app-name to a full resource name and display name.
+
+    Resolution order:
+    1. If --app-name is a full resource name (contains "projects/"), use it.
+    2. If --app-name is a display name, look it up via the Apps API
+       (requires --project-id and --location, or defaults from config).
+    3. If --app-name is not provided, fall back to defaults.app_name
+       from .cxas/trace.yaml.
+
+    Returns:
+        Tuple of (resource_name, display_name, config_path).
+    """
+    explicit_config = getattr(args, "config", None)
+    config_path = TraceConfig._pick_path(explicit_config) or ""
+    config = TraceConfig.load(explicit_config)
+    app_name = getattr(args, "app_name", None)
+
+    if not app_name:
+        app_name = config.defaults.app_name
+    if not app_name:
+        print("Error: --app-name is required (or set defaults.app_name in .cxas/trace.yaml)")
+        sys.exit(1)
+
+    if "projects/" in app_name:
+        display_name = app_name
+        try:
+            from cxas_scrapi.core.apps import Apps
+            parts = app_name.split("/")
+            pid = parts[parts.index("projects") + 1]
+            loc = parts[parts.index("locations") + 1]
+            app = Apps(project_id=pid, location=loc).get_app(app_name)
+            display_name = app.display_name or app_name
+        except Exception:
+            pass
+        return app_name, display_name, config_path
+
+    display_name = app_name
+    project_id = getattr(args, "project_id", None) or config.defaults.project_id
+    location = getattr(args, "location", None) or config.defaults.location
+    if not project_id or not location:
+        print(
+            f"Error: Display name '{app_name}' requires --project-id and "
+            "--location (or set defaults.project_id and defaults.location "
+            "in .cxas/trace.yaml)"
+        )
+        sys.exit(1)
+
+    from cxas_scrapi.core.apps import Apps
+    apps_client = Apps(project_id=project_id, location=location)
+    app = apps_client.get_app_by_display_name(app_name)
+    if not app:
+        print(f"Error: App '{app_name}' not found in {project_id}/{location}")
+        sys.exit(1)
+
+    logger.info("Resolved '%s' -> %s", app_name, app.name)
+    return app.name, display_name, config_path
+
+
+def chat_interactive(args: argparse.Namespace) -> None:
+    """Main REPL handler for `cxas chat`."""
+    warnings.filterwarnings("ignore", message=".*end user credentials.*")
+    logging.getLogger("cxas_scrapi.core.traces").setLevel(logging.WARNING)
+    logging.getLogger("cxas_scrapi.core.conversation_history").setLevel(
+        logging.WARNING
+    )
+
+    app_name, display_name, config_path = _resolve_app_name(args)
+
+    historical_contexts = None
+    if getattr(args, "fork", None):
+        traces = Traces(app_name=app_name)
+        fork_result = traces.fork(
+            args.fork, at_turn=getattr(args, "fork_at_turn", None)
+        )
+        historical_contexts = fork_result.get("historical_contexts")
+
+    session = ChatSession(
+        app_name=app_name,
+        channel=getattr(args, "channel", None),
+        deployment_id=getattr(args, "deployment_id", None),
+        historical_contexts=historical_contexts,
+    )
+
+    renderer = ChatRenderer(verbose=getattr(args, "verbose", False))
+    renderer.render_session_start(
+        session.session_id, app_name, display_name, config_path,
+    )
+    _setup_readline()
+
+    try:
+        while True:
+            try:
+                user_input = input("You: ")
+            except (EOFError, KeyboardInterrupt):
+                break
+
+            if not user_input.strip():
+                continue
+
+            if user_input.strip().startswith("/"):
+                should_continue = _handle_slash_command(
+                    user_input.strip(), session, renderer, args
+                )
+                if not should_continue:
+                    break
+                continue
+
+            try:
+                turn = session.send(user_input)
+                renderer.render_turn(turn)
+                if session.is_ended:
+                    break
+            except SessionEndedError:
+                renderer.render_error("Session has already ended.")
+                break
+    except Exception as e:
+        renderer.render_error(f"Unexpected error: {e}")
+
+    # Post-session: auto-trace if requested
+    if getattr(args, "trace", False):
+        try:
+            trace_fmt = getattr(args, "trace_format", "text")
+            trace_output = session.get_trace(fmt=trace_fmt)
+            print(trace_output)
+        except Exception as e:
+            renderer.render_error(f"Failed to fetch trace: {e}")
+
+    trace_command = (
+        f"cxas trace get --app-name {app_name} "
+        f"{session.session_id}"
+    )
+    renderer.render_session_end(
+        session.session_id, len(session.turns), trace_command
+    )
+
+    # Save session ID for later reference
+    _save_last_session(session.session_id)
+
+
+def chat_tui_interactive(args: argparse.Namespace) -> None:
+    """Launch the Textual TUI for `cxas chat --tui`."""
+    warnings.filterwarnings("ignore", message=".*end user credentials.*")
+
+    app_name, display_name, _ = _resolve_app_name(args)
+    session = ChatSession(
+        app_name=app_name,
+        channel=getattr(args, "channel", None),
+        deployment_id=getattr(args, "deployment_id", None),
+    )
+
+    from cxas_scrapi.cli.chat_tui import ChatApp
+    app = ChatApp(
+        session=session,
+        display_name=display_name,
+        verbose=getattr(args, "verbose", False),
+    )
+    app.run()
+
+
+def chat_script(args: argparse.Namespace) -> None:
+    """Handler for `cxas chat --script <path>`."""
+    from cxas_scrapi.utils.script_runner import ScriptRunner
+
+    app_name, _, _ = _resolve_app_name(args)
+    script = ScriptRunner.load_script(args.script)
+    runner = ScriptRunner(
+        app_name=app_name,
+        channel=getattr(args, "channel", None),
+    )
+    result = runner.run_script(script)
+    print(json.dumps(
+        {
+            "script_name": result.script_name,
+            "passed": result.passed,
+            "total_turns": result.total_turns,
+            "passed_turns": result.passed_turns,
+            "failed_turns": result.failed_turns,
+        },
+        indent=2,
+    ))
+    if not result.passed:
+        sys.exit(1)
+
+
+def _handle_slash_command(
+    cmd: str,
+    session: ChatSession,
+    renderer: ChatRenderer,
+    args: argparse.Namespace,
+) -> bool:
+    """Dispatch slash commands. Returns True if session should continue."""
+    parts = cmd.split(maxsplit=1)
+    command = parts[0].lower()
+    command_arg = parts[1] if len(parts) > 1 else ""
+
+    if command == "/help":
+        renderer.render_slash_help()
+        return True
+
+    if command == "/state":
+        state = session.get_state()
+        _paged(renderer, lambda: renderer.render_state(state))
+        return True
+
+    if command == "/trace":
+        try:
+            trace_fmt = getattr(args, "trace_format", "text")
+            trace_output = session.get_trace(fmt=trace_fmt)
+            print(trace_output)
+        except Exception as e:
+            renderer.render_error(f"Failed to fetch trace: {e}")
+        return True
+
+    if command == "/slots":
+        if not session.turns:
+            renderer.render_error("Send at least one message before using /slots.")
+            return True
+        try:
+            from cxas_scrapi.utils.slot_inspector import SlotInspector
+            sm = session.get_slot_machine()
+            if not sm:
+                renderer.render_error("No slot machine state found.")
+                return True
+            inspection = SlotInspector.inspect(sm)
+            flow_context = session.get_flow_context()
+            category_filter = command_arg.strip() if command_arg.strip() else None
+            _paged(renderer, lambda: renderer.render_slots(
+                inspection,
+                category=category_filter,
+                flow_context=flow_context,
+            ))
+        except Exception as e:
+            renderer.render_error(f"Slot inspection failed: {e}")
+        return True
+
+    if command == "/log":
+        if not session.turns:
+            renderer.render_error("Send at least one message before using /log.")
+            return True
+        try:
+            sm = session.get_slot_machine()
+            if not sm:
+                renderer.render_error("No slot machine state found.")
+                return True
+            log_entries = sm.get("_log", [])
+            if not log_entries:
+                renderer.render_error("No log entries in slot machine.")
+                return True
+            level = command_arg.strip().upper() if command_arg.strip() else "INFO"
+            valid_levels = {"DEBUG", "INFO", "WARN", "ERROR"}
+            if level not in valid_levels:
+                renderer.render_error(
+                    f"Unknown level '{level}'. Use: debug, info, warn, error"
+                )
+                return True
+            _paged(renderer, lambda: renderer.render_log(log_entries, min_level=level))
+        except Exception as e:
+            renderer.render_error(f"Log display failed: {e}")
+        return True
+
+    if command == "/bug":
+        if not command_arg:
+            renderer.render_error("Usage: /bug <reason>")
+            return True
+        try:
+            traces = Traces(app_name=session._app_name)
+            result = traces.report_bug(
+                conversation_id=session.session_id,
+                reason=command_arg,
+            )
+            print(json.dumps(result, indent=2))
+        except Exception as e:
+            renderer.render_error(f"Failed to report bug: {e}")
+        return True
+
+    if command == "/save":
+        if not command_arg:
+            renderer.render_error("Usage: /save <path>")
+            return True
+        try:
+            summary = session.export_turns_summary()
+            with open(command_arg, "w") as f:
+                json.dump(summary, f, indent=2)
+            print(f"Saved to {command_arg}")
+        except Exception as e:
+            renderer.render_error(f"Failed to save: {e}")
+        return True
+
+    if command == "/clear":
+        renderer.console.clear()
+        return True
+
+    if command == "/quit":
+        return False
+
+    renderer.render_error(f"Unknown command: {command}. Type /help for help.")
+    return True
+
+
+def _save_last_session(session_id: str) -> None:
+    """Save the session ID to .cxas/last_session.txt."""
+    try:
+        os.makedirs(".cxas", exist_ok=True)
+        with open(".cxas/last_session.txt", "w") as f:
+            f.write(session_id)
+    except OSError:
+        pass
+
+
+_HISTORY_FILE = os.path.join(".cxas", "chat_history")
+_COMPLETABLE_COMMANDS = sorted({
+    k.split()[0] for k in SLASH_COMMANDS
+})
+
+
+def _slash_completer(text: str, state: int) -> str | None:
+    if text.startswith("/"):
+        matches = [c for c in _COMPLETABLE_COMMANDS if c.startswith(text)]
+        return matches[state] if state < len(matches) else None
+    return None
+
+
+def _paged(renderer: ChatRenderer, fn: callable) -> None:
+    """Run fn() and display output in less -R (alternate screen, ANSI colors).
+
+    Bypasses pydoc.pager() which misdetects TTY and garbles Rich output.
+    Falls back to inline rendering if less is not available.
+    """
+    if not shutil.which("less"):
+        fn()
+        return
+    from io import StringIO
+    from rich.console import Console
+    buf = StringIO()
+    pager_console = Console(file=buf, force_terminal=True, width=renderer.console.width)
+    original = renderer.console
+    renderer.console = pager_console
+    try:
+        fn()
+    finally:
+        renderer.console = original
+    content = buf.getvalue()
+    if not content.strip():
+        return
+    try:
+        proc = subprocess.Popen(
+            ["less", "-R"],
+            stdin=subprocess.PIPE,
+            text=True,
+        )
+        proc.communicate(input=content)
+    except OSError:
+        original.print(content, highlight=False)
+
+
+def _setup_readline() -> None:
+    """Enable command history, tab completion, and Ctrl+R support."""
+    readline.set_history_length(1000)
+    try:
+        readline.read_history_file(_HISTORY_FILE)
+    except FileNotFoundError:
+        pass
+
+    readline.set_completer(_slash_completer)
+    readline.set_completer_delims(" \t\n")
+    if "libedit" in (getattr(readline, "__doc__", "") or ""):
+        readline.parse_and_bind("bind ^I rl_complete")
+    readline.parse_and_bind("tab: complete")
+
+    def _save() -> None:
+        try:
+            os.makedirs(os.path.dirname(_HISTORY_FILE), exist_ok=True)
+            readline.write_history_file(_HISTORY_FILE)
+        except OSError:
+            pass
+    atexit.register(_save)
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:
+    """Adds the `chat` subcommand to the CLI."""
+    parser_chat = subparsers.add_parser(
+        "chat",
+        help="Interactive chat with a CES agent, with trace integration.",
+    )
+    parser_chat.add_argument(
+        "--app-name",
+        default=None,
+        help=(
+            "App resource name or display name. "
+            "Falls back to defaults.app_name in .cxas/trace.yaml."
+        ),
+    )
+    parser_chat.add_argument(
+        "--project-id",
+        default=None,
+        help="GCP Project ID (required when using a display name).",
+    )
+    parser_chat.add_argument(
+        "--location",
+        default=None,
+        help="GCP Location (required when using a display name).",
+    )
+    parser_chat.add_argument(
+        "--channel",
+        default=None,
+        help="Channel to inject as event_data.channel variable.",
+    )
+    parser_chat.add_argument(
+        "--deployment-id",
+        default=None,
+        help="Deployment ID to target.",
+    )
+    parser_chat.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Show tool calls, responses, and variable updates.",
+    )
+    parser_chat.add_argument(
+        "--trace",
+        action="store_true",
+        help="Auto-fetch and display trace on session end.",
+    )
+    parser_chat.add_argument(
+        "--trace-format",
+        choices=["json", "md", "text", "html"],
+        default="text",
+        help="Format for auto-trace output (default: text).",
+    )
+    parser_chat.add_argument(
+        "--metrics",
+        action="store_true",
+        help="Show per-turn latency and token metrics.",
+    )
+    parser_chat.add_argument(
+        "--script",
+        default=None,
+        help="Path to a YAML conversation script (non-interactive mode).",
+    )
+    parser_chat.add_argument(
+        "--fork",
+        default=None,
+        metavar="CONV_ID",
+        help=(
+            "Fork from an existing conversation "
+            "(load as historical context)."
+        ),
+    )
+    parser_chat.add_argument(
+        "--fork-at-turn",
+        type=int,
+        default=None,
+        help="When forking, load only the first N turns.",
+    )
+    parser_chat.add_argument(
+        "--config",
+        default=None,
+        help="Path to trace.yaml config file.",
+    )
+    parser_chat.add_argument(
+        "--tui",
+        action="store_true",
+        help="Launch interactive TUI with clickable buttons (requires textual).",
+    )
+
+    def _chat_dispatch(args: argparse.Namespace) -> None:
+        if args.script:
+            chat_script(args)
+        elif args.tui:
+            chat_tui_interactive(args)
+        else:
+            chat_interactive(args)
+
+    parser_chat.set_defaults(func=_chat_dispatch)

--- a/src/cxas_scrapi/cli/chat_step_cli.py
+++ b/src/cxas_scrapi/cli/chat_step_cli.py
@@ -1,0 +1,226 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Programmatic single-turn chat command with JSON output."""
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+from cxas_scrapi.core.programmatic_chat import ProgrammaticChatDriver
+
+
+def _enrich_result(
+    result: dict[str, Any],
+    driver: ProgrammaticChatDriver,
+    args: argparse.Namespace,
+) -> None:
+    if getattr(args, "with_slots", False):
+        full_state = driver.get_full_state()
+        result["slot_inspection"] = full_state.get("slot_inspection")
+
+    if getattr(args, "with_log", None) is not None:
+        result["sm_log"] = driver.get_sm_log(args.with_log)
+
+    if getattr(args, "with_flow_context", False):
+        result["flow_context"] = driver.get_flow_context()
+
+    if getattr(args, "with_trace_report", None) is not None:
+        result["trace_report"] = driver.get_trace_report(args.with_trace_report)
+
+    if getattr(args, "with_turns", False):
+        result["turns_summary"] = driver.get_turns_summary()
+
+    if getattr(args, "bug", None) is not None:
+        result["bug_report"] = driver.report_bug(args.bug)
+
+
+def _build_inspect_result(
+    driver: ProgrammaticChatDriver,
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "session_id": driver.session_id,
+        "state": driver.get_full_state(),
+        "inspect_only": True,
+    }
+    _enrich_result(result, driver, args)
+    return result
+
+
+def chat_step(args: argparse.Namespace) -> None:
+    """Handle the `cxas chat-step` command."""
+    inspect_only = getattr(args, "inspect_only", False)
+    if not inspect_only and not args.message:
+        print("Error: --message is required unless --inspect-only is set.", file=sys.stderr)
+        sys.exit(1)
+
+    session_id = None
+    initial_turn_count = 0
+    initial_variable_state = None
+
+    if args.session_file and os.path.exists(args.session_file):
+        try:
+            with open(args.session_file) as f:
+                session_data = json.load(f)
+            session_id = session_data.get("session_id")
+            initial_turn_count = session_data.get("turn_count", 0)
+            initial_variable_state = session_data.get("variable_state")
+        except (json.JSONDecodeError, OSError) as e:
+            print(f"Failed to load session file: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    if inspect_only and not session_id:
+        print("Error: --inspect-only requires --session-file with existing session.", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        driver = ProgrammaticChatDriver(
+            app_name=args.app_name,
+            channel=getattr(args, "channel", None),
+            deployment_id=getattr(args, "deployment_id", None),
+            include_trace=getattr(args, "with_trace", False),
+            include_metrics=getattr(args, "with_metrics", False),
+            session_id=session_id,
+            initial_turn_count=initial_turn_count,
+            initial_variable_state=initial_variable_state,
+        )
+    except Exception as e:
+        print(f"Failed to create session: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        if inspect_only:
+            result = _build_inspect_result(driver, args)
+        else:
+            result = driver.step(args.message)
+            _enrich_result(result, driver, args)
+
+        print(json.dumps(result, indent=2, default=str))
+
+        if args.session_file and not inspect_only:
+            session_state = {
+                "session_id": driver.session_id,
+                "turn_count": result["state"]["turn_count"],
+                "app_name": args.app_name,
+                "variable_state": driver._session._variable_state,
+            }
+            try:
+                with open(args.session_file, "w") as f:
+                    json.dump(session_state, f, indent=2, default=str)
+            except OSError as e:
+                print(f"Failed to save session file: {e}", file=sys.stderr)
+
+    except Exception as e:
+        print(f"Chat step failed: {e}", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        driver.close()
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:
+    """Register the `chat-step` subcommand."""
+    p = subparsers.add_parser(
+        "chat-step",
+        help="Single-turn programmatic chat with JSON output.",
+        description=(
+            "Send one message to a CES agent and receive a structured JSON response. "
+            "Use --session-file for multi-turn conversations across invocations."
+        ),
+    )
+    p.add_argument(
+        "--app-name",
+        required=True,
+        help="Full CES app resource name.",
+    )
+    p.add_argument(
+        "--message", "-m",
+        default=None,
+        help="User message to send.",
+    )
+    p.add_argument(
+        "--session-file",
+        default=None,
+        help="Path to session state file for multi-turn conversations.",
+    )
+    p.add_argument(
+        "--channel",
+        default=None,
+        help="Channel identifier (e.g., web, sms).",
+    )
+    p.add_argument(
+        "--deployment-id",
+        default=None,
+        help="Deployment ID to target.",
+    )
+    p.add_argument(
+        "--with-trace",
+        action="store_true",
+        default=False,
+        help="Include normalized trace in output.",
+    )
+    p.add_argument(
+        "--with-metrics",
+        action="store_true",
+        default=False,
+        help="Include per-turn metrics in output.",
+    )
+    p.add_argument(
+        "--with-slots",
+        action="store_true",
+        default=False,
+        help="Include deep slot inspection in output.",
+    )
+    p.add_argument(
+        "--with-log",
+        nargs="?",
+        const="INFO",
+        default=None,
+        metavar="LEVEL",
+        help="Include SM event log (levels: debug, info, warn, error; default: info).",
+    )
+    p.add_argument(
+        "--with-flow-context",
+        action="store_true",
+        default=False,
+        help="Include multi-flow context in output.",
+    )
+    p.add_argument(
+        "--with-trace-report",
+        choices=["json", "md", "text", "html"],
+        default=None,
+        metavar="FMT",
+        help="Include formatted trace report in output.",
+    )
+    p.add_argument(
+        "--with-turns",
+        action="store_true",
+        default=False,
+        help="Include conversation turn summaries in output.",
+    )
+    p.add_argument(
+        "--bug",
+        default=None,
+        metavar="REASON",
+        help="Report a bug for this conversation.",
+    )
+    p.add_argument(
+        "--inspect-only",
+        action="store_true",
+        default=False,
+        help="Inspect existing session state without sending a message.",
+    )
+    p.set_defaults(func=chat_step)

--- a/src/cxas_scrapi/cli/chat_tui.py
+++ b/src/cxas_scrapi/cli/chat_tui.py
@@ -1,0 +1,522 @@
+"""Textual TUI for `cxas chat --tui`.
+
+Interactive chat with clickable chip buttons, scrollable history,
+and rich payload rendering. Uses VerticalScroll with Static widgets
+for Rich renderables and Textual Button widgets for interactive elements.
+"""
+
+import json
+import webbrowser
+
+from rich.panel import Panel
+from rich.text import Text
+from textual import on, work
+from textual.app import App, ComposeResult
+from textual.containers import Horizontal, VerticalScroll
+from textual.widgets import Button, Footer, Header, Input, Static
+
+from cxas_scrapi.core.chat_session import ChatSession, SessionEndedError
+
+_BUTTON_ICONS = {
+    "doc": "\U0001f4c4",
+    "hyperLink": "\U0001f517",
+    "deepLink": "\U0001f4f1",
+    "event": "▶",
+    "cms": "\U0001f4c4",
+}
+
+
+class ChatApp(App):
+    """Interactive chat TUI with clickable payload widgets."""
+
+    TITLE = "cxas chat"
+    CSS = """
+    #chat-log {
+        height: 1fr;
+        scrollbar-gutter: stable;
+        padding: 0 1;
+    }
+    #user-input {
+        dock: bottom;
+        margin: 0 1;
+    }
+    .agent-panel { margin: 0 0 1 0; }
+    .user-msg { margin: 0 0 1 0; }
+    .chip-row {
+        height: auto;
+        layout: horizontal;
+        margin: 0 0 1 0;
+    }
+    .chip-btn {
+        min-width: 0;
+        width: auto;
+        margin: 0 1 0 0;
+    }
+    .link-btn {
+        min-width: 0;
+        width: auto;
+        margin: 0 1 0 0;
+    }
+    .info-panel { margin: 0 0 1 0; }
+    .scenario-panel { margin: 0 0 1 0; }
+    .slash-output { margin: 0 0 1 0; }
+    """
+
+    BINDINGS = [
+        ("ctrl+c", "quit", "Quit"),
+        ("ctrl+l", "clear", "Clear"),
+    ]
+
+    def __init__(
+        self,
+        session: ChatSession,
+        display_name: str = "",
+        verbose: bool = False,
+    ):
+        super().__init__()
+        self._session = session
+        self._display_name = display_name
+        self._verbose = verbose
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield VerticalScroll(id="chat-log")
+        yield Input(placeholder="Type a message or /help ...", id="user-input")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.title = self._display_name or "cxas chat"
+        self.sub_title = f"Session: {self._session.session_id}"
+        self.query_one("#user-input", Input).focus()
+
+    # ── Input handling ──────────────────────────────────
+
+    @on(Input.Submitted, "#user-input")
+    def on_user_submit(self, event: Input.Submitted) -> None:
+        text = event.value.strip()
+        if not text:
+            return
+        event.input.clear()
+
+        if text.startswith("/"):
+            self._handle_slash(text)
+            return
+
+        self._append_user(text)
+        self._send_message(text)
+
+    @on(Button.Pressed)
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        ces_event = getattr(event.button, "_ces_event", None)
+        if ces_event:
+            display = ces_event.get("display", ces_event.get("name", ""))
+            self._append_user(f"[{display}]")
+            self._fire_event(ces_event["name"])
+            return
+        chip_text = getattr(event.button, "_chip_text", None)
+        if chip_text:
+            self._append_user(chip_text)
+            self._send_message(chip_text)
+            return
+        link = getattr(event.button, "_link", None)
+        if link:
+            webbrowser.open(link)
+
+    # ── Message sending (background worker) ─────────────
+
+    @work(thread=True)
+    def _send_message(self, text: str) -> None:
+        try:
+            turn = self._session.send(text)
+            self.call_from_thread(self._render_turn, turn)
+            if self._session.is_ended:
+                self.call_from_thread(self._show_ended)
+        except SessionEndedError:
+            self.call_from_thread(self._show_ended)
+        except Exception as exc:
+            self.call_from_thread(
+                self._append_static,
+                Panel(
+                    Text(str(exc), style="bold white"),
+                    title="Error",
+                    border_style="red",
+                ),
+            )
+
+    @work(thread=True)
+    def _fire_event(self, event_name: str) -> None:
+        try:
+            turn = self._session.send_event(event_name)
+            self.call_from_thread(self._render_turn, turn)
+            if self._session.is_ended:
+                self.call_from_thread(self._show_ended)
+        except SessionEndedError:
+            self.call_from_thread(self._show_ended)
+        except Exception as exc:
+            self.call_from_thread(
+                self._append_static,
+                Panel(
+                    Text(str(exc), style="bold white"),
+                    title="Error",
+                    border_style="red",
+                ),
+            )
+
+    # ── Rendering ───────────────────────────────────────
+
+    def _append_user(self, text: str) -> None:
+        label = Text()
+        label.append("You: ", style="bold blue")
+        label.append(text)
+        log = self.query_one("#chat-log")
+        log.mount(Static(label, classes="user-msg"))
+        log.scroll_end(animate=False)
+
+    def _append_static(self, renderable, classes: str = "") -> None:
+        log = self.query_one("#chat-log")
+        log.mount(Static(renderable, classes=classes))
+        log.scroll_end(animate=False)
+
+    def _render_turn(self, turn) -> None:
+        log = self.query_one("#chat-log")
+
+        payloads = getattr(turn, "payloads", [])
+        show_text = turn.agent_text and not self._text_in_payloads(
+            turn.agent_text, payloads,
+        )
+        if show_text:
+            panel = Panel(
+                Text(turn.agent_text),
+                title=f"Agent [Turn {turn.turn_index}]",
+                border_style="green",
+            )
+            log.mount(Static(panel, classes="agent-panel"))
+
+        if self._verbose:
+            for tc in turn.tool_calls:
+                tool = tc.get("action", tc.get("name", "?"))
+                agent = tc.get("agent", "")
+                args = tc.get("args", {})
+                title = f"{agent}: {tool}" if agent else tool
+                log.mount(Static(
+                    Panel(
+                        Text(json.dumps(args, indent=2, default=str)),
+                        title=title,
+                        border_style="red",
+                    ),
+                    classes="agent-panel",
+                ))
+
+        for payload in getattr(turn, "payloads", []):
+            self._mount_payload(log, payload)
+
+        if turn.agent_transfer:
+            target = turn.agent_transfer
+            if isinstance(target, dict):
+                name = target.get("display_name", target.get("target_agent", str(target)))
+            elif hasattr(target, "display_name"):
+                name = target.display_name
+            else:
+                name = str(target)
+            t = Text()
+            t.append("Transferred to: ", style="bold cyan")
+            t.append(name, style="cyan")
+            log.mount(Static(t, classes="agent-panel"))
+
+        log.scroll_end(animate=False)
+
+    @staticmethod
+    def _text_in_payloads(text: str, payloads: list[dict]) -> bool:
+        """True if agent_text is duplicated inside a payload."""
+        if not text or not payloads:
+            return False
+        stripped = text.strip()
+        for payload in payloads:
+            for scenario in payload.get("scenarios", []):
+                if not isinstance(scenario, dict):
+                    continue
+                for resp in scenario.get("responses", []):
+                    if (
+                        isinstance(resp, dict)
+                        and resp.get("type") == "text"
+                        and resp.get("text", "").strip() == stripped
+                    ):
+                        return True
+            for group in payload.get("richContent", []):
+                if not isinstance(group, list):
+                    continue
+                for item in group:
+                    if not isinstance(item, dict):
+                        continue
+                    for field in ("title", "subtitle", "text"):
+                        if item.get(field, "").strip() == stripped:
+                            return True
+        return False
+
+    def _show_ended(self) -> None:
+        panel = Panel(
+            Text(f"Session ended after {len(self._session.turns)} turns."),
+            title="Session Ended",
+            border_style="red",
+        )
+        self._append_static(panel)
+        self.query_one("#user-input", Input).disabled = True
+
+    # ── Payload mounting ────────────────────────────────
+
+    def _mount_payload(self, container, payload: dict) -> None:
+        if "richContent" in payload:
+            self._mount_rich_content(container, payload["richContent"])
+        elif "scenarios" in payload:
+            self._mount_scenarios(container, payload["scenarios"])
+        else:
+            container.mount(Static(
+                Panel(
+                    Text(json.dumps(payload, indent=2, default=str), style="dim"),
+                    title="Custom Payload",
+                    border_style="dim",
+                ),
+                classes="scenario-panel",
+            ))
+
+    def _mount_rich_content(self, container, content: list) -> None:
+        for group in content:
+            if not isinstance(group, list):
+                continue
+            for item in group:
+                if not isinstance(item, dict):
+                    continue
+                item_type = item.get("type", "")
+                if item_type == "chips":
+                    self._mount_chips(container, item.get("options", []))
+                elif item_type == "info":
+                    self._mount_info_card(container, item)
+
+    def _mount_chips(self, container, options: list) -> None:
+        if not options:
+            return
+        row = Horizontal(classes="chip-row")
+        container.mount(row)
+        for opt in options:
+            label = opt.get("text", "")
+            btn = Button(label, classes="chip-btn", variant="primary")
+            btn._chip_text = label
+            row.mount(btn)
+
+    def _mount_info_card(self, container, item: dict) -> None:
+        content = Text()
+        subtitle = item.get("subtitle", "")
+        if subtitle:
+            content.append(subtitle, style="bold")
+        body = item.get("text", "")
+        if body:
+            if subtitle:
+                content.append("\n\n")
+            content.append(body)
+        title = item.get("title", "")
+        container.mount(Static(
+            Panel(
+                content,
+                title=title or None,
+                title_align="left",
+                border_style="blue",
+                padding=(0, 1),
+            ),
+            classes="info-panel",
+        ))
+
+    def _mount_scenarios(self, container, scenarios: list) -> None:
+        for scenario in scenarios:
+            if not isinstance(scenario, dict):
+                continue
+            name = scenario.get("name", "")
+            responses = scenario.get("responses", [])
+            if not responses:
+                continue
+
+            text_content = Text()
+            buttons = []
+            for resp in responses:
+                if not isinstance(resp, dict):
+                    continue
+                if resp.get("type") == "text":
+                    t = resp.get("text", "")
+                    if t:
+                        if text_content.plain:
+                            text_content.append("\n")
+                        text_content.append(t)
+                elif resp.get("type") == "button":
+                    buttons.append(resp)
+
+            if text_content.plain:
+                container.mount(Static(
+                    Panel(
+                        text_content,
+                        title=name or None,
+                        title_align="left",
+                        border_style="dim cyan",
+                        padding=(0, 1),
+                    ),
+                    classes="scenario-panel",
+                ))
+
+            if buttons:
+                row = Horizontal(classes="chip-row")
+                container.mount(row)
+                for btn_data in buttons:
+                    btn_type = btn_data.get("buttonType", "")
+                    icon = _BUTTON_ICONS.get(btn_type, "▶")
+                    label = f"{icon} {btn_data.get('text', '')}"
+                    link = btn_data.get("link", "")
+                    event_data = btn_data.get("event", {})
+                    btn = Button(label, classes="link-btn")
+                    btn._chip_text = None
+                    btn._link = None
+                    btn._ces_event = None
+                    if event_data and event_data.get("name"):
+                        btn._ces_event = event_data
+                    elif link:
+                        btn._link = link
+                    else:
+                        btn._chip_text = btn_data.get("text", "")
+                    row.mount(btn)
+
+    # ── Slash commands ──────────────────────────────────
+
+    def _handle_slash(self, cmd: str) -> None:
+        parts = cmd.split(maxsplit=1)
+        command = parts[0].lower()
+        arg = parts[1] if len(parts) > 1 else ""
+
+        if command == "/quit":
+            self.exit()
+            return
+
+        if command == "/clear":
+            self.action_clear()
+            return
+
+        if command == "/help":
+            from cxas_scrapi.utils.chat_renderer import SLASH_COMMANDS
+            from rich.table import Table
+            table = Table(title="Commands", show_header=True)
+            table.add_column("Command", style="bold cyan")
+            table.add_column("Description")
+            for c, desc in SLASH_COMMANDS.items():
+                table.add_row(c, desc)
+            self._append_static(table, classes="slash-output")
+            return
+
+        if command == "/state":
+            state = self._session.get_state()
+            from rich.table import Table
+            table = Table(title="Session State", show_header=True)
+            table.add_column("Key", style="bold")
+            table.add_column("Value")
+            for key, value in state.items():
+                if isinstance(value, dict):
+                    display = json.dumps(value, indent=2, default=str)
+                else:
+                    display = str(value)
+                table.add_row(key, display)
+            self._append_static(table, classes="slash-output")
+            return
+
+        if command == "/slots":
+            if not self._session.turns:
+                self._append_static(
+                    Panel("Send a message first.", border_style="red"),
+                )
+                return
+            try:
+                from cxas_scrapi.utils.slot_inspector import SlotInspector
+                from cxas_scrapi.utils.chat_renderer import ChatRenderer
+                from io import StringIO
+                from rich.console import Console
+
+                sm = self._session.get_slot_machine()
+                if not sm:
+                    self._append_static(
+                        Panel("No slot machine state.", border_style="red"),
+                    )
+                    return
+                inspection = SlotInspector.inspect(sm)
+                flow_context = self._session.get_flow_context()
+                buf = StringIO()
+                c = Console(file=buf, force_terminal=True, width=100)
+                r = ChatRenderer(console=c)
+                cat = arg.strip() if arg.strip() else None
+                r.render_slots(inspection, category=cat, flow_context=flow_context)
+                self._append_static(
+                    Text.from_ansi(buf.getvalue()), classes="slash-output",
+                )
+            except Exception as e:
+                self._append_static(
+                    Panel(Text(str(e), style="bold white"), border_style="red"),
+                )
+            return
+
+        if command == "/log":
+            if not self._session.turns:
+                self._append_static(
+                    Panel("Send a message first.", border_style="red"),
+                )
+                return
+            try:
+                from cxas_scrapi.utils.chat_renderer import ChatRenderer
+                from io import StringIO
+                from rich.console import Console
+
+                sm = self._session.get_slot_machine()
+                if not sm:
+                    self._append_static(
+                        Panel("No slot machine state.", border_style="red"),
+                    )
+                    return
+                log_entries = sm.get("_log", [])
+                if not log_entries:
+                    self._append_static(
+                        Panel("No log entries.", border_style="dim"),
+                    )
+                    return
+                level = arg.strip().upper() if arg.strip() else "INFO"
+                buf = StringIO()
+                c = Console(file=buf, force_terminal=True, width=100)
+                r = ChatRenderer(console=c)
+                r.render_log(log_entries, min_level=level)
+                self._append_static(
+                    Text.from_ansi(buf.getvalue()), classes="slash-output",
+                )
+            except Exception as e:
+                self._append_static(
+                    Panel(Text(str(e), style="bold white"), border_style="red"),
+                )
+            return
+
+        if command == "/trace":
+            try:
+                fmt = arg.strip() if arg.strip() else "text"
+                trace_output = self._session.get_trace(fmt=fmt)
+                self._append_static(
+                    Text(trace_output), classes="slash-output",
+                )
+            except Exception as e:
+                self._append_static(
+                    Panel(Text(str(e), style="bold white"), border_style="red"),
+                )
+            return
+
+        self._append_static(
+            Panel(
+                Text(f"Unknown command: {command}. Type /help", style="bold white"),
+                border_style="red",
+            ),
+        )
+
+    # ── Actions ─────────────────────────────────────────
+
+    def action_clear(self) -> None:
+        self.query_one("#chat-log").remove_children()
+
+    def action_quit(self) -> None:
+        self.exit()

--- a/src/cxas_scrapi/cli/main.py
+++ b/src/cxas_scrapi/cli/main.py
@@ -48,6 +48,9 @@ from cxas_scrapi.cli.migration_cli import (
 from cxas_scrapi.cli.migration_cli import (
     register as register_dfcx_cxas_subparsers,
 )
+from cxas_scrapi.cli.chat_cli import register as register_chat_subparser
+from cxas_scrapi.cli.chat_step_cli import register as register_chat_step_subparser
+from cxas_scrapi.cli.slots_cli import register as register_slots_subparser
 from cxas_scrapi.cli.trace_cli import register as register_trace_subparser
 from cxas_scrapi.core.apps import Apps
 from cxas_scrapi.core.common import Common
@@ -1864,6 +1867,15 @@ def get_parser() -> argparse.ArgumentParser:
 
     # Subparsers for 'trace' — observability/debugging for past conversations.
     register_trace_subparser(subparsers)
+
+    # Subparsers for 'chat' — interactive chat with trace integration.
+    register_chat_subparser(subparsers)
+
+    # Subparsers for 'chat-step' — programmatic single-turn chat.
+    register_chat_step_subparser(subparsers)
+
+    # Subparsers for 'slots' — deep slot machine inspection.
+    register_slots_subparser(subparsers)
 
     return parser
 

--- a/src/cxas_scrapi/cli/slots_cli.py
+++ b/src/cxas_scrapi/cli/slots_cli.py
@@ -1,0 +1,81 @@
+"""CLI subcommands for deep slot machine inspection."""
+
+import argparse
+import json
+import sys
+from typing import Any
+
+from cxas_scrapi.core.traces import Traces
+from cxas_scrapi.utils.slot_inspector import SlotInspector
+
+
+def _build_traces(args: argparse.Namespace) -> Traces:
+    """Construct a Traces instance from CLI args."""
+    return Traces(app_name=args.app_name)
+
+
+def slots_inspect(args: argparse.Namespace) -> None:
+    """Handle `cxas slots inspect CONVERSATION_ID`."""
+    try:
+        traces = _build_traces(args)
+        normalized = traces.get_normalized(args.conversation_id)
+    except Exception as e:
+        print(f"Failed to fetch trace: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    result = SlotInspector.inspect_from_trace(
+        normalized, turn=getattr(args, "at_turn", None)
+    )
+
+    category = getattr(args, "category", None)
+    if category:
+        if category in result.get("categories", {}):
+            result = {
+                "summary": result["summary"],
+                "categories": {category: result["categories"][category]},
+                "slot_dag": result["slot_dag"],
+            }
+        else:
+            available = sorted(result.get("categories", {}).keys())
+            print(
+                f"Unknown category '{category}'. Available: {available}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    print(json.dumps(result, indent=2, default=str))
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:
+    """Register the `slots` subcommand with its sub-subcommands."""
+    p = subparsers.add_parser(
+        "slots",
+        help="Deep slot machine inspection.",
+        description="Inspect slot machine state from conversation traces.",
+    )
+    slots_sub = p.add_subparsers(
+        title="slots commands", dest="slots_command", required=True
+    )
+
+    p_inspect = slots_sub.add_parser(
+        "inspect",
+        help="Inspect slots from a conversation trace.",
+    )
+    p_inspect.add_argument(
+        "--app-name", required=True, help="Full CES app resource name."
+    )
+    p_inspect.add_argument(
+        "conversation_id", help="Conversation ID to inspect."
+    )
+    p_inspect.add_argument(
+        "--at-turn",
+        type=int,
+        default=None,
+        help="Inspect slot state at a specific turn number.",
+    )
+    p_inspect.add_argument(
+        "--category",
+        default=None,
+        help="Show only a specific category (e.g., core_data, configuration).",
+    )
+    p_inspect.set_defaults(func=slots_inspect)

--- a/src/cxas_scrapi/cli/trace_cli.py
+++ b/src/cxas_scrapi/cli/trace_cli.py
@@ -253,6 +253,82 @@ def trace_replay(args: argparse.Namespace) -> None:
         print(json.dumps(result, indent=2, default=str))
 
 
+# ---------------------------------- fork --------------------------------------
+
+
+def trace_fork(args: argparse.Namespace) -> None:
+    """Handles the `trace fork` command."""
+    try:
+        traces = _build_traces(args)
+        result = traces.fork(args.conversation_id, at_turn=args.at_turn)
+    except Exception as e:
+        print(f"Fork failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.format == "json":
+        print(json.dumps(result, indent=2, default=str))
+    else:
+        print(f"Forked conversation {args.conversation_id}")
+        print(f"  Loaded {result['turn_count']} turns")
+        if result["forked_at_turn"] is not None:
+            print(f"  Truncated at turn {result['forked_at_turn']}")
+        print(f"  {len(result['historical_contexts'])} context messages ready")
+        print(
+            f"\nUse with: cxas chat --app-name APP "
+            f"--fork {args.conversation_id}"
+        )
+
+
+# ---------------------------------- diff --------------------------------------
+
+
+def trace_diff(args: argparse.Namespace) -> None:
+    """Handles the `trace diff` command."""
+    try:
+        traces = _build_traces(args)
+        result = traces.diff(args.conversation_id_a, args.conversation_id_b)
+    except Exception as e:
+        print(f"Diff failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.format == "json":
+        print(json.dumps(result, indent=2, default=str))
+    elif args.format == "md":
+        s = result["summary"]
+        print("# Trace Diff\n")
+        print("| Metric | Value |")
+        print("|---|---|")
+        print(f"| Conversation A | `{result['conversation_a']}` |")
+        print(f"| Conversation B | `{result['conversation_b']}` |")
+        print(f"| Turns A / B | {s['total_turns_a']} / {s['total_turns_b']} |")
+        print(f"| Matching | {s['matching_turns']} |")
+        print(f"| Differing | {s['differing_turns']} |")
+        print()
+        if result["agent_text_diff"]:
+            print("## Agent Text Diff\n```diff")
+            print(result["agent_text_diff"])
+            print("```")
+        else:
+            print("## Agent Text Diff\n_(identical)_")
+    else:  # text
+        s = result["summary"]
+        print(
+            f"Comparing {result['conversation_a']} "
+            f"vs {result['conversation_b']}"
+        )
+        print(f"  Turns: {s['total_turns_a']} vs {s['total_turns_b']}")
+        print(
+            f"  Matching: {s['matching_turns']}, "
+            f"Differing: {s['differing_turns']}"
+        )
+        if result["agent_text_diff"]:
+            print("\n--- Agent text diff ---")
+            print(result["agent_text_diff"])
+        if result["tool_call_diff"]:
+            print("\n--- Tool call diff ---")
+            print(result["tool_call_diff"])
+
+
 # ---------------------------------- stats -----------------------------------
 
 
@@ -574,6 +650,40 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     )
     p_replay.add_argument("--format", choices=["md", "json"], default="md")
     p_replay.set_defaults(func=trace_replay, diff=True)
+
+    # fork
+    p_fork = trace_subparsers.add_parser(
+        "fork",
+        help=(
+            "Prepare historical context from an existing conversation "
+            "for a new chat."
+        ),
+    )
+    add_trace_args(p_fork)
+    p_fork.add_argument("conversation_id")
+    p_fork.add_argument(
+        "--at-turn",
+        type=int,
+        default=None,
+        help="Load only turns up to this index (inclusive).",
+    )
+    p_fork.add_argument(
+        "--format", choices=["json", "text"], default="text"
+    )
+    p_fork.set_defaults(func=trace_fork)
+
+    # diff
+    p_diff = trace_subparsers.add_parser(
+        "diff",
+        help="Compare two conversations turn-by-turn.",
+    )
+    add_trace_args(p_diff)
+    p_diff.add_argument("conversation_id_a")
+    p_diff.add_argument("conversation_id_b")
+    p_diff.add_argument(
+        "--format", choices=["json", "text", "md"], default="text"
+    )
+    p_diff.set_defaults(func=trace_diff)
 
     # stats
     p_stats = trace_subparsers.add_parser(

--- a/src/cxas_scrapi/core/__init__.py
+++ b/src/cxas_scrapi/core/__init__.py
@@ -15,5 +15,6 @@
 """Core module for CXAS Scrapi."""
 
 from .common import Common
+from .programmatic_chat import ProgrammaticChatDriver
 
-__all__ = ["Common"]
+__all__ = ["Common", "ProgrammaticChatDriver"]

--- a/src/cxas_scrapi/core/chat_session.py
+++ b/src/cxas_scrapi/core/chat_session.py
@@ -1,0 +1,329 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Interactive chat session with turn tracking and trace integration."""
+
+import logging
+from typing import Any
+
+from google.protobuf import json_format
+
+from cxas_scrapi.core.sessions import Modality, Sessions
+from cxas_scrapi.core.traces import Traces
+
+logger = logging.getLogger(__name__)
+
+
+class SessionEndedError(Exception):
+    """Raised when trying to send to an ended session."""
+
+    pass
+
+
+class TurnRecord:
+    """Immutable record of a single conversation turn."""
+
+    def __init__(
+        self, turn_index: int, user_text: str, response: dict[str, Any]
+    ):
+        self.turn_index = turn_index
+        self.user_text = user_text
+        self.agent_text: str = response.get("agent_text", "")
+        self.tool_calls: list[dict] = response.get("tool_calls", [])
+        self.tool_responses: list[dict] = response.get("tool_responses", [])
+        self.agent_transfer: Any = response.get("agent_transfer")
+        self.session_ended: bool = response.get("session_ended", False)
+        self.payloads: list[dict] = response.get("payloads", [])
+        self.raw_response: dict[str, Any] = response
+
+
+class ChatSession:
+    """Manages a live conversation with turn history and state tracking.
+
+    Usage:
+        session = ChatSession(app_name="projects/.../apps/...")
+        result = session.send("Hello")
+        result = session.send("I'd like a table for 4")
+        trace = session.get_trace()  # fetch trace for this session
+        session.close()
+    """
+
+    def __init__(
+        self,
+        app_name: str,
+        channel: str | None = None,
+        deployment_id: str | None = None,
+        historical_contexts: list[dict] | str | None = None,
+        turn_count: int | None = None,
+        session_id: str | None = None,
+        initial_turn_count: int = 0,
+        initial_variable_state: dict[str, Any] | None = None,
+        **session_kwargs: Any,
+    ):
+        self._app_name = app_name
+        self._channel = channel
+        self._deployment_id = deployment_id
+        self._historical_contexts = historical_contexts
+        self._turn_count = turn_count
+        self._initial_turn_count = initial_turn_count
+        self._session_kwargs = session_kwargs
+
+        self._sessions = Sessions(
+            app_name=app_name,
+            deployment_id=deployment_id,
+            **session_kwargs,
+        )
+        self._session_id = (
+            session_id
+            if session_id is not None
+            else self._sessions.create_session_id()
+        )
+        self._turns: list[TurnRecord] = []
+        self._variable_state: dict[str, Any] = dict(initial_variable_state) if initial_variable_state else {}
+        self._closed = False
+
+    @property
+    def session_id(self) -> str:
+        """The unique session ID for this conversation."""
+        return self._session_id
+
+    @property
+    def turns(self) -> list[TurnRecord]:
+        """All turns in this conversation so far."""
+        return list(self._turns)
+
+    @property
+    def is_ended(self) -> bool:
+        """Whether the session has ended (via agent or explicit close)."""
+        if self._closed:
+            return True
+        if self._turns and self._turns[-1].session_ended:
+            return True
+        return False
+
+    @property
+    def current_turn_index(self) -> int:
+        """The index that will be assigned to the next turn."""
+        return self._initial_turn_count + len(self._turns)
+
+    def send(self, text: str) -> TurnRecord:
+        """Send a message and return the turn record.
+
+        Raises SessionEndedError if session has already ended.
+        Uses self._sessions.run() + get_structured_response().
+        Tracks the turn in self._turns list.
+        If channel was set, injects {"event_data": {"channel": channel}}
+        as variables on the first turn only.
+        """
+        if self.is_ended:
+            raise SessionEndedError(
+                f"Session {self._session_id} has already ended."
+            )
+
+        turn_index = self.current_turn_index
+        variables = None
+        if self._channel and turn_index == 0:
+            variables = {"event_data": {"channel": self._channel}}
+
+        kwargs: dict[str, Any] = {
+            "session_id": self._session_id,
+            "text": text,
+            "modality": Modality.TEXT,
+        }
+        if variables is not None:
+            kwargs["variables"] = variables
+        if self._historical_contexts is not None and turn_index == 0:
+            kwargs["historical_contexts"] = self._historical_contexts
+        if self._turn_count is not None and turn_index == 0:
+            kwargs["turn_count"] = self._turn_count
+
+        raw_response = self._sessions.run(**kwargs)
+        structured = self._sessions.get_structured_response(raw_response)
+
+        for var_dict in structured.get("variable_updates", []):
+            if isinstance(var_dict, dict):
+                self._variable_state.update(var_dict)
+
+        turn = TurnRecord(
+            turn_index=turn_index,
+            user_text=text,
+            response=structured,
+        )
+        self._turns.append(turn)
+        return turn
+
+    def send_event(
+        self,
+        event_name: str,
+        event_vars: dict[str, Any] | None = None,
+    ) -> TurnRecord:
+        """Fire a CES event and return the turn record."""
+        if self.is_ended:
+            raise SessionEndedError(
+                f"Session {self._session_id} has already ended."
+            )
+
+        turn_index = self.current_turn_index
+        raw_response = self._sessions.run(
+            session_id=self._session_id,
+            event=event_name,
+            event_vars=event_vars,
+        )
+        structured = self._sessions.get_structured_response(raw_response)
+
+        for var_dict in structured.get("variable_updates", []):
+            if isinstance(var_dict, dict):
+                self._variable_state.update(var_dict)
+
+        turn = TurnRecord(
+            turn_index=turn_index,
+            user_text=f"[event: {event_name}]",
+            response=structured,
+        )
+        self._turns.append(turn)
+        return turn
+
+    def get_state(self) -> dict[str, Any]:
+        """Extract current variable/slot state from the turn history.
+
+        Returns dict with keys:
+        - "active_agent": str | None (from last agent_transfer or initial)
+        - "slot_machine": dict (from accumulated variable updates)
+        - "filled_slots": dict (from sm.filled)
+        - "session_ended": bool
+        - "turn_count": int
+        - "pending_transfer": str | None
+        """
+        state: dict[str, Any] = {
+            "active_agent": None,
+            "slot_machine": {},
+            "filled_slots": {},
+            "session_ended": False,
+            "turn_count": len(self._turns),
+            "pending_transfer": None,
+        }
+
+        for turn in self._turns:
+            if turn.agent_transfer:
+                target = turn.agent_transfer
+                if hasattr(target, "display_name"):
+                    state["active_agent"] = target.display_name
+                elif isinstance(target, dict):
+                    state["active_agent"] = target.get(
+                        "display_name", target.get("target_agent")
+                    )
+                else:
+                    state["active_agent"] = str(target)
+                state["pending_transfer"] = state["active_agent"]
+
+            if turn.session_ended:
+                state["session_ended"] = True
+
+        sm = self.get_slot_machine()
+        if sm:
+            state["slot_machine"] = sm
+            filled = sm.get("filled", {})
+            if isinstance(filled, dict):
+                state["filled_slots"] = filled
+
+        return state
+
+    def get_trace(self, fmt: str = "json") -> str:
+        """Fetch the full trace report for this session's conversation.
+
+        Creates a Traces instance and calls get_report().
+        The conversation_id is the session_id.
+        """
+        traces = Traces(
+            app_name=self._app_name, **self._session_kwargs
+        )
+        return traces.get_report(self._session_id, fmt=fmt)
+
+    def get_normalized_trace(self) -> dict[str, Any]:
+        """Fetch the normalized trace dict for this session."""
+        traces = Traces(
+            app_name=self._app_name, **self._session_kwargs
+        )
+        return traces.get_normalized(self._session_id)
+
+    def get_slot_machine(self) -> dict[str, Any]:
+        """Get slot_machine state from accumulated session variables.
+
+        Checks both 'sm' and 'slot_machine' keys since agents use
+        either name for the slot machine variable.
+        """
+        for key in ("sm", "slot_machine"):
+            val = self._variable_state.get(key)
+            if isinstance(val, dict) and val:
+                return val
+        return {}
+
+    def get_flow_context(self) -> dict[str, Any]:
+        """Get multi-flow context from top-level session variables.
+
+        Returns dict with:
+        - active_config_id: currently active flow config
+        - agent_config_map: {agent_name: config_id} for all flows
+        - active_sm_key: which variable key holds the active sm
+        """
+        agent_map = self._variable_state.get("agent_config_map", "")
+        if isinstance(agent_map, str) and agent_map:
+            try:
+                import json
+                agent_map = json.loads(agent_map)
+            except (ValueError, TypeError):
+                agent_map = {}
+
+        return {
+            "active_config_id": self._variable_state.get(
+                "_active_config_id"
+            ),
+            "agent_config_map": agent_map if isinstance(agent_map, dict) else {},
+            "active_sm_key": self._variable_state.get("_active_sm_key"),
+        }
+
+    def export_turns_summary(self) -> list[dict[str, Any]]:
+        """Export turns as a list of dicts for scripting/comparison.
+
+        Each dict: {"turn": int, "user": str, "agent": str,
+                     "tool_calls": [...], "transfer": str|None}
+        """
+        summaries = []
+        for turn in self._turns:
+            transfer = None
+            if turn.agent_transfer:
+                if hasattr(turn.agent_transfer, "display_name"):
+                    transfer = turn.agent_transfer.display_name
+                elif isinstance(turn.agent_transfer, dict):
+                    transfer = turn.agent_transfer.get(
+                        "display_name",
+                        turn.agent_transfer.get("target_agent"),
+                    )
+                else:
+                    transfer = str(turn.agent_transfer)
+
+            summaries.append(
+                {
+                    "turn": turn.turn_index,
+                    "user": turn.user_text,
+                    "agent": turn.agent_text,
+                    "tool_calls": turn.tool_calls,
+                    "transfer": transfer,
+                }
+            )
+        return summaries
+
+    def close(self) -> None:
+        """Mark session as closed. Idempotent."""
+        self._closed = True

--- a/src/cxas_scrapi/core/programmatic_chat.py
+++ b/src/cxas_scrapi/core/programmatic_chat.py
@@ -1,0 +1,221 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Programmatic turn-by-turn chat driver with JSON-serializable output."""
+
+from typing import Any
+
+from cxas_scrapi.core.chat_session import ChatSession
+
+
+class ProgrammaticChatDriver:
+    """Drives a ChatSession programmatically.
+
+    Returns JSON-serializable dicts per turn.
+
+    Usage:
+        driver = ProgrammaticChatDriver(
+            app_name="projects/.../apps/..."
+        )
+        result = driver.step("Hello")
+        print(json.dumps(result, indent=2))
+        result = driver.step("Table for 4")
+        driver.close()
+    """
+
+    def __init__(
+        self,
+        app_name: str,
+        channel: str | None = None,
+        deployment_id: str | None = None,
+        include_trace: bool = False,
+        include_metrics: bool = False,
+        historical_contexts: list[dict] | str | None = None,
+        session_id: str | None = None,
+        initial_turn_count: int = 0,
+        initial_variable_state: dict | None = None,
+        **session_kwargs: Any,
+    ):
+        self._session = ChatSession(
+            app_name=app_name,
+            channel=channel,
+            deployment_id=deployment_id,
+            historical_contexts=historical_contexts,
+            session_id=session_id,
+            initial_turn_count=initial_turn_count,
+            initial_variable_state=initial_variable_state,
+            **session_kwargs,
+        )
+        self._include_raw_trace = include_trace
+        self._include_metrics = include_metrics
+
+    @property
+    def session_id(self) -> str:
+        return self._session.session_id
+
+    @property
+    def is_ended(self) -> bool:
+        return self._session.is_ended
+
+    def step(self, text: str) -> dict[str, Any]:
+        """Send one message, return a JSON-serializable dict."""
+        turn = self._session.send(text)
+        state = self._session.get_state()
+
+        result: dict[str, Any] = {
+            "turn_index": turn.turn_index,
+            "user_text": turn.user_text,
+            "agent_text": turn.agent_text,
+            "tool_calls": turn.tool_calls,
+            "tool_responses": turn.tool_responses,
+            "agent_transfer": self._serialize_transfer(turn.agent_transfer),
+            "session_ended": turn.session_ended,
+            "state": state,
+            "session_id": self._session.session_id,
+            "trace": None,
+            "metrics": None,
+        }
+        if turn.payloads:
+            result["payloads"] = turn.payloads
+
+        try:
+            normalized = self._session.get_normalized_trace()
+            self._enrich_from_trace(result, normalized, turn.turn_index)
+            if self._include_raw_trace:
+                result["trace"] = normalized
+            if self._include_metrics:
+                turn_metrics = normalized.get("turn_metrics", [])
+                if turn.turn_index < len(turn_metrics):
+                    result["metrics"] = turn_metrics[turn.turn_index]
+        except Exception as e:
+            if self._include_raw_trace:
+                result["trace"] = {"error": str(e)}
+
+        return result
+
+    def get_full_state(self) -> dict[str, Any]:
+        """Return current state with optional deep slot inspection."""
+        state = self._session.get_state()
+        try:
+            from cxas_scrapi.utils.slot_inspector import SlotInspector
+            sm = state.get("slot_machine")
+            if sm and isinstance(sm, dict):
+                state["slot_inspection"] = SlotInspector.inspect(sm)
+        except ImportError:
+            pass
+        return state
+
+    def get_sm_log(self, min_level: str = "INFO") -> list[dict[str, Any]]:
+        """Return slot machine log entries at or above *min_level*."""
+        sm = self._session.get_slot_machine()
+        if not sm:
+            return []
+        log = sm.get("_log", [])
+        level_order = {"DEBUG": 0, "INFO": 1, "WARN": 2, "ERROR": 3}
+        min_ord = level_order.get(min_level.upper(), 1)
+        return [
+            e for e in log
+            if level_order.get(e.get("level", "INFO").upper(), 1) >= min_ord
+        ]
+
+    def get_flow_context(self) -> dict[str, Any]:
+        """Return the multi-flow context from the session."""
+        return self._session.get_flow_context()
+
+    def get_trace_report(self, fmt: str = "json") -> str:
+        """Return the trace report for this session."""
+        return self._session.get_trace(fmt=fmt)
+
+    def get_turns_summary(self) -> list[dict[str, Any]]:
+        """Return a concise summary of every turn."""
+        return self._session.export_turns_summary()
+
+    def report_bug(self, reason: str) -> dict[str, Any]:
+        """File a bug report against this conversation."""
+        from cxas_scrapi.core.traces import Traces
+        traces = Traces(app_name=self._session._app_name)
+        return traces.report_bug(
+            conversation_id=self._session.session_id,
+            reason=reason,
+        )
+
+    @staticmethod
+    def _enrich_from_trace(
+        result: dict[str, Any],
+        trace: dict[str, Any],
+        turn_index: int,
+    ) -> None:
+        """Rebuild tool_calls and tool_responses from the trace.
+
+        The CES API returns empty diagnostic_info chunks for tool calls
+        during multi-agent turns, so the structured response misses them.
+        The trace is the authoritative source.
+
+        The trace numbers exchanges with its own cumulative ``turn`` field,
+        which can drift from the session's ``turn_index`` (CES
+        ``state.turn_count`` does not increment in lockstep across a
+        multi-turn ``--session-file`` conversation, especially after agent
+        transfers). A single ``send()`` always produces the latest trace
+        turn, so we anchor on the maximum ``turn`` present rather than
+        trusting the passed ``turn_index`` — otherwise enrichment surfaces
+        tool calls from an earlier exchange.
+        """
+        entries = trace.get("entries", []) or []
+        turns = [
+            e.get("turn") for e in entries
+            if isinstance(e, dict) and isinstance(e.get("turn"), int)
+        ]
+        target_turn = max(turns) if turns else turn_index
+        tool_calls = []
+        tool_responses = []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            if entry.get("turn") != target_turn:
+                continue
+            kind = entry.get("kind")
+            if kind == "tool_call":
+                tool_calls.append({
+                    "action": entry.get("tool", ""),
+                    "args": entry.get("args", {}),
+                    "agent": entry.get("agent", ""),
+                })
+            elif kind == "tool_response":
+                tool_responses.append({
+                    "action": entry.get("tool", ""),
+                    "response": entry.get("response", {}),
+                    "agent": entry.get("agent", ""),
+                })
+        if tool_calls:
+            result["tool_calls"] = tool_calls
+        if tool_responses:
+            result["tool_responses"] = tool_responses
+
+    @staticmethod
+    def _serialize_transfer(agent_transfer: Any) -> str | None:
+        """Convert agent_transfer to a JSON-serializable string."""
+        if agent_transfer is None:
+            return None
+        if isinstance(agent_transfer, dict):
+            return agent_transfer.get(
+                "display_name",
+                agent_transfer.get("target_agent"),
+            )
+        if hasattr(agent_transfer, "display_name"):
+            return agent_transfer.display_name
+        return str(agent_transfer)
+
+    def close(self) -> None:
+        """Close the underlying session."""
+        self._session.close()

--- a/src/cxas_scrapi/core/sessions.py
+++ b/src/cxas_scrapi/core/sessions.py
@@ -709,6 +709,28 @@ class Sessions(Common):
                     agent_transfer = actions.transfer_to_agent
         return agent_transfer, session_ended
 
+    @staticmethod
+    def _extract_variable_updates(
+        output: Any, variable_updates: list[Dict[str, Any]]
+    ) -> None:
+        """Extract default_variables and updated_variables from diagnostic info chunks."""
+        diagnostic_info = getattr(output, "diagnostic_info", None)
+        if not diagnostic_info or not hasattr(diagnostic_info, "messages"):
+            return
+        for message in diagnostic_info.messages:
+            for chunk in getattr(message, "chunks", []):
+                chunk_type = (
+                    chunk._pb.WhichOneof("data")
+                    if hasattr(chunk, "_pb")
+                    else None
+                )
+                if chunk_type in ("default_variables", "updated_variables"):
+                    raw = getattr(chunk, chunk_type, None)
+                    if raw is not None:
+                        variable_updates.append(
+                            Sessions._expand_pb_struct(raw)
+                        )
+
     def get_structured_response(self, response) -> Dict[str, Any]:
         """Parse response, avoiding duplicate text from diagnostic info.
 
@@ -718,15 +740,25 @@ class Sessions(Common):
         - tool_responses: List of tool responses received.
         - agent_transfer: Target agent if a transfer occurred.
         - session_ended: Boolean indicating if session ended.
+        - variable_updates: List of variable dicts from diagnostic info.
+        - payloads: List of custom payload dicts from outputs.
         """
-        agent_texts = []
+        agent_texts_seen: set[str] = set()
+        agent_texts: list[str] = []
         tool_calls = []
+        variable_updates = []
+        payloads = []
         agent_transfer = None
         session_ended = False
 
         for output in response.outputs:
-            if hasattr(output, "text") and output.text:
-                agent_texts.append(output.text)
+            payload = getattr(output, "payload", None)
+            if payload:
+                payloads.append(Sessions._expand_pb_struct(payload))
+            elif hasattr(output, "text") and output.text:
+                if output.text not in agent_texts_seen:
+                    agent_texts.append(output.text)
+                    agent_texts_seen.add(output.text)
 
             session_ended = self._process_output_tool_calls(
                 output, tool_calls, session_ended
@@ -734,10 +766,11 @@ class Sessions(Common):
             agent_transfer, session_ended = self._process_diagnostic_info(
                 output, tool_calls, agent_transfer, session_ended
             )
+            self._extract_variable_updates(output, variable_updates)
 
         agent_text = " ".join(agent_texts).strip() if agent_texts else ""
 
-        return {
+        result = {
             "agent_text": agent_text,
             "tool_calls": [
                 t
@@ -749,7 +782,11 @@ class Sessions(Common):
             ],
             "agent_transfer": agent_transfer,
             "session_ended": session_ended,
+            "variable_updates": variable_updates,
         }
+        if payloads:
+            result["payloads"] = payloads
+        return result
 
     def async_bidi_run_session(
         self, config: dict, inputs: list[dict[str, Any]]

--- a/src/cxas_scrapi/core/traces.py
+++ b/src/cxas_scrapi/core/traces.py
@@ -475,11 +475,18 @@ class Traces(Common):
         self,
         conversation_id: str,
         diff: bool = True,
+        interactive: bool = False,
+        on_turn: "callable | None" = None,
     ) -> dict[str, Any]:
         """Re-runs original user inputs against the current agent.
 
         Returns `{"original": [...], "replay": [...], "diff": "..."}`. The
         diff is a unified diff of the agent text per turn.
+
+        If *interactive* is True and *on_turn* is provided, the callback is
+        invoked after each replayed turn with ``(turn_index,
+        original_agent_text, replayed_agent_text)``.  If it returns a
+        non-None value the replay is marked as diverged at that turn.
         """
         normalized = self.get_normalized(conversation_id)
         user_turns = [
@@ -493,7 +500,13 @@ class Traces(Common):
 
         original_agents = _agent_text_per_turn(normalized)
         replay_agents: list[str] = []
-        for ut in user_turns:
+        result: dict[str, Any] = {
+            "conversation_id": conversation_id,
+            "original": original_agents,
+            "replay": replay_agents,
+            "diverged_at": None,
+        }
+        for i, ut in enumerate(user_turns):
             try:
                 response = sess.run(
                     session_id=session_id,
@@ -505,11 +518,17 @@ class Traces(Common):
             except Exception as e:
                 replay_agents.append(f"<replay error: {e}>")
 
-        result: dict[str, Any] = {
-            "conversation_id": conversation_id,
-            "original": original_agents,
-            "replay": replay_agents,
-        }
+            if interactive and on_turn is not None:
+                override = on_turn(
+                    i,
+                    original_agents[i] if i < len(original_agents) else "",
+                    replay_agents[-1],
+                )
+                if override is not None:
+                    # User wants to diverge - record the divergence point
+                    if result["diverged_at"] is None:
+                        result["diverged_at"] = i
+
         if diff:
             result["diff"] = "\n".join(
                 difflib.unified_diff(
@@ -521,6 +540,120 @@ class Traces(Common):
                 )
             )
         return result
+
+    def fork(
+        self,
+        conversation_id: str,
+        at_turn: int | None = None,
+    ) -> dict[str, Any]:
+        """Prepare historical_contexts for forking from an existing conversation.
+
+        Fetches the conversation, extracts message dicts (role + chunks) from
+        each turn up to `at_turn` (inclusive). Returns a dict with the
+        historical_contexts list ready for Sessions.run().
+        """
+        conv = self.history.get_conversation(conversation_id)
+        conv_dict = (
+            type(conv).to_dict(conv) if not isinstance(conv, dict) else conv
+        )
+        turns = conv_dict.get("turns", [])
+        if at_turn is not None:
+            turns = turns[: at_turn + 1]
+
+        contexts = []
+        for turn in turns:
+            for msg in turn.get("messages", []):
+                if "role" in msg and "chunks" in msg:
+                    contexts.append(
+                        {"role": msg["role"], "chunks": msg["chunks"]}
+                    )
+
+        return {
+            "historical_contexts": contexts,
+            "turn_count": len(turns),
+            "original_conversation_id": conversation_id,
+            "forked_at_turn": at_turn,
+        }
+
+    def diff(
+        self,
+        conversation_id_a: str,
+        conversation_id_b: str,
+        context_lines: int = 3,
+    ) -> dict[str, Any]:
+        """Compare two conversations turn-by-turn.
+
+        Builds per-turn comparison of agent text and tool call sequences,
+        plus unified diffs.
+        """
+        norm_a = self.get_normalized(conversation_id_a)
+        norm_b = self.get_normalized(conversation_id_b)
+
+        agents_a = _agent_text_per_turn(norm_a)
+        agents_b = _agent_text_per_turn(norm_b)
+
+        tools_a = _tool_calls_per_turn(norm_a)
+        tools_b = _tool_calls_per_turn(norm_b)
+
+        max_turns = max(len(agents_a), len(agents_b))
+        turn_comparison = []
+        matching = 0
+        for i in range(max_turns):
+            a_text = agents_a[i] if i < len(agents_a) else ""
+            b_text = agents_b[i] if i < len(agents_b) else ""
+            a_tools = tools_a[i] if i < len(tools_a) else []
+            b_tools = tools_b[i] if i < len(tools_b) else []
+            text_match = a_text.strip() == b_text.strip()
+            tools_match = a_tools == b_tools
+            if text_match and tools_match:
+                matching += 1
+            turn_comparison.append(
+                {
+                    "turn": i,
+                    "a_agent": a_text,
+                    "b_agent": b_text,
+                    "a_tools": a_tools,
+                    "b_tools": b_tools,
+                    "text_match": text_match,
+                    "tools_match": tools_match,
+                }
+            )
+
+        agent_diff = "\n".join(
+            difflib.unified_diff(
+                agents_a,
+                agents_b,
+                fromfile=conversation_id_a,
+                tofile=conversation_id_b,
+                lineterm="",
+                n=context_lines,
+            )
+        )
+
+        tool_diff = "\n".join(
+            difflib.unified_diff(
+                [str(t) for t in tools_a],
+                [str(t) for t in tools_b],
+                fromfile=f"{conversation_id_a} (tools)",
+                tofile=f"{conversation_id_b} (tools)",
+                lineterm="",
+                n=context_lines,
+            )
+        )
+
+        return {
+            "conversation_a": conversation_id_a,
+            "conversation_b": conversation_id_b,
+            "agent_text_diff": agent_diff,
+            "tool_call_diff": tool_diff,
+            "turn_comparison": turn_comparison,
+            "summary": {
+                "total_turns_a": len(agents_a),
+                "total_turns_b": len(agents_b),
+                "matching_turns": matching,
+                "differing_turns": max_turns - matching,
+            },
+        }
 
     # ------------------------------ stats -----------------------------------
 
@@ -868,6 +1001,18 @@ def _agent_text_per_turn(normalized: dict[str, Any]) -> list[str]:
         if e["kind"] == "agent" and e.get("text"):
             by_turn.setdefault(e.get("turn", 0), []).append(e["text"])
     return [" ".join(by_turn[k]) for k in sorted(by_turn.keys())]
+
+
+def _tool_calls_per_turn(normalized: dict[str, Any]) -> list[list[str]]:
+    """Extracts tool call names grouped by turn."""
+    by_turn: dict[int, list[str]] = {}
+    for e in normalized.get("entries", []):
+        if e["kind"] == "tool_call" and e.get("tool"):
+            by_turn.setdefault(e.get("turn", 0), []).append(e["tool"])
+    if not by_turn:
+        return []
+    max_turn = max(by_turn.keys())
+    return [by_turn.get(i, []) for i in range(max_turn + 1)]
 
 
 def _git_sha() -> str | None:

--- a/src/cxas_scrapi/utils/chat_renderer.py
+++ b/src/cxas_scrapi/utils/chat_renderer.py
@@ -1,0 +1,1480 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rich-based terminal renderer for interactive chat sessions.
+
+Uses the same visual language as cxas trace HTML/text output:
+- User messages: blue background
+- Agent messages: green background
+- Tool calls: red/dark with collapsible args
+- Transfers: cyan
+- Variables: gold/yellow
+"""
+
+import json
+from typing import Any
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.rule import Rule
+from rich.table import Table
+from rich.text import Text
+
+from cxas_scrapi.core.chat_session import TurnRecord
+
+# Slash commands available during interactive chat sessions.
+SLASH_COMMANDS = {
+    "/help": "Show available commands",
+    "/trace": "Fetch and display the trace for this session",
+    "/state": "Show current variable/slot state",
+    "/slots": "Deep slot machine inspection (phase, DAG, all fields)",
+    "/slots <category>": "Show one category (e.g., core_data, configuration)",
+    "/slots flows": "List all flows with status (active/suspended/idle)",
+    "/slots flow:<name>": "Inspect saved slots in a suspended flow",
+    "/spans": "Show execution spans for the last turn",
+    "/bug <reason>": "Bundle this conversation as a bug report",
+    "/save <path>": "Export the conversation to a file",
+    "/clear": "Clear the terminal",
+    "/quit": "End the session",
+}
+
+
+# ---------------------------------------------------------------------------
+# /log timeline constants
+# ---------------------------------------------------------------------------
+
+TAG_PHASE: dict[str, str] = {
+    # init
+    "config_loaded": "init",
+    "config_registered": "init",
+    "dag_initialized": "init",
+    # flow
+    "bootstrap_stored": "flow",
+    "bootstrap_transfer": "flow",
+    "transfer_dispatched": "flow",
+    "flow_state_saved": "flow",
+    "flow_state_restored": "flow",
+    "flow_deferred": "flow",
+    "flow_resumed": "flow",
+    "cancel_flow": "flow",
+    "cancel_requested": "flow",
+    # collection
+    "invoke": "collection",
+    "progress": "collection",
+    "auto_confirm": "collection",
+    "auto_confirm_inline": "collection",
+    "readback_transition": "collection",
+    "deferred_transition": "collection",
+    "skip_deferred": "collection",
+    # setter
+    "setter_stored": "setter",
+    "multi_setter_stored": "setter",
+    "event_prefill": "setter",
+    "announce_stored": "setter",
+    # validation
+    "slot_error": "validation",
+    "slot_error_retry": "validation",
+    "slot_error_exhaust": "validation",
+    "slot_validated": "validation",
+    "validate_against_fail": "validation",
+    "validate_against_pass": "validation",
+    # task
+    "task": "task",
+    "task_dispatched": "task",
+    "task_completed": "task",
+    "task_failed": "task",
+    "task_retry": "task",
+    "task_exhaust": "task",
+    # steer
+    "steer_back_soft": "steer",
+    "steer_back_hard": "steer",
+    "steer_back_escalate": "steer",
+    "steer_back_reset": "steer",
+    "progress_turns": "steer",
+    # correction
+    "correction_pending": "correction",
+    "correction_applied": "correction",
+    "correction_cleared": "correction",
+    "post_correction_readback": "correction",
+    "rejection_snapshot": "correction",
+    # deferred
+    "deferred_slot": "deferred",
+    "deferred_restored": "deferred",
+    "auto_resume_deferred": "deferred",
+    # preempt
+    "preempt": "preempt",
+    "preempt_payload": "preempt",
+    "preempt_response": "preempt",
+    # zombie
+    "zombie_created": "zombie",
+    "zombie_reaped_on_reentry": "zombie",
+}
+
+PHASE_STYLE: dict[str, str] = {
+    "init": "blue",
+    "flow": "magenta",
+    "collection": "green",
+    "setter": "green",
+    "validation": "red",
+    "task": "cyan",
+    "steer": "yellow",
+    "correction": "magenta",
+    "deferred": "blue",
+    "preempt": "dim",
+    "zombie": "red",
+}
+
+LEVEL_ORDER: dict[str, int] = {"DEBUG": 0, "INFO": 1, "WARN": 2, "ERROR": 3}
+
+LEVEL_MARKER: dict[str, tuple[str, str]] = {
+    "DEBUG": (" ", "dim"),
+    "INFO": ("·", ""),
+    "WARN": ("⚠", "yellow"),
+    "ERROR": ("✗", "bold red"),
+}
+
+_TIMELINE_EVENTS: dict[str, tuple[str, str, str]] = {
+    # Flow lifecycle
+    "config_loaded": ("FLOW", "▶", "magenta"),
+    "bootstrap_stored": ("FLOW", "▶", "magenta"),
+    "bootstrap_transfer": ("FLOW", "▶", "magenta"),
+    "flow_state_saved": ("FLOW", "▶", "magenta"),
+    "flow_state_restored": ("FLOW", "▶", "magenta"),
+    "cancel_flow_called": ("FLOW", "▶", "magenta"),
+    # Slot collection
+    "setter_stored": ("SET", "→", "green"),
+    "multi_setter_stored": ("SET", "→", "green"),
+    "event_prefill": ("SET", "→", "green"),
+    # Confirmation
+    "auto_confirm": ("CONFIRM", "✓", "cyan"),
+    "auto_confirm_inline": ("CONFIRM", "✓", "cyan"),
+    "progress": ("PROGRESS", "→", "green"),
+    # Tasks
+    "task_completed": ("TASK", "⚙", "cyan"),
+    "task_retry": ("TASK", "⚙", "yellow"),
+    "task_exhaust": ("TASK", "⚙", "red"),
+    # Corrections
+    "correction_applied": ("CORRECT", "↻", "yellow"),
+    "slot_correction_pending": ("CORRECT", "↻", "yellow"),
+    # Errors
+    "slot_error": ("ERROR", "✗", "red"),
+    "slot_error_exhaust": ("ERROR", "✗", "bold red"),
+    "validation_failed": ("ERROR", "✗", "red"),
+    # Steer-back
+    "steer_back_soft": ("STEER", "⚠", "yellow"),
+    "steer_back_hard": ("STEER", "⚠", "yellow"),
+    "steer_back_escalate": ("STEER", "⚠", "bold red"),
+    # Zombie lifecycle
+    "zombie_created": ("ZOMBIE", "💀", "red"),
+    "zombie_reaped_on_reentry": ("ZOMBIE", "♻", "green"),
+}
+
+_DEDUP_TAGS = frozenset({
+    "config_loaded", "bootstrap_transfer",
+})
+
+
+def _trunc(s: str, n: int) -> str:
+    """Return *s* truncated to *n* chars with an ellipsis if needed."""
+    return s[:n] + "…" if len(s) > n else s
+
+
+def _format_log_detail(tag: str, data: dict) -> str:
+    """Return a compact detail string for a log entry based on its tag."""
+    if not data:
+        return ""
+
+    if tag == "invoke":
+        return (
+            f"#{data.get('n', '')} {data.get('phase', '')}  "
+            f"filled={data.get('filled', 0)} asking={data.get('asking', '')}"
+        )
+
+    if tag in ("setter_stored", "announce_stored", "event_prefill",
+               "bootstrap_stored"):
+        return (
+            f"{data.get('slot', '')} = "
+            f"'{_trunc(str(data.get('value', '')), 50)}'"
+        )
+
+    if tag == "multi_setter_stored":
+        stored = data.get("stored", {})
+        return ", ".join(f"{k}={v}" for k, v in stored.items())
+
+    if tag in ("task", "task_dispatched"):
+        return f"{data.get('name', '')}"
+
+    if tag == "task_completed":
+        return f"{data.get('name', '')} ✓"
+
+    if tag in ("task_failed", "task_exhaust"):
+        return f"{data.get('name', '')} ✗"
+
+    if tag == "task_retry":
+        return f"{data.get('name', '')} retry #{data.get('attempt', '')}"
+
+    if tag in ("bootstrap_transfer", "transfer_dispatched"):
+        return f"-> {data.get('agent', '')}"
+
+    if tag in ("flow_state_saved", "flow_state_restored"):
+        slots = data.get("slots", [])
+        if isinstance(slots, dict):
+            keys = sorted(slots.keys())[:5]
+        else:
+            keys = list(slots)[:5]
+        return f"flow={data.get('flow', '')} [{', '.join(keys)}]"
+
+    if tag in ("steer_back_soft", "steer_back_hard", "steer_back_escalate"):
+        return f"turns={data.get('turns', '')}"
+
+    if tag in ("slot_error", "slot_error_retry"):
+        return (
+            f"{data.get('slot', '')} code={data.get('code', '')} "
+            f"retries={data.get('retries', '')}"
+        )
+
+    if tag == "slot_error_exhaust":
+        return f"{data.get('slot', '')}"
+
+    if tag == "progress":
+        parts = []
+        confirmed = data.get("confirmed", [])
+        if confirmed:
+            parts.append(f"confirmed: {', '.join(confirmed)}")
+        pending = data.get("pending+", {})
+        if pending:
+            names = ", ".join(sorted(pending.keys()) if isinstance(pending, dict) else pending)
+            parts.append(f"pending: {names}")
+        task_out = data.get("task+", {})
+        if task_out:
+            names = ", ".join(sorted(task_out.keys()) if isinstance(task_out, dict) else task_out)
+            parts.append(f"task-filled: {names}")
+        rejected = data.get("rejected", [])
+        if rejected:
+            parts.append(f"rejected: {', '.join(rejected)}")
+        return " | ".join(parts) if parts else "no change"
+
+    if tag == "auto_confirm":
+        return f"\"{_trunc(str(data.get('text', '')), 50)}\""
+
+    if tag == "auto_confirm_inline":
+        return f"{', '.join(data.get('slots', []))}"
+
+    if tag == "correction_applied":
+        return (
+            f"{data.get('slot', '')} "
+            f"'{_trunc(str(data.get('old', '')), 20)}' -> "
+            f"'{_trunc(str(data.get('new', '')), 20)}'"
+        )
+
+    if tag == "config_loaded":
+        return (
+            f"{data.get('config_id', '')}  "
+            f"slots={data.get('slot_count', '')} "
+            f"tasks={data.get('task_count', '')}"
+        )
+
+    if tag == "zombie_created":
+        zombie = data.get("zombie", {})
+        parts = [f"task={data.get('task', '')}"]
+        if zombie.get("flow"):
+            parts.append(f"flow={zombie['flow']}")
+        exit_keys = list(zombie.get("exit_status", {}).keys())
+        if exit_keys:
+            parts.append(f"exit={','.join(exit_keys)}")
+        if zombie.get("transfer_to"):
+            parts.append(f"transfer→{zombie['transfer_to']}")
+        return " ".join(parts)
+
+    if tag == "zombie_reaped_on_reentry":
+        return (
+            f"gate={data.get('gate_slot', '')} "
+            f"val={_trunc(str(data.get('gate_val', '')), 30)}"
+        )
+
+    # Fallback: compact key=val for first 4 items
+    items = list(data.items())[:4]
+    return " ".join(f"{k}={v}" for k, v in items)
+
+
+def _timeline_detail(tag: str, data: dict) -> str:
+    """Return a human-readable detail string for a timeline event."""
+    if not data:
+        return ""
+
+    if tag == "config_loaded":
+        return f"Loaded {data.get('config_id', '')} ({data.get('n_slots', '')} slots, {data.get('n_tasks', '')} tasks)"
+    if tag == "bootstrap_stored":
+        return f"Set {data.get('slot', '')} = \"{_trunc(str(data.get('value', '')), 40)}\""
+    if tag == "bootstrap_transfer":
+        return f"Transfer → {data.get('target', data.get('agent', ''))}"
+    if tag == "flow_state_saved":
+        slots = data.get('slots', [])
+        names = sorted(slots.keys()) if isinstance(slots, dict) else list(slots)
+        label = ", ".join(names[:5])
+        if len(names) > 5:
+            label += f" (+{len(names) - 5})"
+        return f"Paused {data.get('flow', '')} — saved: {label}" if names else f"Paused {data.get('flow', '')}"
+    if tag == "flow_state_restored":
+        slots = data.get('slots', [])
+        names = sorted(slots.keys()) if isinstance(slots, dict) else list(slots)
+        label = ", ".join(names[:5])
+        if len(names) > 5:
+            label += f" (+{len(names) - 5})"
+        return f"Resumed {data.get('flow', '')} — restored: {label}" if names else f"Resumed {data.get('flow', '')}"
+    if tag == "cancel_flow_called":
+        return f"Cancelled: {data.get('reason', '')}"
+
+    if tag in ("setter_stored", "multi_setter_stored"):
+        return f"{data.get('slot', '')} = \"{_trunc(str(data.get('value', '')), 40)}\""
+    if tag == "event_prefill":
+        return f"{data.get('slot', '')} = \"{_trunc(str(data.get('value', '')), 40)}\" (pre-filled)"
+
+    if tag == "auto_confirm":
+        return f"User: \"{_trunc(str(data.get('user_msg', '')), 50)}\""
+    if tag == "auto_confirm_inline":
+        return ", ".join(data.get("committed", []))
+
+    if tag == "progress":
+        parts = []
+        confirmed = data.get("confirmed", [])
+        if confirmed:
+            parts.append(f"Confirmed: {', '.join(confirmed)}")
+        pending = data.get("pending+", {})
+        if pending:
+            names = sorted(pending.keys()) if isinstance(pending, dict) else list(pending)
+            parts.append(f"Pending: {', '.join(names)}")
+        task_out = data.get("task+", {})
+        if task_out:
+            names = sorted(task_out.keys()) if isinstance(task_out, dict) else list(task_out)
+            parts.append(f"Task-filled: {', '.join(names)}")
+        rejected = data.get("rejected", [])
+        if rejected:
+            parts.append(f"Rejected: {', '.join(rejected)}")
+        return " | ".join(parts) if parts else "State changed"
+
+    if tag == "task_completed":
+        mark = "✓" if data.get("success") else "✗"
+        return f"{data.get('task', '')} {mark}"
+    if tag == "task_retry":
+        return f"{data.get('name', '')} ↻ retry #{data.get('attempt', '')}"
+    if tag == "task_exhaust":
+        return f"{data.get('name', '')} ✗ exhausted"
+
+    if tag == "correction_applied":
+        return f"{data.get('slot', '')}: \"{_trunc(str(data.get('old', '')), 20)}\" → \"{_trunc(str(data.get('new', '')), 20)}\""
+    if tag == "slot_correction_pending":
+        return f"Pending: {data.get('slot', '')} = \"{_trunc(str(data.get('value', '')), 30)}\""
+
+    if tag == "slot_error":
+        return f"{data.get('slot', '')}: {data.get('code', '')} (retry {data.get('retries', '')})"
+    if tag == "slot_error_exhaust":
+        return f"{data.get('slot', '')} — retries exhausted"
+    if tag == "validation_failed":
+        return f"{data.get('slot', '')}: {data.get('code', '')}"
+
+    if tag == "steer_back_soft":
+        return f"Soft redirect (turn {data.get('turns', '')})"
+    if tag == "steer_back_hard":
+        return f"Hard redirect (turn {data.get('turns', '')})"
+    if tag == "steer_back_escalate":
+        return f"Escalated (turn {data.get('turns', '')})"
+
+    if tag == "zombie_created":
+        zombie = data.get("zombie", {})
+        flow = zombie.get("flow", "")
+        transfer = zombie.get("transfer_to", "")
+        parts = [f"Task '{data.get('task', '')}' → zombie"]
+        if flow:
+            parts[0] += f" (flow={flow})"
+        if transfer:
+            parts.append(f"transfer → {transfer}")
+        return ", ".join(parts)
+
+    if tag == "zombie_reaped_on_reentry":
+        gate = data.get("gate_slot", "")
+        val = _trunc(str(data.get("gate_val", "")), 30)
+        return f"Reaped → new flow via {gate}={val}"
+
+    # Fallback
+    items = list(data.items())[:4]
+    return " ".join(f"{k}={v}" for k, v in items)
+
+
+class ChatRenderer:
+    """Renders chat turns and state to the terminal using Rich."""
+
+    def __init__(
+        self,
+        console: Console | None = None,
+        verbose: bool = False,
+    ):
+        self.console = console or Console()
+        self.verbose = verbose
+
+    def render_session_start(
+        self, session_id: str, app_name: str,
+        display_name: str = "", config_path: str = "",
+    ) -> None:
+        """Print session header with ID and app name."""
+        content = Text()
+        content.append("Session: ", style="bold")
+        content.append(session_id, style="cyan")
+        content.append("\n")
+        content.append("App: ", style="bold")
+        if display_name and display_name != app_name:
+            content.append(display_name, style="cyan")
+            content.append(f"  ({app_name})", style="dim")
+        else:
+            content.append(app_name, style="dim")
+        if config_path:
+            content.append("\n")
+            content.append("Config: ", style="bold")
+            content.append(config_path, style="dim")
+        panel = Panel(
+            content,
+            title="Chat Session Started",
+            border_style="green",
+        )
+        self.console.print(panel)
+
+    def render_user_message(self, turn_index: int, text: str) -> None:
+        """Render a user message."""
+        label = Text(f"[Turn {turn_index}] You: ", style="bold blue")
+        label.append(text)
+        self.console.print(label)
+
+    def render_turn(self, turn: TurnRecord) -> None:
+        """Render a complete agent turn: text, tool calls, transfers.
+
+        In non-verbose mode: only agent text + transfers.
+        In verbose mode: tool calls with args, tool responses,
+        variable updates.
+        """
+        if turn.agent_text:
+            self.render_agent_text(turn.turn_index, turn.agent_text)
+
+        if turn.payloads:
+            self.render_payloads(turn.payloads)
+
+        if self.verbose:
+            for tc in turn.tool_calls:
+                tool_name = tc.get("action", tc.get("name", "unknown"))
+                args = tc.get("args", {})
+                self.render_tool_call(tool_name, args)
+
+            for tr in turn.tool_responses:
+                tool_name = tr.get("action", tr.get("name", "unknown"))
+                response = tr.get("response", {})
+                self.render_tool_response(tool_name, response)
+
+        if turn.agent_transfer:
+            target = turn.agent_transfer
+            if hasattr(target, "display_name"):
+                target_name = target.display_name
+            elif isinstance(target, dict):
+                target_name = target.get(
+                    "display_name", target.get("target_agent", str(target))
+                )
+            else:
+                target_name = str(target)
+            self.render_transfer(target_name)
+
+    def render_agent_text(
+        self, turn_index: int, text: str, role: str = ""
+    ) -> None:
+        """Render agent response text."""
+        title = f"Agent [Turn {turn_index}]"
+        if role:
+            title = f"{role} [Turn {turn_index}]"
+        panel = Panel(
+            Text(text),
+            title=title,
+            border_style="green",
+        )
+        self.console.print(panel)
+
+    def render_tool_call(self, tool_name: str, args: dict) -> None:
+        """Render a tool call (verbose mode only)."""
+        args_text = json.dumps(args, indent=2, default=str)
+        panel = Panel(
+            Text(args_text),
+            title=f"Tool Call: {tool_name}",
+            border_style="red",
+        )
+        self.console.print(panel)
+
+    def render_tool_response(
+        self, tool_name: str, response: dict
+    ) -> None:
+        """Render a tool response (verbose mode only)."""
+        resp_text = json.dumps(response, indent=2, default=str)
+        panel = Panel(
+            Text(resp_text),
+            title=f"Tool Response: {tool_name}",
+            border_style="yellow",
+        )
+        self.console.print(panel)
+
+    def render_transfer(self, target: str) -> None:
+        """Render an agent transfer."""
+        text = Text()
+        text.append("Transferred to: ", style="bold cyan")
+        text.append(target, style="cyan")
+        self.console.print(text)
+
+    def render_state(self, state: dict) -> None:
+        """Render the current session state as a Rich table/panel.
+
+        Used by /state slash command.
+        """
+        table = Table(title="Session State", show_header=True)
+        table.add_column("Key", style="bold")
+        table.add_column("Value")
+
+        for key, value in state.items():
+            if isinstance(value, dict):
+                display = json.dumps(value, indent=2, default=str)
+            else:
+                display = str(value)
+            table.add_row(key, display)
+
+        self.console.print(table)
+
+    def render_session_end(
+        self,
+        session_id: str,
+        turn_count: int,
+        trace_command: str,
+    ) -> None:
+        """Print session footer with summary and trace command hint."""
+        content = Text()
+        content.append("Session: ", style="bold")
+        content.append(session_id, style="cyan")
+        content.append("\n")
+        content.append("Turns: ", style="bold")
+        content.append(str(turn_count))
+        content.append("\n")
+        content.append("View trace: ", style="bold")
+        content.append(trace_command, style="dim")
+        panel = Panel(
+            content,
+            title="Session Ended",
+            border_style="red",
+        )
+        self.console.print(panel)
+
+    def render_metrics(
+        self,
+        duration_ms: float | None,
+        tokens: dict[str, Any] | None,
+        tool_count: int,
+    ) -> None:
+        """Render per-turn metrics inline (when --metrics flag is set)."""
+        parts = []
+        if duration_ms is not None:
+            parts.append(f"{duration_ms:.0f}ms")
+        if tokens:
+            parts.append(f"tokens={tokens}")
+        parts.append(f"tools={tool_count}")
+        metrics_text = Text(" | ".join(parts), style="dim")
+        self.console.print(metrics_text)
+
+    # Categories collapsed by default (shown only via /slots <category>).
+    # Key state from these is already surfaced in the Flags line.
+    _COLLAPSED_CATEGORIES = frozenset({
+        "configuration", "engine_control", "system_instruction",
+        "channel", "phase_state", "transfer", "steer_back",
+        "flow_context",
+    })
+
+    def render_slots(
+        self,
+        inspection: dict[str, Any],
+        category: str | None = None,
+        flow_context: dict[str, Any] | None = None,
+    ) -> None:
+        """Render deep slot inspection with focus on meaningful state."""
+        summary = inspection.get("summary", {})
+        dag = inspection.get("slot_dag", {})
+        categories = inspection.get("categories", {})
+
+        if category:
+            if category == "flows":
+                self._render_flow_list(summary, flow_context)
+                return
+            if category.startswith("flow:"):
+                flow_name = category[5:]
+                self._render_flow_detail(flow_name, summary, dag)
+                return
+            if category not in categories:
+                available = sorted(categories.keys())
+                self.render_error(
+                    f"Unknown category '{category}'. "
+                    f"Available: {', '.join(available)}, flows, flow:<name>"
+                )
+                return
+            self._render_category_detail(category, categories[category])
+            return
+
+        phase = summary.get("phase", "unknown")
+        phase_style = {
+            "collection": "bold green",
+            "fresh_readback": "bold yellow",
+            "awaiting_confirmation": "bold yellow",
+            "readback_transition": "bold yellow",
+            "deferred_transition": "bold blue",
+            "correction": "bold magenta",
+            "post_correction_readback": "bold magenta",
+            "complete": "bold cyan",
+            "escalated": "bold red",
+            "uninitialized": "dim",
+        }.get(phase, "bold")
+
+        # --- Phase header with flow context ---
+        header = Text()
+        header.append("Phase: ", style="bold")
+        header.append(phase, style=phase_style)
+
+        core = categories.get("core_data", {}).get("fields", {})
+        filled = core.get("filled", {})
+        if isinstance(filled, dict):
+            flow_val = filled.get("active_flow")
+            if flow_val:
+                header.append(f"  flow={flow_val}", style="bold cyan")
+
+        suspended = summary.get("suspended_flows", [])
+        if suspended:
+            names = [s["flow"] for s in suspended]
+            header.append(
+                f"  suspended: {', '.join(names)}",
+                style="bold yellow",
+            )
+
+        if summary.get("restored_flow"):
+            header.append("  [restored]", style="bold magenta")
+
+        fc = flow_context or {}
+        agent_map = fc.get("agent_config_map", {})
+        if agent_map and len(agent_map) > 1:
+            active_cfg = fc.get("active_config_id") or summary.get("config_id")
+            other_flows = [
+                agent for agent, cfg in agent_map.items()
+                if cfg != active_cfg
+            ]
+            if other_flows:
+                header.append(
+                    f"  (other: {', '.join(other_flows)})",
+                    style="dim",
+                )
+        self.console.print(header)
+
+        # --- Slot values by state ---
+        pending = core.get("pending", {})
+        deferred = core.get("deferred", {})
+
+        if filled or pending or deferred or dag.get("blocked"):
+            self.console.print()
+            self._render_slot_values(filled, pending, deferred, dag)
+
+        # --- Suspended flows ---
+        suspended = summary.get("suspended_flows", [])
+        if suspended:
+            self.console.print()
+            self._render_suspended_flows(suspended)
+
+        # --- Active flags (only non-default/interesting state) ---
+        flags = self._collect_active_flags(summary, categories)
+        if flags:
+            self.console.print()
+            flags_text = Text()
+            flags_text.append("Flags: ", style="bold")
+            flags_text.append("  ".join(flags), style="dim yellow")
+            self.console.print(flags_text)
+
+        # --- Expanded categories (non-collapsed, non-core) ---
+        shown_cats = []
+        for cat_key, cat_data in categories.items():
+            if cat_key == "core_data":
+                continue
+            if cat_key in self._COLLAPSED_CATEGORIES:
+                continue
+            fields = cat_data.get("fields", {})
+            interesting = self._filter_interesting_fields(cat_key, fields)
+            if interesting:
+                shown_cats.append((cat_data["label"], interesting))
+
+        for label, fields in shown_cats:
+            self.console.print()
+            self._render_state_fields(label, fields)
+
+        # --- Collapsed hint ---
+        collapsed = [
+            k for k in self._COLLAPSED_CATEGORIES if k in categories
+        ]
+        if collapsed:
+            self.console.print()
+            hint = Text("Collapsed: ", style="dim")
+            hint.append(
+                ", ".join(f"/slots {c}" for c in sorted(collapsed)),
+                style="dim cyan",
+            )
+            self.console.print(hint)
+
+    def _render_slot_values(
+        self,
+        filled: Any,
+        pending: Any,
+        deferred: Any,
+        dag: dict[str, Any],
+    ) -> None:
+        """Render slot name=value pairs grouped by state with color.
+
+        Meta/bootstrap slots (active_flow, welcome) are separated from
+        flow data slots. Shared slots are annotated with a marker.
+        Slots not owned by the current flow's tools are dimmed.
+        """
+        meta_slots = set(dag.get("meta_slots", []))
+        flow_slots = set(dag.get("flow_slots", []))
+        shared_slots = set(dag.get("shared_slots", []))
+
+        table = Table(
+            title="Slots",
+            show_header=True,
+            title_style="bold",
+            border_style="dim",
+            pad_edge=False,
+        )
+        table.add_column("Slot", style="bold")
+        table.add_column("Value")
+        table.add_column("State", justify="right")
+
+        blocked_map: dict[str, list[str]] = {}
+        for b in dag.get("blocked", []):
+            blocked_map[b["slot"]] = b["blocked_by"]
+
+        def _slot_name(slot: str) -> Text:
+            name = Text()
+            is_owned = not flow_slots or slot in flow_slots
+            name.append(slot, style="bold" if is_owned else "dim")
+            if slot in shared_slots:
+                name.append(" *", style="cyan")
+            return name
+
+        def _add_slots(
+            slots: dict, state_label: str, state_style: str
+        ) -> None:
+            if not isinstance(slots, dict):
+                return
+            for slot in sorted(slots):
+                if slot in meta_slots:
+                    continue
+                val = self._format_slot_value(slots[slot])
+                table.add_row(
+                    _slot_name(slot),
+                    val,
+                    Text(state_label, style=state_style),
+                )
+
+        _add_slots(filled, "filled", "green")
+        _add_slots(pending, "pending", "yellow")
+        _add_slots(deferred, "deferred", "blue")
+
+        for slot, blocked_by in sorted(blocked_map.items()):
+            if (
+                slot not in (filled or {})
+                and slot not in (pending or {})
+                and slot not in (deferred or {})
+                and slot not in meta_slots
+            ):
+                needs = ", ".join(blocked_by)
+                table.add_row(
+                    _slot_name(slot),
+                    Text(f"needs {needs}", style="dim"),
+                    Text("blocked", style="red"),
+                )
+
+        if table.row_count > 0:
+            self.console.print(table)
+            if shared_slots:
+                self.console.print(
+                    Text("  * shared across flows", style="dim cyan")
+                )
+
+    def _render_suspended_flows(
+        self, suspended: list[dict[str, Any]]
+    ) -> None:
+        """Render suspended flow states showing saved private slots."""
+        table = Table(
+            title="Suspended Flows",
+            show_header=True,
+            title_style="bold yellow",
+            border_style="dim yellow",
+            pad_edge=False,
+        )
+        table.add_column("Flow", style="bold")
+        table.add_column("Saved Slots")
+        table.add_column("Pending")
+        table.add_column("Deferred")
+
+        for entry in suspended:
+            slots = entry.get("slots", [])
+            pending = entry.get("pending", [])
+            deferred = entry.get("deferred", [])
+            table.add_row(
+                entry.get("flow", "?"),
+                ", ".join(slots) if slots else "-",
+                ", ".join(pending) if pending else "-",
+                ", ".join(deferred) if deferred else "-",
+            )
+        self.console.print(table)
+
+    def _render_flow_list(
+        self,
+        summary: dict[str, Any],
+        flow_context: dict[str, Any] | None,
+    ) -> None:
+        """Render a table of all flows with their status and slot counts."""
+        fc = flow_context or {}
+        agent_map = fc.get("agent_config_map", {})
+        active_cfg = fc.get("active_config_id") or summary.get("config_id")
+        suspended = summary.get("suspended_flows", [])
+        suspended_map = {s["flow"]: s for s in suspended}
+
+        table = Table(
+            title="Flows",
+            show_header=True,
+            title_style="bold",
+            border_style="dim",
+        )
+        table.add_column("Flow", style="bold")
+        table.add_column("Agent")
+        table.add_column("Status")
+        table.add_column("Slots")
+
+        for agent_name, config_id in sorted(
+            agent_map.items(), key=lambda x: x[1]
+        ):
+            is_active = config_id == active_cfg
+            flow_name = config_id
+
+            if is_active:
+                status = Text("active", style="bold green")
+                filled = summary.get("filled_count", 0)
+                pending = summary.get("pending_count", 0)
+                counts = f"{filled} filled, {pending} pending"
+            elif flow_name in suspended_map:
+                status = Text("suspended", style="bold yellow")
+                s = suspended_map[flow_name]
+                n_slots = len(s.get("slots", []))
+                n_pending = len(s.get("pending", []))
+                counts = f"{n_slots} saved, {n_pending} pending"
+            else:
+                status = Text("idle", style="dim")
+                counts = "-"
+
+            table.add_row(agent_name, flow_name, status, counts)
+
+        if not agent_map:
+            active = summary.get("config_id")
+            if active:
+                table.add_row(
+                    "-", active,
+                    Text("active", style="bold green"),
+                    f"{summary.get('filled_count', 0)} filled",
+                )
+
+        self.console.print(table)
+        self.console.print(
+            Text(
+                "  Use /slots flow:<name> to inspect a suspended flow",
+                style="dim",
+            )
+        )
+
+    def _render_flow_detail(
+        self,
+        flow_name: str,
+        summary: dict[str, Any],
+        dag: dict[str, Any],
+    ) -> None:
+        """Render full slot detail for a suspended flow."""
+        suspended = summary.get("suspended_flows", [])
+        match = None
+        for s in suspended:
+            if s.get("flow") == flow_name:
+                match = s
+                break
+        if not match:
+            available = [s["flow"] for s in suspended]
+            if available:
+                self.render_error(
+                    f"No suspended flow '{flow_name}'. "
+                    f"Suspended: {', '.join(available)}"
+                )
+            else:
+                self.render_error(
+                    f"No suspended flow '{flow_name}'. "
+                    "No flows are currently suspended."
+                )
+            return
+
+        shared_slots = set(dag.get("shared_slots", []))
+
+        table = Table(
+            title=f"Suspended: {flow_name}",
+            show_header=True,
+            title_style="bold yellow",
+            border_style="dim yellow",
+            pad_edge=False,
+        )
+        table.add_column("Slot", style="bold")
+        table.add_column("Value")
+        table.add_column("State", justify="right")
+
+        for slot, val in sorted(match.get("slot_values", {}).items()):
+            name = Text(slot, style="bold")
+            if slot in shared_slots:
+                name.append(" *", style="cyan")
+            table.add_row(
+                name,
+                self._format_slot_value(val),
+                Text("saved", style="green"),
+            )
+        for slot, val in sorted(match.get("pending_values", {}).items()):
+            name = Text(slot, style="bold")
+            if slot in shared_slots:
+                name.append(" *", style="cyan")
+            table.add_row(
+                name,
+                self._format_slot_value(val),
+                Text("pending", style="yellow"),
+            )
+        for slot, val in sorted(match.get("deferred_values", {}).items()):
+            name = Text(slot, style="bold")
+            if slot in shared_slots:
+                name.append(" *", style="cyan")
+            table.add_row(
+                name,
+                self._format_slot_value(val),
+                Text("deferred", style="blue"),
+            )
+
+        if table.row_count > 0:
+            self.console.print(table)
+            if shared_slots:
+                self.console.print(
+                    Text("  * shared across flows", style="dim cyan")
+                )
+        else:
+            self.console.print(
+                Text(f"  Flow '{flow_name}' has no saved slots.", style="dim")
+            )
+
+    @staticmethod
+    def _format_slot_value(value: Any) -> Text:
+        """Format a single slot value for display."""
+        if value is None or value == "":
+            return Text("-", style="dim")
+        if isinstance(value, dict):
+            if not value:
+                return Text("{}", style="dim")
+            parts = ", ".join(
+                f"{k}={v}" for k, v in list(value.items())[:5]
+            )
+            if len(value) > 5:
+                parts += f" (+{len(value) - 5} more)"
+            return Text(parts)
+        if isinstance(value, list):
+            if not value:
+                return Text("[]", style="dim")
+            return Text(", ".join(str(v) for v in value[:5]))
+        return Text(str(value))
+
+    def _collect_active_flags(
+        self,
+        summary: dict[str, Any],
+        categories: dict[str, Any],
+    ) -> list[str]:
+        """Collect non-default state flags worth surfacing."""
+        flags: list[str] = []
+
+        steer = summary.get("steer_back_turns", 0)
+        if steer:
+            flags.append(f"steer_back={steer}")
+
+        retries = summary.get("retries", {})
+        if isinstance(retries, dict) and retries:
+            for tool, count in retries.items():
+                flags.append(f"retry({tool})={count}")
+
+        flag_fields = {
+            "confirmation": [
+                ("_correction_pending", "correction_pending"),
+                ("_correction_applied", "correction_applied"),
+                ("_rejection_requested", "rejection_requested"),
+                ("_post_correction_readback", "post_correction_readback"),
+            ],
+            "phase_state": [
+                ("_auto_confirm_pending", "auto_confirm"),
+                ("_readback_transition", "readback_transition"),
+                ("_deferred_transition", "deferred_transition"),
+                ("_inline_confirm", "inline_confirm"),
+            ],
+            "transfer": [
+                ("_cancel_requested", "cancel_requested"),
+                ("_pending_transfer", "pending_transfer"),
+            ],
+            "task_state": [
+                ("_task_just_completed", "task_completed"),
+                ("_zombie", "zombie"),
+            ],
+            "flow_context": [
+                ("_restored_flow", "restored_flow"),
+                ("_auto_resume_deferred", "auto_resume"),
+            ],
+        }
+
+        for cat_key, field_defs in flag_fields.items():
+            cat_fields = (
+                categories.get(cat_key, {}).get("fields", {})
+            )
+            for field_name, display_name in field_defs:
+                val = cat_fields.get(field_name)
+                if val and val is not None:
+                    if isinstance(val, bool):
+                        flags.append(display_name)
+                    elif isinstance(val, dict):
+                        detail = val.get(
+                            "flow", val.get("name", "active")
+                        )
+                        flags.append(f"{display_name}({detail})")
+                    elif isinstance(val, str) and val not in ("", "false"):
+                        flags.append(f"{display_name}={val}")
+                    elif isinstance(val, (int, float)) and val:
+                        flags.append(f"{display_name}={val}")
+
+        return flags
+
+    def _filter_interesting_fields(
+        self, cat_key: str, fields: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Filter out empty/default values from a category's fields.
+
+        For categories like confirmation, steer_back, etc — only show
+        fields that have non-default values.
+        """
+        result: dict[str, Any] = {}
+        for k, v in fields.items():
+            if v is None or v == "" or v == {} or v == [] or v == 0:
+                continue
+            if isinstance(v, bool) and not v:
+                continue
+            if isinstance(v, str) and v in ("false", "False"):
+                continue
+            result[k] = v
+        return result
+
+    def _render_state_fields(
+        self, label: str, fields: dict[str, Any]
+    ) -> None:
+        """Render a category's non-empty fields as a compact table."""
+        table = Table(
+            title=label,
+            show_header=False,
+            title_style="bold",
+            border_style="dim",
+            pad_edge=False,
+        )
+        table.add_column("Field", style="bold dim")
+        table.add_column("Value", overflow="fold")
+        for k, v in fields.items():
+            table.add_row(
+                k.lstrip("_"),
+                self._format_field_value(v),
+            )
+        self.console.print(table)
+
+    @staticmethod
+    def _format_field_value(value: Any) -> str:
+        """Format a field value — flatten dicts/lists for readability."""
+        if isinstance(value, bool):
+            return str(value)
+        if isinstance(value, dict):
+            if not value:
+                return "-"
+            if len(value) <= 4:
+                return ", ".join(f"{k}={v}" for k, v in value.items())
+            display = json.dumps(value, default=str)
+            if len(display) > 120:
+                return display[:120] + "..."
+            return display
+        if isinstance(value, list):
+            if not value:
+                return "-"
+            return ", ".join(str(v) for v in value)
+        return str(value)
+
+    def _render_category_detail(
+        self, cat_key: str, cat_data: dict[str, Any]
+    ) -> None:
+        """Render a single category in full detail (for /slots <category>)."""
+        table = Table(
+            title=cat_data["label"],
+            show_header=True,
+            title_style="bold",
+            border_style="dim",
+        )
+        table.add_column("Field", style="bold")
+        table.add_column("Value", overflow="fold")
+        for field_name, value in cat_data.get("fields", {}).items():
+            if isinstance(value, (dict, list)):
+                display = json.dumps(value, indent=2, default=str)
+            else:
+                display = str(value)
+            if len(display) > 300:
+                display = display[:300] + "..."
+            table.add_row(field_name.lstrip("_"), display)
+        self.console.print(table)
+
+    def _render_log_debug(
+        self,
+        log_entries: list[dict],
+        min_level: str = "INFO",
+    ) -> None:
+        """Render SM lifecycle log as a colour-coded timeline.
+
+        Args:
+            log_entries: List of ``{src, tag, level, data}`` dicts.
+            min_level: Minimum severity to display (DEBUG/INFO/WARN/ERROR).
+        """
+        min_level = min_level.upper()
+        if min_level not in LEVEL_ORDER:
+            min_level = "INFO"
+        threshold = LEVEL_ORDER[min_level]
+
+        visible = [
+            e for e in log_entries
+            if LEVEL_ORDER.get(e.get("level", "INFO"), 1) >= threshold
+        ]
+
+        if not visible:
+            self.console.print(
+                Panel("No log entries at this level.", border_style="dim")
+            )
+            return
+
+        self.console.print(Rule("Slot Filling Timeline", style="dim"))
+
+        current_phase: str | None = None
+        for entry in visible:
+            tag = entry.get("tag", "")
+            phase = TAG_PHASE.get(tag, "collection")
+
+            if phase != current_phase:
+                self.console.print(
+                    Rule(phase, style=PHASE_STYLE.get(phase, "dim"))
+                )
+                current_phase = phase
+
+            level = entry.get("level", "INFO")
+            marker, marker_style = LEVEL_MARKER.get(level, ("·", ""))
+            detail = _format_log_detail(tag, entry.get("data", {}))
+            tag_style = PHASE_STYLE.get(phase, "")
+
+            line = Text()
+            line.append(marker, style=marker_style)
+            line.append(" ")
+            line.append(tag.ljust(22), style=tag_style)
+            line.append("  ")
+            line.append(detail)
+            self.console.print(line)
+
+    def render_log(
+        self,
+        log_entries: list[dict],
+        min_level: str = "INFO",
+    ) -> None:
+        """Render SM lifecycle as a high-level conversation timeline.
+
+        Default view shows only user-facing events in a table.
+        Use min_level="DEBUG" for the detailed tag-by-tag view.
+        """
+        min_level = min_level.upper()
+        if min_level not in LEVEL_ORDER:
+            min_level = "INFO"
+
+        if min_level == "DEBUG":
+            self._render_log_debug(log_entries, "DEBUG")
+            return
+
+        threshold = LEVEL_ORDER[min_level]
+        total = len(log_entries)
+
+        table = Table(
+            title="Conversation Timeline",
+            show_header=True,
+            title_style="bold",
+            border_style="dim",
+            pad_edge=False,
+        )
+        table.add_column("#", style="dim", justify="right", width=4)
+        table.add_column("Event", width=10)
+        table.add_column("Details")
+
+        seq = 0
+        seen: dict[str, str] = {}
+        for entry in log_entries:
+            tag = entry.get("tag", "")
+            event_def = _TIMELINE_EVENTS.get(tag)
+            if not event_def:
+                continue
+
+            level = entry.get("level", "INFO")
+            if LEVEL_ORDER.get(level, 1) < threshold:
+                continue
+
+            detail = _timeline_detail(tag, entry.get("data", {}))
+
+            dedup_key = f"{tag}:{detail}"
+            if tag in _DEDUP_TAGS and seen.get(tag) == dedup_key:
+                continue
+            seen[tag] = dedup_key
+
+            seq += 1
+            label, marker, style = event_def
+            event_text = Text(f"{marker} {label}", style=style)
+
+            detail_style = ""
+            if label == "ERROR":
+                detail_style = "red"
+            elif label == "STEER":
+                detail_style = "yellow"
+
+            table.add_row(str(seq), event_text, Text(detail, style=detail_style))
+
+        if seq == 0:
+            self.console.print(
+                Panel("No events at this level.", border_style="dim")
+            )
+            return
+
+        self.console.print(table)
+
+        hidden = total - seq
+        if hidden > 0:
+            self.console.print(
+                Text(
+                    f" {seq} events shown ({hidden} internal events hidden"
+                    " — use /log debug)",
+                    style="dim",
+                )
+            )
+
+    def render_error(self, message: str) -> None:
+        """Render an error message."""
+        panel = Panel(
+            Text(message, style="bold white"),
+            title="Error",
+            border_style="red",
+        )
+        self.console.print(panel)
+
+    def render_slash_help(self) -> None:
+        """Print available slash commands."""
+        table = Table(
+            title="Available Commands", show_header=True
+        )
+        table.add_column("Command", style="bold cyan")
+        table.add_column("Description")
+
+        for cmd, desc in SLASH_COMMANDS.items():
+            table.add_row(cmd, desc)
+
+        self.console.print(table)
+
+    # ── Payload rendering ───────────────────────────────────
+
+    _BUTTON_ICONS: dict[str, str] = {
+        "doc": "\U0001f4c4",
+        "hyperLink": "\U0001f517",
+        "deepLink": "\U0001f4f1",
+        "event": "▶",
+        "cms": "\U0001f4c4",
+    }
+
+    def render_payloads(self, payloads: list[dict]) -> None:
+        """Render custom payloads as terminal UI elements."""
+        for payload in payloads:
+            if "richContent" in payload:
+                self._render_rich_content(payload["richContent"])
+            elif "scenarios" in payload:
+                self._render_scenarios(payload["scenarios"])
+            else:
+                self._render_unknown_payload(payload)
+
+    def _render_rich_content(
+        self, content: list[list[dict]]
+    ) -> None:
+        """Render Dialogflow richContent items."""
+        for group in content:
+            if not isinstance(group, list):
+                continue
+            for item in group:
+                if not isinstance(item, dict):
+                    continue
+                item_type = item.get("type", "")
+                if item_type == "chips":
+                    options = item.get("options", [])
+                    if options:
+                        self._render_chips(options)
+                    elif item.get("options_from"):
+                        self._render_chips(
+                            [{"text": f"(from {item['options_from']})"}]
+                        )
+                elif item_type == "info":
+                    self._render_info_card(item)
+                else:
+                    self._render_unknown_payload(item)
+
+    def _render_chips(self, options: list[dict]) -> None:
+        """Render chip options as a horizontal button bar."""
+        if not options:
+            return
+        labels = [opt.get("text", "") for opt in options]
+        width = self.console.width
+
+        rows: list[list[str]] = []
+        current_row: list[str] = []
+        current_width = 2
+        for label in labels:
+            chip_width = len(label) + 5
+            if current_row and current_width + chip_width > width:
+                rows.append(current_row)
+                current_row = []
+                current_width = 2
+            current_row.append(label)
+            current_width += chip_width
+        if current_row:
+            rows.append(current_row)
+
+        for row in rows:
+            top = Text("  ")
+            mid = Text("  ")
+            bot = Text("  ")
+            for i, label in enumerate(row):
+                w = len(label) + 2
+                if i > 0:
+                    top.append(" ")
+                    mid.append(" ")
+                    bot.append(" ")
+                top.append(
+                    f"╭{'─' * w}╮", style="cyan"
+                )
+                mid.append(
+                    f"│ {label} │", style="bold cyan"
+                )
+                bot.append(
+                    f"╰{'─' * w}╯", style="cyan"
+                )
+            self.console.print(top)
+            self.console.print(mid)
+            self.console.print(bot)
+
+    def _render_info_card(self, item: dict) -> None:
+        """Render an info card with title, subtitle, and body text."""
+        content = Text()
+        subtitle = item.get("subtitle", "")
+        if subtitle:
+            content.append(subtitle, style="bold")
+        body = item.get("text", "")
+        if body:
+            if subtitle:
+                content.append("\n\n")
+            content.append(body)
+
+        title = item.get("title", "")
+        self.console.print(Panel(
+            content,
+            title=title if title else None,
+            title_align="left",
+            border_style="blue",
+            padding=(0, 1),
+        ))
+
+    def _render_scenarios(
+        self, scenarios: list[dict]
+    ) -> None:
+        """Render scenario payloads with text and buttons."""
+        for scenario in scenarios:
+            if not isinstance(scenario, dict):
+                continue
+            name = scenario.get("name", "")
+            responses = scenario.get("responses", [])
+            if not responses:
+                continue
+
+            content = Text()
+            for resp in responses:
+                if not isinstance(resp, dict):
+                    continue
+                resp_type = resp.get("type", "")
+                if resp_type == "text":
+                    text = resp.get("text", "")
+                    if text:
+                        if content.plain:
+                            content.append("\n")
+                        content.append(text)
+                elif resp_type == "button":
+                    self._render_scenario_button(resp, content)
+
+            if content.plain:
+                self.console.print(Panel(
+                    content,
+                    title=name if name else None,
+                    title_align="left",
+                    border_style="dim cyan",
+                    padding=(0, 1),
+                ))
+
+    def _render_scenario_button(
+        self, btn: dict, content: Text
+    ) -> None:
+        """Append a button to scenario content."""
+        btn_type = btn.get("buttonType", "")
+        icon = self._BUTTON_ICONS.get(btn_type, "▶")
+        label = btn.get("text", "")
+        link = btn.get("link", "")
+
+        if content.plain:
+            content.append("\n")
+        content.append(f"  {icon} ", style="blue")
+        content.append(label, style="bold blue")
+        if link:
+            content.append(f"\n     {link}", style="dim")
+
+    def _render_unknown_payload(
+        self, payload: dict
+    ) -> None:
+        """Fallback: render unknown payload as dimmed JSON."""
+        self.console.print(Panel(
+            Text(
+                json.dumps(payload, indent=2, default=str),
+                style="dim",
+            ),
+            title="Custom Payload",
+            title_align="left",
+            border_style="dim",
+            padding=(0, 1),
+        ))

--- a/src/cxas_scrapi/utils/script_runner.py
+++ b/src/cxas_scrapi/utils/script_runner.py
@@ -1,0 +1,484 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Loads and executes YAML conversation scripts against a CES agent."""
+
+from __future__ import annotations
+
+import json
+import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from io import StringIO
+from pathlib import Path
+from typing import Any
+
+import yaml
+from rich.console import Console
+from rich.table import Table
+
+from cxas_scrapi.core.chat_session import ChatSession, TurnRecord
+
+
+@dataclass
+class TurnExpectation:
+    """Expected outcome for a single turn."""
+
+    agent_contains: str | None = None
+    agent_not_contains: str | None = None
+    tools_called: list[str] | None = None
+    no_transfer: bool = False
+    session_ended: bool | None = None
+
+
+@dataclass
+class ScriptTurn:
+    """A single turn in a conversation script."""
+
+    user: str
+    expect: TurnExpectation | None = None
+
+
+@dataclass
+class ConversationScript:
+    """A full conversation script loaded from YAML."""
+
+    name: str
+    turns: list[ScriptTurn]
+    description: str = ""
+    app_name: str | None = None
+    channel: str | None = None
+
+
+@dataclass
+class TurnResult:
+    """Result of executing a single script turn."""
+
+    turn_index: int
+    user_text: str
+    agent_text: str
+    tool_calls: list[dict]
+    transfer: str | None
+    session_ended: bool
+    expectation_failures: list[str]
+    passed: bool
+
+
+@dataclass
+class ScriptResult:
+    """Result of executing a full conversation script."""
+
+    script_name: str
+    turns: list[TurnResult]
+    passed: bool
+    total_turns: int
+    passed_turns: int
+    failed_turns: int
+    error: str | None = None
+
+
+class ScriptRunner:
+    """Loads and executes conversation scripts."""
+
+    @staticmethod
+    def load_script(path: str | Path) -> ConversationScript:
+        """Load a YAML conversation script from disk.
+
+        YAML format:
+            name: "test name"
+            description: "optional"
+            app_name: "optional override"
+            channel: "optional"
+            turns:
+              - user: "message text"
+                expect:
+                  agent_contains: "substring"
+                  tools_called: ["tool1", "tool2"]
+                  no_transfer: true
+                  session_ended: false
+
+        Args:
+            path: Path to the YAML script file.
+
+        Returns:
+            A parsed ConversationScript.
+
+        Raises:
+            FileNotFoundError: If the path does not exist.
+            ValueError: If the YAML structure is invalid.
+        """
+        path = Path(path)
+        if not path.exists():
+            raise FileNotFoundError(f"Script file not found: {path}")
+
+        with open(path, "r") as f:
+            data = yaml.safe_load(f)
+
+        if not isinstance(data, dict):
+            raise ValueError(f"Invalid script format in {path}: expected a YAML mapping")
+
+        if "name" not in data:
+            raise ValueError(f"Invalid script format in {path}: missing 'name' field")
+
+        if "turns" not in data or not isinstance(data.get("turns"), list):
+            raise ValueError(
+                f"Invalid script format in {path}: missing or invalid 'turns' field"
+            )
+
+        turns = []
+        for i, turn_data in enumerate(data["turns"]):
+            if not isinstance(turn_data, dict) or "user" not in turn_data:
+                raise ValueError(
+                    f"Invalid turn {i} in {path}: each turn must have a 'user' field"
+                )
+
+            expect = None
+            if "expect" in turn_data and turn_data["expect"] is not None:
+                exp_data = turn_data["expect"]
+                expect = TurnExpectation(
+                    agent_contains=exp_data.get("agent_contains"),
+                    agent_not_contains=exp_data.get("agent_not_contains"),
+                    tools_called=exp_data.get("tools_called"),
+                    no_transfer=exp_data.get("no_transfer", False),
+                    session_ended=exp_data.get("session_ended"),
+                )
+
+            turns.append(ScriptTurn(user=turn_data["user"], expect=expect))
+
+        return ConversationScript(
+            name=data["name"],
+            turns=turns,
+            description=data.get("description", ""),
+            app_name=data.get("app_name"),
+            channel=data.get("channel"),
+        )
+
+    @staticmethod
+    def load_scripts(paths: list[str | Path]) -> list[ConversationScript]:
+        """Load multiple scripts. Supports glob patterns via Path.glob.
+
+        Each entry in paths can be:
+        - A direct file path (loaded as-is)
+        - A glob pattern (e.g., "scripts/*.yaml") resolved from the pattern's parent
+
+        Args:
+            paths: List of file paths or glob patterns.
+
+        Returns:
+            List of parsed ConversationScripts.
+        """
+        scripts = []
+        for p in paths:
+            p = Path(p)
+            if p.exists() and p.is_file():
+                scripts.append(ScriptRunner.load_script(p))
+            elif "*" in str(p) or "?" in str(p):
+                # Treat as glob pattern relative to parent directory
+                parent = p.parent if p.parent != p else Path(".")
+                pattern = p.name
+                matched = sorted(parent.glob(pattern))
+                for match in matched:
+                    scripts.append(ScriptRunner.load_script(match))
+            else:
+                # Try loading anyway; load_script will raise FileNotFoundError
+                scripts.append(ScriptRunner.load_script(p))
+        return scripts
+
+    def __init__(
+        self,
+        app_name: str,
+        channel: str | None = None,
+        delay: float = 0.5,
+        **session_kwargs: Any,
+    ):
+        self.app_name = app_name
+        self.channel = channel
+        self.delay = delay
+        self.session_kwargs = session_kwargs
+
+    def run_script(self, script: ConversationScript) -> ScriptResult:
+        """Execute a single script and return results.
+
+        Creates a new ChatSession per script. Evaluates expectations after each
+        turn. Continues even if expectations fail (collects all failures). Stops
+        early if the session ends unexpectedly.
+
+        Args:
+            script: The conversation script to execute.
+
+        Returns:
+            ScriptResult with all TurnResults.
+        """
+        effective_app = script.app_name or self.app_name
+        effective_channel = script.channel or self.channel
+
+        try:
+            session = ChatSession(
+                app_name=effective_app,
+                channel=effective_channel,
+                **self.session_kwargs,
+            )
+        except Exception as exc:
+            return ScriptResult(
+                script_name=script.name,
+                turns=[],
+                passed=False,
+                total_turns=len(script.turns),
+                passed_turns=0,
+                failed_turns=0,
+                error=f"Failed to create ChatSession: {exc}",
+            )
+
+        turn_results: list[TurnResult] = []
+
+        try:
+            for i, script_turn in enumerate(script.turns):
+                # Check if session already ended before sending
+                if session.is_ended:
+                    # Mark remaining turns as skipped
+                    for j in range(i, len(script.turns)):
+                        turn_results.append(
+                            TurnResult(
+                                turn_index=j,
+                                user_text=script.turns[j].user,
+                                agent_text="",
+                                tool_calls=[],
+                                transfer=None,
+                                session_ended=True,
+                                expectation_failures=["Skipped: session ended early"],
+                                passed=False,
+                            )
+                        )
+                    break
+
+                try:
+                    turn_record = session.send(script_turn.user)
+                except Exception as exc:
+                    # Record the error and stop execution
+                    turn_results.append(
+                        TurnResult(
+                            turn_index=i,
+                            user_text=script_turn.user,
+                            agent_text="",
+                            tool_calls=[],
+                            transfer=None,
+                            session_ended=False,
+                            expectation_failures=[f"Exception during send: {exc}"],
+                            passed=False,
+                        )
+                    )
+                    break
+
+                # Check expectations
+                failures = []
+                if script_turn.expect is not None:
+                    failures = ScriptRunner.check_expectations(
+                        turn_record, script_turn.expect
+                    )
+
+                turn_results.append(
+                    TurnResult(
+                        turn_index=i,
+                        user_text=script_turn.user,
+                        agent_text=turn_record.agent_text,
+                        tool_calls=turn_record.tool_calls,
+                        transfer=turn_record.agent_transfer,
+                        session_ended=turn_record.session_ended,
+                        expectation_failures=failures,
+                        passed=len(failures) == 0,
+                    )
+                )
+
+                # Delay between turns (skip after the last turn)
+                if i < len(script.turns) - 1 and self.delay > 0:
+                    time.sleep(self.delay)
+
+        finally:
+            try:
+                session.close()
+            except Exception:
+                pass
+
+        passed_count = sum(1 for t in turn_results if t.passed)
+        failed_count = sum(1 for t in turn_results if not t.passed)
+
+        return ScriptResult(
+            script_name=script.name,
+            turns=turn_results,
+            passed=failed_count == 0 and len(turn_results) == len(script.turns),
+            total_turns=len(script.turns),
+            passed_turns=passed_count,
+            failed_turns=failed_count,
+        )
+
+    def run_batch(
+        self,
+        scripts: list[ConversationScript],
+        max_workers: int = 1,
+    ) -> list[ScriptResult]:
+        """Run multiple scripts sequentially or in parallel.
+
+        Args:
+            scripts: List of scripts to execute.
+            max_workers: Number of parallel workers. 1 = sequential.
+
+        Returns:
+            List of ScriptResults in the same order as input scripts.
+        """
+        if max_workers <= 1:
+            return [self.run_script(s) for s in scripts]
+
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            results = list(executor.map(self.run_script, scripts))
+        return results
+
+    @staticmethod
+    def check_expectations(
+        turn: TurnRecord,
+        expect: TurnExpectation,
+    ) -> list[str]:
+        """Check a turn against expectations, return list of failures.
+
+        Checks:
+        - agent_contains: turn.agent_text must contain the substring
+          (case-insensitive)
+        - agent_not_contains: turn.agent_text must NOT contain the substring
+          (case-insensitive)
+        - tools_called: each expected tool must appear in
+          turn.tool_calls[*]["action"]
+        - no_transfer: turn.agent_transfer must be None/falsy
+        - session_ended: turn.session_ended must match expected value
+
+        Args:
+            turn: The TurnRecord from the ChatSession.
+            expect: The TurnExpectation to check against.
+
+        Returns:
+            List of failure description strings. Empty list means all passed.
+        """
+        failures = []
+
+        if expect.agent_contains is not None:
+            if expect.agent_contains.lower() not in turn.agent_text.lower():
+                failures.append(
+                    f"agent_contains: expected '{expect.agent_contains}' "
+                    f"in agent text, got: '{turn.agent_text[:100]}'"
+                )
+
+        if expect.agent_not_contains is not None:
+            if expect.agent_not_contains.lower() in turn.agent_text.lower():
+                failures.append(
+                    f"agent_not_contains: expected '{expect.agent_not_contains}' "
+                    f"NOT in agent text, but found it"
+                )
+
+        if expect.tools_called is not None:
+            actual_tools = {tc.get("action", "") for tc in turn.tool_calls}
+            for expected_tool in expect.tools_called:
+                if expected_tool not in actual_tools:
+                    failures.append(
+                        f"tools_called: expected tool '{expected_tool}' not found "
+                        f"in actual tools: {sorted(actual_tools)}"
+                    )
+
+        if expect.no_transfer:
+            if turn.agent_transfer:
+                failures.append(
+                    f"no_transfer: expected no transfer, "
+                    f"but got transfer to '{turn.agent_transfer}'"
+                )
+
+        if expect.session_ended is not None:
+            if turn.session_ended != expect.session_ended:
+                failures.append(
+                    f"session_ended: expected {expect.session_ended}, "
+                    f"got {turn.session_ended}"
+                )
+
+        return failures
+
+    @staticmethod
+    def results_to_table(results: list[ScriptResult]) -> str:
+        """Render batch results as a Rich table string.
+
+        Shows: | Script | Turns | Passed | Failed | Status |
+
+        Args:
+            results: List of ScriptResults to render.
+
+        Returns:
+            String containing the rendered Rich table.
+        """
+        table = Table(title="Script Results")
+        table.add_column("Script", style="cyan")
+        table.add_column("Turns", justify="right")
+        table.add_column("Passed", justify="right", style="green")
+        table.add_column("Failed", justify="right", style="red")
+        table.add_column("Status")
+
+        for result in results:
+            status = "[green]PASS[/green]" if result.passed else "[red]FAIL[/red]"
+            if result.error:
+                status = "[red]ERROR[/red]"
+            table.add_row(
+                result.script_name,
+                str(result.total_turns),
+                str(result.passed_turns),
+                str(result.failed_turns),
+                status,
+            )
+
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=False, width=120)
+        console.print(table)
+        return buf.getvalue()
+
+    @staticmethod
+    def results_to_json(results: list[ScriptResult]) -> str:
+        """Render batch results as JSON with full turn details.
+
+        Args:
+            results: List of ScriptResults to render.
+
+        Returns:
+            JSON string of the results.
+        """
+        output = []
+        for result in results:
+            turns_data = []
+            for turn in result.turns:
+                turns_data.append(
+                    {
+                        "turn_index": turn.turn_index,
+                        "user_text": turn.user_text,
+                        "agent_text": turn.agent_text,
+                        "tool_calls": turn.tool_calls,
+                        "transfer": turn.transfer,
+                        "session_ended": turn.session_ended,
+                        "expectation_failures": turn.expectation_failures,
+                        "passed": turn.passed,
+                    }
+                )
+            output.append(
+                {
+                    "script_name": result.script_name,
+                    "passed": result.passed,
+                    "total_turns": result.total_turns,
+                    "passed_turns": result.passed_turns,
+                    "failed_turns": result.failed_turns,
+                    "error": result.error,
+                    "turns": turns_data,
+                }
+            )
+        return json.dumps(output, indent=2)

--- a/src/cxas_scrapi/utils/slot_inspector.py
+++ b/src/cxas_scrapi/utils/slot_inspector.py
@@ -1,0 +1,282 @@
+"""Deep inspection and categorization of CES slot machine state."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+SLOT_CATEGORIES = {
+    "core_data": {
+        "label": "Core Data",
+        "fields": ["filled", "pending", "deferred", "status", "task_results"],
+    },
+    "engine_control": {
+        "label": "Engine Control",
+        "fields": ["_invoke_n", "_last_state", "_retries", "_log", "_log_level"],
+    },
+    "configuration": {
+        "label": "Configuration",
+        "fields": [
+            "_config_id", "_bootstrap", "_cancel_tool", "_gate_slot",
+            "_setter_slots", "_multi_setter_slots", "_slot_requires",
+            "_slot_validates", "_executor_tasks", "_correction_tool",
+        ],
+    },
+    "phase_state": {
+        "label": "Phase State",
+        "fields": [
+            "_first_engine_run", "_initialized", "_auto_confirm_pending",
+            "_inline_confirm", "_readback_transition", "_deferred_transition",
+        ],
+    },
+    "confirmation": {
+        "label": "Confirmation",
+        "fields": [
+            "_rejection_snapshot", "_rejection_requested", "_correction_pending",
+            "_post_correction_readback", "_correction_applied",
+        ],
+    },
+    "steer_back": {
+        "label": "Steer-back Control",
+        "fields": [
+            "_steer_back_turns", "_steer_last_text",
+            "_correction_grace_used", "_progress_turns",
+        ],
+    },
+    "system_instruction": {
+        "label": "System Instruction Fragments",
+        "fields": [
+            "_tool_selection", "_slot_ordering", "_prereq_note", "_correction_hint",
+        ],
+    },
+    "payloads": {
+        "label": "Payloads",
+        "fields": [
+            "_pending_payloads", "_pending_question_payloads",
+            "_event_prefilled_this_turn",
+        ],
+    },
+    "task_state": {
+        "label": "Task State",
+        "fields": [
+            "_task_just_completed", "_just_completed_task", "_zombie",
+        ],
+    },
+    "transfer": {
+        "label": "Transfer",
+        "fields": [
+            "_cancel_requested", "_pending_transfer", "_transfer_slots",
+            "_active_sm_key",
+        ],
+    },
+    "flow_context": {
+        "label": "Flow Context",
+        "fields": [
+            "_shared_slots", "_flow_state", "_flow_instance_seq",
+            "_restored_flow", "_auto_resume_deferred",
+        ],
+    },
+    "channel": {
+        "label": "Channel",
+        "fields": ["channel"],
+    },
+}
+
+
+class SlotInspector:
+    """Categorizes and inspects raw slot machine state dicts."""
+
+    @staticmethod
+    def inspect(slot_machine: dict[str, Any]) -> dict[str, Any]:
+        """Categorize all fields, derive phase, build slot DAG.
+
+        Args:
+            slot_machine: Raw slot machine dict from CES state.
+
+        Returns:
+            JSON-serializable dict with summary, categories, and slot_dag.
+        """
+        categorized: dict[str, Any] = {}
+        all_known_fields: set[str] = set()
+
+        for cat_key, cat_def in SLOT_CATEGORIES.items():
+            all_known_fields.update(cat_def["fields"])
+            group = {}
+            for field_name in cat_def["fields"]:
+                if field_name in slot_machine:
+                    group[field_name] = slot_machine[field_name]
+            if group:
+                categorized[cat_key] = {
+                    "label": cat_def["label"],
+                    "fields": group,
+                }
+
+        uncategorized = {
+            k: v for k, v in slot_machine.items() if k not in all_known_fields
+        }
+        if uncategorized:
+            categorized["uncategorized"] = {
+                "label": "Uncategorized",
+                "fields": uncategorized,
+            }
+
+        filled = slot_machine.get("filled", {})
+        pending = slot_machine.get("pending", {})
+        deferred = slot_machine.get("deferred", {})
+
+        flow_state = slot_machine.get("_flow_state", [])
+        suspended = []
+        for entry in flow_state if isinstance(flow_state, list) else []:
+            suspended.append({
+                "flow": entry.get("flow", "?"),
+                "slots": sorted(entry.get("slots", {}).keys()),
+                "pending": sorted(entry.get("pending", {}).keys()),
+                "deferred": sorted(entry.get("deferred", {}).keys()),
+                "slot_values": dict(entry.get("slots", {})),
+                "pending_values": dict(entry.get("pending", {})),
+                "deferred_values": dict(entry.get("deferred", {})),
+            })
+
+        return {
+            "summary": {
+                "phase": SlotInspector._derive_phase(slot_machine),
+                "status": slot_machine.get("status"),
+                "filled_count": len(filled) if isinstance(filled, dict) else 0,
+                "pending_count": len(pending) if isinstance(pending, dict) else 0,
+                "deferred_count": len(deferred) if isinstance(deferred, dict) else 0,
+                "retries": slot_machine.get("_retries", {}),
+                "steer_back_turns": slot_machine.get("_steer_back_turns", 0),
+                "config_id": slot_machine.get("_config_id"),
+                "suspended_flows": suspended,
+                "restored_flow": bool(slot_machine.get("_restored_flow")),
+                "auto_resume_deferred": bool(
+                    slot_machine.get("_auto_resume_deferred")
+                ),
+            },
+            "categories": categorized,
+            "slot_dag": SlotInspector._build_slot_dag(slot_machine),
+        }
+
+    @staticmethod
+    def inspect_from_trace(
+        normalized_trace: dict[str, Any],
+        turn: int | None = None,
+    ) -> dict[str, Any]:
+        """Extract slot_machine from normalized trace entries and inspect.
+
+        Walks variable_update and variable_default entries to find the latest
+        slot_machine state, optionally up to a specific turn number.
+
+        Args:
+            normalized_trace: Output of Traces.get_normalized().
+            turn: If set, only consider entries up to this turn (inclusive).
+
+        Returns:
+            Result of inspect() on the extracted slot_machine, or inspect({})
+            if no slot_machine found.
+        """
+        entries = normalized_trace.get("entries", [])
+        last_sm: dict[str, Any] = {}
+
+        for entry in entries:
+            if turn is not None and entry.get("turn", 0) > turn:
+                break
+            kind = entry.get("kind")
+            if kind in ("variable_update", "variable_default"):
+                variables = entry.get("variables", {})
+                if "slot_machine" in variables:
+                    last_sm = variables["slot_machine"]
+
+        return SlotInspector.inspect(last_sm)
+
+    @staticmethod
+    def _derive_phase(sm: dict[str, Any]) -> str:
+        """Derive the current slot machine phase from state flags."""
+        if sm.get("status") in ("complete", "escalated", "zombie"):
+            return sm["status"]
+        if sm.get("_correction_pending"):
+            return "correction"
+        if sm.get("_post_correction_readback"):
+            return "post_correction_readback"
+        pending = sm.get("pending", {})
+        if sm.get("_auto_confirm_pending") and pending:
+            return "awaiting_confirmation"
+        if sm.get("_readback_transition"):
+            return "readback_transition"
+        if sm.get("_deferred_transition"):
+            return "deferred_transition"
+        if pending:
+            return "fresh_readback"
+        if not sm.get("_initialized", True):
+            return "uninitialized"
+        return "collection"
+
+    @staticmethod
+    def _meta_slots(sm: dict[str, Any]) -> set[str]:
+        """Identify bootstrap/routing slots that aren't flow data."""
+        meta: set[str] = set()
+        bootstrap = sm.get("_bootstrap", {})
+        if isinstance(bootstrap, dict):
+            for key in ("slot", "welcome_slot"):
+                val = bootstrap.get(key)
+                if val:
+                    meta.add(val)
+        gate = sm.get("_gate_slot")
+        if gate:
+            meta.add(gate)
+        return meta
+
+    @staticmethod
+    def _flow_slots(sm: dict[str, Any]) -> set[str]:
+        """Identify slots owned by the current flow's tools."""
+        flow: set[str] = set()
+        setter = sm.get("_setter_slots", {})
+        if isinstance(setter, dict):
+            for slots in setter.values():
+                if isinstance(slots, str):
+                    flow.add(slots)
+                elif isinstance(slots, list):
+                    flow.update(slots)
+        multi = sm.get("_multi_setter_slots", {})
+        if isinstance(multi, dict):
+            for mapping in multi.values():
+                if isinstance(mapping, dict):
+                    flow.update(mapping.values())
+        ordering = sm.get("_slot_ordering", "")
+        if isinstance(ordering, str) and ordering:
+            for slot in ordering.replace("→", ",").split(","):
+                s = slot.strip()
+                if s:
+                    flow.add(s)
+        return flow
+
+    @staticmethod
+    def _build_slot_dag(sm: dict[str, Any]) -> dict[str, Any]:
+        """Build a DAG of slot states, dependencies, and flow ownership."""
+        filled = sm.get("filled", {})
+        pending = sm.get("pending", {})
+        deferred = sm.get("deferred", {})
+        requires = sm.get("_slot_requires", {})
+
+        meta = SlotInspector._meta_slots(sm)
+        flow = SlotInspector._flow_slots(sm)
+        shared_list = sm.get("_shared_slots", [])
+        shared = set(shared_list) if isinstance(shared_list, list) else set()
+
+        blocked: list[dict[str, Any]] = []
+        if isinstance(requires, dict) and isinstance(filled, dict):
+            for slot, prereqs in requires.items():
+                if isinstance(prereqs, list):
+                    unmet = [p for p in prereqs if p not in filled]
+                    if unmet and slot not in filled:
+                        blocked.append({"slot": slot, "blocked_by": unmet})
+
+        return {
+            "filled": sorted(filled.keys()) if isinstance(filled, dict) else [],
+            "pending": sorted(pending.keys()) if isinstance(pending, dict) else [],
+            "deferred": sorted(deferred.keys()) if isinstance(deferred, dict) else [],
+            "blocked": blocked,
+            "meta_slots": sorted(meta),
+            "flow_slots": sorted(flow),
+            "shared_slots": sorted(shared),
+        }

--- a/src/cxas_scrapi/utils/tracing/trace_config.py
+++ b/src/cxas_scrapi/utils/tracing/trace_config.py
@@ -121,7 +121,23 @@ class BugReportConfig(BaseModel):
     )
 
 
+class ChatConfig(BaseModel):
+    auto_trace: bool = False
+    auto_trace_format: str = "text"
+    verbose: bool = False
+    show_metrics: bool = False
+    save_session: bool = True
+    latency_warning_ms: float = 5000
+
+
+class DefaultsConfig(BaseModel):
+    app_name: str | None = None
+    project_id: str | None = None
+    location: str | None = None
+
+
 class TraceConfig(BaseModel):
+    defaults: DefaultsConfig = Field(default_factory=DefaultsConfig)
     audio: AudioConfig = Field(default_factory=AudioConfig)
     cloud_logging: CloudLoggingConfig = Field(
         default_factory=CloudLoggingConfig
@@ -129,6 +145,7 @@ class TraceConfig(BaseModel):
     gemini: GeminiConfig = Field(default_factory=GeminiConfig)
     ui: UIConfig = Field(default_factory=UIConfig)
     bug_report: BugReportConfig = Field(default_factory=BugReportConfig)
+    chat: ChatConfig = Field(default_factory=ChatConfig)
 
     @classmethod
     def load(cls, explicit_path: str | None = None) -> "TraceConfig":

--- a/src/cxas_scrapi/utils/tracing/trace_report.py
+++ b/src/cxas_scrapi/utils/tracing/trace_report.py
@@ -39,6 +39,9 @@ def normalize(conversation: Any) -> dict[str, Any]:
     fed back into a Pydantic model, or rendered. Each entry has a `kind`
     (`user`, `agent`, `tool_call`, `tool_response`, `agent_transfer`,
     `custom_payload`, `system`) plus a small payload.
+
+    Handles both the internal "turns" format and the CES proto
+    "interactions" format (Conversation.interactions[]).
     """
     conv_dict = (
         type(conversation).to_dict(conversation)
@@ -46,9 +49,13 @@ def normalize(conversation: Any) -> dict[str, Any]:
         else conversation
     )
 
+    turns = conv_dict.get("turns", [])
+    if not turns:
+        turns = _interactions_to_turns(conv_dict.get("interactions", []))
+
     entries: list[dict[str, Any]] = []
     turn_metrics: list[dict[str, Any]] = []
-    for turn_idx, turn in enumerate(conv_dict.get("turns", [])):
+    for turn_idx, turn in enumerate(turns):
         for msg in turn.get("messages", []):
             role = msg.get("role", "")
             for chunk in msg.get("chunks", []) or []:
@@ -68,12 +75,58 @@ def normalize(conversation: Any) -> dict[str, Any]:
         "channel": _channel_label(raw_input_types),
         "start_time": _to_iso(conv_dict.get("start_time")),
         "end_time": _to_iso(conv_dict.get("end_time")),
-        "num_turns": len(conv_dict.get("turns", [])),
+        "num_turns": len(turns),
         "entries": entries,
         "turn_metrics": turn_metrics,
         "totals": _conversation_totals(turn_metrics),
         "raw": conv_dict,
     }
+
+
+def _interactions_to_turns(
+    interactions: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Convert CES Conversation.interactions[] to the internal turns format.
+
+    Each interaction has response.query_result with diagnostic_info
+    (messages/chunks) and parameters (session variables including slot_machine).
+    """
+    turns: list[dict[str, Any]] = []
+    for interaction in interactions:
+        response = interaction.get("response", {})
+        qr = response.get("query_result", {})
+        di = qr.get("diagnostic_info", {})
+
+        messages = []
+        if isinstance(di, dict):
+            messages = di.get("messages", [])
+
+        params = qr.get("parameters")
+        if isinstance(params, dict) and params:
+            messages.append({
+                "role": "",
+                "chunks": [{"updated_variables": params}],
+            })
+
+        root_span = {}
+        step_metrics = interaction.get("step_metrics", [])
+        if step_metrics:
+            child_spans = []
+            for sm in step_metrics:
+                child_spans.append({
+                    "name": sm.get("name"),
+                    "start_time": sm.get("latency"),
+                })
+            root_span = {
+                "child_spans": child_spans,
+                "start_time": interaction.get("create_time"),
+            }
+
+        turns.append({
+            "messages": messages,
+            "root_span": root_span,
+        })
+    return turns
 
 
 def _turn_metrics(turn: dict[str, Any], turn_idx: int) -> dict[str, Any]:

--- a/tests/cxas_scrapi/cli/test_chat_cli.py
+++ b/tests/cxas_scrapi/cli/test_chat_cli.py
@@ -1,0 +1,578 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cxas_scrapi.cli import chat_cli
+from cxas_scrapi.utils.tracing.trace_config import (
+    ChatConfig,
+    TraceConfig,
+)
+
+APP = "projects/p/locations/l/apps/a"
+
+
+def _ns(**overrides):
+    """Build a minimal argparse.Namespace for chat commands."""
+    base = dict(
+        app_name=APP,
+        channel=None,
+        deployment_id=None,
+        verbose=False,
+        trace=False,
+        trace_format="text",
+        metrics=False,
+        script=None,
+        fork=None,
+        fork_at_turn=None,
+        config=None,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+# -----------------------------------------------------------------------
+# Registration / argparse tests
+# -----------------------------------------------------------------------
+
+
+def test_register_smoke():
+    """Verify `cxas chat --app-name APP` parses correctly."""
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    chat_cli.register(sub)
+    args = parser.parse_args(["chat", "--app-name", APP])
+    assert args.app_name == APP
+    assert hasattr(args, "func")
+
+
+def test_register_all_flags():
+    """Verify all flags parse without errors."""
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    chat_cli.register(sub)
+    args = parser.parse_args(
+        [
+            "chat",
+            "--app-name",
+            APP,
+            "--channel",
+            "web",
+            "--deployment-id",
+            "dep-1",
+            "--verbose",
+            "--trace",
+            "--trace-format",
+            "json",
+            "--metrics",
+            "--script",
+            "/tmp/script.yaml",
+            "--fork",
+            "conv-123",
+            "--fork-at-turn",
+            "3",
+            "--config",
+            "/tmp/trace.yaml",
+        ]
+    )
+    assert args.app_name == APP
+    assert args.channel == "web"
+    assert args.deployment_id == "dep-1"
+    assert args.verbose is True
+    assert args.trace is True
+    assert args.trace_format == "json"
+    assert args.metrics is True
+    assert args.script == "/tmp/script.yaml"
+    assert args.fork == "conv-123"
+    assert args.fork_at_turn == 3
+    assert args.config == "/tmp/trace.yaml"
+
+
+# -----------------------------------------------------------------------
+# Slash command tests
+# -----------------------------------------------------------------------
+
+
+def test_slash_command_help():
+    session = MagicMock()
+    renderer = MagicMock()
+    result = chat_cli._handle_slash_command("/help", session, renderer, _ns())
+    assert result is True
+    renderer.render_slash_help.assert_called_once()
+
+
+def test_slash_command_state():
+    session = MagicMock()
+    session.get_state.return_value = {"active_agent": "Agent1"}
+    renderer = MagicMock()
+    result = chat_cli._handle_slash_command("/state", session, renderer, _ns())
+    assert result is True
+    session.get_state.assert_called_once()
+    renderer.render_state.assert_called_once_with({"active_agent": "Agent1"})
+
+
+def test_slash_command_trace():
+    session = MagicMock()
+    session.get_trace.return_value = "trace output"
+    renderer = MagicMock()
+    result = chat_cli._handle_slash_command(
+        "/trace", session, renderer, _ns(trace_format="json")
+    )
+    assert result is True
+    session.get_trace.assert_called_once_with(fmt="json")
+
+
+def test_slash_command_quit():
+    session = MagicMock()
+    renderer = MagicMock()
+    result = chat_cli._handle_slash_command("/quit", session, renderer, _ns())
+    assert result is False
+
+
+def test_slash_command_save(tmp_path):
+    session = MagicMock()
+    session.export_turns_summary.return_value = [
+        {"turn": 0, "user": "hi", "agent": "hello"}
+    ]
+    renderer = MagicMock()
+    save_path = str(tmp_path / "conv.json")
+    result = chat_cli._handle_slash_command(
+        f"/save {save_path}", session, renderer, _ns()
+    )
+    assert result is True
+    session.export_turns_summary.assert_called_once()
+    with open(save_path) as f:
+        data = json.load(f)
+    assert data == [{"turn": 0, "user": "hi", "agent": "hello"}]
+
+
+def test_slash_command_unknown():
+    session = MagicMock()
+    renderer = MagicMock()
+    result = chat_cli._handle_slash_command(
+        "/unknown", session, renderer, _ns()
+    )
+    assert result is True
+    renderer.render_error.assert_called_once()
+
+
+def test_slash_command_bug_no_reason():
+    session = MagicMock()
+    renderer = MagicMock()
+    result = chat_cli._handle_slash_command("/bug", session, renderer, _ns())
+    assert result is True
+    renderer.render_error.assert_called_once()
+
+
+def test_slash_command_save_no_path():
+    session = MagicMock()
+    renderer = MagicMock()
+    result = chat_cli._handle_slash_command("/save", session, renderer, _ns())
+    assert result is True
+    renderer.render_error.assert_called_once()
+
+
+def test_slash_command_clear():
+    session = MagicMock()
+    renderer = MagicMock()
+    result = chat_cli._handle_slash_command("/clear", session, renderer, _ns())
+    assert result is True
+    renderer.console.clear.assert_called_once()
+
+
+@patch.object(chat_cli, "_paged")
+def test_state_uses_pager(mock_paged):
+    session = MagicMock()
+    session.get_state.return_value = {"active_agent": "Agent1"}
+    renderer = MagicMock()
+    result = chat_cli._handle_slash_command("/state", session, renderer, _ns())
+    assert result is True
+    mock_paged.assert_called_once()
+
+
+@patch("shutil.which", return_value=None)
+def test_paged_falls_back_without_less(mock_which):
+    renderer = MagicMock()
+    fn = MagicMock()
+    chat_cli._paged(renderer, fn)
+    fn.assert_called_once()
+
+
+# -----------------------------------------------------------------------
+# chat_interactive tests
+# -----------------------------------------------------------------------
+
+
+@patch.object(chat_cli, "ChatSession")
+@patch.object(chat_cli, "ChatRenderer")
+@patch("builtins.input")
+def test_chat_interactive_basic(mock_input, mock_renderer_cls, mock_session_cls):
+    """Mock input to return 'hello' then '/quit'; verify send called."""
+    mock_input.side_effect = ["hello", "/quit"]
+
+    mock_session = MagicMock()
+    mock_session.session_id = "sess-123"
+    mock_session.turns = []
+    mock_session.is_ended = False
+    mock_session_cls.return_value = mock_session
+
+    mock_renderer = MagicMock()
+    mock_renderer_cls.return_value = mock_renderer
+
+    # After send(), add a turn to the list so len(turns) is correct
+    def _send_side_effect(text):
+        turn = MagicMock()
+        turn.session_ended = False
+        mock_session.turns.append(turn)
+        return turn
+
+    mock_session.send.side_effect = _send_side_effect
+
+    chat_cli.chat_interactive(_ns())
+
+    mock_session.send.assert_called_once_with("hello")
+    mock_renderer.render_turn.assert_called_once()
+    mock_renderer.render_session_end.assert_called_once()
+
+
+@patch.object(chat_cli, "ChatSession")
+@patch.object(chat_cli, "ChatRenderer")
+@patch("builtins.input")
+def test_chat_interactive_session_end(
+    mock_input, mock_renderer_cls, mock_session_cls
+):
+    """Mock session that returns is_ended=True after first send."""
+    mock_input.side_effect = ["hello", "should not reach this"]
+
+    mock_session = MagicMock()
+    mock_session.session_id = "sess-456"
+    mock_session.turns = []
+
+    def _send_side_effect(text):
+        turn = MagicMock()
+        turn.session_ended = True
+        mock_session.turns.append(turn)
+        mock_session.is_ended = True
+        return turn
+
+    mock_session.send.side_effect = _send_side_effect
+    mock_session.is_ended = False
+    mock_session_cls.return_value = mock_session
+
+    mock_renderer = MagicMock()
+    mock_renderer_cls.return_value = mock_renderer
+
+    chat_cli.chat_interactive(_ns())
+
+    # Only one send call because session ended
+    mock_session.send.assert_called_once_with("hello")
+    mock_renderer.render_session_end.assert_called_once()
+
+
+@patch.object(chat_cli, "ChatSession")
+@patch.object(chat_cli, "ChatRenderer")
+@patch("builtins.input")
+def test_chat_interactive_keyboard_interrupt(
+    mock_input, mock_renderer_cls, mock_session_cls
+):
+    """Verify KeyboardInterrupt exits gracefully."""
+    mock_input.side_effect = KeyboardInterrupt
+
+    mock_session = MagicMock()
+    mock_session.session_id = "sess-789"
+    mock_session.turns = []
+    mock_session_cls.return_value = mock_session
+
+    mock_renderer = MagicMock()
+    mock_renderer_cls.return_value = mock_renderer
+
+    # Should not raise
+    chat_cli.chat_interactive(_ns())
+    mock_renderer.render_session_end.assert_called_once()
+
+
+@patch.object(chat_cli, "ChatSession")
+@patch.object(chat_cli, "ChatRenderer")
+@patch("builtins.input")
+def test_chat_interactive_auto_trace(
+    mock_input, mock_renderer_cls, mock_session_cls
+):
+    """Verify --trace flag triggers get_trace on exit."""
+    mock_input.side_effect = ["/quit"]
+
+    mock_session = MagicMock()
+    mock_session.session_id = "sess-trace"
+    mock_session.turns = []
+    mock_session.get_trace.return_value = "trace data"
+    mock_session_cls.return_value = mock_session
+
+    mock_renderer = MagicMock()
+    mock_renderer_cls.return_value = mock_renderer
+
+    chat_cli.chat_interactive(_ns(trace=True, trace_format="md"))
+
+    mock_session.get_trace.assert_called_once_with(fmt="md")
+
+
+# -----------------------------------------------------------------------
+# ChatConfig / TraceConfig tests
+# -----------------------------------------------------------------------
+
+
+def test_chat_config_defaults():
+    cfg = ChatConfig()
+    assert cfg.auto_trace is False
+    assert cfg.auto_trace_format == "text"
+    assert cfg.verbose is False
+    assert cfg.show_metrics is False
+    assert cfg.save_session is True
+    assert cfg.latency_warning_ms == 5000
+
+
+def test_chat_config_in_trace_config():
+    cfg = TraceConfig()
+    assert isinstance(cfg.chat, ChatConfig)
+    assert cfg.chat.auto_trace is False
+
+
+def test_chat_config_override():
+    cfg = ChatConfig(auto_trace=True, verbose=True, latency_warning_ms=3000)
+    assert cfg.auto_trace is True
+    assert cfg.verbose is True
+    assert cfg.latency_warning_ms == 3000
+
+
+# -----------------------------------------------------------------------
+# SLASH_COMMANDS dict test
+# -----------------------------------------------------------------------
+
+
+def test_slash_commands_dict():
+    assert "/help" in chat_cli.SLASH_COMMANDS
+    assert "/trace" in chat_cli.SLASH_COMMANDS
+    assert "/state" in chat_cli.SLASH_COMMANDS
+    assert "/slots" in chat_cli.SLASH_COMMANDS
+    assert "/clear" in chat_cli.SLASH_COMMANDS
+    assert "/quit" in chat_cli.SLASH_COMMANDS
+    assert "/save <path>" in chat_cli.SLASH_COMMANDS
+    assert "/bug <reason>" in chat_cli.SLASH_COMMANDS
+
+
+def test_slash_command_slots_no_turns():
+    session = MagicMock()
+    session.turns = []
+    renderer = MagicMock()
+    result = chat_cli._handle_slash_command("/slots", session, renderer, _ns())
+    assert result is True
+    renderer.render_error.assert_called_once()
+    assert "Send at least one message" in renderer.render_error.call_args[0][0]
+
+
+def test_slash_command_slots():
+    session = MagicMock()
+    session.turns = [MagicMock()]
+    session.get_slot_machine.return_value = {
+        "filled": {"party_size": "4"},
+        "pending": {"preferred_date": "Friday"},
+        "status": "in_progress",
+    }
+    renderer = MagicMock()
+    result = chat_cli._handle_slash_command("/slots", session, renderer, _ns())
+    assert result is True
+    session.get_slot_machine.assert_called_once()
+    renderer.render_slots.assert_called_once()
+    inspection = renderer.render_slots.call_args[0][0]
+    assert inspection["summary"]["filled_count"] == 1
+    assert inspection["summary"]["pending_count"] == 1
+
+
+def test_slash_command_slots_with_category():
+    session = MagicMock()
+    session.turns = [MagicMock()]
+    session.get_slot_machine.return_value = {
+        "filled": {"party_size": "4"},
+        "pending": {},
+        "status": "in_progress",
+    }
+    renderer = MagicMock()
+    result = chat_cli._handle_slash_command(
+        "/slots core_data", session, renderer, _ns()
+    )
+    assert result is True
+    renderer.render_slots.assert_called_once()
+    assert renderer.render_slots.call_args[1]["category"] == "core_data"
+
+
+def test_slash_command_slots_no_sm():
+    session = MagicMock()
+    session.turns = [MagicMock()]
+    session.get_slot_machine.return_value = {}
+    renderer = MagicMock()
+    result = chat_cli._handle_slash_command("/slots", session, renderer, _ns())
+    assert result is True
+    renderer.render_error.assert_called_once()
+
+
+# -----------------------------------------------------------------------
+# /log slash command tests
+# -----------------------------------------------------------------------
+
+
+def test_log_no_turns():
+    session = MagicMock()
+    session.turns = []
+    renderer = MagicMock()
+    result = chat_cli._handle_slash_command("/log", session, renderer, _ns())
+    assert result is True
+    renderer.render_error.assert_called_once()
+    assert "Send at least one message" in renderer.render_error.call_args[0][0]
+
+
+def test_log_no_slot_machine():
+    session = MagicMock()
+    session.turns = [MagicMock()]
+    session.get_slot_machine.return_value = None
+    renderer = MagicMock()
+    result = chat_cli._handle_slash_command("/log", session, renderer, _ns())
+    assert result is True
+    renderer.render_error.assert_called_once()
+    assert "No slot machine state" in renderer.render_error.call_args[0][0]
+
+
+def test_log_no_log_entries():
+    session = MagicMock()
+    session.turns = [MagicMock()]
+    session.get_slot_machine.return_value = {"_log": []}
+    renderer = MagicMock()
+    result = chat_cli._handle_slash_command("/log", session, renderer, _ns())
+    assert result is True
+    renderer.render_error.assert_called_once()
+    assert "No log entries" in renderer.render_error.call_args[0][0]
+
+
+def test_log_dispatches_to_renderer():
+    session = MagicMock()
+    session.turns = [MagicMock()]
+    log_entries = [
+        {"level": "INFO", "message": "slot filled", "ts": "12:00"},
+        {"level": "DEBUG", "message": "evaluating DAG", "ts": "12:01"},
+    ]
+    session.get_slot_machine.return_value = {"_log": log_entries}
+    renderer = MagicMock()
+    result = chat_cli._handle_slash_command("/log", session, renderer, _ns())
+    assert result is True
+    renderer.render_log.assert_called_once_with(log_entries, min_level="INFO")
+
+
+def test_log_invalid_level():
+    session = MagicMock()
+    session.turns = [MagicMock()]
+    session.get_slot_machine.return_value = {
+        "_log": [{"level": "INFO", "message": "x"}]
+    }
+    renderer = MagicMock()
+    result = chat_cli._handle_slash_command(
+        "/log foobar", session, renderer, _ns()
+    )
+    assert result is True
+    renderer.render_error.assert_called_once()
+    assert "Unknown level" in renderer.render_error.call_args[0][0]
+
+
+@pytest.mark.parametrize("level_input,expected", [
+    ("debug", "DEBUG"),
+    ("WARN", "WARN"),
+    ("info", "INFO"),
+    ("Error", "ERROR"),
+])
+def test_log_valid_levels(level_input, expected):
+    session = MagicMock()
+    session.turns = [MagicMock()]
+    log_entries = [{"level": "DEBUG", "message": "test"}]
+    session.get_slot_machine.return_value = {"_log": log_entries}
+    renderer = MagicMock()
+    result = chat_cli._handle_slash_command(
+        f"/log {level_input}", session, renderer, _ns()
+    )
+    assert result is True
+    renderer.render_log.assert_called_once_with(log_entries, min_level=expected)
+
+
+# -----------------------------------------------------------------------
+# readline setup tests
+# -----------------------------------------------------------------------
+
+
+@patch("cxas_scrapi.cli.chat_cli.readline")
+def test_setup_readline_reads_history(mock_readline):
+    chat_cli._setup_readline()
+    mock_readline.set_history_length.assert_called_once_with(1000)
+    mock_readline.read_history_file.assert_called_once_with(
+        chat_cli._HISTORY_FILE
+    )
+
+
+@patch("cxas_scrapi.cli.chat_cli.readline")
+def test_setup_readline_handles_missing_file(mock_readline):
+    mock_readline.read_history_file.side_effect = FileNotFoundError
+    # Should not raise
+    chat_cli._setup_readline()
+    mock_readline.set_history_length.assert_called_once_with(1000)
+
+
+@patch("cxas_scrapi.cli.chat_cli.readline")
+def test_setup_readline_sets_completer(mock_readline):
+    chat_cli._setup_readline()
+    mock_readline.set_completer.assert_called_once_with(chat_cli._slash_completer)
+    mock_readline.set_completer_delims.assert_called_once_with(" \t\n")
+    mock_readline.parse_and_bind.assert_called_once_with("tab: complete")
+
+
+def test_completable_commands_match_slash_commands():
+    """Every completable command should derive from a SLASH_COMMANDS key."""
+    base_commands = {k.split()[0] for k in chat_cli.SLASH_COMMANDS}
+    for cmd in chat_cli._COMPLETABLE_COMMANDS:
+        assert cmd in base_commands
+
+
+def test_completable_commands_are_base_commands():
+    """Completable commands are the unique base words from SLASH_COMMANDS."""
+    for cmd in chat_cli._COMPLETABLE_COMMANDS:
+        assert " " not in cmd
+        assert cmd.startswith("/")
+
+
+def test_slash_completer_returns_matches():
+    assert chat_cli._slash_completer("/h", 0) == "/help"
+    assert chat_cli._slash_completer("/h", 1) is None
+
+
+def test_slash_completer_returns_none_without_slash():
+    assert chat_cli._slash_completer("help", 0) is None
+
+
+def test_slash_completer_returns_multiple_matches():
+    results = []
+    for i in range(10):
+        r = chat_cli._slash_completer("/s", i)
+        if r is None:
+            break
+        results.append(r)
+    assert "/save" in results
+    assert "/slots" in results
+    assert "/state" in results

--- a/tests/cxas_scrapi/cli/test_chat_step_cli.py
+++ b/tests/cxas_scrapi/cli/test_chat_step_cli.py
@@ -1,0 +1,646 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the chat-step CLI module."""
+
+import argparse
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cxas_scrapi.cli import chat_step_cli
+
+APP = "projects/p/locations/l/apps/a"
+
+
+def _ns(**overrides):
+    """Build a minimal argparse.Namespace for chat-step commands."""
+    base = dict(
+        app_name=APP,
+        message="Hello",
+        session_file=None,
+        channel=None,
+        deployment_id=None,
+        with_trace=False,
+        with_metrics=False,
+        with_slots=False,
+        with_log=None,
+        with_flow_context=False,
+        with_trace_report=None,
+        with_turns=False,
+        bug=None,
+        inspect_only=False,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def _step_result(**overrides):
+    """Build a mock step() return value."""
+    base = {
+        "turn_index": 0,
+        "user_text": "Hello",
+        "agent_text": "Hi there!",
+        "tool_calls": [],
+        "tool_responses": [],
+        "agent_transfer": None,
+        "session_ended": False,
+        "state": {
+            "active_agent": None,
+            "slot_machine": {},
+            "filled_slots": {},
+            "session_ended": False,
+            "turn_count": 1,
+            "pending_transfer": None,
+        },
+        "session_id": "test-session-id",
+        "trace": None,
+        "metrics": None,
+    }
+    base.update(overrides)
+    return base
+
+
+# -----------------------------------------------------------------------
+# Registration / argparse tests
+# -----------------------------------------------------------------------
+
+
+def test_register_smoke():
+    """Verify `cxas chat-step --app-name APP -m "hi"` parses correctly."""
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    chat_step_cli.register(sub)
+    args = parser.parse_args(["chat-step", "--app-name", APP, "-m", "hi"])
+    assert args.app_name == APP
+    assert args.message == "hi"
+    assert hasattr(args, "func")
+
+
+def test_register_all_flags():
+    """Verify all flags parse without errors."""
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    chat_step_cli.register(sub)
+    args = parser.parse_args(
+        [
+            "chat-step",
+            "--app-name",
+            APP,
+            "--message",
+            "test message",
+            "--session-file",
+            "/tmp/session.json",
+            "--channel",
+            "web",
+            "--deployment-id",
+            "dep-1",
+            "--with-trace",
+            "--with-metrics",
+            "--with-slots",
+        ]
+    )
+    assert args.app_name == APP
+    assert args.message == "test message"
+    assert args.session_file == "/tmp/session.json"
+    assert args.channel == "web"
+    assert args.deployment_id == "dep-1"
+    assert args.with_trace is True
+    assert args.with_metrics is True
+    assert args.with_slots is True
+
+
+# -----------------------------------------------------------------------
+# chat_step() handler tests
+# -----------------------------------------------------------------------
+
+
+@patch.object(chat_step_cli, "ProgrammaticChatDriver")
+def test_chat_step_basic(MockDriver, capsys):
+    """New session sends message and prints JSON to stdout."""
+    mock_driver = MagicMock()
+    mock_driver.session_id = "test-session-id"
+    mock_driver.step.return_value = _step_result()
+    mock_driver.is_ended = False
+    MockDriver.return_value = mock_driver
+
+    chat_step_cli.chat_step(_ns())
+
+    mock_driver.step.assert_called_once_with("Hello")
+    mock_driver.close.assert_called_once()
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    assert output["agent_text"] == "Hi there!"
+
+
+@patch.object(chat_step_cli, "ProgrammaticChatDriver")
+def test_chat_step_with_session_file_new(MockDriver, capsys, tmp_path):
+    """When session file doesn't exist yet, creates it after the step."""
+    mock_driver = MagicMock()
+    mock_driver.session_id = "new-session-id"
+    mock_driver.step.return_value = _step_result(session_id="new-session-id")
+    MockDriver.return_value = mock_driver
+
+    session_file = str(tmp_path / "session.json")
+    chat_step_cli.chat_step(_ns(session_file=session_file))
+
+    with open(session_file) as f:
+        saved = json.load(f)
+    assert saved["session_id"] == "new-session-id"
+    assert saved["turn_count"] == 1
+    assert saved["app_name"] == APP
+
+
+@patch.object(chat_step_cli, "ProgrammaticChatDriver")
+def test_chat_step_with_session_file_resume(MockDriver, capsys, tmp_path):
+    """Existing session file passes session_id and turn_count to driver."""
+    session_file = str(tmp_path / "session.json")
+    with open(session_file, "w") as f:
+        json.dump({"session_id": "existing-session", "turn_count": 3, "app_name": APP}, f)
+
+    mock_driver = MagicMock()
+    mock_driver.session_id = "existing-session"
+    mock_driver.step.return_value = _step_result(
+        turn_index=3,
+        state={
+            "active_agent": None,
+            "slot_machine": {},
+            "filled_slots": {},
+            "session_ended": False,
+            "turn_count": 4,
+            "pending_transfer": None,
+        },
+    )
+    MockDriver.return_value = mock_driver
+
+    chat_step_cli.chat_step(_ns(session_file=session_file))
+
+    MockDriver.assert_called_once_with(
+        app_name=APP,
+        channel=None,
+        deployment_id=None,
+        include_trace=False,
+        include_metrics=False,
+        session_id="existing-session",
+        initial_turn_count=3,
+        initial_variable_state=None,
+    )
+
+
+@patch.object(chat_step_cli, "ProgrammaticChatDriver")
+def test_chat_step_with_trace(MockDriver, capsys):
+    """--with-trace passes include_trace=True to driver."""
+    mock_driver = MagicMock()
+    mock_driver.session_id = "test-session-id"
+    mock_driver.step.return_value = _step_result(trace={"spans": []})
+    MockDriver.return_value = mock_driver
+
+    chat_step_cli.chat_step(_ns(with_trace=True))
+
+    MockDriver.assert_called_once_with(
+        app_name=APP,
+        channel=None,
+        deployment_id=None,
+        include_trace=True,
+        include_metrics=False,
+        session_id=None,
+        initial_turn_count=0,
+        initial_variable_state=None,
+    )
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    assert output["trace"] == {"spans": []}
+
+
+@patch.object(chat_step_cli, "ProgrammaticChatDriver")
+def test_chat_step_with_metrics(MockDriver, capsys):
+    """--with-metrics passes include_metrics=True to driver."""
+    mock_driver = MagicMock()
+    mock_driver.session_id = "test-session-id"
+    mock_driver.step.return_value = _step_result(metrics={"latency_ms": 150})
+    MockDriver.return_value = mock_driver
+
+    chat_step_cli.chat_step(_ns(with_metrics=True))
+
+    MockDriver.assert_called_once_with(
+        app_name=APP,
+        channel=None,
+        deployment_id=None,
+        include_trace=False,
+        include_metrics=True,
+        session_id=None,
+        initial_turn_count=0,
+        initial_variable_state=None,
+    )
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    assert output["metrics"] == {"latency_ms": 150}
+
+
+@patch.object(chat_step_cli, "ProgrammaticChatDriver")
+def test_chat_step_with_slots(MockDriver, capsys):
+    """--with-slots calls get_full_state and adds slot_inspection to output."""
+    mock_driver = MagicMock()
+    mock_driver.session_id = "test-session-id"
+    mock_driver.step.return_value = _step_result()
+    mock_driver.get_full_state.return_value = {
+        "active_agent": None,
+        "slot_machine": {},
+        "filled_slots": {"name": "Alice"},
+        "session_ended": False,
+        "turn_count": 1,
+        "pending_transfer": None,
+        "slot_inspection": {"name": {"value": "Alice", "source": "user"}},
+    }
+    MockDriver.return_value = mock_driver
+
+    chat_step_cli.chat_step(_ns(with_slots=True))
+
+    mock_driver.get_full_state.assert_called_once()
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    assert output["slot_inspection"] == {"name": {"value": "Alice", "source": "user"}}
+
+
+@patch.object(chat_step_cli, "ProgrammaticChatDriver")
+def test_chat_step_session_file_updated(MockDriver, capsys, tmp_path):
+    """Session file is written with correct turn_count after step."""
+    session_file = str(tmp_path / "session.json")
+
+    mock_driver = MagicMock()
+    mock_driver.session_id = "sess-42"
+    mock_driver.step.return_value = _step_result(
+        state={
+            "active_agent": None,
+            "slot_machine": {},
+            "filled_slots": {},
+            "session_ended": False,
+            "turn_count": 5,
+            "pending_transfer": None,
+        },
+    )
+    MockDriver.return_value = mock_driver
+
+    chat_step_cli.chat_step(_ns(session_file=session_file))
+
+    with open(session_file) as f:
+        saved = json.load(f)
+    assert saved["session_id"] == "sess-42"
+    assert saved["turn_count"] == 5
+    assert saved["app_name"] == APP
+
+
+@patch.object(chat_step_cli, "ProgrammaticChatDriver")
+def test_chat_step_driver_error(MockDriver, capsys):
+    """driver.step() raising prints error to stderr and exits with 1."""
+    mock_driver = MagicMock()
+    mock_driver.step.side_effect = RuntimeError("connection lost")
+    MockDriver.return_value = mock_driver
+
+    with pytest.raises(SystemExit) as exc_info:
+        chat_step_cli.chat_step(_ns())
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "Chat step failed: connection lost" in captured.err
+    mock_driver.close.assert_called_once()
+
+
+@patch.object(chat_step_cli, "ProgrammaticChatDriver")
+def test_chat_step_session_file_corrupt(MockDriver, capsys, tmp_path):
+    """Corrupt session file prints error to stderr and exits with 1."""
+    session_file = str(tmp_path / "session.json")
+    with open(session_file, "w") as f:
+        f.write("{not valid json")
+
+    with pytest.raises(SystemExit) as exc_info:
+        chat_step_cli.chat_step(_ns(session_file=session_file))
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "Failed to load session file" in captured.err
+    MockDriver.assert_not_called()
+
+
+@patch.object(chat_step_cli, "ProgrammaticChatDriver")
+def test_chat_step_json_output_valid(MockDriver, capsys):
+    """Stdout is valid JSON with all expected keys."""
+    mock_driver = MagicMock()
+    mock_driver.session_id = "test-session-id"
+    mock_driver.step.return_value = _step_result()
+    MockDriver.return_value = mock_driver
+
+    chat_step_cli.chat_step(_ns())
+
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    expected_keys = {
+        "turn_index", "user_text", "agent_text", "tool_calls",
+        "tool_responses", "agent_transfer", "session_ended",
+        "state", "session_id", "trace", "metrics",
+    }
+    assert expected_keys == set(output.keys())
+    assert isinstance(output["state"], dict)
+    assert "turn_count" in output["state"]
+
+
+@patch.object(chat_step_cli, "ProgrammaticChatDriver")
+def test_chat_step_driver_creation_error(MockDriver, capsys):
+    """Driver constructor raising prints error and exits with 1."""
+    MockDriver.side_effect = ValueError("invalid app name")
+
+    with pytest.raises(SystemExit) as exc_info:
+        chat_step_cli.chat_step(_ns())
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "Failed to create session: invalid app name" in captured.err
+
+
+# -----------------------------------------------------------------------
+# New flag tests
+# -----------------------------------------------------------------------
+
+
+def test_register_new_flags():
+    """All new flags parse without errors."""
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    chat_step_cli.register(sub)
+    args = parser.parse_args([
+        "chat-step", "--app-name", APP, "-m", "test",
+        "--with-log", "debug",
+        "--with-flow-context",
+        "--with-trace-report", "md",
+        "--with-turns",
+        "--bug", "something broke",
+    ])
+    assert args.with_log == "debug"
+    assert args.with_flow_context is True
+    assert args.with_trace_report == "md"
+    assert args.with_turns is True
+    assert args.bug == "something broke"
+
+
+def test_register_with_log_default_level():
+    """--with-log alone defaults to INFO."""
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    chat_step_cli.register(sub)
+    args = parser.parse_args([
+        "chat-step", "--app-name", APP, "-m", "test", "--with-log",
+    ])
+    assert args.with_log == "INFO"
+
+
+def test_register_inspect_only():
+    """--inspect-only makes --message optional."""
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    chat_step_cli.register(sub)
+    args = parser.parse_args([
+        "chat-step", "--app-name", APP, "--inspect-only",
+    ])
+    assert args.inspect_only is True
+    assert args.message is None
+
+
+@patch.object(chat_step_cli, "ProgrammaticChatDriver")
+def test_with_log_enriches(MockDriver, capsys):
+    """--with-log adds sm_log to output."""
+    mock_driver = MagicMock()
+    mock_driver.session_id = "test-session-id"
+    mock_driver.step.return_value = _step_result()
+    mock_driver.get_sm_log.return_value = [{"tag": "config_loaded", "level": "INFO"}]
+    MockDriver.return_value = mock_driver
+
+    chat_step_cli.chat_step(_ns(with_log="INFO"))
+
+    mock_driver.get_sm_log.assert_called_once_with("INFO")
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    assert output["sm_log"] == [{"tag": "config_loaded", "level": "INFO"}]
+
+
+@patch.object(chat_step_cli, "ProgrammaticChatDriver")
+def test_with_flow_context_enriches(MockDriver, capsys):
+    """--with-flow-context adds flow_context to output."""
+    mock_driver = MagicMock()
+    mock_driver.session_id = "test-session-id"
+    mock_driver.step.return_value = _step_result()
+    mock_driver.get_flow_context.return_value = {
+        "active_config_id": "reservation",
+        "agent_config_map": {},
+        "active_sm_key": "sm",
+    }
+    MockDriver.return_value = mock_driver
+
+    chat_step_cli.chat_step(_ns(with_flow_context=True))
+
+    mock_driver.get_flow_context.assert_called_once()
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    assert output["flow_context"]["active_config_id"] == "reservation"
+
+
+@patch.object(chat_step_cli, "ProgrammaticChatDriver")
+def test_with_trace_report_enriches(MockDriver, capsys):
+    """--with-trace-report adds trace_report to output."""
+    mock_driver = MagicMock()
+    mock_driver.session_id = "test-session-id"
+    mock_driver.step.return_value = _step_result()
+    mock_driver.get_trace_report.return_value = "# Trace Report\n..."
+    MockDriver.return_value = mock_driver
+
+    chat_step_cli.chat_step(_ns(with_trace_report="md"))
+
+    mock_driver.get_trace_report.assert_called_once_with("md")
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    assert output["trace_report"] == "# Trace Report\n..."
+
+
+@patch.object(chat_step_cli, "ProgrammaticChatDriver")
+def test_with_turns_enriches(MockDriver, capsys):
+    """--with-turns adds turns_summary to output."""
+    mock_driver = MagicMock()
+    mock_driver.session_id = "test-session-id"
+    mock_driver.step.return_value = _step_result()
+    mock_driver.get_turns_summary.return_value = [
+        {"turn": 0, "user": "Hello", "agent": "Hi!"},
+    ]
+    MockDriver.return_value = mock_driver
+
+    chat_step_cli.chat_step(_ns(with_turns=True))
+
+    mock_driver.get_turns_summary.assert_called_once()
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    assert len(output["turns_summary"]) == 1
+
+
+@patch.object(chat_step_cli, "ProgrammaticChatDriver")
+def test_bug_flag_enriches(MockDriver, capsys):
+    """--bug adds bug_report to output."""
+    mock_driver = MagicMock()
+    mock_driver.session_id = "test-session-id"
+    mock_driver.step.return_value = _step_result()
+    mock_driver.report_bug.return_value = {"status": "reported", "id": "bug-123"}
+    MockDriver.return_value = mock_driver
+
+    chat_step_cli.chat_step(_ns(bug="something broke"))
+
+    mock_driver.report_bug.assert_called_once_with("something broke")
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    assert output["bug_report"]["status"] == "reported"
+
+
+@patch.object(chat_step_cli, "ProgrammaticChatDriver")
+def test_inspect_only_no_step(MockDriver, capsys, tmp_path):
+    """--inspect-only doesn't call driver.step()."""
+    session_file = str(tmp_path / "session.json")
+    with open(session_file, "w") as f:
+        json.dump({"session_id": "existing-sess", "turn_count": 2, "app_name": APP}, f)
+
+    mock_driver = MagicMock()
+    mock_driver.session_id = "existing-sess"
+    mock_driver.get_full_state.return_value = {
+        "active_agent": None,
+        "slot_machine": {},
+        "filled_slots": {},
+        "session_ended": False,
+        "turn_count": 2,
+        "pending_transfer": None,
+    }
+    MockDriver.return_value = mock_driver
+
+    chat_step_cli.chat_step(_ns(
+        inspect_only=True,
+        message=None,
+        session_file=session_file,
+    ))
+
+    mock_driver.step.assert_not_called()
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    assert output["inspect_only"] is True
+    assert output["session_id"] == "existing-sess"
+
+
+@patch.object(chat_step_cli, "ProgrammaticChatDriver")
+def test_inspect_only_requires_session_file(MockDriver, capsys):
+    """--inspect-only without session file errors."""
+    with pytest.raises(SystemExit) as exc_info:
+        chat_step_cli.chat_step(_ns(inspect_only=True, message=None))
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "--inspect-only requires --session-file" in captured.err
+
+
+@patch.object(chat_step_cli, "ProgrammaticChatDriver")
+def test_inspect_only_with_enrichments(MockDriver, capsys, tmp_path):
+    """--inspect-only works with --with-* flags."""
+    session_file = str(tmp_path / "session.json")
+    with open(session_file, "w") as f:
+        json.dump({"session_id": "existing-sess", "turn_count": 2, "app_name": APP}, f)
+
+    mock_driver = MagicMock()
+    mock_driver.session_id = "existing-sess"
+    mock_driver.get_full_state.return_value = {"slot_machine": {}, "filled_slots": {}}
+    mock_driver.get_sm_log.return_value = [{"tag": "test"}]
+    mock_driver.get_flow_context.return_value = {"active_config_id": "test"}
+    MockDriver.return_value = mock_driver
+
+    chat_step_cli.chat_step(_ns(
+        inspect_only=True,
+        message=None,
+        session_file=session_file,
+        with_log="INFO",
+        with_flow_context=True,
+    ))
+
+    mock_driver.step.assert_not_called()
+    mock_driver.get_sm_log.assert_called_once()
+    mock_driver.get_flow_context.assert_called_once()
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    assert "sm_log" in output
+    assert "flow_context" in output
+
+
+@patch.object(chat_step_cli, "ProgrammaticChatDriver")
+def test_variable_state_persisted(MockDriver, capsys, tmp_path):
+    """Session file includes variable_state after a step."""
+    session_file = str(tmp_path / "session.json")
+    mock_driver = MagicMock()
+    mock_driver.session_id = "sess-42"
+    mock_driver.step.return_value = _step_result(
+        state={"turn_count": 1, "active_agent": None, "slot_machine": {}, "filled_slots": {}, "session_ended": False, "pending_transfer": None},
+    )
+    mock_driver._session._variable_state = {"sm": {"filled": {"name": "Alice"}}}
+    MockDriver.return_value = mock_driver
+
+    chat_step_cli.chat_step(_ns(session_file=session_file))
+
+    with open(session_file) as f:
+        saved = json.load(f)
+    assert "variable_state" in saved
+    assert saved["variable_state"]["sm"]["filled"]["name"] == "Alice"
+
+
+@patch.object(chat_step_cli, "ProgrammaticChatDriver")
+def test_variable_state_loaded(MockDriver, capsys, tmp_path):
+    """variable_state from session file is passed to driver."""
+    session_file = str(tmp_path / "session.json")
+    var_state = {"sm": {"filled": {"name": "Bob"}, "_log": []}}
+    with open(session_file, "w") as f:
+        json.dump({
+            "session_id": "existing-sess",
+            "turn_count": 1,
+            "app_name": APP,
+            "variable_state": var_state,
+        }, f)
+
+    mock_driver = MagicMock()
+    mock_driver.session_id = "existing-sess"
+    mock_driver.step.return_value = _step_result(
+        state={"turn_count": 2, "active_agent": None, "slot_machine": {}, "filled_slots": {}, "session_ended": False, "pending_transfer": None},
+    )
+    mock_driver._session._variable_state = var_state
+    MockDriver.return_value = mock_driver
+
+    chat_step_cli.chat_step(_ns(session_file=session_file))
+
+    MockDriver.assert_called_once_with(
+        app_name=APP,
+        channel=None,
+        deployment_id=None,
+        include_trace=False,
+        include_metrics=False,
+        session_id="existing-sess",
+        initial_turn_count=1,
+        initial_variable_state=var_state,
+    )
+
+
+@patch.object(chat_step_cli, "ProgrammaticChatDriver")
+def test_message_required_without_inspect_only(MockDriver, capsys):
+    """Without --inspect-only, missing --message is an error."""
+    with pytest.raises(SystemExit) as exc_info:
+        chat_step_cli.chat_step(_ns(message=None))
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "--message is required" in captured.err

--- a/tests/cxas_scrapi/cli/test_slots_cli.py
+++ b/tests/cxas_scrapi/cli/test_slots_cli.py
@@ -1,0 +1,155 @@
+import argparse
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cxas_scrapi.cli import slots_cli
+
+APP = "projects/p/locations/l/apps/a"
+
+
+class TestRegister:
+    def test_register_smoke(self):
+        parser = argparse.ArgumentParser()
+        sub = parser.add_subparsers(dest="cmd", required=True)
+        slots_cli.register(sub)
+        args = parser.parse_args(
+            ["slots", "inspect", "--app-name", APP, "conv-123"]
+        )
+        assert args.func == slots_cli.slots_inspect
+        assert args.conversation_id == "conv-123"
+        assert args.app_name == APP
+
+    def test_register_with_flags(self):
+        parser = argparse.ArgumentParser()
+        sub = parser.add_subparsers(dest="cmd", required=True)
+        slots_cli.register(sub)
+        args = parser.parse_args(
+            [
+                "slots", "inspect",
+                "--app-name", APP,
+                "conv-456",
+                "--at-turn", "3",
+                "--category", "core_data",
+            ]
+        )
+        assert args.at_turn == 3
+        assert args.category == "core_data"
+
+
+class TestSlotsInspect:
+    @patch.object(slots_cli, "_build_traces")
+    def test_slots_inspect_basic(self, mock_build, capsys):
+        mock_traces = MagicMock()
+        mock_traces.get_normalized.return_value = {
+            "entries": [
+                {
+                    "kind": "variable_update",
+                    "turn": 0,
+                    "variables": {
+                        "slot_machine": {
+                            "filled": {"party_size": "4"},
+                            "pending": {},
+                            "status": "in_progress",
+                        }
+                    },
+                }
+            ]
+        }
+        mock_build.return_value = mock_traces
+
+        args = argparse.Namespace(
+            app_name=APP, conversation_id="conv-123",
+            at_turn=None, category=None,
+        )
+        slots_cli.slots_inspect(args)
+
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+        assert output["summary"]["filled_count"] == 1
+        assert output["summary"]["phase"] == "collection"
+
+    @patch.object(slots_cli, "_build_traces")
+    def test_slots_inspect_with_turn(self, mock_build, capsys):
+        mock_traces = MagicMock()
+        mock_traces.get_normalized.return_value = {
+            "entries": [
+                {
+                    "kind": "variable_update",
+                    "turn": 0,
+                    "variables": {
+                        "slot_machine": {
+                            "filled": {"a": "1"},
+                            "pending": {},
+                        }
+                    },
+                },
+                {
+                    "kind": "variable_update",
+                    "turn": 3,
+                    "variables": {
+                        "slot_machine": {
+                            "filled": {"a": "1", "b": "2", "c": "3"},
+                            "pending": {},
+                        }
+                    },
+                },
+            ]
+        }
+        mock_build.return_value = mock_traces
+
+        args = argparse.Namespace(
+            app_name=APP, conversation_id="conv-123",
+            at_turn=1, category=None,
+        )
+        slots_cli.slots_inspect(args)
+
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+        assert output["summary"]["filled_count"] == 1
+
+    @patch.object(slots_cli, "_build_traces")
+    def test_slots_inspect_with_category(self, mock_build, capsys):
+        mock_traces = MagicMock()
+        mock_traces.get_normalized.return_value = {
+            "entries": [
+                {
+                    "kind": "variable_update",
+                    "turn": 0,
+                    "variables": {
+                        "slot_machine": {
+                            "filled": {"party_size": "4"},
+                            "pending": {"time": "7pm"},
+                            "status": "in_progress",
+                            "_config_id": "reservation",
+                        }
+                    },
+                }
+            ]
+        }
+        mock_build.return_value = mock_traces
+
+        args = argparse.Namespace(
+            app_name=APP, conversation_id="conv-123",
+            at_turn=None, category="core_data",
+        )
+        slots_cli.slots_inspect(args)
+
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+        assert "core_data" in output["categories"]
+        assert len(output["categories"]) == 1
+
+    @patch.object(slots_cli, "_build_traces")
+    def test_slots_inspect_failure(self, mock_build, capsys):
+        mock_build.side_effect = RuntimeError("connection refused")
+
+        args = argparse.Namespace(
+            app_name=APP, conversation_id="conv-123",
+            at_turn=None, category=None,
+        )
+        with pytest.raises(SystemExit) as exc:
+            slots_cli.slots_inspect(args)
+        assert exc.value.code == 1
+        assert "connection refused" in capsys.readouterr().err

--- a/tests/cxas_scrapi/cli/test_trace_cli.py
+++ b/tests/cxas_scrapi/cli/test_trace_cli.py
@@ -305,6 +305,221 @@ def test_trace_replay_failure(fake_traces):
         )
 
 
+# ---------------------------------- fork --------------------------------------
+
+
+def test_trace_fork_text(fake_traces, capsys):
+    fake_traces.fork.return_value = {
+        "historical_contexts": [{"role": "user", "chunks": []}],
+        "turn_count": 3,
+        "original_conversation_id": "c1",
+        "forked_at_turn": 1,
+    }
+    trace_cli.trace_fork(
+        _ns(conversation_id="c1", at_turn=1, format="text")
+    )
+    out = capsys.readouterr().out
+    assert "Forked conversation c1" in out
+    assert "Loaded 3 turns" in out
+    assert "Truncated at turn 1" in out
+    assert "1 context messages ready" in out
+
+
+def test_trace_fork_json(fake_traces, capsys):
+    fake_traces.fork.return_value = {
+        "historical_contexts": [],
+        "turn_count": 2,
+        "original_conversation_id": "c1",
+        "forked_at_turn": None,
+    }
+    trace_cli.trace_fork(
+        _ns(conversation_id="c1", at_turn=None, format="json")
+    )
+    out = capsys.readouterr().out
+    parsed = json.loads(out)
+    assert parsed["turn_count"] == 2
+
+
+def test_trace_fork_text_no_truncation(fake_traces, capsys):
+    fake_traces.fork.return_value = {
+        "historical_contexts": [{"role": "user", "chunks": []}],
+        "turn_count": 3,
+        "original_conversation_id": "c1",
+        "forked_at_turn": None,
+    }
+    trace_cli.trace_fork(
+        _ns(conversation_id="c1", at_turn=None, format="text")
+    )
+    out = capsys.readouterr().out
+    assert "Truncated" not in out
+
+
+def test_trace_fork_failure(fake_traces):
+    fake_traces.fork.side_effect = RuntimeError("boom")
+    with pytest.raises(SystemExit):
+        trace_cli.trace_fork(
+            _ns(conversation_id="c1", at_turn=None, format="text")
+        )
+
+
+# ---------------------------------- diff --------------------------------------
+
+
+def test_trace_diff_text(fake_traces, capsys):
+    fake_traces.diff.return_value = {
+        "conversation_a": "ca",
+        "conversation_b": "cb",
+        "agent_text_diff": "--- ca\n+++ cb\n-hello\n+hi",
+        "tool_call_diff": "",
+        "turn_comparison": [],
+        "summary": {
+            "total_turns_a": 2,
+            "total_turns_b": 2,
+            "matching_turns": 1,
+            "differing_turns": 1,
+        },
+    }
+    trace_cli.trace_diff(
+        _ns(conversation_id_a="ca", conversation_id_b="cb", format="text")
+    )
+    out = capsys.readouterr().out
+    assert "Comparing ca vs cb" in out
+    assert "Matching: 1" in out
+    assert "--- Agent text diff ---" in out
+
+
+def test_trace_diff_json(fake_traces, capsys):
+    fake_traces.diff.return_value = {
+        "conversation_a": "ca",
+        "conversation_b": "cb",
+        "agent_text_diff": "",
+        "tool_call_diff": "",
+        "turn_comparison": [],
+        "summary": {
+            "total_turns_a": 1,
+            "total_turns_b": 1,
+            "matching_turns": 1,
+            "differing_turns": 0,
+        },
+    }
+    trace_cli.trace_diff(
+        _ns(conversation_id_a="ca", conversation_id_b="cb", format="json")
+    )
+    parsed = json.loads(capsys.readouterr().out)
+    assert parsed["conversation_a"] == "ca"
+
+
+def test_trace_diff_md(fake_traces, capsys):
+    fake_traces.diff.return_value = {
+        "conversation_a": "ca",
+        "conversation_b": "cb",
+        "agent_text_diff": "+changed",
+        "tool_call_diff": "",
+        "turn_comparison": [],
+        "summary": {
+            "total_turns_a": 2,
+            "total_turns_b": 2,
+            "matching_turns": 1,
+            "differing_turns": 1,
+        },
+    }
+    trace_cli.trace_diff(
+        _ns(conversation_id_a="ca", conversation_id_b="cb", format="md")
+    )
+    out = capsys.readouterr().out
+    assert "# Trace Diff" in out
+    assert "## Agent Text Diff" in out
+    assert "+changed" in out
+
+
+def test_trace_diff_md_identical(fake_traces, capsys):
+    fake_traces.diff.return_value = {
+        "conversation_a": "ca",
+        "conversation_b": "cb",
+        "agent_text_diff": "",
+        "tool_call_diff": "",
+        "turn_comparison": [],
+        "summary": {
+            "total_turns_a": 1,
+            "total_turns_b": 1,
+            "matching_turns": 1,
+            "differing_turns": 0,
+        },
+    }
+    trace_cli.trace_diff(
+        _ns(conversation_id_a="ca", conversation_id_b="cb", format="md")
+    )
+    out = capsys.readouterr().out
+    assert "_(identical)_" in out
+
+
+def test_trace_diff_text_with_tool_diff(fake_traces, capsys):
+    fake_traces.diff.return_value = {
+        "conversation_a": "ca",
+        "conversation_b": "cb",
+        "agent_text_diff": "",
+        "tool_call_diff": "--- ca (tools)\n+++ cb (tools)",
+        "turn_comparison": [],
+        "summary": {
+            "total_turns_a": 1,
+            "total_turns_b": 1,
+            "matching_turns": 0,
+            "differing_turns": 1,
+        },
+    }
+    trace_cli.trace_diff(
+        _ns(conversation_id_a="ca", conversation_id_b="cb", format="text")
+    )
+    out = capsys.readouterr().out
+    assert "--- Tool call diff ---" in out
+
+
+def test_trace_diff_failure(fake_traces):
+    fake_traces.diff.side_effect = RuntimeError("boom")
+    with pytest.raises(SystemExit):
+        trace_cli.trace_diff(
+            _ns(
+                conversation_id_a="ca",
+                conversation_id_b="cb",
+                format="text",
+            )
+        )
+
+
+def test_register_fork_subcommand():
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    trace_cli.register(sub)
+    args = parser.parse_args(
+        ["trace", "fork", "--app-name", APP, "conv-1", "--at-turn", "2"]
+    )
+    assert args.func == trace_cli.trace_fork
+    assert args.conversation_id == "conv-1"
+    assert args.at_turn == 2
+
+
+def test_register_diff_subcommand():
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    trace_cli.register(sub)
+    args = parser.parse_args(
+        [
+            "trace",
+            "diff",
+            "--app-name",
+            APP,
+            "conv-a",
+            "conv-b",
+            "--format",
+            "md",
+        ]
+    )
+    assert args.func == trace_cli.trace_diff
+    assert args.conversation_id_a == "conv-a"
+    assert args.conversation_id_b == "conv-b"
+    assert args.format == "md"
+
+
 def test_trace_stats_markdown(fake_traces, capsys):
     fake_traces.aggregate_stats.return_value = {
         "time_filter": "7d",

--- a/tests/cxas_scrapi/core/test_chat_session.py
+++ b/tests/cxas_scrapi/core/test_chat_session.py
@@ -1,0 +1,437 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cxas_scrapi.core.chat_session import (
+    ChatSession,
+    SessionEndedError,
+    TurnRecord,
+)
+
+APP = "projects/p/locations/l/apps/a"
+
+
+def _structured_response(
+    agent_text="Hello!",
+    tool_calls=None,
+    tool_responses=None,
+    agent_transfer=None,
+    session_ended=False,
+    **extras,
+):
+    """Build a dict matching Sessions.get_structured_response() output."""
+    result = {
+        "agent_text": agent_text,
+        "tool_calls": tool_calls or [],
+        "tool_responses": tool_responses or [],
+        "agent_transfer": agent_transfer,
+        "session_ended": session_ended,
+    }
+    result.update(extras)
+    return result
+
+
+@pytest.fixture
+def mock_sessions():
+    """Patch Sessions so construction doesn't hit real auth."""
+    with patch(
+        "cxas_scrapi.core.chat_session.Sessions"
+    ) as MockSessions:
+        instance = MagicMock()
+        instance.create_session_id.return_value = "test-session-id"
+        instance.run.return_value = SimpleNamespace(outputs=[])
+        instance.get_structured_response.return_value = (
+            _structured_response()
+        )
+        MockSessions.return_value = instance
+        yield instance
+
+
+class TestTurnRecord:
+    def test_fields_from_response(self):
+        resp = _structured_response(
+            agent_text="Hi there",
+            tool_calls=[{"action": "lookup", "args": {"q": "x"}}],
+            session_ended=True,
+        )
+        record = TurnRecord(turn_index=0, user_text="hello", response=resp)
+        assert record.turn_index == 0
+        assert record.user_text == "hello"
+        assert record.agent_text == "Hi there"
+        assert len(record.tool_calls) == 1
+        assert record.session_ended is True
+        assert record.raw_response is resp
+
+    def test_defaults_for_missing_keys(self):
+        record = TurnRecord(turn_index=1, user_text="hi", response={})
+        assert record.agent_text == ""
+        assert record.tool_calls == []
+        assert record.tool_responses == []
+        assert record.agent_transfer is None
+        assert record.session_ended is False
+
+
+class TestChatSessionConstruction:
+    def test_construction(self, mock_sessions):
+        session = ChatSession(app_name=APP)
+        assert session.session_id == "test-session-id"
+        assert session.turns == []
+        assert session.is_ended is False
+        assert session.current_turn_index == 0
+
+    def test_construction_passes_deployment_id(self, mock_sessions):
+        with patch(
+            "cxas_scrapi.core.chat_session.Sessions"
+        ) as MockSessions:
+            MockSessions.return_value = mock_sessions
+            ChatSession(app_name=APP, deployment_id="dep-1")
+            MockSessions.assert_called_once_with(
+                app_name=APP, deployment_id="dep-1"
+            )
+
+
+class TestChatSessionSend:
+    def test_send_basic(self, mock_sessions):
+        session = ChatSession(app_name=APP)
+        turn = session.send("Hello")
+
+        assert isinstance(turn, TurnRecord)
+        assert turn.turn_index == 0
+        assert turn.user_text == "Hello"
+        assert turn.agent_text == "Hello!"
+        mock_sessions.run.assert_called_once()
+        mock_sessions.get_structured_response.assert_called_once()
+
+    def test_send_accumulates_turns(self, mock_sessions):
+        session = ChatSession(app_name=APP)
+
+        responses = [
+            _structured_response(agent_text="Reply 1"),
+            _structured_response(agent_text="Reply 2"),
+            _structured_response(agent_text="Reply 3"),
+        ]
+        mock_sessions.get_structured_response.side_effect = responses
+
+        session.send("msg1")
+        session.send("msg2")
+        session.send("msg3")
+
+        assert len(session.turns) == 3
+        assert session.turns[0].agent_text == "Reply 1"
+        assert session.turns[1].agent_text == "Reply 2"
+        assert session.turns[2].agent_text == "Reply 3"
+        assert session.current_turn_index == 3
+
+    def test_send_raises_after_session_end(self, mock_sessions):
+        session = ChatSession(app_name=APP)
+
+        mock_sessions.get_structured_response.return_value = (
+            _structured_response(session_ended=True)
+        )
+        session.send("bye")
+
+        assert session.is_ended is True
+        with pytest.raises(SessionEndedError):
+            session.send("more")
+
+    def test_send_raises_after_close(self, mock_sessions):
+        session = ChatSession(app_name=APP)
+        session.close()
+        assert session.is_ended is True
+        with pytest.raises(SessionEndedError):
+            session.send("after close")
+
+    def test_channel_injection_first_turn_only(self, mock_sessions):
+        session = ChatSession(app_name=APP, channel="web")
+
+        mock_sessions.get_structured_response.side_effect = [
+            _structured_response(agent_text="r1"),
+            _structured_response(agent_text="r2"),
+        ]
+
+        session.send("first")
+        session.send("second")
+
+        # First call should include variables with channel
+        first_call_kwargs = mock_sessions.run.call_args_list[0]
+        assert first_call_kwargs.kwargs.get("variables") == {
+            "event_data": {"channel": "web"}
+        }
+
+        # Second call should NOT include variables
+        second_call_kwargs = mock_sessions.run.call_args_list[1]
+        assert "variables" not in second_call_kwargs.kwargs
+
+    def test_historical_contexts_passthrough(self, mock_sessions):
+        contexts = [
+            {"role": "user", "chunks": [{"text": "old msg"}]},
+            {"role": "model", "chunks": [{"text": "old reply"}]},
+        ]
+        session = ChatSession(
+            app_name=APP, historical_contexts=contexts
+        )
+        session.send("new msg")
+
+        call_kwargs = mock_sessions.run.call_args_list[0].kwargs
+        assert call_kwargs["historical_contexts"] == contexts
+
+    def test_historical_contexts_not_sent_on_second_turn(
+        self, mock_sessions
+    ):
+        contexts = [
+            {"role": "user", "chunks": [{"text": "old"}]}
+        ]
+        session = ChatSession(
+            app_name=APP, historical_contexts=contexts
+        )
+
+        mock_sessions.get_structured_response.side_effect = [
+            _structured_response(agent_text="r1"),
+            _structured_response(agent_text="r2"),
+        ]
+
+        session.send("first")
+        session.send("second")
+
+        second_call_kwargs = mock_sessions.run.call_args_list[1].kwargs
+        assert "historical_contexts" not in second_call_kwargs
+
+
+class TestChatSessionGetState:
+    def test_get_state_empty(self, mock_sessions):
+        session = ChatSession(app_name=APP)
+        state = session.get_state()
+        assert state == {
+            "active_agent": None,
+            "slot_machine": {},
+            "filled_slots": {},
+            "session_ended": False,
+            "turn_count": 0,
+            "pending_transfer": None,
+        }
+
+    def test_get_state_with_transfer(self, mock_sessions):
+        session = ChatSession(app_name=APP)
+        mock_sessions.get_structured_response.return_value = (
+            _structured_response(
+                agent_transfer={"display_name": "Reservation_Agent"}
+            )
+        )
+        session.send("hello")
+        state = session.get_state()
+        assert state["active_agent"] == "Reservation_Agent"
+        assert state["pending_transfer"] == "Reservation_Agent"
+        assert state["turn_count"] == 1
+
+    def test_get_state_with_slot_machine(self, mock_sessions):
+        session = ChatSession(app_name=APP)
+        mock_sessions.get_structured_response.return_value = (
+            _structured_response(
+                variable_updates=[
+                    {
+                        "slot_machine": {
+                            "current": "party_size",
+                            "filled": {"party_size": "4", "date": "Friday"},
+                        }
+                    }
+                ],
+            )
+        )
+        session.send("table for 4 on Friday")
+        state = session.get_state()
+        assert state["slot_machine"]["current"] == "party_size"
+        assert state["filled_slots"] == {
+            "party_size": "4",
+            "date": "Friday",
+        }
+
+    def test_get_state_with_sm_key(self, mock_sessions):
+        session = ChatSession(app_name=APP)
+        mock_sessions.get_structured_response.return_value = (
+            _structured_response(
+                variable_updates=[
+                    {
+                        "sm": {
+                            "filled": {"party_size": "4"},
+                            "pending": {"date": None},
+                        }
+                    }
+                ],
+            )
+        )
+        session.send("table for 4")
+        state = session.get_state()
+        assert state["slot_machine"]["filled"] == {"party_size": "4"}
+        assert state["filled_slots"] == {"party_size": "4"}
+
+    def test_variable_state_accumulates_across_turns(self, mock_sessions):
+        session = ChatSession(app_name=APP)
+        mock_sessions.get_structured_response.side_effect = [
+            _structured_response(
+                variable_updates=[
+                    {"slot_machine": {"filled": {"party_size": "4"}, "pending": {}}}
+                ],
+            ),
+            _structured_response(
+                variable_updates=[
+                    {"slot_machine": {"filled": {"party_size": "4", "date": "Fri"}, "pending": {}}}
+                ],
+            ),
+        ]
+        session.send("table for 4")
+        session.send("on Friday")
+        state = session.get_state()
+        assert state["filled_slots"] == {"party_size": "4", "date": "Fri"}
+
+    def test_get_state_session_ended(self, mock_sessions):
+        session = ChatSession(app_name=APP)
+        mock_sessions.get_structured_response.return_value = (
+            _structured_response(session_ended=True)
+        )
+        session.send("bye")
+        state = session.get_state()
+        assert state["session_ended"] is True
+
+
+class TestChatSessionExport:
+    def test_export_turns_summary(self, mock_sessions):
+        session = ChatSession(app_name=APP)
+
+        mock_sessions.get_structured_response.side_effect = [
+            _structured_response(
+                agent_text="Hi",
+                tool_calls=[{"action": "greet", "args": {}}],
+            ),
+            _structured_response(
+                agent_text="Transferring",
+                agent_transfer={"display_name": "Other_Agent"},
+            ),
+        ]
+
+        session.send("hello")
+        session.send("transfer me")
+
+        summary = session.export_turns_summary()
+        assert len(summary) == 2
+        assert summary[0] == {
+            "turn": 0,
+            "user": "hello",
+            "agent": "Hi",
+            "tool_calls": [{"action": "greet", "args": {}}],
+            "transfer": None,
+        }
+        assert summary[1]["turn"] == 1
+        assert summary[1]["transfer"] == "Other_Agent"
+
+    def test_export_turns_summary_empty(self, mock_sessions):
+        session = ChatSession(app_name=APP)
+        assert session.export_turns_summary() == []
+
+
+class TestChatSessionTrace:
+    def test_get_trace(self, mock_sessions):
+        with patch(
+            "cxas_scrapi.core.chat_session.Traces"
+        ) as MockTraces:
+            mock_traces_inst = MagicMock()
+            mock_traces_inst.get_report.return_value = '{"trace": "data"}'
+            MockTraces.return_value = mock_traces_inst
+
+            session = ChatSession(app_name=APP)
+            result = session.get_trace(fmt="json")
+
+            assert result == '{"trace": "data"}'
+            mock_traces_inst.get_report.assert_called_once_with(
+                "test-session-id", fmt="json"
+            )
+
+    def test_get_normalized_trace(self, mock_sessions):
+        with patch(
+            "cxas_scrapi.core.chat_session.Traces"
+        ) as MockTraces:
+            mock_traces_inst = MagicMock()
+            mock_traces_inst.get_normalized.return_value = {
+                "entries": []
+            }
+            MockTraces.return_value = mock_traces_inst
+
+            session = ChatSession(app_name=APP)
+            result = session.get_normalized_trace()
+
+            assert result == {"entries": []}
+            mock_traces_inst.get_normalized.assert_called_once_with(
+                "test-session-id"
+            )
+
+
+class TestGetSlotMachine:
+    def test_returns_slot_machine_key(self, mock_sessions):
+        session = ChatSession(app_name=APP)
+        mock_sessions.get_structured_response.return_value = (
+            _structured_response(
+                variable_updates=[
+                    {"slot_machine": {"filled": {"party_size": "4"}, "status": "ok"}}
+                ],
+            )
+        )
+        session.send("table for 4")
+        sm = session.get_slot_machine()
+        assert sm["filled"] == {"party_size": "4"}
+
+    def test_returns_sm_key(self, mock_sessions):
+        session = ChatSession(app_name=APP)
+        mock_sessions.get_structured_response.return_value = (
+            _structured_response(
+                variable_updates=[
+                    {"sm": {"filled": {"date": "Friday"}, "pending": {}}}
+                ],
+            )
+        )
+        session.send("Friday")
+        sm = session.get_slot_machine()
+        assert sm["filled"] == {"date": "Friday"}
+
+    def test_prefers_sm_over_slot_machine(self, mock_sessions):
+        session = ChatSession(app_name=APP)
+        mock_sessions.get_structured_response.return_value = (
+            _structured_response(
+                variable_updates=[
+                    {
+                        "sm": {"filled": {"date": "Friday"}},
+                        "slot_machine": {"filled": {"old": "data"}},
+                    }
+                ],
+            )
+        )
+        session.send("Friday")
+        sm = session.get_slot_machine()
+        assert sm["filled"] == {"date": "Friday"}
+
+    def test_returns_empty_dict_when_no_data(self, mock_sessions):
+        session = ChatSession(app_name=APP)
+        session.send("hello")
+        sm = session.get_slot_machine()
+        assert sm == {}
+
+
+class TestChatSessionClose:
+    def test_close_is_idempotent(self, mock_sessions):
+        session = ChatSession(app_name=APP)
+        session.close()
+        session.close()  # should not raise
+        assert session.is_ended is True

--- a/tests/cxas_scrapi/core/test_programmatic_chat.py
+++ b/tests/cxas_scrapi/core/test_programmatic_chat.py
@@ -1,0 +1,389 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cxas_scrapi.core.chat_session import ChatSession
+from cxas_scrapi.core.programmatic_chat import ProgrammaticChatDriver
+
+APP = "projects/p/locations/l/apps/a"
+
+
+def _structured_response(
+    agent_text="Hello!",
+    tool_calls=None,
+    tool_responses=None,
+    agent_transfer=None,
+    session_ended=False,
+    **extras,
+):
+    result = {
+        "agent_text": agent_text,
+        "tool_calls": tool_calls or [],
+        "tool_responses": tool_responses or [],
+        "agent_transfer": agent_transfer,
+        "session_ended": session_ended,
+    }
+    result.update(extras)
+    return result
+
+
+@pytest.fixture
+def mock_sessions():
+    with patch("cxas_scrapi.core.chat_session.Sessions") as MockSessions:
+        instance = MagicMock()
+        instance.create_session_id.return_value = "test-session-id"
+        instance.run.return_value = SimpleNamespace(outputs=[])
+        instance.get_structured_response.return_value = _structured_response()
+        MockSessions.return_value = instance
+        yield instance
+
+
+class TestProgrammaticChatDriverConstruction:
+    def test_construction_default(self, mock_sessions):
+        driver = ProgrammaticChatDriver(app_name=APP)
+        assert driver.session_id == "test-session-id"
+        assert driver.is_ended is False
+
+    def test_construction_with_session_id(self, mock_sessions):
+        driver = ProgrammaticChatDriver(
+            app_name=APP, session_id="custom-session-123"
+        )
+        assert driver.session_id == "custom-session-123"
+        mock_sessions.create_session_id.assert_not_called()
+
+    def test_construction_with_initial_turn_count(self, mock_sessions):
+        driver = ProgrammaticChatDriver(
+            app_name=APP, initial_turn_count=5
+        )
+        result = driver.step("hello")
+        assert result["turn_index"] == 5
+
+
+class TestStep:
+    def test_step_returns_dict(self, mock_sessions):
+        driver = ProgrammaticChatDriver(app_name=APP)
+        result = driver.step("Hello")
+
+        assert isinstance(result, dict)
+        expected_keys = {
+            "turn_index", "user_text", "agent_text", "tool_calls",
+            "tool_responses", "agent_transfer", "session_ended",
+            "state", "session_id", "trace", "metrics",
+        }
+        assert set(result.keys()) == expected_keys
+
+    def test_step_json_serializable(self, mock_sessions):
+        driver = ProgrammaticChatDriver(app_name=APP)
+        result = driver.step("Hello")
+        serialized = json.dumps(result)
+        assert isinstance(serialized, str)
+        parsed = json.loads(serialized)
+        assert parsed["user_text"] == "Hello"
+
+    def test_step_includes_state(self, mock_sessions):
+        mock_sessions.get_structured_response.return_value = (
+            _structured_response(
+                agent_transfer={"display_name": "Reservation_Agent"}
+            )
+        )
+        driver = ProgrammaticChatDriver(app_name=APP)
+        result = driver.step("hello")
+
+        state = result["state"]
+        assert "active_agent" in state
+        assert "filled_slots" in state
+        assert "session_ended" in state
+        assert state["active_agent"] == "Reservation_Agent"
+
+    def test_step_with_trace(self, mock_sessions):
+        with patch(
+            "cxas_scrapi.core.chat_session.Traces"
+        ) as MockTraces:
+            mock_traces_inst = MagicMock()
+            mock_traces_inst.get_normalized.return_value = {
+                "entries": [{"event": "start"}],
+                "turn_metrics": [{"latency_ms": 100}],
+                "totals": {"total_latency_ms": 100},
+            }
+            MockTraces.return_value = mock_traces_inst
+
+            driver = ProgrammaticChatDriver(
+                app_name=APP, include_trace=True
+            )
+            result = driver.step("Hello")
+
+            assert result["trace"] is not None
+            assert result["trace"]["entries"] == [{"event": "start"}]
+
+    def test_step_with_metrics(self, mock_sessions):
+        with patch(
+            "cxas_scrapi.core.chat_session.Traces"
+        ) as MockTraces:
+            mock_traces_inst = MagicMock()
+            mock_traces_inst.get_normalized.return_value = {
+                "entries": [],
+                "turn_metrics": [{"latency_ms": 42}],
+                "totals": {},
+            }
+            MockTraces.return_value = mock_traces_inst
+
+            driver = ProgrammaticChatDriver(
+                app_name=APP, include_metrics=True
+            )
+            result = driver.step("Hello")
+
+            assert result["metrics"] == {"latency_ms": 42}
+
+    def test_step_without_trace(self, mock_sessions):
+        driver = ProgrammaticChatDriver(app_name=APP, include_trace=False)
+        result = driver.step("Hello")
+        assert result["trace"] is None
+        assert result["metrics"] is None
+
+    def test_step_trace_error_handled(self, mock_sessions):
+        with patch(
+            "cxas_scrapi.core.chat_session.Traces"
+        ) as MockTraces:
+            mock_traces_inst = MagicMock()
+            mock_traces_inst.get_normalized.side_effect = RuntimeError(
+                "Trace fetch failed"
+            )
+            MockTraces.return_value = mock_traces_inst
+
+            driver = ProgrammaticChatDriver(
+                app_name=APP, include_trace=True
+            )
+            result = driver.step("Hello")
+
+            assert result["trace"] == {"error": "Trace fetch failed"}
+
+    def test_step_accumulates_turns(self, mock_sessions):
+        mock_sessions.get_structured_response.side_effect = [
+            _structured_response(agent_text="Reply 1"),
+            _structured_response(agent_text="Reply 2"),
+            _structured_response(agent_text="Reply 3"),
+        ]
+
+        driver = ProgrammaticChatDriver(app_name=APP)
+        r1 = driver.step("msg1")
+        r2 = driver.step("msg2")
+        r3 = driver.step("msg3")
+
+        assert r1["turn_index"] == 0
+        assert r2["turn_index"] == 1
+        assert r3["turn_index"] == 2
+        assert r1["agent_text"] == "Reply 1"
+        assert r2["agent_text"] == "Reply 2"
+        assert r3["agent_text"] == "Reply 3"
+
+
+class TestSerializeTransfer:
+    def test_serialize_transfer_none(self):
+        assert ProgrammaticChatDriver._serialize_transfer(None) is None
+
+    def test_serialize_transfer_dict(self):
+        transfer = {
+            "display_name": "Res_Agent",
+            "target_agent": "res",
+        }
+        result = ProgrammaticChatDriver._serialize_transfer(transfer)
+        assert result == "Res_Agent"
+
+    def test_serialize_transfer_dict_fallback(self):
+        transfer = {"target_agent": "res_agent"}
+        result = ProgrammaticChatDriver._serialize_transfer(transfer)
+        assert result == "res_agent"
+
+    def test_serialize_transfer_object(self):
+        obj = SimpleNamespace(display_name="Object_Agent")
+        assert ProgrammaticChatDriver._serialize_transfer(obj) == "Object_Agent"
+
+    def test_serialize_transfer_string(self):
+        assert ProgrammaticChatDriver._serialize_transfer(12345) == "12345"
+
+
+class TestGetFullState:
+    def test_get_full_state_without_slot_inspector(self, mock_sessions):
+        driver = ProgrammaticChatDriver(app_name=APP)
+        state = driver.get_full_state()
+        assert "active_agent" in state
+        assert "filled_slots" in state
+        assert "slot_inspection" not in state
+
+    def test_get_full_state_with_slot_machine(self, mock_sessions):
+        mock_sessions.get_structured_response.return_value = (
+            _structured_response(
+                variable_updates=[
+                    {
+                        "slot_machine": {
+                            "current": "party_size",
+                            "filled": {"party_size": "4"},
+                        }
+                    }
+                ],
+            )
+        )
+        driver = ProgrammaticChatDriver(app_name=APP)
+        driver.step("table for 4")
+        state = driver.get_full_state()
+        assert state["slot_machine"]["current"] == "party_size"
+        assert state["filled_slots"] == {"party_size": "4"}
+
+
+class TestClose:
+    def test_close_ends_session(self, mock_sessions):
+        driver = ProgrammaticChatDriver(app_name=APP)
+        assert driver.is_ended is False
+        driver.close()
+        assert driver.is_ended is True
+
+
+class TestChatSessionResumeSupport:
+    def test_session_id_passthrough(self, mock_sessions):
+        session = ChatSession(
+            app_name=APP, session_id="custom-id-abc"
+        )
+        assert session.session_id == "custom-id-abc"
+        mock_sessions.create_session_id.assert_not_called()
+
+    def test_session_id_generated_when_none(self, mock_sessions):
+        session = ChatSession(app_name=APP)
+        assert session.session_id == "test-session-id"
+        mock_sessions.create_session_id.assert_called_once()
+
+    def test_initial_turn_count(self, mock_sessions):
+        session = ChatSession(
+            app_name=APP, initial_turn_count=5
+        )
+        assert session.current_turn_index == 5
+
+    def test_initial_turn_count_accumulates(self, mock_sessions):
+        mock_sessions.get_structured_response.side_effect = [
+            _structured_response(agent_text="r1"),
+            _structured_response(agent_text="r2"),
+        ]
+        session = ChatSession(
+            app_name=APP, initial_turn_count=10
+        )
+        assert session.current_turn_index == 10
+        session.send("hello")
+        assert session.current_turn_index == 11
+        session.send("world")
+        assert session.current_turn_index == 12
+
+
+class TestNewMethods:
+    def test_get_sm_log_returns_filtered_entries(self, mock_sessions):
+        mock_sessions.get_structured_response.return_value = _structured_response(
+            variable_updates=[{
+                "sm": {
+                    "filled": {},
+                    "_log": [
+                        {"tag": "invoke", "level": "DEBUG", "data": {}},
+                        {"tag": "config_loaded", "level": "INFO", "data": {}},
+                        {"tag": "slot_error", "level": "ERROR", "data": {}},
+                    ],
+                }
+            }],
+        )
+        driver = ProgrammaticChatDriver(app_name=APP)
+        driver.step("hello")
+        log = driver.get_sm_log("INFO")
+        assert len(log) == 2
+        assert log[0]["tag"] == "config_loaded"
+        assert log[1]["tag"] == "slot_error"
+
+    def test_get_sm_log_empty_when_no_sm(self, mock_sessions):
+        driver = ProgrammaticChatDriver(app_name=APP)
+        assert driver.get_sm_log() == []
+
+    def test_get_sm_log_debug_returns_all(self, mock_sessions):
+        mock_sessions.get_structured_response.return_value = _structured_response(
+            variable_updates=[{
+                "sm": {
+                    "filled": {},
+                    "_log": [
+                        {"tag": "invoke", "level": "DEBUG", "data": {}},
+                        {"tag": "config_loaded", "level": "INFO", "data": {}},
+                    ],
+                }
+            }],
+        )
+        driver = ProgrammaticChatDriver(app_name=APP)
+        driver.step("hello")
+        log = driver.get_sm_log("DEBUG")
+        assert len(log) == 2
+
+    def test_get_flow_context_delegates(self, mock_sessions):
+        mock_sessions.get_structured_response.return_value = _structured_response(
+            variable_updates=[{
+                "_active_config_id": "reservation",
+                "agent_config_map": '{"Reservation_Agent": "reservation"}',
+                "_active_sm_key": "sm",
+            }],
+        )
+        driver = ProgrammaticChatDriver(app_name=APP)
+        driver.step("hello")
+        ctx = driver.get_flow_context()
+        assert ctx["active_config_id"] == "reservation"
+        assert ctx["agent_config_map"] == {"Reservation_Agent": "reservation"}
+
+    def test_get_trace_report_delegates(self, mock_sessions):
+        with patch("cxas_scrapi.core.chat_session.Traces") as MockTraces:
+            mock_traces_inst = MagicMock()
+            mock_traces_inst.get_report.return_value = "# Trace Report"
+            MockTraces.return_value = mock_traces_inst
+            driver = ProgrammaticChatDriver(app_name=APP)
+            report = driver.get_trace_report(fmt="md")
+            mock_traces_inst.get_report.assert_called_once()
+
+    def test_get_turns_summary_delegates(self, mock_sessions):
+        mock_sessions.get_structured_response.side_effect = [
+            _structured_response(agent_text="Reply 1"),
+            _structured_response(agent_text="Reply 2"),
+        ]
+        driver = ProgrammaticChatDriver(app_name=APP)
+        driver.step("msg1")
+        driver.step("msg2")
+        summary = driver.get_turns_summary()
+        assert len(summary) == 2
+        assert summary[0]["user"] == "msg1"
+        assert summary[1]["agent"] == "Reply 2"
+
+    def test_report_bug_delegates(self, mock_sessions):
+        with patch("cxas_scrapi.core.traces.Traces") as MockTraces:
+            mock_traces_inst = MagicMock()
+            mock_traces_inst.report_bug.return_value = {"status": "reported"}
+            MockTraces.return_value = mock_traces_inst
+            driver = ProgrammaticChatDriver(app_name=APP)
+            result = driver.report_bug("something broke")
+            mock_traces_inst.report_bug.assert_called_once_with(
+                conversation_id="test-session-id",
+                reason="something broke",
+            )
+            assert result["status"] == "reported"
+
+    def test_initial_variable_state_seeded(self, mock_sessions):
+        driver = ProgrammaticChatDriver(
+            app_name=APP,
+            initial_variable_state={"sm": {"filled": {"name": "Alice"}, "_log": [{"tag": "test", "level": "INFO"}]}},
+        )
+        log = driver.get_sm_log()
+        assert len(log) == 1
+        assert log[0]["tag"] == "test"

--- a/tests/cxas_scrapi/core/test_trace_enhancements.py
+++ b/tests/cxas_scrapi/core/test_trace_enhancements.py
@@ -1,0 +1,413 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Traces.fork(), Traces.diff(), enhanced Traces.replay(),
+and the _tool_calls_per_turn helper added in Stream 4 (cxas chat)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from cxas_scrapi.core import traces as traces_mod
+from cxas_scrapi.core.traces import Traces
+
+APP = "projects/p/locations/l/apps/a"
+
+
+# ----------------------------- helpers ----------------------------------------
+
+
+def _multi_turn_conv(cid="c1"):
+    """Returns a dict-shaped conversation with three turns."""
+    return {
+        "name": f"{APP}/conversations/{cid}",
+        "source": "LIVE",
+        "input_types": ["INPUT_TYPE_TEXT"],
+        "start_time": "2026-05-01T00:00:00",
+        "end_time": "2026-05-01T00:01:00",
+        "turns": [
+            {
+                "messages": [
+                    {"role": "user", "chunks": [{"text": "hello"}]},
+                    {"role": "agent", "chunks": [{"text": "hi there"}]},
+                ]
+            },
+            {
+                "messages": [
+                    {"role": "user", "chunks": [{"text": "book a table"}]},
+                    {
+                        "role": "agent",
+                        "chunks": [
+                            {"text": "sure, how many?"},
+                            {
+                                "tool_call": {
+                                    "display_name": "set_flow",
+                                    "args": {"flow": "reservation"},
+                                }
+                            },
+                        ],
+                    },
+                ]
+            },
+            {
+                "messages": [
+                    {"role": "user", "chunks": [{"text": "4 people"}]},
+                    {
+                        "role": "agent",
+                        "chunks": [
+                            {"text": "party of 4, got it"},
+                            {
+                                "tool_call": {
+                                    "display_name": "set_party_size",
+                                    "args": {"size": 4},
+                                }
+                            },
+                        ],
+                    },
+                ]
+            },
+        ],
+    }
+
+
+def _conv_dict_single(cid="c1"):
+    """Single-turn conversation for simpler tests."""
+    return {
+        "name": f"{APP}/conversations/{cid}",
+        "source": "LIVE",
+        "input_types": ["INPUT_TYPE_TEXT"],
+        "start_time": "2026-05-01T00:00:00",
+        "end_time": "2026-05-01T00:01:00",
+        "turns": [
+            {
+                "messages": [
+                    {"role": "user", "chunks": [{"text": "hi"}]},
+                    {
+                        "role": "agent",
+                        "chunks": [
+                            {"text": "hello"},
+                            {
+                                "tool_call": {
+                                    "display_name": "lookup",
+                                    "args": {"q": 1},
+                                }
+                            },
+                        ],
+                    },
+                ]
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def traces_obj(tmp_path, monkeypatch):
+    """Traces with no app dir; mocks TraceConfig path resolution."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(traces_mod.TraceConfig, "_pick_path", lambda *_: None)
+    return Traces(app_name=APP, app_dir=str(tmp_path / "missing"))
+
+
+# ========================== _tool_calls_per_turn ==============================
+
+
+class TestToolCallsPerTurn:
+    def test_basic(self):
+        n = {
+            "entries": [
+                {"kind": "tool_call", "turn": 0, "tool": "lookup"},
+                {"kind": "tool_call", "turn": 1, "tool": "set_flow"},
+                {"kind": "tool_call", "turn": 1, "tool": "set_party_size"},
+            ]
+        }
+        result = traces_mod._tool_calls_per_turn(n)
+        assert result == [["lookup"], ["set_flow", "set_party_size"]]
+
+    def test_empty_entries(self):
+        assert traces_mod._tool_calls_per_turn({"entries": []}) == []
+
+    def test_no_tool_calls(self):
+        n = {"entries": [{"kind": "agent", "turn": 0, "text": "hi"}]}
+        assert traces_mod._tool_calls_per_turn(n) == []
+
+    def test_gap_in_turns(self):
+        n = {
+            "entries": [
+                {"kind": "tool_call", "turn": 0, "tool": "a"},
+                {"kind": "tool_call", "turn": 2, "tool": "b"},
+            ]
+        }
+        result = traces_mod._tool_calls_per_turn(n)
+        assert result == [["a"], [], ["b"]]
+
+
+# ============================== fork() ========================================
+
+
+class TestFork:
+    def test_fork_basic(self, traces_obj):
+        traces_obj.history = MagicMock()
+        traces_obj.history.get_conversation.return_value = _multi_turn_conv()
+
+        result = traces_obj.fork("c1")
+
+        assert result["original_conversation_id"] == "c1"
+        assert result["turn_count"] == 3
+        assert result["forked_at_turn"] is None
+        # 3 turns x 2 messages each (user + agent) = 6 context messages
+        assert len(result["historical_contexts"]) == 6
+        assert result["historical_contexts"][0]["role"] == "user"
+        assert result["historical_contexts"][1]["role"] == "agent"
+
+    def test_fork_at_turn(self, traces_obj):
+        traces_obj.history = MagicMock()
+        traces_obj.history.get_conversation.return_value = _multi_turn_conv()
+
+        result = traces_obj.fork("c1", at_turn=1)
+
+        assert result["turn_count"] == 2
+        assert result["forked_at_turn"] == 1
+        # 2 turns x 2 messages each = 4 context messages
+        assert len(result["historical_contexts"]) == 4
+
+    def test_fork_at_turn_zero(self, traces_obj):
+        traces_obj.history = MagicMock()
+        traces_obj.history.get_conversation.return_value = _multi_turn_conv()
+
+        result = traces_obj.fork("c1", at_turn=0)
+
+        assert result["turn_count"] == 1
+        assert result["forked_at_turn"] == 0
+        # 1 turn x 2 messages = 2 context messages
+        assert len(result["historical_contexts"]) == 2
+
+    def test_fork_return_structure(self, traces_obj):
+        traces_obj.history = MagicMock()
+        traces_obj.history.get_conversation.return_value = _multi_turn_conv()
+
+        result = traces_obj.fork("c1", at_turn=1)
+
+        assert set(result.keys()) == {
+            "historical_contexts",
+            "turn_count",
+            "original_conversation_id",
+            "forked_at_turn",
+        }
+        # Verify each context message has role and chunks
+        for ctx in result["historical_contexts"]:
+            assert "role" in ctx
+            assert "chunks" in ctx
+
+    def test_fork_filters_messages_without_role_or_chunks(self, traces_obj):
+        """Messages lacking role or chunks should be skipped."""
+        traces_obj.history = MagicMock()
+        conv = {
+            "name": f"{APP}/conversations/c1",
+            "turns": [
+                {
+                    "messages": [
+                        {"role": "user", "chunks": [{"text": "hi"}]},
+                        {"no_role": True},  # missing role
+                        {"role": "agent"},  # missing chunks
+                    ]
+                }
+            ],
+        }
+        traces_obj.history.get_conversation.return_value = conv
+
+        result = traces_obj.fork("c1")
+        assert len(result["historical_contexts"]) == 1
+
+
+# ============================== diff() ========================================
+
+
+class TestDiff:
+    def _normalized_conv(self, cid, agent_texts, tool_entries=None):
+        """Build a normalized-style dict for diff testing."""
+        entries = []
+        for i, text in enumerate(agent_texts):
+            entries.append(
+                {"kind": "user", "turn": i, "text": f"user msg {i}"}
+            )
+            entries.append({"kind": "agent", "turn": i, "text": text})
+        for te in tool_entries or []:
+            entries.append(te)
+        return {
+            "conversation_id": cid,
+            "entries": entries,
+        }
+
+    def test_diff_identical(self, traces_obj):
+        norm = self._normalized_conv("c1", ["hi there", "sure thing"])
+        traces_obj.get_normalized = MagicMock(return_value=norm)
+
+        result = traces_obj.diff("c1", "c1")
+
+        assert result["summary"]["matching_turns"] == 2
+        assert result["summary"]["differing_turns"] == 0
+        assert result["agent_text_diff"] == ""
+        assert result["tool_call_diff"] == ""
+
+    def test_diff_different_text(self, traces_obj):
+        norm_a = self._normalized_conv("ca", ["hello", "yes"])
+        norm_b = self._normalized_conv("cb", ["hello", "no"])
+        traces_obj.get_normalized = MagicMock(
+            side_effect=lambda cid: norm_a if cid == "ca" else norm_b
+        )
+
+        result = traces_obj.diff("ca", "cb")
+
+        assert result["summary"]["differing_turns"] > 0
+        assert result["agent_text_diff"] != ""
+        assert result["conversation_a"] == "ca"
+        assert result["conversation_b"] == "cb"
+
+    def test_diff_different_tools(self, traces_obj):
+        norm_a = self._normalized_conv(
+            "ca",
+            ["hello"],
+            tool_entries=[
+                {"kind": "tool_call", "turn": 0, "tool": "lookup"},
+            ],
+        )
+        norm_b = self._normalized_conv(
+            "cb",
+            ["hello"],
+            tool_entries=[
+                {"kind": "tool_call", "turn": 0, "tool": "search"},
+            ],
+        )
+        traces_obj.get_normalized = MagicMock(
+            side_effect=lambda cid: norm_a if cid == "ca" else norm_b
+        )
+
+        result = traces_obj.diff("ca", "cb")
+
+        # Text matches but tools differ
+        assert result["turn_comparison"][0]["text_match"] is True
+        assert result["turn_comparison"][0]["tools_match"] is False
+        assert result["tool_call_diff"] != ""
+
+    def test_diff_different_turn_counts(self, traces_obj):
+        norm_a = self._normalized_conv("ca", ["hello", "sure", "bye"])
+        norm_b = self._normalized_conv("cb", ["hello"])
+        traces_obj.get_normalized = MagicMock(
+            side_effect=lambda cid: norm_a if cid == "ca" else norm_b
+        )
+
+        result = traces_obj.diff("ca", "cb")
+
+        s = result["summary"]
+        assert s["total_turns_a"] == 3
+        assert s["total_turns_b"] == 1
+        # Turn 0 matches, turns 1-2 are only in A
+        assert s["matching_turns"] == 1
+        assert s["differing_turns"] == 2
+
+    def test_diff_summary_counts(self, traces_obj):
+        norm_a = self._normalized_conv("ca", ["a", "b", "c"])
+        norm_b = self._normalized_conv("cb", ["a", "x", "c"])
+        traces_obj.get_normalized = MagicMock(
+            side_effect=lambda cid: norm_a if cid == "ca" else norm_b
+        )
+
+        result = traces_obj.diff("ca", "cb")
+
+        s = result["summary"]
+        assert s["total_turns_a"] == 3
+        assert s["total_turns_b"] == 3
+        assert s["matching_turns"] == 2  # turns 0 and 2 match
+        assert s["differing_turns"] == 1  # turn 1 differs
+        assert s["matching_turns"] + s["differing_turns"] == max(
+            s["total_turns_a"], s["total_turns_b"]
+        )
+
+
+# ======================== enhanced replay() ===================================
+
+
+class TestEnhancedReplay:
+    def test_replay_backward_compat(self, traces_obj, monkeypatch):
+        """Calling replay() without new params gives same structure as before,
+        plus the new diverged_at key."""
+        traces_obj.history = MagicMock()
+        traces_obj.history.get_conversation.return_value = _conv_dict_single()
+
+        fake_sess = MagicMock()
+        fake_sess.create_session_id.return_value = "sid"
+        fake_sess.run.return_value = "raw"
+        fake_sess.get_structured_response.return_value = {
+            "agent_text": "hello back",
+        }
+        monkeypatch.setattr(
+            traces_mod, "Sessions", MagicMock(return_value=fake_sess)
+        )
+
+        out = traces_obj.replay("c1")
+        assert "original" in out
+        assert "replay" in out
+        assert "diff" in out
+        assert "diverged_at" in out
+        assert out["diverged_at"] is None
+
+    def test_replay_interactive_callback(self, traces_obj, monkeypatch):
+        """on_turn callback is invoked with correct arguments."""
+        traces_obj.history = MagicMock()
+        traces_obj.history.get_conversation.return_value = _conv_dict_single()
+
+        fake_sess = MagicMock()
+        fake_sess.create_session_id.return_value = "sid"
+        fake_sess.run.return_value = "raw"
+        fake_sess.get_structured_response.return_value = {
+            "agent_text": "replayed",
+        }
+        monkeypatch.setattr(
+            traces_mod, "Sessions", MagicMock(return_value=fake_sess)
+        )
+
+        callback = MagicMock(return_value=None)
+        out = traces_obj.replay(
+            "c1", interactive=True, on_turn=callback
+        )
+
+        callback.assert_called_once()
+        call_args = callback.call_args[0]
+        assert call_args[0] == 0  # turn index
+        assert isinstance(call_args[1], str)  # original text
+        assert isinstance(call_args[2], str)  # replayed text
+        assert out["diverged_at"] is None  # callback returned None
+
+    def test_replay_diverged_at(self, traces_obj, monkeypatch):
+        """When on_turn returns a non-None value, diverged_at is set."""
+        traces_obj.history = MagicMock()
+        traces_obj.history.get_conversation.return_value = _conv_dict_single()
+
+        fake_sess = MagicMock()
+        fake_sess.create_session_id.return_value = "sid"
+        fake_sess.run.return_value = "raw"
+        fake_sess.get_structured_response.return_value = {
+            "agent_text": "replayed",
+        }
+        monkeypatch.setattr(
+            traces_mod, "Sessions", MagicMock(return_value=fake_sess)
+        )
+
+        # Return a string to signal divergence
+        callback = MagicMock(return_value="I want something else")
+        out = traces_obj.replay(
+            "c1", interactive=True, on_turn=callback
+        )
+
+        assert out["diverged_at"] == 0

--- a/tests/cxas_scrapi/utils/test_chat_renderer.py
+++ b/tests/cxas_scrapi/utils/test_chat_renderer.py
@@ -1,0 +1,844 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from io import StringIO
+
+import pytest
+from rich.console import Console
+
+from cxas_scrapi.core.chat_session import TurnRecord
+from cxas_scrapi.utils.chat_renderer import SLASH_COMMANDS, ChatRenderer
+
+
+def _make_console() -> tuple[Console, StringIO]:
+    """Create a Console that writes to a StringIO for capture."""
+    buf = StringIO()
+    console = Console(file=buf, force_terminal=True, width=120)
+    return console, buf
+
+
+def _make_turn(
+    turn_index=0,
+    user_text="hi",
+    agent_text="hello",
+    tool_calls=None,
+    tool_responses=None,
+    agent_transfer=None,
+    session_ended=False,
+) -> TurnRecord:
+    return TurnRecord(
+        turn_index=turn_index,
+        user_text=user_text,
+        response={
+            "agent_text": agent_text,
+            "tool_calls": tool_calls or [],
+            "tool_responses": tool_responses or [],
+            "agent_transfer": agent_transfer,
+            "session_ended": session_ended,
+        },
+    )
+
+
+class TestRenderSessionStart:
+    def test_render_session_start(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        renderer.render_session_start("sid-123", "projects/p/apps/a")
+        output = buf.getvalue()
+        assert "sid-123" in output
+        assert "projects/p/apps/a" in output
+        assert "Chat Session Started" in output
+
+    def test_render_session_start_with_display_name(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        renderer.render_session_start(
+            "sid-123", "projects/p/apps/a", display_name="Bella Notte",
+        )
+        output = buf.getvalue()
+        assert "Bella Notte" in output
+        assert "projects/p/apps/a" in output
+
+
+class TestRenderUserMessage:
+    def test_render_user_message(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        renderer.render_user_message(0, "Hello agent!")
+        output = buf.getvalue()
+        assert "Turn 0" in output
+        assert "Hello agent!" in output
+
+
+class TestRenderTurn:
+    def test_render_turn_basic(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        turn = _make_turn(agent_text="I can help with that!")
+        renderer.render_turn(turn)
+        output = buf.getvalue()
+        assert "I can help with that!" in output
+
+    def test_render_turn_verbose_shows_tool_calls(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console, verbose=True)
+        turn = _make_turn(
+            agent_text="Let me look that up.",
+            tool_calls=[
+                {"action": "lookup_info", "args": {"query": "test"}}
+            ],
+            tool_responses=[
+                {
+                    "action": "_response:lookup_info",
+                    "response": {"result": "found"},
+                }
+            ],
+        )
+        renderer.render_turn(turn)
+        output = buf.getvalue()
+        assert "lookup_info" in output
+        assert "Let me look that up." in output
+
+    def test_render_turn_non_verbose_hides_tool_calls(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console, verbose=False)
+        turn = _make_turn(
+            agent_text="Let me check.",
+            tool_calls=[
+                {"action": "secret_tool", "args": {"key": "value"}}
+            ],
+        )
+        renderer.render_turn(turn)
+        output = buf.getvalue()
+        assert "Let me check." in output
+        # Tool call details should not appear in non-verbose mode
+        assert "Tool Call" not in output
+
+    def test_render_turn_with_transfer(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        turn = _make_turn(
+            agent_text="Transferring now.",
+            agent_transfer={"display_name": "Reservation_Agent"},
+        )
+        renderer.render_turn(turn)
+        output = buf.getvalue()
+        assert "Reservation_Agent" in output
+        assert "Transferred to" in output
+
+    def test_render_turn_empty_agent_text(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        turn = _make_turn(agent_text="")
+        renderer.render_turn(turn)
+        output = buf.getvalue()
+        # Should not render an empty agent panel
+        assert "Agent" not in output
+
+
+class TestRenderAgentText:
+    def test_render_agent_text(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        renderer.render_agent_text(2, "Response text here")
+        output = buf.getvalue()
+        assert "Turn 2" in output
+        assert "Response text here" in output
+
+    def test_render_agent_text_with_role(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        renderer.render_agent_text(0, "text", role="Greeter")
+        output = buf.getvalue()
+        assert "Greeter" in output
+
+
+class TestRenderToolCall:
+    def test_render_tool_call(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        renderer.render_tool_call(
+            "set_party_size", {"party_size": 4}
+        )
+        output = buf.getvalue()
+        assert "set_party_size" in output
+        assert "party_size" in output
+
+
+class TestRenderToolResponse:
+    def test_render_tool_response(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        renderer.render_tool_response(
+            "set_party_size", {"status": "ok"}
+        )
+        output = buf.getvalue()
+        assert "set_party_size" in output
+        assert "status" in output
+
+
+class TestRenderTransfer:
+    def test_render_transfer(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        renderer.render_transfer("Takeout_Agent")
+        output = buf.getvalue()
+        assert "Transferred to" in output
+        assert "Takeout_Agent" in output
+
+
+class TestRenderState:
+    def test_render_state(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        state = {
+            "active_agent": "Reservation_Agent",
+            "slot_machine": {"current": "party_size"},
+            "filled_slots": {"party_size": "4"},
+            "session_ended": False,
+            "turn_count": 2,
+            "pending_transfer": None,
+        }
+        renderer.render_state(state)
+        output = buf.getvalue()
+        assert "Session State" in output
+        assert "active_agent" in output
+        assert "Reservation_Agent" in output
+        assert "party_size" in output
+
+    def test_render_state_empty(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        renderer.render_state({})
+        output = buf.getvalue()
+        assert "Session State" in output
+
+
+class TestRenderSessionEnd:
+    def test_render_session_end(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        renderer.render_session_end(
+            "sid-456",
+            turn_count=5,
+            trace_command="cxas trace get sid-456",
+        )
+        output = buf.getvalue()
+        assert "sid-456" in output
+        assert "Session Ended" in output
+        assert "5" in output
+        assert "cxas trace get sid-456" in output
+
+
+class TestRenderMetrics:
+    def test_render_metrics(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        renderer.render_metrics(
+            duration_ms=1234.5,
+            tokens={"input": 100, "output": 50},
+            tool_count=3,
+        )
+        output = buf.getvalue()
+        assert "1234ms" in output
+        assert "tools=3" in output
+
+    def test_render_metrics_none_duration(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        renderer.render_metrics(
+            duration_ms=None, tokens=None, tool_count=0
+        )
+        output = buf.getvalue()
+        assert "tools=0" in output
+
+
+class TestRenderError:
+    def test_render_error(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        renderer.render_error("Something went wrong")
+        output = buf.getvalue()
+        assert "Error" in output
+        assert "Something went wrong" in output
+
+
+class TestRenderSlashHelp:
+    def test_render_slash_help(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        renderer.render_slash_help()
+        output = buf.getvalue()
+        assert "Available Commands" in output
+        # Verify all slash commands appear
+        for cmd in SLASH_COMMANDS:
+            assert cmd in output
+
+
+class TestRenderLog:
+    def test_render_log_basic(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        entries = [
+            {"tag": "config_loaded", "level": "INFO",
+             "data": {"config_id": "bella_notte", "n_slots": 5, "n_tasks": 2}},
+            {"tag": "invoke", "level": "INFO",
+             "data": {"n": 1, "phase": "collection", "filled": 0, "asking": "party_size"}},
+            {"tag": "setter_stored", "level": "INFO",
+             "data": {"slot": "party_size", "value": "4"}},
+            {"tag": "task_completed", "level": "INFO",
+             "data": {"task": "lookup", "success": True}},
+        ]
+        renderer.render_log(entries)
+        output = buf.getvalue()
+        assert "Conversation Timeline" in output
+        assert "FLOW" in output
+        assert "SET" in output
+        assert "TASK" in output
+        assert "bella_notte" in output
+        assert "party_size" in output
+
+    def test_render_log_empty(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        renderer.render_log([])
+        output = buf.getvalue()
+        assert "No events at this level" in output
+
+    def test_render_log_internal_tags_hidden(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        entries = [
+            {"tag": "invoke", "level": "INFO",
+             "data": {"n": 1, "phase": "collection", "filled": 0, "asking": "x"}},
+            {"tag": "gate_active", "level": "INFO",
+             "data": {"config_id": "takeout"}},
+            {"tag": "announce_stored", "level": "INFO",
+             "data": {"slot": "welcome", "value": "hi"}},
+        ]
+        renderer.render_log(entries)
+        output = buf.getvalue()
+        assert "No events at this level" in output
+
+    def test_render_log_hidden_count_footer(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        entries = [
+            {"tag": "setter_stored", "level": "INFO",
+             "data": {"slot": "party_size", "value": "4"}},
+            {"tag": "invoke", "level": "INFO",
+             "data": {"n": 1, "phase": "collection", "filled": 0, "asking": "x"}},
+            {"tag": "announce_stored", "level": "INFO",
+             "data": {"slot": "welcome", "value": "hi"}},
+        ]
+        renderer.render_log(entries)
+        output = buf.getvalue()
+        assert "1 events shown" in output
+        assert "2 internal events hidden" in output
+        assert "/log debug" in output
+
+    def test_render_log_level_filter_warn(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        entries = [
+            {"tag": "setter_stored", "level": "INFO",
+             "data": {"slot": "x", "value": "1"}},
+            {"tag": "steer_back_soft", "level": "WARN",
+             "data": {"turns": 3}},
+        ]
+        renderer.render_log(entries, min_level="WARN")
+        output = buf.getvalue()
+        assert "STEER" in output
+        assert "SET" not in output
+
+    def test_render_log_debug_fallback(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        entries = [
+            {"tag": "invoke", "level": "DEBUG",
+             "data": {"n": 1, "phase": "collection", "filled": 0, "asking": "x"}},
+            {"tag": "setter_stored", "level": "INFO",
+             "data": {"slot": "x", "value": "1"}},
+        ]
+        renderer.render_log(entries, min_level="DEBUG")
+        output = buf.getvalue()
+        # DEBUG fallback uses _render_log_debug which shows "Slot Filling Timeline"
+        assert "Slot Filling Timeline" in output
+        assert "Conversation Timeline" not in output
+
+    def test_render_log_task_completed_format(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        entries = [
+            {"tag": "task_completed", "level": "INFO",
+             "data": {"task": "lookup_reservation", "success": True}},
+        ]
+        renderer.render_log(entries)
+        output = buf.getvalue()
+        assert "✓" in output
+
+        console2, buf2 = _make_console()
+        renderer2 = ChatRenderer(console=console2)
+        entries2 = [
+            {"tag": "task_completed", "level": "INFO",
+             "data": {"task": "submit_order", "success": False}},
+        ]
+        renderer2.render_log(entries2)
+        output2 = buf2.getvalue()
+        assert "✗" in output2
+
+    def test_render_log_setter_format(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        entries = [
+            {"tag": "setter_stored", "level": "INFO",
+             "data": {"slot": "party_size", "value": "4"}},
+        ]
+        renderer.render_log(entries)
+        output = buf.getvalue()
+        assert "party_size" in output
+        assert '= "4"' in output
+
+    def test_render_log_steer_back_format(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        entries = [
+            {"tag": "steer_back_soft", "level": "INFO",
+             "data": {"turns": 3}},
+        ]
+        renderer.render_log(entries)
+        output = buf.getvalue()
+        assert "Soft redirect" in output
+        assert "STEER" in output
+
+    def test_render_log_correction_format(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        entries = [
+            {"tag": "correction_applied", "level": "INFO",
+             "data": {"slot": "date", "old": "Friday", "new": "Saturday"}},
+        ]
+        renderer.render_log(entries)
+        output = buf.getvalue()
+        assert "date" in output
+        assert "Friday" in output
+        assert "Saturday" in output
+        assert "→" in output  # → arrow
+
+    def test_render_log_flow_events(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        entries = [
+            {"tag": "bootstrap_transfer", "level": "INFO",
+             "data": {"agent": "Reservation_Agent"}},
+        ]
+        renderer.render_log(entries)
+        output = buf.getvalue()
+        assert "Transfer" in output
+        assert "Reservation_Agent" in output
+        assert "FLOW" in output
+
+    def test_render_log_error_styling(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        entries = [
+            {"tag": "slot_error", "level": "WARN",
+             "data": {"slot": "date", "code": "INVALID", "retries": 2}},
+        ]
+        renderer.render_log(entries)
+        output = buf.getvalue()
+        assert "ERROR" in output
+
+    def test_render_log_invalid_level_defaults_info(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        entries = [
+            {"tag": "setter_stored", "level": "INFO",
+             "data": {"slot": "x", "value": "1"}},
+        ]
+        # Invalid level string should default to INFO behavior (no crash)
+        renderer.render_log(entries, min_level="BOGUS")
+        output = buf.getvalue()
+        assert "Conversation Timeline" in output
+        assert "SET" in output
+
+    def test_render_log_dedup_repeated_config_loaded(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        entries = [
+            {"tag": "config_loaded", "level": "INFO",
+             "data": {"config_id": "bella_notte", "n_slots": 6, "n_tasks": 2}},
+            {"tag": "setter_stored", "level": "INFO",
+             "data": {"slot": "party_size", "value": "4"}},
+            {"tag": "config_loaded", "level": "INFO",
+             "data": {"config_id": "bella_notte", "n_slots": 6, "n_tasks": 2}},
+            {"tag": "config_loaded", "level": "INFO",
+             "data": {"config_id": "bella_notte", "n_slots": 6, "n_tasks": 2}},
+            {"tag": "setter_stored", "level": "INFO",
+             "data": {"slot": "date", "value": "Friday"}},
+        ]
+        renderer.render_log(entries)
+        output = buf.getvalue()
+        assert output.count("bella_notte") == 1
+        assert "party_size" in output
+        assert "date" in output
+
+    def test_render_log_dedup_different_config_shown(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        entries = [
+            {"tag": "config_loaded", "level": "INFO",
+             "data": {"config_id": "reservation", "n_slots": 6, "n_tasks": 2}},
+            {"tag": "config_loaded", "level": "INFO",
+             "data": {"config_id": "takeout", "n_slots": 4, "n_tasks": 1}},
+        ]
+        renderer.render_log(entries)
+        output = buf.getvalue()
+        assert "reservation" in output
+        assert "takeout" in output
+
+
+class TestRenderSlots:
+    def test_render_slots_full(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        inspection = {
+            "summary": {
+                "phase": "collection",
+                "status": "in_progress",
+                "filled_count": 2,
+                "pending_count": 1,
+                "deferred_count": 0,
+                "retries": {},
+                "steer_back_turns": 0,
+                "config_id": "bella_notte",
+            },
+            "categories": {
+                "core_data": {
+                    "label": "Core Data",
+                    "fields": {
+                        "filled": {"party_size": "4", "date": "Friday"},
+                        "pending": {"time": "7pm"},
+                        "status": "in_progress",
+                    },
+                },
+            },
+            "slot_dag": {
+                "filled": ["date", "party_size"],
+                "pending": ["time"],
+                "deferred": [],
+                "blocked": [],
+            },
+        }
+        renderer.render_slots(inspection)
+        output = buf.getvalue()
+        assert "collection" in output
+        assert "Slots" in output
+        assert "party_size" in output
+        assert "date" in output
+        assert "filled" in output
+        assert "pending" in output
+
+    def test_render_slots_with_blocked(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        inspection = {
+            "summary": {"phase": "collection", "status": None,
+                        "filled_count": 0, "pending_count": 0,
+                        "deferred_count": 0, "retries": {},
+                        "steer_back_turns": 0, "config_id": None},
+            "categories": {},
+            "slot_dag": {
+                "filled": [],
+                "pending": [],
+                "deferred": [],
+                "blocked": [{"slot": "phone", "blocked_by": ["party_size"]}],
+            },
+        }
+        renderer.render_slots(inspection)
+        output = buf.getvalue()
+        assert "phone" in output
+        assert "party_size" in output
+        assert "blocked" in output
+
+    def test_render_slots_category_filter(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        inspection = {
+            "summary": {"phase": "collection", "status": None,
+                        "filled_count": 0, "pending_count": 0,
+                        "deferred_count": 0, "retries": {},
+                        "steer_back_turns": 0, "config_id": None},
+            "categories": {
+                "core_data": {"label": "Core Data", "fields": {"filled": {}}},
+                "engine_control": {"label": "Engine Control", "fields": {"_invoke_n": 3}},
+            },
+            "slot_dag": {"filled": [], "pending": [], "deferred": [], "blocked": []},
+        }
+        renderer.render_slots(inspection, category="core_data")
+        output = buf.getvalue()
+        assert "Core Data" in output
+        assert "Engine Control" not in output
+
+    def test_render_slots_invalid_category(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        inspection = {
+            "summary": {"phase": "collection", "status": None,
+                        "filled_count": 0, "pending_count": 0,
+                        "deferred_count": 0, "retries": {},
+                        "steer_back_turns": 0, "config_id": None},
+            "categories": {"core_data": {"label": "Core Data", "fields": {}}},
+            "slot_dag": {"filled": [], "pending": [], "deferred": [], "blocked": []},
+        }
+        renderer.render_slots(inspection, category="nonexistent")
+        output = buf.getvalue()
+        assert "Unknown category" in output
+
+    def test_render_slots_collapsed_categories_shown_as_hint(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        inspection = {
+            "summary": {"phase": "collection", "status": None,
+                        "filled_count": 0, "pending_count": 0,
+                        "deferred_count": 0, "retries": {},
+                        "steer_back_turns": 0, "config_id": None},
+            "categories": {
+                "core_data": {"label": "Core Data", "fields": {"filled": {}}},
+                "configuration": {"label": "Configuration", "fields": {"_config_id": "res"}},
+                "engine_control": {"label": "Engine Control", "fields": {"_invoke_n": 3}},
+            },
+            "slot_dag": {"filled": [], "pending": [], "deferred": [], "blocked": []},
+        }
+        renderer.render_slots(inspection)
+        output = buf.getvalue()
+        assert "/slots configuration" in output
+        assert "/slots engine_control" in output
+        assert "Configuration" not in output or "Collapsed" in output
+
+    def test_render_slots_flags_shown(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        inspection = {
+            "summary": {"phase": "correction", "status": "in_progress",
+                        "filled_count": 1, "pending_count": 0,
+                        "deferred_count": 0, "retries": {"set_date": 2},
+                        "steer_back_turns": 3, "config_id": "res"},
+            "categories": {
+                "core_data": {"label": "Core Data", "fields": {
+                    "filled": {"party_size": "4"}, "pending": {},
+                }},
+                "confirmation": {"label": "Confirmation", "fields": {
+                    "_correction_pending": True,
+                }},
+            },
+            "slot_dag": {"filled": ["party_size"], "pending": [], "deferred": [], "blocked": []},
+        }
+        renderer.render_slots(inspection)
+        output = buf.getvalue()
+        assert "steer_back=3" in output
+        assert "retry(set_date)=2" in output
+        assert "correction_pending" in output
+
+    def test_render_slots_suspended_flows(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        inspection = {
+            "summary": {"phase": "collection", "status": "in_progress",
+                        "filled_count": 1, "pending_count": 0,
+                        "deferred_count": 0, "retries": {},
+                        "steer_back_turns": 0, "config_id": "takeout",
+                        "suspended_flows": [
+                            {"flow": "reservation",
+                             "slots": ["date", "time"],
+                             "deferred": ["guest_name"]},
+                        ],
+                        "restored_flow": False,
+                        "auto_resume_deferred": False},
+            "categories": {
+                "core_data": {"label": "Core Data", "fields": {
+                    "filled": {"pickup_time": "6pm"}, "pending": {},
+                }},
+            },
+            "slot_dag": {"filled": ["pickup_time"], "pending": [],
+                         "deferred": [], "blocked": [],
+                         "shared_slots": []},
+        }
+        renderer.render_slots(inspection)
+        output = buf.getvalue()
+        assert "Suspended Flows" in output
+        assert "reservation" in output
+        assert "date" in output
+        assert "suspended" in output.lower()
+
+    def test_render_slots_shared_annotation(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        inspection = {
+            "summary": {"phase": "collection", "status": "in_progress",
+                        "filled_count": 2, "pending_count": 0,
+                        "deferred_count": 0, "retries": {},
+                        "steer_back_turns": 0, "config_id": "res",
+                        "suspended_flows": [],
+                        "restored_flow": False,
+                        "auto_resume_deferred": False},
+            "categories": {
+                "core_data": {"label": "Core Data", "fields": {
+                    "filled": {"party_size": "4", "guest_name": "Alice"},
+                    "pending": {},
+                }},
+            },
+            "slot_dag": {"filled": ["guest_name", "party_size"],
+                         "pending": [], "deferred": [], "blocked": [],
+                         "meta_slots": [], "flow_slots": [],
+                         "shared_slots": ["guest_name"]},
+        }
+        renderer.render_slots(inspection)
+        output = buf.getvalue()
+        assert "shared across flows" in output
+        assert "*" in output
+
+    def test_render_slots_restored_flow_header(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        inspection = {
+            "summary": {"phase": "collection", "status": "in_progress",
+                        "filled_count": 0, "pending_count": 1,
+                        "deferred_count": 0, "retries": {},
+                        "steer_back_turns": 0, "config_id": "res",
+                        "suspended_flows": [],
+                        "restored_flow": True,
+                        "auto_resume_deferred": False},
+            "categories": {
+                "core_data": {"label": "Core Data", "fields": {
+                    "filled": {}, "pending": {"date": "Friday"},
+                }},
+            },
+            "slot_dag": {"filled": [], "pending": ["date"],
+                         "deferred": [], "blocked": [],
+                         "shared_slots": []},
+        }
+        renderer.render_slots(inspection)
+        output = buf.getvalue()
+        assert "restored" in output.lower()
+
+    def test_render_slots_flows_list(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        inspection = {
+            "summary": {"phase": "collection", "status": "in_progress",
+                        "filled_count": 2, "pending_count": 0,
+                        "deferred_count": 0, "retries": {},
+                        "steer_back_turns": 0, "config_id": "bella_notte",
+                        "suspended_flows": [
+                            {"flow": "takeout", "slots": ["pickup_time"],
+                             "pending": [], "deferred": [],
+                             "slot_values": {"pickup_time": "6pm"},
+                             "pending_values": {}, "deferred_values": {}},
+                        ],
+                        "restored_flow": False,
+                        "auto_resume_deferred": False},
+            "categories": {},
+            "slot_dag": {"filled": [], "pending": [], "deferred": [],
+                         "blocked": [], "shared_slots": []},
+        }
+        flow_context = {
+            "active_config_id": "bella_notte",
+            "agent_config_map": {
+                "Reservation_Agent": "bella_notte",
+                "Takeout_Agent": "takeout",
+            },
+        }
+        renderer.render_slots(inspection, category="flows",
+                              flow_context=flow_context)
+        output = buf.getvalue()
+        assert "Flows" in output
+        assert "Reservation_Agent" in output
+        assert "Takeout_Agent" in output
+        assert "active" in output
+        assert "suspended" in output
+
+    def test_render_slots_flow_detail(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        inspection = {
+            "summary": {"phase": "collection", "status": "in_progress",
+                        "filled_count": 1, "pending_count": 0,
+                        "deferred_count": 0, "retries": {},
+                        "steer_back_turns": 0, "config_id": "takeout",
+                        "suspended_flows": [
+                            {"flow": "bella_notte", "slots": ["date", "time"],
+                             "pending": ["guest_name"], "deferred": [],
+                             "slot_values": {"date": "Friday", "time": "7pm"},
+                             "pending_values": {"guest_name": "Alice"},
+                             "deferred_values": {}},
+                        ],
+                        "restored_flow": False,
+                        "auto_resume_deferred": False},
+            "categories": {},
+            "slot_dag": {"filled": [], "pending": [], "deferred": [],
+                         "blocked": [], "shared_slots": ["guest_name"]},
+        }
+        renderer.render_slots(inspection, category="flow:bella_notte")
+        output = buf.getvalue()
+        assert "bella_notte" in output
+        assert "Friday" in output
+        assert "7pm" in output
+        assert "Alice" in output
+        assert "saved" in output
+        assert "pending" in output
+
+    def test_render_slots_flow_detail_not_found(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        inspection = {
+            "summary": {"phase": "collection", "status": "in_progress",
+                        "filled_count": 0, "pending_count": 0,
+                        "deferred_count": 0, "retries": {},
+                        "steer_back_turns": 0, "config_id": "res",
+                        "suspended_flows": [],
+                        "restored_flow": False,
+                        "auto_resume_deferred": False},
+            "categories": {},
+            "slot_dag": {"filled": [], "pending": [], "deferred": [],
+                         "blocked": [], "shared_slots": []},
+        }
+        renderer.render_slots(inspection, category="flow:nonexistent")
+        output = buf.getvalue()
+        assert "No suspended flow" in output
+
+    def test_render_slots_flow_detail_shared_annotation(self):
+        console, buf = _make_console()
+        renderer = ChatRenderer(console=console)
+        inspection = {
+            "summary": {"phase": "collection", "status": "in_progress",
+                        "filled_count": 0, "pending_count": 0,
+                        "deferred_count": 0, "retries": {},
+                        "steer_back_turns": 0, "config_id": "takeout",
+                        "suspended_flows": [
+                            {"flow": "bella_notte",
+                             "slots": ["date", "guest_name"],
+                             "pending": [], "deferred": [],
+                             "slot_values": {"date": "Fri", "guest_name": "Al"},
+                             "pending_values": {}, "deferred_values": {}},
+                        ],
+                        "restored_flow": False,
+                        "auto_resume_deferred": False},
+            "categories": {},
+            "slot_dag": {"filled": [], "pending": [], "deferred": [],
+                         "blocked": [], "shared_slots": ["guest_name"]},
+        }
+        renderer.render_slots(inspection, category="flow:bella_notte")
+        output = buf.getvalue()
+        assert "shared across flows" in output

--- a/tests/cxas_scrapi/utils/test_script_runner.py
+++ b/tests/cxas_scrapi/utils/test_script_runner.py
@@ -1,0 +1,964 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the ScriptRunner module."""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cxas_scrapi.utils.script_runner import (
+    ConversationScript,
+    ScriptResult,
+    ScriptRunner,
+    ScriptTurn,
+    TurnExpectation,
+    TurnResult,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_turn_record(
+    turn_index: int = 0,
+    user_text: str = "",
+    agent_text: str = "",
+    tool_calls: list[dict] | None = None,
+    agent_transfer: str | None = None,
+    session_ended: bool = False,
+) -> MagicMock:
+    """Create a mock TurnRecord with the expected attributes."""
+    tr = MagicMock()
+    tr.turn_index = turn_index
+    tr.user_text = user_text
+    tr.agent_text = agent_text
+    tr.tool_calls = tool_calls or []
+    tr.agent_transfer = agent_transfer
+    tr.session_ended = session_ended
+    return tr
+
+
+def _mock_chat_session(turns_data: list[dict]) -> MagicMock:
+    """Create a mock ChatSession that returns predefined TurnRecords.
+
+    Args:
+        turns_data: List of dicts with keys matching _make_turn_record params.
+            Each dict can have: user, agent, tool_calls, transfer, session_ended.
+    """
+    mock_session = MagicMock()
+    mock_session.session_id = "test-session-id"
+    mock_session.is_ended = False
+
+    turn_records = []
+    for i, data in enumerate(turns_data):
+        tr = _make_turn_record(
+            turn_index=i,
+            user_text=data.get("user", ""),
+            agent_text=data.get("agent", ""),
+            tool_calls=data.get("tool_calls", []),
+            agent_transfer=data.get("transfer", None),
+            session_ended=data.get("session_ended", False),
+        )
+        turn_records.append(tr)
+
+    # Track call count so is_ended updates after a session_ended turn
+    call_count = {"n": 0}
+    original_side_effect = list(turn_records)
+
+    def send_side_effect(text):
+        idx = call_count["n"]
+        call_count["n"] += 1
+        record = original_side_effect[idx]
+        if record.session_ended:
+            mock_session.is_ended = True
+        return record
+
+    mock_session.send.side_effect = send_side_effect
+    return mock_session
+
+
+def _write_yaml(tmp_path: Path, filename: str, content: str) -> Path:
+    """Write YAML content to a temp file and return the path."""
+    filepath = tmp_path / filename
+    filepath.write_text(textwrap.dedent(content))
+    return filepath
+
+
+# ===========================================================================
+# YAML Loading Tests
+# ===========================================================================
+
+
+class TestLoadScript:
+    """Tests for ScriptRunner.load_script()."""
+
+    def test_load_script_basic(self, tmp_path):
+        """Load a basic script with name, description, and turns."""
+        p = _write_yaml(
+            tmp_path,
+            "basic.yaml",
+            """\
+            name: "Basic test"
+            description: "A basic conversation"
+            app_name: "projects/p/locations/l/apps/a"
+            channel: "web"
+            turns:
+              - user: "Hello"
+              - user: "How are you?"
+            """,
+        )
+        script = ScriptRunner.load_script(p)
+
+        assert script.name == "Basic test"
+        assert script.description == "A basic conversation"
+        assert script.app_name == "projects/p/locations/l/apps/a"
+        assert script.channel == "web"
+        assert len(script.turns) == 2
+        assert script.turns[0].user == "Hello"
+        assert script.turns[0].expect is None
+        assert script.turns[1].user == "How are you?"
+
+    def test_load_script_with_expectations(self, tmp_path):
+        """Load a script with full expectation fields."""
+        p = _write_yaml(
+            tmp_path,
+            "expect.yaml",
+            """\
+            name: "Expectation test"
+            turns:
+              - user: "Book a table"
+                expect:
+                  agent_contains: "party"
+                  agent_not_contains: "error"
+                  tools_called: ["set_party_size", "set_date"]
+                  no_transfer: true
+                  session_ended: false
+            """,
+        )
+        script = ScriptRunner.load_script(p)
+
+        assert len(script.turns) == 1
+        exp = script.turns[0].expect
+        assert exp is not None
+        assert exp.agent_contains == "party"
+        assert exp.agent_not_contains == "error"
+        assert exp.tools_called == ["set_party_size", "set_date"]
+        assert exp.no_transfer is True
+        assert exp.session_ended is False
+
+    def test_load_script_minimal(self, tmp_path):
+        """Load a script with only required fields (name + turns)."""
+        p = _write_yaml(
+            tmp_path,
+            "minimal.yaml",
+            """\
+            name: "Minimal"
+            turns:
+              - user: "Hi"
+            """,
+        )
+        script = ScriptRunner.load_script(p)
+
+        assert script.name == "Minimal"
+        assert script.description == ""
+        assert script.app_name is None
+        assert script.channel is None
+        assert len(script.turns) == 1
+
+    def test_load_script_missing_file(self):
+        """Verify FileNotFoundError for nonexistent file."""
+        with pytest.raises(FileNotFoundError, match="Script file not found"):
+            ScriptRunner.load_script("/nonexistent/path/script.yaml")
+
+    def test_load_script_invalid_yaml(self, tmp_path):
+        """Verify ValueError for malformed YAML."""
+        p = _write_yaml(
+            tmp_path,
+            "bad.yaml",
+            """\
+            - this is a list not a dict
+            """,
+        )
+        with pytest.raises(ValueError, match="expected a YAML mapping"):
+            ScriptRunner.load_script(p)
+
+    def test_load_script_missing_name(self, tmp_path):
+        """Verify ValueError when 'name' field is missing."""
+        p = _write_yaml(
+            tmp_path,
+            "no_name.yaml",
+            """\
+            turns:
+              - user: "Hi"
+            """,
+        )
+        with pytest.raises(ValueError, match="missing 'name' field"):
+            ScriptRunner.load_script(p)
+
+    def test_load_script_missing_turns(self, tmp_path):
+        """Verify ValueError when 'turns' field is missing."""
+        p = _write_yaml(
+            tmp_path,
+            "no_turns.yaml",
+            """\
+            name: "No turns"
+            """,
+        )
+        with pytest.raises(ValueError, match="missing or invalid 'turns' field"):
+            ScriptRunner.load_script(p)
+
+    def test_load_script_turn_missing_user(self, tmp_path):
+        """Verify ValueError when a turn lacks 'user' field."""
+        p = _write_yaml(
+            tmp_path,
+            "no_user.yaml",
+            """\
+            name: "Bad turn"
+            turns:
+              - expect:
+                  agent_contains: "hello"
+            """,
+        )
+        with pytest.raises(ValueError, match="must have a 'user' field"):
+            ScriptRunner.load_script(p)
+
+
+class TestLoadScripts:
+    """Tests for ScriptRunner.load_scripts()."""
+
+    def test_load_scripts_multiple(self, tmp_path):
+        """Load two scripts from explicit paths."""
+        p1 = _write_yaml(
+            tmp_path,
+            "script1.yaml",
+            """\
+            name: "Script 1"
+            turns:
+              - user: "Hello"
+            """,
+        )
+        p2 = _write_yaml(
+            tmp_path,
+            "script2.yaml",
+            """\
+            name: "Script 2"
+            turns:
+              - user: "Goodbye"
+            """,
+        )
+        scripts = ScriptRunner.load_scripts([p1, p2])
+
+        assert len(scripts) == 2
+        assert scripts[0].name == "Script 1"
+        assert scripts[1].name == "Script 2"
+
+    def test_load_scripts_glob_pattern(self, tmp_path):
+        """Load scripts via glob pattern."""
+        for i in range(3):
+            _write_yaml(
+                tmp_path,
+                f"test_{i}.yaml",
+                f"""\
+                name: "Test {i}"
+                turns:
+                  - user: "Turn {i}"
+                """,
+            )
+        # Also create a non-matching file
+        _write_yaml(
+            tmp_path,
+            "readme.txt",
+            "not a script",
+        )
+
+        scripts = ScriptRunner.load_scripts([tmp_path / "test_*.yaml"])
+        assert len(scripts) == 3
+
+
+# ===========================================================================
+# Expectation Checking Tests
+# ===========================================================================
+
+
+class TestCheckExpectations:
+    """Tests for ScriptRunner.check_expectations()."""
+
+    def test_check_agent_contains_pass(self):
+        """Text contains expected substring -- no failures."""
+        turn = _make_turn_record(agent_text="How many in your party?")
+        expect = TurnExpectation(agent_contains="party")
+        failures = ScriptRunner.check_expectations(turn, expect)
+        assert failures == []
+
+    def test_check_agent_contains_fail(self):
+        """Text missing expected substring -- failure reported."""
+        turn = _make_turn_record(agent_text="What time would you like?")
+        expect = TurnExpectation(agent_contains="party")
+        failures = ScriptRunner.check_expectations(turn, expect)
+        assert len(failures) == 1
+        assert "agent_contains" in failures[0]
+        assert "party" in failures[0]
+
+    def test_check_agent_contains_case_insensitive(self):
+        """Case-insensitive matching for agent_contains."""
+        turn = _make_turn_record(agent_text="How many in your PARTY?")
+        expect = TurnExpectation(agent_contains="party")
+        failures = ScriptRunner.check_expectations(turn, expect)
+        assert failures == []
+
+    def test_check_agent_not_contains_pass(self):
+        """Text doesn't contain forbidden substring -- no failures."""
+        turn = _make_turn_record(agent_text="How many in your party?")
+        expect = TurnExpectation(agent_not_contains="error")
+        failures = ScriptRunner.check_expectations(turn, expect)
+        assert failures == []
+
+    def test_check_agent_not_contains_fail(self):
+        """Text contains forbidden substring -- failure reported."""
+        turn = _make_turn_record(agent_text="An error occurred")
+        expect = TurnExpectation(agent_not_contains="error")
+        failures = ScriptRunner.check_expectations(turn, expect)
+        assert len(failures) == 1
+        assert "agent_not_contains" in failures[0]
+
+    def test_check_agent_not_contains_case_insensitive(self):
+        """Case-insensitive matching for agent_not_contains."""
+        turn = _make_turn_record(agent_text="An ERROR occurred")
+        expect = TurnExpectation(agent_not_contains="error")
+        failures = ScriptRunner.check_expectations(turn, expect)
+        assert len(failures) == 1
+
+    def test_check_tools_called_pass(self):
+        """All expected tools are present."""
+        turn = _make_turn_record(
+            tool_calls=[
+                {"action": "set_party_size", "args": {"size": 4}},
+                {"action": "set_date", "args": {"date": "2026-06-01"}},
+            ]
+        )
+        expect = TurnExpectation(tools_called=["set_party_size", "set_date"])
+        failures = ScriptRunner.check_expectations(turn, expect)
+        assert failures == []
+
+    def test_check_tools_called_fail(self):
+        """Expected tool is missing."""
+        turn = _make_turn_record(
+            tool_calls=[{"action": "set_party_size", "args": {}}]
+        )
+        expect = TurnExpectation(tools_called=["set_party_size", "set_date"])
+        failures = ScriptRunner.check_expectations(turn, expect)
+        assert len(failures) == 1
+        assert "set_date" in failures[0]
+
+    def test_check_tools_called_partial(self):
+        """Some tools match, others don't -- only missing ones reported."""
+        turn = _make_turn_record(
+            tool_calls=[
+                {"action": "set_party_size", "args": {}},
+                {"action": "other_tool", "args": {}},
+            ]
+        )
+        expect = TurnExpectation(
+            tools_called=["set_party_size", "set_date", "set_time"]
+        )
+        failures = ScriptRunner.check_expectations(turn, expect)
+        assert len(failures) == 2
+        failure_text = " ".join(failures)
+        assert "set_date" in failure_text
+        assert "set_time" in failure_text
+
+    def test_check_no_transfer_pass(self):
+        """No transfer occurred -- no failure."""
+        turn = _make_turn_record(agent_transfer=None)
+        expect = TurnExpectation(no_transfer=True)
+        failures = ScriptRunner.check_expectations(turn, expect)
+        assert failures == []
+
+    def test_check_no_transfer_fail(self):
+        """Transfer occurred when not expected -- failure."""
+        turn = _make_turn_record(agent_transfer="Takeout_Agent")
+        expect = TurnExpectation(no_transfer=True)
+        failures = ScriptRunner.check_expectations(turn, expect)
+        assert len(failures) == 1
+        assert "no_transfer" in failures[0]
+        assert "Takeout_Agent" in failures[0]
+
+    def test_check_session_ended_pass(self):
+        """Session ended status matches expectation."""
+        turn = _make_turn_record(session_ended=True)
+        expect = TurnExpectation(session_ended=True)
+        failures = ScriptRunner.check_expectations(turn, expect)
+        assert failures == []
+
+    def test_check_session_ended_pass_false(self):
+        """Session not ended matches expectation of False."""
+        turn = _make_turn_record(session_ended=False)
+        expect = TurnExpectation(session_ended=False)
+        failures = ScriptRunner.check_expectations(turn, expect)
+        assert failures == []
+
+    def test_check_session_ended_fail(self):
+        """Session ended status doesn't match expectation."""
+        turn = _make_turn_record(session_ended=False)
+        expect = TurnExpectation(session_ended=True)
+        failures = ScriptRunner.check_expectations(turn, expect)
+        assert len(failures) == 1
+        assert "session_ended" in failures[0]
+
+    def test_check_multiple_expectations(self):
+        """Combine several expectations -- all are checked."""
+        turn = _make_turn_record(
+            agent_text="Here is your reservation",
+            tool_calls=[{"action": "BookReservation", "args": {}}],
+            agent_transfer="Farewell_Agent",
+            session_ended=False,
+        )
+        expect = TurnExpectation(
+            agent_contains="reservation",
+            agent_not_contains="error",
+            tools_called=["BookReservation"],
+            no_transfer=True,  # will fail
+            session_ended=True,  # will fail
+        )
+        failures = ScriptRunner.check_expectations(turn, expect)
+        # agent_contains passes, agent_not_contains passes,
+        # tools_called passes, no_transfer fails, session_ended fails
+        assert len(failures) == 2
+        failure_text = " ".join(failures)
+        assert "no_transfer" in failure_text
+        assert "session_ended" in failure_text
+
+    def test_check_no_expectations(self):
+        """Empty expectation -- no failures."""
+        turn = _make_turn_record(agent_text="Anything")
+        expect = TurnExpectation()
+        failures = ScriptRunner.check_expectations(turn, expect)
+        assert failures == []
+
+
+# ===========================================================================
+# Script Execution Tests
+# ===========================================================================
+
+
+class TestRunScript:
+    """Tests for ScriptRunner.run_script() with mocked ChatSession."""
+
+    @patch("cxas_scrapi.utils.script_runner.ChatSession")
+    @patch("cxas_scrapi.utils.script_runner.time.sleep")
+    def test_run_script_all_pass(self, mock_sleep, MockChatSession):
+        """3-turn script where all expectations pass."""
+        mock_session = _mock_chat_session(
+            [
+                {"agent": "How many in your party?", "tool_calls": []},
+                {
+                    "agent": "What time would you like?",
+                    "tool_calls": [{"action": "set_party_size", "args": {"size": 4}}],
+                },
+                {"agent": "Confirmed for 6 PM", "tool_calls": []},
+            ]
+        )
+        MockChatSession.return_value = mock_session
+
+        script = ConversationScript(
+            name="Happy path",
+            turns=[
+                ScriptTurn(
+                    user="Table for 4",
+                    expect=TurnExpectation(agent_contains="party"),
+                ),
+                ScriptTurn(
+                    user="4 people",
+                    expect=TurnExpectation(tools_called=["set_party_size"]),
+                ),
+                ScriptTurn(
+                    user="6 PM",
+                    expect=TurnExpectation(agent_contains="6"),
+                ),
+            ],
+        )
+
+        runner = ScriptRunner(app_name="test-app", delay=0)
+        result = runner.run_script(script)
+
+        assert result.passed is True
+        assert result.total_turns == 3
+        assert result.passed_turns == 3
+        assert result.failed_turns == 0
+        assert result.error is None
+        assert len(result.turns) == 3
+        for tr in result.turns:
+            assert tr.passed is True
+            assert tr.expectation_failures == []
+
+    @patch("cxas_scrapi.utils.script_runner.ChatSession")
+    @patch("cxas_scrapi.utils.script_runner.time.sleep")
+    def test_run_script_with_failures(self, mock_sleep, MockChatSession):
+        """Expectations fail but execution continues to collect all failures."""
+        mock_session = _mock_chat_session(
+            [
+                {"agent": "Hello!", "tool_calls": []},
+                {"agent": "I don't understand", "tool_calls": []},
+            ]
+        )
+        MockChatSession.return_value = mock_session
+
+        script = ConversationScript(
+            name="Failure test",
+            turns=[
+                ScriptTurn(
+                    user="Hi",
+                    expect=TurnExpectation(agent_contains="party"),  # will fail
+                ),
+                ScriptTurn(
+                    user="Book a table",
+                    expect=TurnExpectation(
+                        tools_called=["set_party_size"]
+                    ),  # will fail
+                ),
+            ],
+        )
+
+        runner = ScriptRunner(app_name="test-app", delay=0)
+        result = runner.run_script(script)
+
+        assert result.passed is False
+        assert result.total_turns == 2
+        assert result.passed_turns == 0
+        assert result.failed_turns == 2
+        assert result.turns[0].passed is False
+        assert len(result.turns[0].expectation_failures) == 1
+        assert result.turns[1].passed is False
+        assert len(result.turns[1].expectation_failures) == 1
+
+    @patch("cxas_scrapi.utils.script_runner.ChatSession")
+    @patch("cxas_scrapi.utils.script_runner.time.sleep")
+    def test_run_script_session_ends_early(self, mock_sleep, MockChatSession):
+        """Session ends at turn 2 of 5 -- remaining turns skipped."""
+        mock_session = _mock_chat_session(
+            [
+                {"agent": "Hello!", "session_ended": False},
+                {"agent": "Goodbye!", "session_ended": True},
+            ]
+        )
+        MockChatSession.return_value = mock_session
+
+        script = ConversationScript(
+            name="Early end",
+            turns=[
+                ScriptTurn(user="Hi"),
+                ScriptTurn(user="Bye"),
+                ScriptTurn(user="Still here?"),
+                ScriptTurn(user="Hello?"),
+                ScriptTurn(user="Anyone?"),
+            ],
+        )
+
+        runner = ScriptRunner(app_name="test-app", delay=0)
+        result = runner.run_script(script)
+
+        assert result.passed is False
+        assert result.total_turns == 5
+        # 2 executed (pass) + 3 skipped (fail)
+        assert result.passed_turns == 2
+        assert result.failed_turns == 3
+        assert len(result.turns) == 5
+        # First two turns executed normally
+        assert result.turns[0].passed is True
+        assert result.turns[1].passed is True
+        # Remaining turns are skipped
+        for tr in result.turns[2:]:
+            assert tr.passed is False
+            assert "Skipped: session ended early" in tr.expectation_failures
+
+    @patch("cxas_scrapi.utils.script_runner.ChatSession")
+    @patch("cxas_scrapi.utils.script_runner.time.sleep")
+    def test_run_script_no_expectations(self, mock_sleep, MockChatSession):
+        """Turns without expect field all pass."""
+        mock_session = _mock_chat_session(
+            [
+                {"agent": "Hello!"},
+                {"agent": "Sure thing!"},
+            ]
+        )
+        MockChatSession.return_value = mock_session
+
+        script = ConversationScript(
+            name="No expectations",
+            turns=[
+                ScriptTurn(user="Hi"),
+                ScriptTurn(user="Do something"),
+            ],
+        )
+
+        runner = ScriptRunner(app_name="test-app", delay=0)
+        result = runner.run_script(script)
+
+        assert result.passed is True
+        assert result.passed_turns == 2
+        assert result.failed_turns == 0
+
+    @patch("cxas_scrapi.utils.script_runner.ChatSession")
+    @patch("cxas_scrapi.utils.script_runner.time.sleep")
+    def test_run_script_exception(self, mock_sleep, MockChatSession):
+        """ChatSession.send() throws -- error captured in result."""
+        mock_session = MagicMock()
+        mock_session.session_id = "test-session-id"
+        mock_session.is_ended = False
+        mock_session.send.side_effect = RuntimeError("API unavailable")
+        MockChatSession.return_value = mock_session
+
+        script = ConversationScript(
+            name="Error test",
+            turns=[
+                ScriptTurn(user="Hi"),
+                ScriptTurn(user="Will not reach"),
+            ],
+        )
+
+        runner = ScriptRunner(app_name="test-app", delay=0)
+        result = runner.run_script(script)
+
+        assert result.passed is False
+        # Only 1 turn attempted before exception
+        assert len(result.turns) == 1
+        assert result.turns[0].passed is False
+        assert "API unavailable" in result.turns[0].expectation_failures[0]
+
+    @patch("cxas_scrapi.utils.script_runner.ChatSession")
+    @patch("cxas_scrapi.utils.script_runner.time.sleep")
+    def test_run_script_uses_script_app_name(self, mock_sleep, MockChatSession):
+        """Script-level app_name overrides runner-level app_name."""
+        mock_session = _mock_chat_session([{"agent": "Hi"}])
+        MockChatSession.return_value = mock_session
+
+        script = ConversationScript(
+            name="Override test",
+            app_name="script-level-app",
+            channel="phone",
+            turns=[ScriptTurn(user="Hi")],
+        )
+
+        runner = ScriptRunner(app_name="runner-level-app", channel="web", delay=0)
+        runner.run_script(script)
+
+        MockChatSession.assert_called_once_with(
+            app_name="script-level-app",
+            channel="phone",
+        )
+
+    @patch("cxas_scrapi.utils.script_runner.ChatSession")
+    @patch("cxas_scrapi.utils.script_runner.time.sleep")
+    def test_run_script_falls_back_to_runner_app_name(
+        self, mock_sleep, MockChatSession
+    ):
+        """When script has no app_name, runner-level app_name is used."""
+        mock_session = _mock_chat_session([{"agent": "Hi"}])
+        MockChatSession.return_value = mock_session
+
+        script = ConversationScript(
+            name="Fallback test",
+            turns=[ScriptTurn(user="Hi")],
+        )
+
+        runner = ScriptRunner(app_name="runner-level-app", channel="web", delay=0)
+        runner.run_script(script)
+
+        MockChatSession.assert_called_once_with(
+            app_name="runner-level-app",
+            channel="web",
+        )
+
+    @patch("cxas_scrapi.utils.script_runner.ChatSession")
+    @patch("cxas_scrapi.utils.script_runner.time.sleep")
+    def test_run_script_delay_between_turns(self, mock_sleep, MockChatSession):
+        """Verifies delay is applied between turns but not after the last."""
+        mock_session = _mock_chat_session(
+            [
+                {"agent": "Turn 1"},
+                {"agent": "Turn 2"},
+                {"agent": "Turn 3"},
+            ]
+        )
+        MockChatSession.return_value = mock_session
+
+        script = ConversationScript(
+            name="Delay test",
+            turns=[
+                ScriptTurn(user="A"),
+                ScriptTurn(user="B"),
+                ScriptTurn(user="C"),
+            ],
+        )
+
+        runner = ScriptRunner(app_name="test-app", delay=1.5)
+        runner.run_script(script)
+
+        # Sleep should be called between turns (2 times for 3 turns)
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_called_with(1.5)
+
+    @patch("cxas_scrapi.utils.script_runner.ChatSession")
+    def test_run_script_session_creation_failure(self, MockChatSession):
+        """ChatSession constructor throws -- error captured in ScriptResult."""
+        MockChatSession.side_effect = RuntimeError("Connection refused")
+
+        script = ConversationScript(
+            name="Creation failure",
+            turns=[ScriptTurn(user="Hi")],
+        )
+
+        runner = ScriptRunner(app_name="test-app", delay=0)
+        result = runner.run_script(script)
+
+        assert result.passed is False
+        assert result.error is not None
+        assert "Connection refused" in result.error
+        assert result.total_turns == 1
+        assert len(result.turns) == 0
+
+
+# ===========================================================================
+# Batch Tests
+# ===========================================================================
+
+
+class TestRunBatch:
+    """Tests for ScriptRunner.run_batch()."""
+
+    @patch("cxas_scrapi.utils.script_runner.ChatSession")
+    @patch("cxas_scrapi.utils.script_runner.time.sleep")
+    def test_run_batch_sequential(self, mock_sleep, MockChatSession):
+        """Two scripts, both executed sequentially."""
+        call_count = {"n": 0}
+
+        def session_factory(*args, **kwargs):
+            call_count["n"] += 1
+            return _mock_chat_session(
+                [{"agent": f"Response from session {call_count['n']}"}]
+            )
+
+        MockChatSession.side_effect = session_factory
+
+        scripts = [
+            ConversationScript(
+                name="Script A", turns=[ScriptTurn(user="Hello A")]
+            ),
+            ConversationScript(
+                name="Script B", turns=[ScriptTurn(user="Hello B")]
+            ),
+        ]
+
+        runner = ScriptRunner(app_name="test-app", delay=0)
+        results = runner.run_batch(scripts, max_workers=1)
+
+        assert len(results) == 2
+        assert results[0].script_name == "Script A"
+        assert results[1].script_name == "Script B"
+        assert all(r.passed for r in results)
+
+    @patch("cxas_scrapi.utils.script_runner.ChatSession")
+    @patch("cxas_scrapi.utils.script_runner.time.sleep")
+    def test_run_batch_results_count(self, mock_sleep, MockChatSession):
+        """Verify all results returned for a batch of 3 scripts."""
+        MockChatSession.side_effect = lambda *a, **kw: _mock_chat_session(
+            [{"agent": "Response"}]
+        )
+
+        scripts = [
+            ConversationScript(name=f"Script {i}", turns=[ScriptTurn(user="Hi")])
+            for i in range(3)
+        ]
+
+        runner = ScriptRunner(app_name="test-app", delay=0)
+        results = runner.run_batch(scripts)
+
+        assert len(results) == 3
+
+    @patch("cxas_scrapi.utils.script_runner.ChatSession")
+    @patch("cxas_scrapi.utils.script_runner.time.sleep")
+    def test_run_batch_parallel(self, mock_sleep, MockChatSession):
+        """Run batch with max_workers > 1 to exercise ThreadPoolExecutor path."""
+        MockChatSession.side_effect = lambda *a, **kw: _mock_chat_session(
+            [{"agent": "Response"}]
+        )
+
+        scripts = [
+            ConversationScript(name=f"Script {i}", turns=[ScriptTurn(user="Hi")])
+            for i in range(3)
+        ]
+
+        runner = ScriptRunner(app_name="test-app", delay=0)
+        results = runner.run_batch(scripts, max_workers=2)
+
+        assert len(results) == 3
+
+
+# ===========================================================================
+# Output Format Tests
+# ===========================================================================
+
+
+class TestOutputFormats:
+    """Tests for results_to_json() and results_to_table()."""
+
+    def _sample_results(self) -> list[ScriptResult]:
+        """Create sample ScriptResults for output tests."""
+        return [
+            ScriptResult(
+                script_name="Happy Path",
+                turns=[
+                    TurnResult(
+                        turn_index=0,
+                        user_text="Hi",
+                        agent_text="Hello!",
+                        tool_calls=[],
+                        transfer=None,
+                        session_ended=False,
+                        expectation_failures=[],
+                        passed=True,
+                    ),
+                ],
+                passed=True,
+                total_turns=1,
+                passed_turns=1,
+                failed_turns=0,
+            ),
+            ScriptResult(
+                script_name="Sad Path",
+                turns=[
+                    TurnResult(
+                        turn_index=0,
+                        user_text="Break",
+                        agent_text="Error",
+                        tool_calls=[],
+                        transfer=None,
+                        session_ended=False,
+                        expectation_failures=["agent_contains: expected 'hello'"],
+                        passed=False,
+                    ),
+                ],
+                passed=False,
+                total_turns=1,
+                passed_turns=0,
+                failed_turns=1,
+            ),
+        ]
+
+    def test_results_to_json(self):
+        """Verify JSON output structure and content."""
+        results = self._sample_results()
+        json_str = ScriptRunner.results_to_json(results)
+        parsed = json.loads(json_str)
+
+        assert len(parsed) == 2
+        assert parsed[0]["script_name"] == "Happy Path"
+        assert parsed[0]["passed"] is True
+        assert parsed[0]["total_turns"] == 1
+        assert parsed[0]["passed_turns"] == 1
+        assert parsed[0]["failed_turns"] == 0
+        assert parsed[0]["error"] is None
+        assert len(parsed[0]["turns"]) == 1
+        assert parsed[0]["turns"][0]["user_text"] == "Hi"
+        assert parsed[0]["turns"][0]["agent_text"] == "Hello!"
+        assert parsed[0]["turns"][0]["passed"] is True
+
+        assert parsed[1]["script_name"] == "Sad Path"
+        assert parsed[1]["passed"] is False
+        assert len(parsed[1]["turns"][0]["expectation_failures"]) == 1
+
+    def test_results_to_json_empty(self):
+        """Empty results list produces valid JSON array."""
+        json_str = ScriptRunner.results_to_json([])
+        parsed = json.loads(json_str)
+        assert parsed == []
+
+    def test_results_to_table(self):
+        """Verify table output contains script names and statuses."""
+        results = self._sample_results()
+        table_str = ScriptRunner.results_to_table(results)
+
+        assert "Happy Path" in table_str
+        assert "Sad Path" in table_str
+        assert "PASS" in table_str
+        assert "FAIL" in table_str
+
+    def test_results_to_table_with_error(self):
+        """Verify table shows ERROR status for scripts with errors."""
+        results = [
+            ScriptResult(
+                script_name="Error Script",
+                turns=[],
+                passed=False,
+                total_turns=3,
+                passed_turns=0,
+                failed_turns=0,
+                error="Connection refused",
+            ),
+        ]
+        table_str = ScriptRunner.results_to_table(results)
+
+        assert "Error Script" in table_str
+        assert "ERROR" in table_str
+
+
+# ===========================================================================
+# Data Class Tests
+# ===========================================================================
+
+
+class TestDataClasses:
+    """Tests for the data classes themselves."""
+
+    def test_turn_expectation_defaults(self):
+        """TurnExpectation has sensible defaults."""
+        exp = TurnExpectation()
+        assert exp.agent_contains is None
+        assert exp.agent_not_contains is None
+        assert exp.tools_called is None
+        assert exp.no_transfer is False
+        assert exp.session_ended is None
+
+    def test_script_turn_defaults(self):
+        """ScriptTurn expect defaults to None."""
+        st = ScriptTurn(user="Hello")
+        assert st.user == "Hello"
+        assert st.expect is None
+
+    def test_conversation_script_defaults(self):
+        """ConversationScript optional fields have defaults."""
+        cs = ConversationScript(name="Test", turns=[])
+        assert cs.description == ""
+        assert cs.app_name is None
+        assert cs.channel is None
+
+    def test_script_result_defaults(self):
+        """ScriptResult error defaults to None."""
+        sr = ScriptResult(
+            script_name="Test",
+            turns=[],
+            passed=True,
+            total_turns=0,
+            passed_turns=0,
+            failed_turns=0,
+        )
+        assert sr.error is None

--- a/tests/cxas_scrapi/utils/test_slot_inspector.py
+++ b/tests/cxas_scrapi/utils/test_slot_inspector.py
@@ -1,0 +1,376 @@
+import json
+
+import pytest
+
+from cxas_scrapi.utils.slot_inspector import SLOT_CATEGORIES, SlotInspector
+
+
+class TestInspect:
+    def test_inspect_empty(self):
+        result = SlotInspector.inspect({})
+        assert "summary" in result
+        assert "categories" in result
+        assert "slot_dag" in result
+        assert result["summary"]["phase"] == "collection"
+        assert result["summary"]["status"] is None
+        assert result["summary"]["filled_count"] == 0
+        assert result["summary"]["pending_count"] == 0
+        assert result["summary"]["deferred_count"] == 0
+
+    def test_inspect_core_data(self):
+        sm = {
+            "filled": {"party_size": "4", "date": "tomorrow"},
+            "pending": {"time": "7pm"},
+            "deferred": {"name": "John"},
+            "status": "in_progress",
+        }
+        result = SlotInspector.inspect(sm)
+        cats = result["categories"]
+        assert "core_data" in cats
+        assert cats["core_data"]["label"] == "Core Data"
+        assert cats["core_data"]["fields"]["filled"] == {"party_size": "4", "date": "tomorrow"}
+        assert cats["core_data"]["fields"]["pending"] == {"time": "7pm"}
+        assert cats["core_data"]["fields"]["deferred"] == {"name": "John"}
+        assert cats["core_data"]["fields"]["status"] == "in_progress"
+
+    def test_inspect_all_categories(self):
+        sm = {}
+        for cat_def in SLOT_CATEGORIES.values():
+            for field in cat_def["fields"]:
+                sm[field] = f"value_{field}"
+
+        result = SlotInspector.inspect(sm)
+        cats = result["categories"]
+        for cat_key, cat_def in SLOT_CATEGORIES.items():
+            assert cat_key in cats, f"Missing category: {cat_key}"
+            assert cats[cat_key]["label"] == cat_def["label"]
+            for field in cat_def["fields"]:
+                assert field in cats[cat_key]["fields"]
+
+        assert "uncategorized" not in cats
+
+    def test_inspect_uncategorized(self):
+        sm = {
+            "filled": {},
+            "custom_field": "abc",
+            "_unknown_internal": 42,
+        }
+        result = SlotInspector.inspect(sm)
+        cats = result["categories"]
+        assert "uncategorized" in cats
+        assert cats["uncategorized"]["fields"]["custom_field"] == "abc"
+        assert cats["uncategorized"]["fields"]["_unknown_internal"] == 42
+
+    def test_inspect_summary_counts(self):
+        sm = {
+            "filled": {"a": 1, "b": 2, "c": 3},
+            "pending": {"d": 4},
+            "deferred": {"e": 5, "f": 6},
+        }
+        result = SlotInspector.inspect(sm)
+        assert result["summary"]["filled_count"] == 3
+        assert result["summary"]["pending_count"] == 1
+        assert result["summary"]["deferred_count"] == 2
+
+    def test_inspect_json_serializable(self):
+        sm = {
+            "filled": {"party_size": "4"},
+            "pending": {},
+            "status": "in_progress",
+            "_retries": {"lookup": 1},
+            "_steer_back_turns": 2,
+            "_config_id": "reservation",
+        }
+        result = SlotInspector.inspect(sm)
+        serialized = json.dumps(result, default=str)
+        assert isinstance(serialized, str)
+        parsed = json.loads(serialized)
+        assert parsed["summary"]["config_id"] == "reservation"
+
+
+class TestDerivePhase:
+    def test_phase_collection(self):
+        sm = {"filled": {"a": 1}, "pending": {}, "_initialized": True}
+        result = SlotInspector.inspect(sm)
+        assert result["summary"]["phase"] == "collection"
+
+    def test_phase_fresh_readback(self):
+        sm = {"pending": {"party_size": "4"}}
+        result = SlotInspector.inspect(sm)
+        assert result["summary"]["phase"] == "fresh_readback"
+
+    def test_phase_awaiting_confirmation(self):
+        sm = {
+            "_auto_confirm_pending": True,
+            "pending": {"party_size": "4"},
+        }
+        result = SlotInspector.inspect(sm)
+        assert result["summary"]["phase"] == "awaiting_confirmation"
+
+    def test_phase_correction(self):
+        sm = {"_correction_pending": True}
+        result = SlotInspector.inspect(sm)
+        assert result["summary"]["phase"] == "correction"
+
+    def test_phase_complete(self):
+        sm = {"status": "complete"}
+        result = SlotInspector.inspect(sm)
+        assert result["summary"]["phase"] == "complete"
+
+    def test_phase_escalated(self):
+        sm = {"status": "escalated"}
+        result = SlotInspector.inspect(sm)
+        assert result["summary"]["phase"] == "escalated"
+
+    def test_phase_uninitialized(self):
+        sm = {"_initialized": False}
+        result = SlotInspector.inspect(sm)
+        assert result["summary"]["phase"] == "uninitialized"
+
+
+class TestBuildSlotDag:
+    def test_dag_basic(self):
+        sm = {
+            "filled": {"party_size": "4", "date": "tomorrow"},
+            "pending": {"time": "7pm"},
+            "deferred": {"name": "John"},
+        }
+        result = SlotInspector.inspect(sm)
+        dag = result["slot_dag"]
+        assert dag["filled"] == ["date", "party_size"]
+        assert dag["pending"] == ["time"]
+        assert dag["deferred"] == ["name"]
+        assert dag["blocked"] == []
+
+    def test_dag_blocked(self):
+        sm = {
+            "filled": {"party_size": "4"},
+            "pending": {},
+            "deferred": {},
+            "_slot_requires": {
+                "time": ["date"],
+                "confirmation": ["party_size", "date", "time"],
+            },
+        }
+        result = SlotInspector.inspect(sm)
+        dag = result["slot_dag"]
+        blocked = dag["blocked"]
+        assert len(blocked) == 2
+        time_blocked = next(b for b in blocked if b["slot"] == "time")
+        assert time_blocked["blocked_by"] == ["date"]
+        conf_blocked = next(b for b in blocked if b["slot"] == "confirmation")
+        assert "date" in conf_blocked["blocked_by"]
+        assert "time" in conf_blocked["blocked_by"]
+
+    def test_dag_meta_slots_from_bootstrap(self):
+        sm = {
+            "filled": {"active_flow": "reservation", "welcome": True,
+                       "party_size": "4"},
+            "pending": {},
+            "_bootstrap": {"slot": "active_flow", "welcome_slot": "welcome"},
+            "_gate_slot": "active_flow",
+        }
+        result = SlotInspector.inspect(sm)
+        dag = result["slot_dag"]
+        assert "active_flow" in dag["meta_slots"]
+        assert "welcome" in dag["meta_slots"]
+        assert "party_size" not in dag["meta_slots"]
+
+    def test_dag_flow_slots_from_setters(self):
+        sm = {
+            "filled": {},
+            "pending": {},
+            "_setter_slots": {"set_time": "selected_time"},
+            "_multi_setter_slots": {
+                "set_basics": {"ps": "party_size", "d": "date"},
+            },
+            "_slot_ordering": "party_size → date → selected_time → name",
+        }
+        result = SlotInspector.inspect(sm)
+        dag = result["slot_dag"]
+        assert "selected_time" in dag["flow_slots"]
+        assert "party_size" in dag["flow_slots"]
+        assert "date" in dag["flow_slots"]
+        assert "name" in dag["flow_slots"]
+
+    def test_dag_no_blocked_when_filled(self):
+        sm = {
+            "filled": {"party_size": "4", "date": "tomorrow"},
+            "pending": {},
+            "deferred": {},
+            "_slot_requires": {
+                "time": ["party_size", "date"],
+            },
+        }
+        result = SlotInspector.inspect(sm)
+        dag = result["slot_dag"]
+        assert dag["blocked"] == []
+
+
+    def test_dag_shared_slots(self):
+        sm = {
+            "filled": {"guest_name": "Alice", "party_size": "4"},
+            "pending": {},
+            "_shared_slots": ["guest_name", "welcome"],
+        }
+        result = SlotInspector.inspect(sm)
+        dag = result["slot_dag"]
+        assert "guest_name" in dag["shared_slots"]
+        assert "welcome" in dag["shared_slots"]
+        assert "party_size" not in dag["shared_slots"]
+
+
+class TestSuspendedFlows:
+    def test_no_suspended_flows(self):
+        result = SlotInspector.inspect({"filled": {}, "pending": {}})
+        assert result["summary"]["suspended_flows"] == []
+        assert result["summary"]["restored_flow"] is False
+        assert result["summary"]["auto_resume_deferred"] is False
+
+    def test_suspended_flow_summary(self):
+        sm = {
+            "filled": {"active_flow": "takeout", "party_size": "2"},
+            "pending": {},
+            "_flow_state": [
+                {
+                    "id": 1,
+                    "flow": "reservation",
+                    "slots": {"date": "Friday", "time": "7pm"},
+                    "deferred": {"guest_name": "Alice"},
+                    "task_results": {},
+                },
+            ],
+        }
+        result = SlotInspector.inspect(sm)
+        suspended = result["summary"]["suspended_flows"]
+        assert len(suspended) == 1
+        assert suspended[0]["flow"] == "reservation"
+        assert "date" in suspended[0]["slots"]
+        assert "time" in suspended[0]["slots"]
+        assert "guest_name" in suspended[0]["deferred"]
+
+    def test_restored_flow_flag(self):
+        sm = {
+            "filled": {"active_flow": "reservation"},
+            "pending": {"date": "Friday"},
+            "_restored_flow": True,
+        }
+        result = SlotInspector.inspect(sm)
+        assert result["summary"]["restored_flow"] is True
+
+    def test_auto_resume_deferred_flag(self):
+        sm = {
+            "status": "complete",
+            "_auto_resume_deferred": True,
+            "_flow_state": [
+                {"id": 1, "flow": "reservation", "slots": {}, "deferred": {}}
+            ],
+        }
+        result = SlotInspector.inspect(sm)
+        assert result["summary"]["auto_resume_deferred"] is True
+
+    def test_multiple_suspended_flows(self):
+        sm = {
+            "filled": {"active_flow": "catering"},
+            "pending": {},
+            "_flow_state": [
+                {"id": 1, "flow": "reservation", "slots": {"date": "Fri"}, "deferred": {}},
+                {"id": 2, "flow": "takeout", "slots": {"pickup_time": "6pm"}, "deferred": {}},
+            ],
+        }
+        result = SlotInspector.inspect(sm)
+        suspended = result["summary"]["suspended_flows"]
+        assert len(suspended) == 2
+        assert suspended[0]["flow"] == "reservation"
+        assert suspended[1]["flow"] == "takeout"
+
+
+class TestInspectFromTrace:
+    def test_from_trace_variable_update(self):
+        trace = {
+            "entries": [
+                {
+                    "kind": "variable_update",
+                    "turn": 0,
+                    "variables": {
+                        "slot_machine": {
+                            "filled": {"party_size": "4"},
+                            "pending": {},
+                            "status": "in_progress",
+                        }
+                    },
+                }
+            ]
+        }
+        result = SlotInspector.inspect_from_trace(trace)
+        assert result["summary"]["filled_count"] == 1
+        assert result["summary"]["phase"] == "collection"
+
+    def test_from_trace_with_turn_filter(self):
+        trace = {
+            "entries": [
+                {
+                    "kind": "variable_update",
+                    "turn": 0,
+                    "variables": {
+                        "slot_machine": {
+                            "filled": {"party_size": "4"},
+                            "pending": {},
+                        }
+                    },
+                },
+                {
+                    "kind": "variable_update",
+                    "turn": 2,
+                    "variables": {
+                        "slot_machine": {
+                            "filled": {"party_size": "4", "date": "tomorrow"},
+                            "pending": {"time": "7pm"},
+                        }
+                    },
+                },
+            ]
+        }
+        result = SlotInspector.inspect_from_trace(trace, turn=1)
+        assert result["summary"]["filled_count"] == 1
+        assert result["summary"]["pending_count"] == 0
+
+    def test_from_trace_no_sm(self):
+        trace = {
+            "entries": [
+                {"kind": "agent_response", "turn": 0, "text": "hello"}
+            ]
+        }
+        result = SlotInspector.inspect_from_trace(trace)
+        assert result["summary"]["filled_count"] == 0
+        assert result["summary"]["phase"] == "collection"
+
+    def test_from_trace_multiple_updates(self):
+        trace = {
+            "entries": [
+                {
+                    "kind": "variable_update",
+                    "turn": 0,
+                    "variables": {
+                        "slot_machine": {
+                            "filled": {"party_size": "4"},
+                            "pending": {},
+                        }
+                    },
+                },
+                {
+                    "kind": "variable_default",
+                    "turn": 1,
+                    "variables": {
+                        "slot_machine": {
+                            "filled": {"party_size": "4", "date": "tomorrow", "time": "7pm"},
+                            "pending": {},
+                            "status": "complete",
+                        }
+                    },
+                },
+            ]
+        }
+        result = SlotInspector.inspect_from_trace(trace)
+        assert result["summary"]["filled_count"] == 3
+        assert result["summary"]["phase"] == "complete"

--- a/tests/cxas_scrapi/utils/tracing/test_trace_report.py
+++ b/tests/cxas_scrapi/utils/tracing/test_trace_report.py
@@ -407,3 +407,106 @@ def test_span_renderers_unknown_name():
     assert "Other" in tr._span_to_text(s)
     md = tr._span_to_markdown(s)
     assert "Other" in md
+
+
+# -----------------------------------------------------------------------
+# _interactions_to_turns / normalize with interactions
+# -----------------------------------------------------------------------
+
+SAMPLE_INTERACTIONS = {
+    "name": "projects/p/locations/global/apps/a/conversations/c2",
+    "interactions": [
+        {
+            "response": {
+                "query_result": {
+                    "diagnostic_info": {
+                        "messages": [
+                            {
+                                "role": "user",
+                                "chunks": [{"text": "table for 4"}],
+                            },
+                            {
+                                "role": "Reservation_Agent",
+                                "chunks": [
+                                    {"text": "I'd be happy to help!"},
+                                    {
+                                        "tool_call": {
+                                            "display_name": "set_party_size",
+                                            "args": {"party_size": 4},
+                                        }
+                                    },
+                                    {
+                                        "tool_response": {
+                                            "display_name": "set_party_size",
+                                            "response": {"status": "ok"},
+                                        }
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    "parameters": {
+                        "slot_machine": {
+                            "filled": {"party_size": "4"},
+                            "pending": {},
+                            "status": "in_progress",
+                            "_config_id": "reservation",
+                        }
+                    },
+                }
+            },
+            "request_utterances": "table for 4",
+            "response_utterances": "I'd be happy to help!",
+        },
+    ],
+}
+
+
+def test_interactions_to_turns_basic():
+    turns = tr._interactions_to_turns(SAMPLE_INTERACTIONS["interactions"])
+    assert len(turns) == 1
+    messages = turns[0]["messages"]
+    assert len(messages) == 3  # 2 from diagnostic_info + 1 from parameters
+
+
+def test_normalize_from_interactions():
+    n = tr.normalize(SAMPLE_INTERACTIONS)
+    assert n["conversation_id"] == "c2"
+    assert n["num_turns"] == 1
+    kinds = [e["kind"] for e in n["entries"]]
+    assert "user" in kinds
+    assert "agent" in kinds
+    assert "tool_call" in kinds
+    assert "tool_response" in kinds
+    assert "variable_update" in kinds
+
+
+def test_normalize_interactions_extracts_slot_machine():
+    n = tr.normalize(SAMPLE_INTERACTIONS)
+    var_entries = [
+        e for e in n["entries"] if e["kind"] == "variable_update"
+    ]
+    assert len(var_entries) >= 1
+    sm = var_entries[-1]["variables"].get("slot_machine")
+    assert sm is not None
+    assert sm["filled"] == {"party_size": "4"}
+    assert sm["_config_id"] == "reservation"
+
+
+def test_normalize_interactions_empty():
+    n = tr.normalize({"name": "p/c3", "interactions": []})
+    assert n["entries"] == []
+    assert n["num_turns"] == 0
+
+
+def test_normalize_prefers_turns_over_interactions():
+    combo = {
+        "name": "p/c4",
+        "turns": [
+            {"messages": [{"role": "user", "chunks": [{"text": "hi"}]}]}
+        ],
+        "interactions": SAMPLE_INTERACTIONS["interactions"],
+    }
+    n = tr.normalize(combo)
+    assert n["num_turns"] == 1
+    assert n["entries"][0]["text"] == "hi"


### PR DESCRIPTION
Add a `cxas chat` experience for building and debugging slot-filling agents turn by turn:

- Interactive chat CLI with slash commands (/slots, /log, /clear) and a Textual-based TUI; supports display names and a default app.
- ChatSession core class with session-file persistence, variable state, and historical-context seeding.
- Programmatic chat driver and `cxas chat-step` for scripted, single-turn JSON I/O — including deep slot inspection (--with-slots), SM log (--with-log), flow context, and per-turn trace enrichment.
- ChatRenderer: high-level turn/timeline rendering, payload and Dialogflow rendering, and SM-event interpretation.
- SlotInspector for structured slot-machine state.

Trace enrichment fix: anchor tool_calls/tool_responses reconstruction on the trace's own latest turn rather than the session turn_index, which drifts from the trace's cumulative numbering across multi-turn --session-file conversations (especially after agent transfers) and otherwise surfaces tool calls from an earlier exchange.

Includes agent-foundry skill docs for chat-based debugging.