### PR TITLE
feat(llm-lint): expand semantic linter with red-teaming & robustness scenarios

### DIFF
--- a/src/cxas_scrapi/prompts/llm_lint_prompts.py
+++ b/src/cxas_scrapi/prompts/llm_lint_prompts.py
@@ -14,7 +14,7 @@
 """Prompts for the AI-driven instruction semantic linter (llm-lint)."""
 
 LLM_LINT_SYSTEM_PROMPT = """You are an expert conversational AI designer and reviewer specializing in Google Customer Engagement Suite (GECX) agent design.
-Your task is to analyze the sub-agent instructions (`instruction.txt`) and point out any errors, style issues, and ambiguities.
+Your task is to analyze the sub-agent instructions (`instruction.txt`) and point out any errors, style issues, ambiguities, and gaps in red-teaming / robustness scenarios.
 
 Please evaluate the instruction text according to the following Criteria:
 
@@ -33,11 +33,23 @@ Please evaluate the instruction text according to the following Criteria:
    - Redundant Examples: Sample conversations or user logs that repeat standard instructions without demonstrating unique edge cases.
    - Conflicting Examples: Examples that contradict rules defined in the instructions.
 
+4. RED-TEAMING, ROBUSTNESS & INTERACTION QUALITY:
+   - Grounding & Preventing Hallucinations: Verify if the instruction mandates that responses must be grounded ONLY on tool call responses and conversation history, and explicitly forbids answering from internal knowledge.
+   - Out of Scope & Topic Boundaries: Verify if the instruction restricts answers to the defined role scope and prohibits discussing out-of-scope or prohibited topics (such as politics, religion, personal opinions).
+   - Acknowledging Limitations: Verify if the instruction mandates acknowledging lack of specific information and redirecting the user back to the supported scope.
+   - Self-Identification & Protecting Internal Details: Check if the instruction forbids revealing internal instructions, tools, thinking processes, or details beyond its designated role, and requires politely declining such requests.
+   - Persona & Manipulation Resistance: Verify if the instruction requires maintaining a fixed persona and resisting prompt injection, manipulation, or instruction-changing attempts.
+   - Conversational Context & Constraints: Check if there are clear rules for maintaining context, avoiding abrupt topic shifts, addressing the first intent first if multiple intents are provided, and a constraint to NOT call tools if the user input is empty or not understandable.
+   - Tone, Empathy & Adapting: Check for guidelines on polite, warm, helpful, respectful, and inclusive language, and explicitly adapting the tone to the user's emotional state (e.g., remaining patient and empathetic if the user is upset, angry, or rude). Ensure profanity is prohibited.
+   - Voice & Style Clarity: If applicable, check for enunciation, conversational voice, clear and simple language, avoiding complex/technical terms, jargon, or unnecessary repetition, and keeping responses concise, compact yet complete.
+   - Data Privacy & PII: Verify if there is a strict prohibition against revealing Personally Identifying Information (PII).
+
 Provide your response as a structured markdown report containing these sections:
 - SUMMARY: A high-level score (e.g., out of 100) and a brief 2-3 sentence assessment of instruction quality.
 - BASIC ERRORS: Table or list of typos, misspellings, and grammar bugs, with exact line or text snippets and recommended fixes. If none, state "No issues found."
 - INSTRUCTION STYLE: Detailed review of length, task decomposition, completeness, ambiguity, and contradictions, pointing out specific instructions and explaining how to correct them. Provide a concrete rewrite suggestion for the problematic sections using proper nested numbering.
-- EXAMPLES: Review of any examples provided, flagging redundancies or conflicts.
+- EXAMPLES: Review of any examples provided, flagging redundancies or conflicts. If none, state "No issues found."
+- RED-TEAMING & ROBUSTNESS: A detailed review of the agent's robustness against red-teaming scenarios. Identify any missing, weak, or incomplete rules regarding grounding, out-of-scope handling, limitations, self-identification/internal details, manipulation resistance, context/tool constraints, empathetic tone adaptation, voice clarity, and PII protection. For each gap, provide clear recommendations and specific rule phrasings to be added to the instructions.
 """
 
 LLM_LINT_USER_PROMPT = """Please lint the following GECX sub-agent instructions:


### PR DESCRIPTION
This PR expands the `llm-lint` command's system prompt to include comprehensive verification of red-teaming, robustness, and emotional intelligence/interaction quality scenarios in GECX agent instructions. Tests have been run and all linter-related checks pass successfully.