### PR TITLE
feat(cli): add --overwrite flag to cxas push

### DIFF
--- a/src/cxas_scrapi/cli/app.py
+++ b/src/cxas_scrapi/cli/app.py
@@ -232,8 +232,15 @@ def _app_push(
         print("Uploading to CES...")
 
         if target_app_name:
+            conflict_strategy = (
+                "OVERWRITE"
+                if args and getattr(args, "overwrite", False)
+                else None
+            )
             result = apps_client.import_app(
-                app_name=target_app_name, app_content=app_content
+                app_name=target_app_name,
+                app_content=app_content,
+                conflict_strategy=conflict_strategy,
             )
         else:
             result = apps_client.import_as_new_app(

--- a/src/cxas_scrapi/cli/main.py
+++ b/src/cxas_scrapi/cli/main.py
@@ -1811,6 +1811,11 @@ def get_parser() -> argparse.ArgumentParser:
         "--version-description",
         help="Description for the created version.",
     )
+    parser_push.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite existing data with imported data. Existing resources that do not have a matching display name in the imported app will be deleted",
+    )
     parser_push.set_defaults(func=app_push)
 
     # Parser for 'lint'

--- a/src/cxas_scrapi/cli/main.py
+++ b/src/cxas_scrapi/cli/main.py
@@ -1814,7 +1814,11 @@ def get_parser() -> argparse.ArgumentParser:
     parser_push.add_argument(
         "--overwrite",
         action="store_true",
-        help="Overwrite existing data with imported data. Existing resources that do not have a matching display name in the imported app will be deleted",
+        help=(
+            "Overwrite existing data with imported data. Existing resources "
+            "that do not have a matching display name in the imported app "
+            "will be deleted"
+        ),
     )
     parser_push.set_defaults(func=app_push)
 


### PR DESCRIPTION
This PR adds a `--overwrite` flag to the `cxas push` command.

When provided, it uses the `OVERWRITE` conflict resolution strategy instead of the default `REPLACE` when importing an app. This allows users to overwrite existing data with imported data, where existing resources that do not have a matching display name in the imported app will be deleted.

### Changes:
- Added `--overwrite` argument to `parser_push` in `src/cxas_scrapi/cli/main.py`.
- Updated `_app_push` in `src/cxas_scrapi/cli/app.py` to pass `conflict_strategy="OVERWRITE"` to `import_app` when the flag is set.