### PR TITLE
feat(migration): add canonical XML instruction validator

### DIFF
--- a/src/cxas_scrapi/migration/xml_validator.py
+++ b/src/cxas_scrapi/migration/xml_validator.py
@@ -1,0 +1,245 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Strict structural validator for canonical CXAS instruction XML.
+
+Used by the consolidation pipeline to gate Gemini-synthesized instruction
+output. Returns a list of diagnostic strings; an empty list means the
+instruction passes. Diagnostics are formatted to be appended verbatim to
+a re-prompt when Gemini drifts from the canonical schema.
+
+The canonical schema is defined in docs/design-guide/instruction-design.md
+and demonstrated by examples/bella_notte/agents/*/instruction.txt.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+REQUIRED_TOP_LEVEL_TAGS: tuple[str, ...] = ("role", "persona")
+
+# Tags that, if present anywhere, force <taskflow> to also be present at
+# the top level. Specialist agents that are purely <role>+<persona>+
+# <guidelines> remain valid; structured behavior steps must live inside
+# <taskflow>.
+TASKFLOW_INDICATOR_TAGS: frozenset[str] = frozenset({"subtask", "step"})
+
+# Tags from the legacy non-canonical schema. Their presence is a strong
+# signal Gemini fell back to the old <Agent><Conversation_Schema> shape.
+BANNED_TAGS: frozenset[str] = frozenset(
+    {
+        "Agent",
+        "Name",
+        "Role",
+        "Persona",
+        "Context",
+        "General_Instruction",
+        "Conversation_Schema",
+        "state",
+        "transitions",
+        "transition",
+        "conditional_logic",
+        "handling_user_negative_sentiment",
+        "communication_style",
+        "prohibited_topics",
+    }
+)
+
+_WRONG_TOOL_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\$\{TOOL:[^}]+\}"),
+    re.compile(r"(?<!\{)\{TOOL:[^}]+\}"),
+    re.compile(r"\$\{@TOOL:[^}]+\}"),
+)
+_WRONG_AGENT_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\$\{AGENT:[^}]+\}"),
+    re.compile(r"(?<!\{)\{AGENT:[^}]+\}"),
+    re.compile(r"\$\{@AGENT:[^}]+\}"),
+)
+
+
+def validate_canonical_instruction(text: str) -> list[str]:
+    """Validate instruction XML against the canonical schema.
+
+    Returns a list of human-readable diagnostic strings. Empty list means
+    the instruction passes all checks.
+    """
+    if not text or not text.strip():
+        return [
+            "Instruction is empty.",
+            "Missing required top-level tag <role>.",
+            "Missing required top-level tag <persona>.",
+        ]
+
+    try:
+        root = ET.fromstring(f"<__doc__>{text}</__doc__>")
+    except ET.ParseError as e:
+        return [f"XML syntax error: {e}"]
+
+    diagnostics: list[str] = []
+    diagnostics.extend(_check_banned_tags(root))
+    diagnostics.extend(_check_required_top_level(root))
+    diagnostics.extend(_check_taskflow_structure(root))
+    diagnostics.extend(_check_reference_syntax(text))
+    return diagnostics
+
+
+def _check_banned_tags(root: ET.Element) -> list[str]:
+    """Flag any tag from the legacy non-canonical schema."""
+    seen: set[str] = set()
+    diagnostics: list[str] = []
+    for elem in root.iter():
+        if elem.tag in BANNED_TAGS and elem.tag not in seen:
+            seen.add(elem.tag)
+            diagnostics.append(
+                f"Found banned tag <{elem.tag}>; remove it and use the"
+                " canonical lowercase taskflow schema (see"
+                " docs/design-guide/instruction-design.md)."
+            )
+    return diagnostics
+
+
+def _check_required_top_level(root: ET.Element) -> list[str]:
+    """Require <role> and <persona> always; <taskflow> when steps exist."""
+    top_level = {child.tag for child in root}
+    diagnostics = [
+        f"Missing required top-level tag <{tag}>."
+        for tag in REQUIRED_TOP_LEVEL_TAGS
+        if tag not in top_level
+    ]
+    if "taskflow" in top_level:
+        return diagnostics
+    has_indicator = any(
+        elem.tag in TASKFLOW_INDICATOR_TAGS for elem in root.iter()
+    )
+    if has_indicator:
+        diagnostics.append(
+            "Missing required top-level tag <taskflow>; <subtask> and"
+            " <step> elements must be wrapped in a <taskflow>."
+        )
+    return diagnostics
+
+
+def _check_taskflow_structure(root: ET.Element) -> list[str]:
+    """Enforce subtask/step/trigger/action nesting inside every taskflow."""
+    diagnostics: list[str] = []
+    for taskflow in root.iter("taskflow"):
+        subtasks = list(taskflow.findall("subtask"))
+        if not subtasks:
+            diagnostics.append(
+                "<taskflow> has 0 <subtask> children; must have at least 1."
+            )
+            continue
+        for subtask in subtasks:
+            diagnostics.extend(_check_subtask(subtask))
+    return diagnostics
+
+
+def _check_subtask(subtask: ET.Element) -> list[str]:
+    diagnostics: list[str] = []
+    name = subtask.get("name")
+    label = name or "?"
+    if not name:
+        diagnostics.append(
+            "<subtask> is missing the required 'name' attribute."
+        )
+    steps = list(subtask.findall("step"))
+    if not steps:
+        diagnostics.append(
+            f'<subtask name="{label}"> has 0 <step> children; must have'
+            " at least 1."
+        )
+        return diagnostics
+    for step in steps:
+        diagnostics.extend(_check_step(step, subtask_label=label))
+    return diagnostics
+
+
+def _check_step(step: ET.Element, *, subtask_label: str) -> list[str]:
+    diagnostics: list[str] = []
+    step_name = step.get("name")
+    step_label = step_name or "?"
+    if not step_name:
+        diagnostics.append(
+            f'<step> in subtask "{subtask_label}" is missing the required'
+            " 'name' attribute."
+        )
+    triggers = step.findall("trigger")
+    actions = step.findall("action")
+    if len(triggers) != 1:
+        diagnostics.append(
+            f'<step name="{step_label}"> must contain exactly 1 <trigger>'
+            f" (found {len(triggers)})."
+        )
+    if len(actions) != 1:
+        diagnostics.append(
+            f'<step name="{step_label}"> must contain exactly 1 <action>'
+            f" (found {len(actions)})."
+        )
+    return diagnostics
+
+
+def _check_reference_syntax(text: str) -> list[str]:
+    """Flag wrong-form {TOOL:...} / {AGENT:...} reference syntax."""
+    diagnostics: list[str] = []
+    for pattern in _WRONG_TOOL_PATTERNS:
+        for match in pattern.finditer(text):
+            diagnostics.append(
+                f"Wrong tool reference syntax: '{match.group(0)}';"
+                " use {@TOOL: name}."
+            )
+    for pattern in _WRONG_AGENT_PATTERNS:
+        for match in pattern.finditer(text):
+            diagnostics.append(
+                f"Wrong agent reference syntax: '{match.group(0)}';"
+                " use {@AGENT: name}."
+            )
+    return diagnostics
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: validate one or more instruction files."""
+    args = list(sys.argv[1:] if argv is None else argv)
+    if not args:
+        print(
+            "usage: python -m cxas_scrapi.migration.xml_validator"
+            " FILE [FILE ...]",
+            file=sys.stderr,
+        )
+        return 2
+
+    exit_code = 0
+    for arg in args:
+        path = Path(arg)
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            print(f"{arg}: ERROR could not read: {exc}")
+            exit_code = 2
+            continue
+        diagnostics = validate_canonical_instruction(text)
+        if diagnostics:
+            print(f"{arg}: FAIL ({len(diagnostics)} issue(s))")
+            for diag in diagnostics:
+                print(f"  - {diag}")
+            exit_code = max(exit_code, 1)
+        else:
+            print(f"{arg}: OK")
+    return exit_code
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/cxas_scrapi/migration/test_xml_validator.py
+++ b/tests/cxas_scrapi/migration/test_xml_validator.py
@@ -1,0 +1,302 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the canonical XML instruction validator."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from cxas_scrapi.migration.xml_validator import (
+    main,
+    validate_canonical_instruction,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+CANONICAL_EXAMPLES = [
+    REPO_ROOT / "examples/bella_notte/agents/Bella_Notte_Host/instruction.txt",
+    REPO_ROOT / "examples/bella_notte/agents/Reservation_Agent/instruction.txt",
+    REPO_ROOT / "examples/bella_notte/agents/Takeout_Agent/instruction.txt",
+    REPO_ROOT
+    / ".agents/skills/cxas-agent-foundry/assets/project-template/cxas_app"
+    / "Sample_Support_Agent/agents/root_agent/instruction.txt",
+]
+
+
+@pytest.mark.parametrize(
+    "path", CANONICAL_EXAMPLES, ids=lambda p: p.parent.name
+)
+def test_canonical_examples_pass(path: Path) -> None:
+    """Every canonical instruction in the repo validates clean."""
+    assert path.exists(), f"missing fixture: {path}"
+    text = path.read_text(encoding="utf-8")
+    assert validate_canonical_instruction(text) == []
+
+
+def test_empty_string_reports_missing_required_tags() -> None:
+    diagnostics = validate_canonical_instruction("")
+    assert "Instruction is empty." in diagnostics
+    assert any(
+        "Missing required top-level tag <role>" in d for d in diagnostics
+    )
+    assert any(
+        "Missing required top-level tag <persona>" in d for d in diagnostics
+    )
+
+
+def test_whitespace_only_is_treated_as_empty() -> None:
+    assert validate_canonical_instruction("   \n  \t  ") != []
+
+
+def test_legacy_camelcase_schema_is_rejected() -> None:
+    """The OLD <Agent><Conversation_Schema> shape produces specific
+    banned-tag diagnostics naming the offending tags."""
+    legacy = """
+<Agent>
+  <Name>FooBot</Name>
+  <Role>do things</Role>
+  <Persona>
+    <communication_style>formal</communication_style>
+  </Persona>
+  <General_Instruction>be careful</General_Instruction>
+  <Conversation_Schema>
+    <state id="main">
+      <instructions>do x</instructions>
+      <transitions>
+        <transition condition="done" next_state="end"/>
+      </transitions>
+    </state>
+  </Conversation_Schema>
+</Agent>
+    """
+    diagnostics = validate_canonical_instruction(legacy)
+    joined = "\n".join(diagnostics)
+    assert "<Agent>" in joined
+    assert "<Conversation_Schema>" in joined
+    assert "<state>" in joined
+    assert "<transitions>" in joined
+    assert "<Persona>" in joined
+    assert "<General_Instruction>" in joined
+    # Required canonical tags absent → also reported.
+    assert any(
+        "Missing required top-level tag <role>" in d for d in diagnostics
+    )
+    assert any(
+        "Missing required top-level tag <persona>" in d for d in diagnostics
+    )
+
+
+def test_taskflow_required_when_steps_exist() -> None:
+    """Bare <subtask>/<step> without a wrapping <taskflow> is rejected."""
+    text = """
+<role>r</role>
+<persona>p</persona>
+<subtask name="X">
+  <step name="Y"><trigger>t</trigger><action>a</action></step>
+</subtask>
+    """
+    diagnostics = validate_canonical_instruction(text)
+    assert any(
+        "Missing required top-level tag <taskflow>" in d for d in diagnostics
+    )
+
+
+def test_taskflow_not_required_when_no_steps() -> None:
+    """Simple role+persona+guidelines instructions are valid."""
+    text = """
+<role>specialist</role>
+<persona>warm</persona>
+<guidelines><guideline name="x">be nice</guideline></guidelines>
+    """
+    assert validate_canonical_instruction(text) == []
+
+
+def test_taskflow_without_subtasks_is_rejected() -> None:
+    text = """
+<role>r</role>
+<persona>p</persona>
+<taskflow></taskflow>
+    """
+    diagnostics = validate_canonical_instruction(text)
+    assert any("<taskflow> has 0 <subtask>" in d for d in diagnostics)
+
+
+def test_subtask_without_steps_is_rejected() -> None:
+    text = """
+<role>r</role>
+<persona>p</persona>
+<taskflow>
+  <subtask name="Empty"></subtask>
+</taskflow>
+    """
+    diagnostics = validate_canonical_instruction(text)
+    assert any('<subtask name="Empty"> has 0 <step>' in d for d in diagnostics)
+
+
+def test_subtask_missing_name_attribute_is_rejected() -> None:
+    text = """
+<role>r</role>
+<persona>p</persona>
+<taskflow>
+  <subtask>
+    <step name="Y"><trigger>t</trigger><action>a</action></step>
+  </subtask>
+</taskflow>
+    """
+    diagnostics = validate_canonical_instruction(text)
+    assert any(
+        "<subtask> is missing the required 'name' attribute" in d
+        for d in diagnostics
+    )
+
+
+def test_step_missing_name_attribute_is_rejected() -> None:
+    text = """
+<role>r</role>
+<persona>p</persona>
+<taskflow>
+  <subtask name="X">
+    <step><trigger>t</trigger><action>a</action></step>
+  </subtask>
+</taskflow>
+    """
+    diagnostics = validate_canonical_instruction(text)
+    assert any(
+        "missing the required 'name' attribute" in d and "<step>" in d
+        for d in diagnostics
+    )
+
+
+def test_step_without_exactly_one_trigger_and_action_is_rejected() -> None:
+    text = """
+<role>r</role>
+<persona>p</persona>
+<taskflow>
+  <subtask name="X">
+    <step name="NoTrigger"><action>a</action></step>
+    <step name="TwoActions">
+      <trigger>t</trigger>
+      <action>a1</action>
+      <action>a2</action>
+    </step>
+  </subtask>
+</taskflow>
+    """
+    diagnostics = validate_canonical_instruction(text)
+    joined = "\n".join(diagnostics)
+    assert '<step name="NoTrigger"> must contain exactly 1 <trigger>' in joined
+    assert '<step name="TwoActions"> must contain exactly 1 <action>' in joined
+
+
+def test_malformed_xml_returns_syntax_error_diagnostic() -> None:
+    diagnostics = validate_canonical_instruction("<role>unclosed")
+    assert len(diagnostics) == 1
+    assert diagnostics[0].startswith("XML syntax error:")
+
+
+def test_wrong_tool_syntax_is_flagged() -> None:
+    text = """
+<role>r</role>
+<persona>p</persona>
+<taskflow>
+  <subtask name="X">
+    <step name="Y">
+      <trigger>t</trigger>
+      <action>1. Call {TOOL: foo}. 2. Call ${@TOOL: bar}.</action>
+    </step>
+  </subtask>
+</taskflow>
+    """
+    diagnostics = validate_canonical_instruction(text)
+    joined = "\n".join(diagnostics)
+    assert "Wrong tool reference syntax: '{TOOL: foo}'" in joined
+    assert "Wrong tool reference syntax: '${@TOOL: bar}'" in joined
+
+
+def test_wrong_agent_syntax_is_flagged() -> None:
+    text = """
+<role>r</role>
+<persona>p</persona>
+<taskflow>
+  <subtask name="X">
+    <step name="Y">
+      <trigger>t</trigger>
+      <action>Transfer to ${AGENT: Foo} then {AGENT: Bar}.</action>
+    </step>
+  </subtask>
+</taskflow>
+    """
+    diagnostics = validate_canonical_instruction(text)
+    joined = "\n".join(diagnostics)
+    assert "Wrong agent reference syntax: '${AGENT: Foo}'" in joined
+    assert "Wrong agent reference syntax: '{AGENT: Bar}'" in joined
+
+
+def test_correct_tool_and_agent_syntax_pass() -> None:
+    text = """
+<role>r</role>
+<persona>p</persona>
+<taskflow>
+  <subtask name="X">
+    <step name="Y">
+      <trigger>t</trigger>
+      <action>Call {@TOOL: foo} then transfer to {@AGENT: Bar}.</action>
+    </step>
+  </subtask>
+</taskflow>
+    """
+    assert validate_canonical_instruction(text) == []
+
+
+def test_main_cli_returns_zero_for_canonical_files(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main([str(CANONICAL_EXAMPLES[0])])
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "OK" in out
+
+
+def test_main_cli_returns_nonzero_for_invalid_input(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    bad = tmp_path / "bad.txt"
+    bad.write_text("<Agent><Name>x</Name></Agent>", encoding="utf-8")
+    exit_code = main([str(bad)])
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "FAIL" in out
+    assert "<Agent>" in out
+
+
+def test_main_cli_reports_missing_files(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    missing = tmp_path / "does_not_exist.txt"
+    exit_code = main([str(missing)])
+    assert exit_code == 2
+    out = capsys.readouterr().out
+    assert "ERROR" in out
+
+
+def test_main_cli_with_no_args_returns_usage_error(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main([])
+    assert exit_code == 2
+    err = capsys.readouterr().err
+    assert "usage:" in err


### PR DESCRIPTION
Strict structural validator that gates Gemini-synthesized consolidation output. Returns a list of human-readable diagnostics (empty list = pass) so failures can be appended verbatim to a re-prompt. Includes a CLI entry point (python -m cxas_scrapi.migration.xml_validator FILE...) for ad-hoc checks.

Validates: required top-level <role>/<persona> (and <taskflow> when any <subtask>/<step> exists), banned legacy tags from the <Agent>/<Conversation_Schema>/<state> schema, taskflow/subtask/step nesting with required name attributes and exactly-one trigger+action per step, and well-formed {@TOOL: name}/{@AGENT: name} references.