### PR TITLE
feat: include global instructions and dynamic DIs to llm-lint

### DIFF
--- a/src/cxas_scrapi/cli/llm_lint.py
+++ b/src/cxas_scrapi/cli/llm_lint.py
@@ -14,6 +14,7 @@
 """CLI subcommand for AI-driven semantic linter on GECX instructions."""
 
 import argparse
+import ast
 import json
 import os
 import sys
@@ -22,6 +23,74 @@ from typing import Optional, Tuple
 
 from cxas_scrapi.prompts import LLM_LINT_SYSTEM_PROMPT, LLM_LINT_USER_PROMPT
 from cxas_scrapi.utils.gemini import GeminiGenerate
+
+
+def discover_agent_callbacks(agent_dir: Path) -> list[Tuple[str, Path]]:
+    """Discovers all dynamic instruction callbacks for a given agent directory.
+
+    Returns:
+        A list of tuples: (callback_display_name, callback_file_path)
+    """
+    callbacks = []
+    callback_types = [
+        "before_agent_callbacks",
+        "after_agent_callbacks",
+        "before_model_callbacks",
+        "after_model_callbacks",
+    ]
+    for cb_type in callback_types:
+        cb_dir = agent_dir / cb_type
+        if cb_dir.exists() and cb_dir.is_dir():
+            for item in sorted(cb_dir.iterdir()):
+                if item.is_dir():
+                    code_file = item / "python_code.py"
+                    if code_file.exists():
+                        display_name = f"{cb_type}/{item.name}"
+                        callbacks.append((display_name, code_file))
+    return callbacks
+
+
+def get_callback_output_path(base_path: Path, callback_name: str) -> Path:
+    """Generates output file path for a callback's lint report."""
+    clean_cb_name = callback_name.replace("/", "_")
+    if base_path.suffix:
+        return base_path.with_name(
+            f"{base_path.stem}_{clean_cb_name}{base_path.suffix}"
+        )
+    return base_path.with_name(f"{base_path.name}_{clean_cb_name}.md")
+
+
+def extract_dynamic_instructions(file_path: Path) -> dict[str, str]:
+    """Parses Python file to extract state -> instruction dictionary mappings.
+
+    Focuses only on top-level (module-level) constant dictionaries where the
+    variable name includes "instruction" (case-insensitive).
+    """
+    dynamic_instructions = {}
+    try:
+        tree = ast.parse(file_path.read_text(encoding="utf-8"))
+        for node in tree.body:
+            if isinstance(node, ast.Assign) and len(node.targets) == 1:
+                target = node.targets[0]
+                if isinstance(target, ast.Name):
+                    var_name = target.id
+                    if "instruction" in var_name.lower():
+                        if isinstance(node.value, ast.Dict):
+                            keys = node.value.keys
+                            values = node.value.values
+                            for k, v in zip(keys, values, strict=True):
+                                if isinstance(k, ast.Constant) and isinstance(
+                                    v, ast.Constant
+                                ):
+                                    if isinstance(k.value, str) and isinstance(
+                                        v.value, str
+                                    ):
+                                        dynamic_instructions[k.value] = v.value
+    except Exception as e:
+        print(
+            f"Warning: Failed to parse AST of {file_path}: {e}", file=sys.stderr
+        )
+    return dynamic_instructions
 
 
 def resolve_gcp_credentials(
@@ -130,6 +199,27 @@ def llm_lint(args: argparse.Namespace) -> None:
         )
         sys.exit(1)
 
+    # Search for global_instruction.txt by walking up from the agent directory
+    global_instruction_content = None
+    global_instruction_file = None
+    current_dir = agent_path.resolve()
+    while current_dir != current_dir.parent:
+        p = current_dir / "global_instruction.txt"
+        if p.exists():
+            global_instruction_file = p
+            break
+        if (
+            (current_dir / "app.json").exists()
+            or (current_dir / "app.yaml").exists()
+            or (current_dir / "gecx-config.json").exists()
+        ):
+            # Stop walking up once we hit app root markers
+            p = current_dir / "global_instruction.txt"
+            if p.exists():
+                global_instruction_file = p
+            break
+        current_dir = current_dir.parent
+
     print("------------------------------------------------------------")
     print(f"LLM LINTER — Starting analysis for agent: {agent_path.name}")
     print("------------------------------------------------------------")
@@ -141,6 +231,8 @@ def llm_lint(args: argparse.Namespace) -> None:
     print(f"GCP Project : {project_id}")
     print(f"GCP Location: {location}")
     print(f"Gemini Model: {args.model}")
+    if global_instruction_file:
+        print(f"Global Inst : {global_instruction_file.resolve()}")
 
     # Load instruction content
     try:
@@ -157,6 +249,17 @@ def llm_lint(args: argparse.Namespace) -> None:
         )
         sys.exit(0)
 
+    # Load global instruction content if found
+    if global_instruction_file:
+        try:
+            with open(global_instruction_file, "r", encoding="utf-8") as f:
+                global_instruction_content = f.read()
+        except OSError as e:
+            print(
+                f"Warning: Failed to read global_instruction.txt: {e}",
+                file=sys.stderr,
+            )
+
     # Initialize Gemini
     print("Initializing Gemini Client...")
     gemini_client = GeminiGenerate(
@@ -165,12 +268,23 @@ def llm_lint(args: argparse.Namespace) -> None:
         model_name=args.model,
     )
 
+    callbacks = discover_agent_callbacks(agent_path)
+    if callbacks:
+        print(
+            f"Found {len(callbacks)} dynamic instruction "
+            "callback(s) to analyze."
+        )
+
+    # --- Run Base Lint ---
     user_prompt = LLM_LINT_USER_PROMPT.format(
-        instruction_content=instruction_content
+        global_instruction_content=global_instruction_content or "",
+        instruction_content=instruction_content,
+        dynamic_instruction_content="",
     )
 
     print(
-        "Running semantic review using Gemini (this may take a few seconds)..."
+        "Running semantic review for base instructions using Gemini "
+        "(this may take a few seconds)..."
     )
     report = gemini_client.generate(
         prompt=user_prompt,
@@ -182,11 +296,11 @@ def llm_lint(args: argparse.Namespace) -> None:
         sys.exit(1)
 
     print("\n============================================================")
-    print("LINT REPORT GENERATED")
+    print("LINT REPORT GENERATED (Base)")
     print("============================================================\n")
     print(report)
 
-    # Optionally save to file
+    # Determine base output path
     if args.output:
         output_path = Path(args.output)
     else:
@@ -196,10 +310,87 @@ def llm_lint(args: argparse.Namespace) -> None:
         with open(output_path, "w", encoding="utf-8") as f:
             f.write(report)
         print("\n------------------------------------------------------------")
-        print(f"Successfully saved report to: {output_path}")
+        print(f"Successfully saved base report to: {output_path}")
         print("------------------------------------------------------------")
     except OSError as e:
         print(
-            f"Warning: Failed to save report file to {output_path}: {e}",
+            f"Warning: Failed to save base report file to {output_path}: {e}",
             file=sys.stderr,
         )
+
+    # --- Run Callback Lints ---
+    for cb_display, cb_path in callbacks:
+        print(f"\nAnalyzing dynamic instruction callback: {cb_display}...")
+
+        # Attempt to extract state -> instruction dictionary mapping
+        dynamic_dis = extract_dynamic_instructions(cb_path)
+
+        if dynamic_dis:
+            is_recommended_cb = cb_display.startswith("before_agent_callbacks/")
+            if not is_recommended_cb:
+                warning_msg = (
+                    "Warning: Dynamic instructions found in "
+                    f"'{cb_display}'.\n"
+                    "The recommended place to include dynamic instructions "
+                    "is only in 'before_agent_callbacks'. Please move "
+                    "these dynamic instructions to a "
+                    "'before_agent_callbacks' callback."
+                )
+                print(warning_msg, file=sys.stderr)
+
+            print(
+                f"Found {len(dynamic_dis)} dynamic state "
+                "instruction(s) inside callback."
+            )
+            for state_name, state_instruction in sorted(dynamic_dis.items()):
+                print(f"  - Linting state: {state_name}...")
+
+                user_prompt = LLM_LINT_USER_PROMPT.format(
+                    global_instruction_content=global_instruction_content or "",
+                    instruction_content=instruction_content,
+                    dynamic_instruction_content=state_instruction,
+                )
+
+                cb_report = gemini_client.generate(
+                    prompt=user_prompt,
+                    system_prompt=LLM_LINT_SYSTEM_PROMPT,
+                )
+
+                if cb_report:
+                    if not is_recommended_cb:
+                        warning_md = (
+                            "> [!WARNING]\n"
+                            "> **LINTER WARNING**: Dynamic instructions "
+                            f"are declared in `{cb_display}`.\n"
+                            "> The recommended place to include dynamic "
+                            "instructions is only in "
+                            "`before_agent_callbacks`.\n"
+                            "> Please move these dynamic instructions to a "
+                            "`before_agent_callbacks` callback.\n\n"
+                        )
+                        cb_report = warning_md + cb_report
+
+                    # Use f"{cb_display}/{state_name}" so
+                    # get_callback_output_path replaces slashes properly
+                    cb_output_path = get_callback_output_path(
+                        output_path, f"{cb_display}/{state_name}"
+                    )
+                    try:
+                        with open(cb_output_path, "w", encoding="utf-8") as f:
+                            f.write(cb_report)
+                        print(
+                            "    Successfully saved state report to: "
+                            f"{cb_output_path}"
+                        )
+                    except OSError as e:
+                        print(
+                            "    Warning: Failed to save state report to "
+                            f"{cb_output_path}: {e}",
+                            file=sys.stderr,
+                        )
+                else:
+                    print(
+                        "    Error: Failed to generate report from Gemini "
+                        f"for state: {state_name}",
+                        file=sys.stderr,
+                    )

--- a/src/cxas_scrapi/prompts/llm_lint_prompts.py
+++ b/src/cxas_scrapi/prompts/llm_lint_prompts.py
@@ -14,35 +14,39 @@
 """Prompts for the AI-driven instruction semantic linter (llm-lint)."""
 
 LLM_LINT_SYSTEM_PROMPT = """You are an expert conversational AI designer and reviewer specializing in Google Customer Engagement Suite (GECX) agent design.
-Your task is to analyze the sub-agent instructions (`instruction.txt`) and point out any errors, style issues, and ambiguities.
+Your task is to analyze the GECX instructions as a unit. This includes the package-level `global_instruction.txt`, the sub-agent specific `instruction.txt`, and optionally a Python callback (`python_code.py`) that dynamically injects instructions or alters prompt context on the fly.
 
-Please evaluate the instruction text according to the following Criteria:
+Please evaluate the instruction texts according to the following Criteria:
 
 1. BASIC ERRORS:
    - Typos: spelling errors or typos.
    - Grammar Errors: grammatical issues that may cause user or model confusion.
 
-2. INSTRUCTION STYLE:
-   - Length: Identify overly long, verbose, or repetitive instructions. Suggest ways to condense them without losing key constraints or details.
+2. INSTRUCTION STYLE & COHESION:
+   - Length & Complexity: Identify overly long, verbose, or repetitive instructions. Suggest ways to condense them without losing key constraints or details.
    - Task Decomposition: Ensure complex workflows are broken down into sequential, numbered steps. Crucially, check that steps use ordered numbering with nesting (e.g., 1., 1.1., 1.2.) rather than flat lists or paragraphs.
    - Completeness & Edge Cases: Identify underspecified instructions, such as conditional `if-then` statements without a clear fallback `else` or fallback action when a condition isn't met.
-   - Clarity & Ambiguity: Identify abbreviations, specialized jargon, or slang that lacks a clear, singular meaning.
-   - Contradictions: Identify directives that contradict each other.
+   - Dynamic Prompt Integration: If a Python callback is provided, check if the dynamic instructions injected by it are consistent with the static instructions. Highlight any conflicts where the callback might override static instructions in a confusing or contradictory way.
+   - Contradictions & Alignment: Identify directives that contradict each other, both within a single instruction file and between the global package instruction (`global_instruction.txt`), the sub-agent instructions (`instruction.txt`), and any active dynamic callbacks. Ensure they are aligned and unified.
 
 3. EXAMPLES:
    - Redundant Examples: Sample conversations or user logs that repeat standard instructions without demonstrating unique edge cases.
    - Conflicting Examples: Examples that contradict rules defined in the instructions.
 
 Provide your response as a structured markdown report containing these sections:
-- SUMMARY: A high-level score (e.g., out of 100) and a brief 2-3 sentence assessment of instruction quality.
+- SUMMARY: A high-level score (e.g., out of 100) and a brief 2-3 sentence assessment of instruction quality and overall cohesion (including dynamic prompt cohesion, if applicable).
 - BASIC ERRORS: Table or list of typos, misspellings, and grammar bugs, with exact line or text snippets and recommended fixes. If none, state "No issues found."
-- INSTRUCTION STYLE: Detailed review of length, task decomposition, completeness, ambiguity, and contradictions, pointing out specific instructions and explaining how to correct them. Provide a concrete rewrite suggestion for the problematic sections using proper nested numbering.
+- INSTRUCTION STYLE & COHESION: Detailed review of length, task decomposition, completeness, ambiguity, and contradictions/alignment, pointing out specific instructions and explaining how to correct them. Provide a concrete rewrite suggestion for the problematic sections using proper nested numbering.
 - EXAMPLES: Review of any examples provided, flagging redundancies or conflicts.
 """
 
-LLM_LINT_USER_PROMPT = """Please lint the following GECX sub-agent instructions:
+LLM_LINT_USER_PROMPT = """Please lint the following GECX instructions:
 
 --- BEGIN INSTRUCTION.TXT ---
+{global_instruction_content}
+
 {instruction_content}
+
+{dynamic_instruction_content}
 --- END INSTRUCTION.TXT ---
 """

--- a/tests/cxas_scrapi/cli/test_llm_lint.py
+++ b/tests/cxas_scrapi/cli/test_llm_lint.py
@@ -63,7 +63,10 @@ def test_resolve_gcp_credentials_from_config(tmp_path):
 
 @mock.patch("cxas_scrapi.cli.llm_lint.GeminiGenerate", autospec=True)
 def test_llm_lint_success(mock_gemini_cls, tmp_path):
-    """Test successful execution of llm_lint with mocking."""
+    """Test execution of llm_lint when no global instruction exists.
+
+    Uses mocking for the Gemini API call.
+    """
     agent_dir = tmp_path / "agents" / "my-agent"
     agent_dir.mkdir(parents=True)
     instruction_file = agent_dir / "instruction.txt"
@@ -103,7 +106,9 @@ def test_llm_lint_success(mock_gemini_cls, tmp_path):
     )
 
     expected_user_prompt = LLM_LINT_USER_PROMPT.format(
-        instruction_content="Don't use generic responses."
+        global_instruction_content="",
+        instruction_content="Don't use generic responses.",
+        dynamic_instruction_content="",
     )
     mock_gemini_inst.generate.assert_called_once_with(
         prompt=expected_user_prompt,
@@ -114,3 +119,278 @@ def test_llm_lint_success(mock_gemini_cls, tmp_path):
     report_file = agent_dir / "llm_lint_report.md"
     assert report_file.exists()
     assert report_file.read_text(encoding="utf-8") == "## SUMMARY\nAll good."
+
+
+@mock.patch("cxas_scrapi.cli.llm_lint.GeminiGenerate", autospec=True)
+def test_llm_lint_with_global_instruction(mock_gemini_cls, tmp_path):
+    """Test execution of llm_lint when global instruction exists.
+
+    Uses mocking for the Gemini API call.
+    """
+    agent_dir = tmp_path / "agents" / "my-agent"
+    agent_dir.mkdir(parents=True)
+    instruction_file = agent_dir / "instruction.txt"
+    instruction_file.write_text(
+        "Don't use generic responses.", encoding="utf-8"
+    )
+
+    # Create global instruction file at root (tmp_path)
+    global_instruction_file = tmp_path / "global_instruction.txt"
+    global_instruction_file.write_text("Always be polite.", encoding="utf-8")
+
+    # Create active project gecx-config.json
+    config_path = tmp_path / "gecx-config.json"
+    config_data = {
+        "gcp_project_id": "test-project",
+        "location": "us-central1",
+    }
+    config_path.write_text(json.dumps(config_data), encoding="utf-8")
+
+    # Stub GeminiGenerate instance
+    mock_gemini_inst = mock_gemini_cls.return_value
+    mock_gemini_inst.generate.return_value = (
+        "## SUMMARY\nAll good with global rules."
+    )
+
+    args = argparse.Namespace(
+        agent_dir=str(agent_dir),
+        project_id=None,
+        location=None,
+        model="gemini-2.5-flash",
+        output=None,
+    )
+
+    # Change directory to tmp_path so CWD resolution works
+    with mock.patch("pathlib.Path.cwd", return_value=tmp_path):
+        llm_lint(args)
+
+    # Assertions
+    mock_gemini_cls.assert_called_once_with(
+        project_id="test-project",
+        location="us-central1",
+        model_name="gemini-2.5-flash",
+    )
+
+    expected_user_prompt = LLM_LINT_USER_PROMPT.format(
+        global_instruction_content="Always be polite.",
+        instruction_content="Don't use generic responses.",
+        dynamic_instruction_content="",
+    )
+    mock_gemini_inst.generate.assert_called_once_with(
+        prompt=expected_user_prompt,
+        system_prompt=LLM_LINT_SYSTEM_PROMPT,
+    )
+
+    # Check if the report is written to file
+    report_file = agent_dir / "llm_lint_report.md"
+    assert report_file.exists()
+    assert (
+        report_file.read_text(encoding="utf-8")
+        == "## SUMMARY\nAll good with global rules."
+    )
+
+
+@mock.patch("cxas_scrapi.cli.llm_lint.GeminiGenerate", autospec=True)
+def test_llm_lint_with_dynamic_callbacks(mock_gemini_cls, tmp_path):
+    """Test execution of llm_lint when callbacks contain no DIs.
+
+    Verifies only the base report is generated.
+    """
+    agent_dir = tmp_path / "agents" / "my-agent"
+    agent_dir.mkdir(parents=True)
+    instruction_file = agent_dir / "instruction.txt"
+    instruction_file.write_text(
+        "Don't use generic responses.", encoding="utf-8"
+    )
+
+    # Create a dummy before_model_callback file
+    # (no dict variables containing "instruction" inside)
+    cb_dir = agent_dir / "before_model_callbacks" / "my_callback"
+    cb_dir.mkdir(parents=True)
+    cb_code_file = cb_dir / "python_code.py"
+    cb_code_file.write_text(
+        "def before_model_callback(): pass", encoding="utf-8"
+    )
+
+    # Create active project gecx-config.json
+    config_path = tmp_path / "gecx-config.json"
+    config_data = {
+        "gcp_project_id": "test-project",
+        "location": "us-central1",
+    }
+    config_path.write_text(json.dumps(config_data), encoding="utf-8")
+
+    # Stub GeminiGenerate instance
+    mock_gemini_inst = mock_gemini_cls.return_value
+    mock_gemini_inst.generate.side_effect = [
+        "## SUMMARY\nBase instructions are great."
+    ]
+
+    args = argparse.Namespace(
+        agent_dir=str(agent_dir),
+        project_id=None,
+        location=None,
+        model="gemini-2.5-flash",
+        output=None,
+    )
+
+    # Change directory to tmp_path so CWD resolution works
+    with mock.patch("pathlib.Path.cwd", return_value=tmp_path):
+        llm_lint(args)
+
+    # Verify call count (only 1 for base because callback has no DI dict)
+    assert mock_gemini_inst.generate.call_count == 1
+
+    # Check if base report is written to file and callback is skipped
+    base_report = agent_dir / "llm_lint_report.md"
+    cb_report = (
+        agent_dir / "llm_lint_report_before_model_callbacks_my_callback.md"
+    )
+
+    assert base_report.exists()
+    assert (
+        base_report.read_text(encoding="utf-8")
+        == "## SUMMARY\nBase instructions are great."
+    )
+    assert not cb_report.exists()
+
+
+@mock.patch("cxas_scrapi.cli.llm_lint.GeminiGenerate", autospec=True)
+def test_llm_lint_with_dict_dynamic_instructions(mock_gemini_cls, tmp_path):
+    """Test execution of llm_lint when callbacks contain dynamic DIs.
+
+    Verifies reports are mapped correctly by state.
+    """
+    agent_dir = tmp_path / "agents" / "my-agent"
+    agent_dir.mkdir(parents=True)
+    instruction_file = agent_dir / "instruction.txt"
+    instruction_file.write_text(
+        "Don't use generic responses.", encoding="utf-8"
+    )
+
+    # Create a callback defining dynamic instructions dictionary mapped by state
+    cb_dir = agent_dir / "before_agent_callbacks" / "my_callback"
+    cb_dir.mkdir(parents=True)
+    cb_code_file = cb_dir / "python_code.py"
+    cb_code_file.write_text(
+        "state_instructions = {\n"
+        "  'payment_failed': 'Explain the payment failure reason.',\n"
+        "  'payment_success': 'Confirm payment details.'\n"
+        "}",
+        encoding="utf-8",
+    )
+
+    # Create active project gecx-config.json
+    config_path = tmp_path / "gecx-config.json"
+    config_data = {
+        "gcp_project_id": "test-project",
+        "location": "us-central1",
+    }
+    config_path.write_text(json.dumps(config_data), encoding="utf-8")
+
+    # Stub GeminiGenerate instance (1 base run + 2 state runs)
+    mock_gemini_inst = mock_gemini_cls.return_value
+    mock_gemini_inst.generate.side_effect = [
+        "## SUMMARY\nBase report.",
+        "## SUMMARY\nPayment failed lint report.",
+        "## SUMMARY\nPayment success lint report.",
+    ]
+
+    args = argparse.Namespace(
+        agent_dir=str(agent_dir),
+        project_id=None,
+        location=None,
+        model="gemini-2.5-flash",
+        output=None,
+    )
+
+    with mock.patch("pathlib.Path.cwd", return_value=tmp_path):
+        llm_lint(args)
+
+    # Verify call count (1 base + 2 states)
+    assert mock_gemini_inst.generate.call_count == 3
+
+    # Check report outputs
+    base_report = agent_dir / "llm_lint_report.md"
+    failed_report_name = (
+        "llm_lint_report_before_agent_callbacks_my_callback_payment_failed.md"
+    )
+    failed_state_report = agent_dir / failed_report_name
+    success_report_name = (
+        "llm_lint_report_before_agent_callbacks_my_callback_payment_success.md"
+    )
+    success_state_report = agent_dir / success_report_name
+
+    assert base_report.exists()
+    assert base_report.read_text(encoding="utf-8") == "## SUMMARY\nBase report."
+
+    assert failed_state_report.exists()
+    assert (
+        failed_state_report.read_text(encoding="utf-8")
+        == "## SUMMARY\nPayment failed lint report."
+    )
+
+    assert success_state_report.exists()
+    assert (
+        success_state_report.read_text(encoding="utf-8")
+        == "## SUMMARY\nPayment success lint report."
+    )
+
+
+@mock.patch("cxas_scrapi.cli.llm_lint.GeminiGenerate", autospec=True)
+def test_llm_lint_warning_on_non_recommended_callbacks(
+    mock_gemini_cls, tmp_path
+):
+    """Test dynamic DIs outside before_agent_callbacks warn."""
+    agent_dir = tmp_path / "agents" / "my-agent"
+    agent_dir.mkdir(parents=True)
+    instruction_file = agent_dir / "instruction.txt"
+    instruction_file.write_text(
+        "Don't use generic responses.", encoding="utf-8"
+    )
+
+    # Create callback under a non-recommended callback type
+    cb_dir = agent_dir / "before_model_callbacks" / "my_callback"
+    cb_dir.mkdir(parents=True)
+    cb_code_file = cb_dir / "python_code.py"
+    cb_code_file.write_text(
+        "state_instructions = {'state_a': 'Dynamic prompt content.'}",
+        encoding="utf-8",
+    )
+
+    # Create active project gecx-config.json
+    config_path = tmp_path / "gecx-config.json"
+    config_data = {
+        "gcp_project_id": "test-project",
+        "location": "us-central1",
+    }
+    config_path.write_text(json.dumps(config_data), encoding="utf-8")
+
+    # Stub GeminiGenerate instance
+    mock_gemini_inst = mock_gemini_cls.return_value
+    mock_gemini_inst.generate.side_effect = [
+        "## SUMMARY\nBase report.",
+        "## SUMMARY\nState A report.",
+    ]
+
+    args = argparse.Namespace(
+        agent_dir=str(agent_dir),
+        project_id=None,
+        location=None,
+        model="gemini-2.5-flash",
+        output=None,
+    )
+
+    with mock.patch("pathlib.Path.cwd", return_value=tmp_path):
+        llm_lint(args)
+
+    # Check that the warning was prepended to the report file
+    failed_report_name = (
+        "llm_lint_report_before_model_callbacks_my_callback_state_a.md"
+    )
+    state_report = agent_dir / failed_report_name
+    assert state_report.exists()
+    content = state_report.read_text(encoding="utf-8")
+    assert "> [!WARNING]" in content
+    assert "**LINTER WARNING**" in content
+    assert "before_model_callbacks/my_callback" in content


### PR DESCRIPTION
This pull request expands llm-lint to evaluate global instructions, sub-agent instructions, and turn-by-turn dynamic instructions within callbacks as a unit. It also enforces that dynamic instructions are declared in the recommended before_agent_callbacks directory.