### PR TITLE
feat(trace): add 'cxas trace search' for full-text conversation search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ This workspace provides several specialized AI skills to assist with development
 ## CLI Features
 
 - **`cxas llm-lint`**: An AI-driven semantic linter for GECX sub-agent instructions. It reviews natural language rules and style guidelines using Gemini for a single sub-agent at a time. Run `cxas llm-lint --help` for details.
+- **`cxas trace search`**: Find conversations whose transcript contains a query, mirroring the console search box. Uses the server-side `ces_transcript.search(...)` full-text function (case-insensitive, substring/prefix; searches the user + agent transcript only). Use `--match {phrase,all,any}` for multi-word handling and `--snippets` to show highlighted excerpts. Example: `cxas trace search "app crashing" --app-name <app> --match all --snippets`. Run `cxas trace search --help` for details.
 
 *Note: For detailed development workflows, linter policies, and GECX-specific conventions, refer to the documentation within the respective skills (e.g., `.agents/skills/cxas-agent-foundry/SKILL.md`).*
 

--- a/src/cxas_scrapi/cli/trace_cli.py
+++ b/src/cxas_scrapi/cli/trace_cli.py
@@ -26,6 +26,7 @@ import io
 import json
 import logging
 import platform
+import re
 import subprocess
 import sys
 
@@ -135,6 +136,94 @@ def trace_list(args: argparse.Namespace) -> None:
             )
         )
     console.print(table)
+
+
+# --------------------------------- search -----------------------------------
+
+
+def trace_search(args: argparse.Namespace) -> None:
+    try:
+        traces = _build_traces(args)
+        rows = traces.search(
+            args.query,
+            match=args.match,
+            time_filter=args.time_filter,
+            sources=args.sources,
+            source_filter=args.source,
+            channel_filter=args.channel,
+            limit=args.limit,
+            page_size=args.page_size,
+            id_match=args.id_match,
+            with_snippets=args.snippets,
+        )
+    except Exception as e:
+        print(f"Search failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    fmt = args.format
+    if fmt == "json":
+        print(json.dumps(rows, indent=2, default=str))
+        return
+    if fmt == "csv":
+        if not rows:
+            return
+        fieldnames = [
+            "id",
+            "source",
+            "channel",
+            "start_time",
+            "end_time",
+            "ces_url",
+        ]
+        if args.snippets:
+            fieldnames.append("snippets")
+        writer = csv.DictWriter(
+            sys.stdout, fieldnames=fieldnames, extrasaction="ignore"
+        )
+        writer.writeheader()
+        for r in rows:
+            out = dict(r)
+            if args.snippets:
+                out["snippets"] = " | ".join(
+                    s.get("text", "") for s in r.get("snippets", [])
+                )
+            writer.writerow(out)
+        return
+
+    # default: table
+    table = Table(title=f'Search "{args.query}" ({len(rows)} matches)')
+    for col in ("id", "source", "channel", "start_time", "end_time"):
+        table.add_column(col)
+    if args.snippets:
+        table.add_column("match")
+    for r in rows:
+        cells = [
+            str(r.get(c) or "")
+            for c in ("id", "source", "channel", "start_time", "end_time")
+        ]
+        if args.snippets:
+            cells.append(_format_snippets(r.get("snippets", []), args.query))
+        table.add_row(*cells)
+    console.print(table)
+
+
+def _format_snippets(snippets: list, query: str) -> str:
+    """Renders snippet excerpts for a table cell, emphasizing the query."""
+    if not snippets:
+        return ""
+    lines = []
+    for s in snippets:
+        text = s.get("text", "")
+        # Case-insensitive highlight of each query word.
+        for word in {w for w in query.split() if w}:
+            text = re.sub(
+                f"({re.escape(word)})",
+                r"[bold yellow]\1[/bold yellow]",
+                text,
+                flags=re.IGNORECASE,
+            )
+        lines.append(f"[{s.get('kind')}] {text}")
+    return "\n".join(lines)
 
 
 # ---------------------------------- get -------------------------------------
@@ -475,6 +564,72 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         "--format", choices=["table", "json", "csv"], default="table"
     )
     p_list.set_defaults(func=trace_list)
+
+    # search
+    p_search = trace_subparsers.add_parser(
+        "search",
+        help="Find conversations whose transcript contains a query.",
+        description=(
+            "Searches conversations by transcript content using the same "
+            "server-side full-text search as the CES console search box. "
+            "Only the user + agent transcript is searched server-side; tool "
+            "call args, tool responses, and variables are not. Matching is "
+            "case-insensitive and substring/prefix based (e.g. 'crash' "
+            "matches 'crashing')."
+        ),
+    )
+    add_trace_args(p_search)
+    p_search.add_argument("query", help="Text to search for in transcripts.")
+    p_search.add_argument(
+        "--match",
+        choices=["phrase", "all", "any"],
+        default="phrase",
+        help=(
+            "Multi-word handling: 'phrase' (contiguous, the UI default), "
+            "'all' (every word must appear) or 'any' (any word). "
+            "Default: phrase."
+        ),
+    )
+    p_search.add_argument(
+        "--time-filter",
+        default=None,
+        help="Relative time filter (e.g. '7d', '24h'). Default: all time.",
+    )
+    p_search.add_argument(
+        "--source",
+        choices=["LIVE", "SIMULATOR", "EVAL"],
+        help="Filter by a single conversation source.",
+    )
+    p_search.add_argument(
+        "--sources",
+        nargs="+",
+        choices=["LIVE", "SIMULATOR", "EVAL"],
+        help="Filter by multiple sources (takes precedence over --source).",
+    )
+    p_search.add_argument(
+        "--channel",
+        choices=["TEXT", "AUDIO", "MULTIMODAL", "OTHER"],
+        help="Filter by input channel (client-side over input_types).",
+    )
+    p_search.add_argument("--limit", type=int)
+    p_search.add_argument(
+        "--page-size", type=int, help="Server-side page size hint."
+    )
+    p_search.add_argument(
+        "--no-id-match",
+        dest="id_match",
+        action="store_false",
+        help="Do not also match an exact customer_conversation_id.",
+    )
+    p_search.add_argument(
+        "--snippets",
+        action="store_true",
+        help="Fetch each match and show a highlighted transcript excerpt.",
+    )
+    p_search.add_argument(
+        "--format", choices=["table", "json", "csv"], default="table"
+    )
+    p_search.set_defaults(func=trace_search, id_match=True)
 
     # get
     p_get = trace_subparsers.add_parser(

--- a/src/cxas_scrapi/core/conversation_history.py
+++ b/src/cxas_scrapi/core/conversation_history.py
@@ -137,6 +137,9 @@ class ConversationHistory(Common):
         self,
         time_filter: str = None,
         source_filter: str = None,
+        extra_filter: str = None,
+        sources: List[str] = None,
+        page_size: int = None,
     ) -> Any:
         """Lists conversations in the configured app.
 
@@ -144,7 +147,14 @@ class ConversationHistory(Common):
             time_filter: An optional relative time filter (e.g. '7d',
                 '24h', '1m').
             source_filter: An optional enum string filter (e.g. 'LIVE',
-                'SIMULATOR', 'EVAL').
+                'SIMULATOR', 'EVAL'). Maps to the singular ``source`` field.
+            extra_filter: An optional raw AIP-160 filter expression that is
+                ANDed with the computed time filter (e.g. a
+                ``ces_transcript.search("...")`` clause for content search).
+            sources: An optional list of enum string filters mapped to the
+                repeated ``sources`` field (e.g. ['LIVE', 'SIMULATOR']). If
+                set, takes precedence over ``source_filter``.
+            page_size: An optional server-side page size hint.
         """
         filter_str = None
         if time_filter:
@@ -170,9 +180,33 @@ class ConversationHistory(Common):
                     f"Unrecognized time_filter format: {time_filter}. Ignoring."
                 )
 
+        if extra_filter:
+            filter_str = (
+                f"{filter_str} AND {extra_filter}"
+                if filter_str
+                else extra_filter
+            )
+
         request_kwargs = {"parent": self.app_name, "filter": filter_str}
 
-        if source_filter:
+        if page_size is not None:
+            request_kwargs["page_size"] = page_size
+
+        if sources:
+            source_enums = []
+            for s in sources:
+                source_enum_val = getattr(
+                    types.Conversation.Source, s.upper(), None
+                )
+                if source_enum_val is not None:
+                    source_enums.append(source_enum_val)
+                else:
+                    logger.warning(
+                        f"Unrecognized source format: {s}. Ignoring."
+                    )
+            if source_enums:
+                request_kwargs["sources"] = source_enums
+        elif source_filter:
             source_enum_val = getattr(
                 types.Conversation.Source, source_filter.upper(), None
             )

--- a/src/cxas_scrapi/core/traces.py
+++ b/src/cxas_scrapi/core/traces.py
@@ -127,6 +127,21 @@ class Traces(Common):
             time_filter=time_filter,
             source_filter=source_filter,
         )
+        return self._rows_from_convs(
+            convs, channel_filter=channel_filter, limit=limit
+        )
+
+    def _rows_from_convs(
+        self,
+        convs: list[Any],
+        channel_filter: str | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Shapes raw conversation protos into summary dicts.
+
+        Applies the client-side `channel_filter` (over `input_types`) and
+        `limit` shared by `list()` and `search()`.
+        """
         rows: list[dict[str, Any]] = []
         for c in convs:
             normalized_channel = trace_report._channel_label(
@@ -150,6 +165,82 @@ class Traces(Common):
             )
             if limit and len(rows) >= limit:
                 break
+        return rows
+
+    def search(
+        self,
+        query: str,
+        match: str = "phrase",
+        time_filter: str | None = None,
+        sources: list[str] | None = None,
+        source_filter: str | None = None,
+        channel_filter: str | None = None,
+        limit: int | None = None,
+        page_size: int | None = None,
+        id_match: bool = True,
+        with_snippets: bool = False,
+        max_workers: int = 8,
+    ) -> list[dict[str, Any]]:
+        """Searches conversations by transcript content, like the console UI.
+
+        Builds an AIP-160 filter using the server-side
+        `ces_transcript.search("...")` function (matching the CES console
+        search box) and lists the conversations that match.
+
+        Args:
+            query: The text to search for.
+            match: How a multi-word query is matched: 'phrase' (one
+                contiguous `search()` call, the UI default), 'all' (every
+                word must appear, ANDed) or 'any' (any word, ORed).
+            time_filter: Optional relative time filter (e.g. '7d'). Defaults
+                to None (all time), like the UI.
+            sources: Optional list of sources (repeated field). Defaults to
+                None (all sources).
+            source_filter: Optional single source (used only if `sources` is
+                not set).
+            channel_filter: Optional client-side channel filter.
+            limit: Optional client-side cap on returned rows.
+            page_size: Optional server-side page size hint.
+            id_match: When True (default), also matches on an exact
+                `customer_conversation_id` equal to `query`, like the UI.
+            with_snippets: When True, fetches each matched conversation and
+                attaches a `snippets` list showing where the terms matched.
+            max_workers: Thread pool size used when fetching snippets.
+
+        Returns:
+            A list of conversation summary dicts (as in `list()`), optionally
+            with an added `snippets` key per row.
+        """
+        search_filter = _build_search_filter(
+            query, match=match, id_match=id_match
+        )
+        convs = self.history.list_conversations(
+            time_filter=time_filter,
+            source_filter=source_filter,
+            extra_filter=search_filter,
+            sources=sources,
+            page_size=page_size,
+        )
+        rows = self._rows_from_convs(
+            convs, channel_filter=channel_filter, limit=limit
+        )
+
+        if with_snippets and rows:
+            terms = _query_terms(query, match)
+            with ThreadPoolExecutor(max_workers=max_workers) as ex:
+                futures = {
+                    ex.submit(self.get_normalized, r["id"]): r for r in rows
+                }
+                for fut in as_completed(futures):
+                    row = futures[fut]
+                    try:
+                        normalized = fut.result()
+                        row["snippets"] = _extract_snippets(normalized, terms)
+                    except Exception as e:
+                        logger.warning(
+                            f"Failed to fetch snippets for {row['id']}: {e}"
+                        )
+                        row["snippets"] = []
         return rows
 
     def get_normalized(self, conversation_id: str) -> dict[str, Any]:
@@ -840,6 +931,108 @@ class Traces(Common):
 
 
 # ----------------------------- module helpers -------------------------------
+
+
+def _escape_filter_literal(s: str) -> str:
+    """Escapes a string for safe use inside an AIP-160 double-quoted literal."""
+    return s.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _query_terms(query: str, match: str) -> list[str]:
+    """Splits a query into the terms used for matching.
+
+    'phrase' keeps the whole query as a single term; 'all'/'any' split on
+    whitespace.
+    """
+    q = query.strip()
+    if match == "phrase":
+        return [q] if q else []
+    return q.split()
+
+
+def _build_search_filter(
+    query: str,
+    match: str = "phrase",
+    id_match: bool = True,
+) -> str:
+    """Builds the AIP-160 filter used by the console conversation search.
+
+    Mirrors the UI, which sends
+    `(customer_conversation_id="<q>" OR ces_transcript.search("<q>"))`.
+
+    Args:
+        query: The raw search text.
+        match: 'phrase' (single `search()` call), 'all' (words ANDed) or
+            'any' (words ORed).
+        id_match: When True, OR an exact `customer_conversation_id` match with
+            the transcript search (matching the UI).
+    """
+    if match not in ("phrase", "all", "any"):
+        raise ValueError(f"Unknown match mode: {match}")
+
+    terms = _query_terms(query, match)
+    if not terms:
+        raise ValueError("Search query must not be empty.")
+
+    joiner = " OR " if match == "any" else " AND "
+    search_expr = joiner.join(
+        f'ces_transcript.search("{_escape_filter_literal(t)}")' for t in terms
+    )
+    if len(terms) > 1:
+        search_expr = f"({search_expr})"
+
+    if id_match:
+        cid = _escape_filter_literal(query.strip())
+        return f'(customer_conversation_id="{cid}" OR {search_expr})'
+    return search_expr
+
+
+def _extract_snippets(
+    normalized: dict[str, Any],
+    terms: list[str],
+    max_snippets: int = 3,
+    window: int = 60,
+) -> list[dict[str, Any]]:
+    """Pulls short transcript excerpts around term matches.
+
+    Searches the same scope as the server (`user`/`agent` entry text), with a
+    case-insensitive substring match, and returns up to `max_snippets`
+    `{turn, role, kind, text}` excerpts with a `window`-char context on each
+    side of the first hit.
+    """
+    lowered = [t.lower() for t in terms if t]
+    if not lowered:
+        return []
+    snippets: list[dict[str, Any]] = []
+    for entry in normalized.get("entries", []):
+        if entry.get("kind") not in ("user", "agent"):
+            continue
+        text = entry.get("text") or ""
+        haystack = text.lower()
+        hit = next(
+            (i for i in (haystack.find(t) for t in lowered) if i != -1),
+            None,
+        )
+        if hit is None:
+            continue
+        start = max(0, hit - window)
+        end = min(len(text), hit + window)
+        excerpt = text[start:end].strip()
+        if start > 0:
+            excerpt = "…" + excerpt
+        if end < len(text):
+            excerpt = excerpt + "…"
+        snippets.append(
+            {
+                "turn": entry.get("turn"),
+                "role": entry.get("role"),
+                "kind": entry.get("kind"),
+                "text": excerpt,
+            }
+        )
+        if len(snippets) >= max_snippets:
+            break
+    return snippets
 
 
 def _enum_name(v: Any) -> str | None:

--- a/tests/cxas_scrapi/cli/test_trace_cli.py
+++ b/tests/cxas_scrapi/cli/test_trace_cli.py
@@ -129,9 +129,7 @@ def test_trace_search_table_with_snippets(fake_traces, capsys):
             "start_time": "s",
             "end_time": "e",
             "ces_url": "u",
-            "snippets": [
-                {"kind": "user", "text": "my app keeps crashing"}
-            ],
+            "snippets": [{"kind": "user", "text": "my app keeps crashing"}],
         }
     ]
     trace_cli.trace_search(_search_ns(snippets=True))

--- a/tests/cxas_scrapi/cli/test_trace_cli.py
+++ b/tests/cxas_scrapi/cli/test_trace_cli.py
@@ -53,6 +53,131 @@ def test_register_smoke():
     assert args.time_filter == "1d"
 
 
+def _search_ns(**overrides):
+    base = dict(
+        query="crashing",
+        match="phrase",
+        time_filter=None,
+        source=None,
+        sources=None,
+        channel=None,
+        limit=None,
+        page_size=None,
+        id_match=True,
+        snippets=False,
+        format="table",
+    )
+    base.update(overrides)
+    return _ns(**base)
+
+
+def test_register_search_smoke():
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    trace_cli.register(sub)
+    args = parser.parse_args(
+        [
+            "trace",
+            "search",
+            "app crashing",
+            "--app-name",
+            APP,
+            "--match",
+            "all",
+            "--sources",
+            "LIVE",
+            "SIMULATOR",
+            "--snippets",
+            "--no-id-match",
+        ]
+    )
+    assert args.func == trace_cli.trace_search
+    assert args.query == "app crashing"
+    assert args.match == "all"
+    assert args.sources == ["LIVE", "SIMULATOR"]
+    assert args.snippets is True
+    assert args.id_match is False
+
+
+def test_trace_search_table(fake_traces, capsys):
+    fake_traces.search.return_value = [
+        {
+            "id": "c1",
+            "source": "LIVE",
+            "channel": "TEXT",
+            "start_time": "s",
+            "end_time": "e",
+            "ces_url": "u",
+        }
+    ]
+    trace_cli.trace_search(_search_ns())
+    out = capsys.readouterr().out
+    assert "Search" in out
+    assert "c1" in out
+    # Forwards the parsed options to Traces.search.
+    kwargs = fake_traces.search.call_args.kwargs
+    assert kwargs["match"] == "phrase"
+    assert kwargs["id_match"] is True
+
+
+def test_trace_search_table_with_snippets(fake_traces, capsys):
+    fake_traces.search.return_value = [
+        {
+            "id": "c1",
+            "source": "LIVE",
+            "channel": "TEXT",
+            "start_time": "s",
+            "end_time": "e",
+            "ces_url": "u",
+            "snippets": [
+                {"kind": "user", "text": "my app keeps crashing"}
+            ],
+        }
+    ]
+    trace_cli.trace_search(_search_ns(snippets=True))
+    out = capsys.readouterr().out
+    assert "crashing" in out
+
+
+def test_trace_search_json(fake_traces, capsys):
+    fake_traces.search.return_value = [{"id": "c1"}]
+    trace_cli.trace_search(_search_ns(format="json"))
+    assert json.loads(capsys.readouterr().out)[0]["id"] == "c1"
+
+
+def test_trace_search_csv_with_snippets(fake_traces, capsys):
+    fake_traces.search.return_value = [
+        {
+            "id": "c1",
+            "source": "LIVE",
+            "channel": "TEXT",
+            "start_time": "s",
+            "end_time": "e",
+            "ces_url": "u",
+            "snippets": [
+                {"text": "a crashing"},
+                {"text": "b crashing"},
+            ],
+        }
+    ]
+    trace_cli.trace_search(_search_ns(format="csv", snippets=True))
+    out = capsys.readouterr().out
+    assert "snippets" in out
+    assert "a crashing | b crashing" in out
+
+
+def test_trace_search_csv_empty_no_output(fake_traces, capsys):
+    fake_traces.search.return_value = []
+    trace_cli.trace_search(_search_ns(format="csv"))
+    assert capsys.readouterr().out == ""
+
+
+def test_trace_search_failure_exits(fake_traces):
+    fake_traces.search.side_effect = RuntimeError("boom")
+    with pytest.raises(SystemExit):
+        trace_cli.trace_search(_search_ns(format="json"))
+
+
 def test_trace_list_table(fake_traces, capsys):
     fake_traces.list.return_value = [
         {

--- a/tests/cxas_scrapi/core/test_conversation_history.py
+++ b/tests/cxas_scrapi/core/test_conversation_history.py
@@ -68,9 +68,7 @@ def test_list_conversations_extra_filter_only(mock_client_cls):
     mock_client.list_conversations.return_value = []
 
     conv_client = ConversationHistory(app_name="projects/p/locations/l/apps/a")
-    conv_client.list_conversations(
-        extra_filter='ces_transcript.search("hi")'
-    )
+    conv_client.list_conversations(extra_filter='ces_transcript.search("hi")')
 
     request = mock_client.list_conversations.call_args.kwargs["request"]
     assert request.filter == 'ces_transcript.search("hi")'

--- a/tests/cxas_scrapi/core/test_conversation_history.py
+++ b/tests/cxas_scrapi/core/test_conversation_history.py
@@ -14,6 +14,8 @@
 
 from unittest.mock import MagicMock, patch
 
+from google.cloud.ces_v1beta import types
+
 from cxas_scrapi.core.conversation_history import ConversationHistory
 
 
@@ -33,6 +35,45 @@ def test_conversation_list(mock_client_cls):
     assert len(res) == 1
     assert res[0].name == "projects/p/locations/l/apps/a/conversations/c1"
     mock_client.list_conversations.assert_called_once()
+
+
+@patch("cxas_scrapi.core.conversation_history.AgentServiceClient")
+def test_list_conversations_extra_filter_and_sources(mock_client_cls):
+    """extra_filter is ANDed with the time filter; sources map to enums."""
+    mock_client = mock_client_cls.return_value
+    mock_client.list_conversations.return_value = []
+
+    conv_client = ConversationHistory(app_name="projects/p/locations/l/apps/a")
+    conv_client.list_conversations(
+        time_filter="7d",
+        extra_filter='ces_transcript.search("hi")',
+        sources=["LIVE", "SIMULATOR"],
+        page_size=15,
+    )
+
+    request = mock_client.list_conversations.call_args.kwargs["request"]
+    assert request.filter.startswith('start_time > "')
+    assert request.filter.endswith('AND ces_transcript.search("hi")')
+    assert request.page_size == 15
+    assert list(request.sources) == [
+        types.Conversation.Source.LIVE,
+        types.Conversation.Source.SIMULATOR,
+    ]
+
+
+@patch("cxas_scrapi.core.conversation_history.AgentServiceClient")
+def test_list_conversations_extra_filter_only(mock_client_cls):
+    """extra_filter alone (no time filter) becomes the whole filter."""
+    mock_client = mock_client_cls.return_value
+    mock_client.list_conversations.return_value = []
+
+    conv_client = ConversationHistory(app_name="projects/p/locations/l/apps/a")
+    conv_client.list_conversations(
+        extra_filter='ces_transcript.search("hi")'
+    )
+
+    request = mock_client.list_conversations.call_args.kwargs["request"]
+    assert request.filter == 'ces_transcript.search("hi")'
 
 
 @patch("cxas_scrapi.core.conversation_history.AgentServiceClient")

--- a/tests/cxas_scrapi/core/test_traces.py
+++ b/tests/cxas_scrapi/core/test_traces.py
@@ -167,6 +167,125 @@ def test_get_normalized(traces_obj):
     assert n["num_turns"] == 1
 
 
+# ------------------------------- search ------------------------------------
+
+
+def test_build_search_filter_phrase_with_id_match():
+    f = traces_mod._build_search_filter("app crashing")
+    assert f == (
+        '(customer_conversation_id="app crashing" OR '
+        'ces_transcript.search("app crashing"))'
+    )
+
+
+def test_build_search_filter_all_and_any():
+    f_all = traces_mod._build_search_filter(
+        "app crashing", match="all", id_match=False
+    )
+    assert f_all == (
+        '(ces_transcript.search("app") AND '
+        'ces_transcript.search("crashing"))'
+    )
+    f_any = traces_mod._build_search_filter(
+        "app crashing", match="any", id_match=False
+    )
+    assert f_any == (
+        '(ces_transcript.search("app") OR '
+        'ces_transcript.search("crashing"))'
+    )
+
+
+def test_build_search_filter_single_word_no_parens():
+    f = traces_mod._build_search_filter(
+        "crashing", match="all", id_match=False
+    )
+    assert f == 'ces_transcript.search("crashing")'
+
+
+def test_build_search_filter_escapes_quotes_and_backslashes():
+    f = traces_mod._build_search_filter('a "b" \\c', id_match=False)
+    assert f == r'ces_transcript.search("a \"b\" \\c")'
+
+
+def test_build_search_filter_rejects_empty_and_bad_mode():
+    with pytest.raises(ValueError):
+        traces_mod._build_search_filter("   ")
+    with pytest.raises(ValueError):
+        traces_mod._build_search_filter("hi", match="fuzzy")
+
+
+def test_search_passes_filter_and_sources(traces_obj):
+    traces_obj.history = MagicMock()
+    traces_obj.history.list_conversations.return_value = [_conv("c-match")]
+
+    rows = traces_obj.search(
+        "crashing", sources=["LIVE", "SIMULATOR"], time_filter="7d"
+    )
+
+    assert [r["id"] for r in rows] == ["c-match"]
+    kwargs = traces_obj.history.list_conversations.call_args.kwargs
+    assert kwargs["extra_filter"] == (
+        '(customer_conversation_id="crashing" OR '
+        'ces_transcript.search("crashing"))'
+    )
+    assert kwargs["sources"] == ["LIVE", "SIMULATOR"]
+    assert kwargs["time_filter"] == "7d"
+
+
+def test_search_with_snippets(traces_obj):
+    traces_obj.history = MagicMock()
+    traces_obj.history.list_conversations.return_value = [_conv("c1")]
+    traces_obj.get_normalized = MagicMock(
+        return_value={
+            "entries": [
+                {
+                    "kind": "user",
+                    "turn": 0,
+                    "role": "user",
+                    "text": "My app keeps crashing when I open it.",
+                },
+                {
+                    "kind": "tool_call",
+                    "turn": 0,
+                    "tool": "lookup",
+                    "args": {"q": "crashing"},
+                },
+            ]
+        }
+    )
+    rows = traces_obj.search("crashing", with_snippets=True)
+    assert len(rows) == 1
+    snippets = rows[0]["snippets"]
+    assert len(snippets) == 1
+    assert snippets[0]["kind"] == "user"
+    assert "crashing" in snippets[0]["text"]
+
+
+def test_extract_snippets_scope_and_window():
+    normalized = {
+        "entries": [
+            {
+                "kind": "agent",
+                "turn": 1,
+                "role": "agent_x",
+                "text": "x" * 200 + "needle" + "y" * 200,
+            },
+            {
+                "kind": "tool_response",
+                "turn": 1,
+                "tool": "t",
+                "response": {"v": "needle"},
+            },
+        ]
+    }
+    out = traces_mod._extract_snippets(normalized, ["needle"], window=10)
+    # Only the agent entry is in scope (tool_response excluded).
+    assert len(out) == 1
+    assert "needle" in out[0]["text"]
+    assert out[0]["text"].startswith("…")
+    assert out[0]["text"].endswith("…")
+
+
 def test_get_report_all_formats(traces_obj):
     traces_obj.history = MagicMock()
     traces_obj.history.get_conversation.return_value = _conv_dict()

--- a/tests/cxas_scrapi/core/test_traces.py
+++ b/tests/cxas_scrapi/core/test_traces.py
@@ -183,22 +183,18 @@ def test_build_search_filter_all_and_any():
         "app crashing", match="all", id_match=False
     )
     assert f_all == (
-        '(ces_transcript.search("app") AND '
-        'ces_transcript.search("crashing"))'
+        '(ces_transcript.search("app") AND ces_transcript.search("crashing"))'
     )
     f_any = traces_mod._build_search_filter(
         "app crashing", match="any", id_match=False
     )
     assert f_any == (
-        '(ces_transcript.search("app") OR '
-        'ces_transcript.search("crashing"))'
+        '(ces_transcript.search("app") OR ces_transcript.search("crashing"))'
     )
 
 
 def test_build_search_filter_single_word_no_parens():
-    f = traces_mod._build_search_filter(
-        "crashing", match="all", id_match=False
-    )
+    f = traces_mod._build_search_filter("crashing", match="all", id_match=False)
     assert f == 'ces_transcript.search("crashing")'
 
 


### PR DESCRIPTION
## Summary

Adds a `cxas trace search <query>` subcommand that lists every conversation
whose transcript contains the query — the CLI equivalent of the console
conversation search box.

- Reproduces the console search exactly: the same `ListConversations` API with
  an AIP-160 filter combining an exact id match with the server-side
  `ces_transcript.search("...")` full-text function
  (`(customer_conversation_id="<q>" OR ces_transcript.search("<q>"))`).
- `--match {phrase,all,any}` controls multi-word handling (phrase = the UI
  default; `all`/`any` join per-word `search()` calls with AND/OR).
- `--snippets` fetches matched conversations and shows a highlighted transcript
  excerpt; `--source/--sources`, `--channel`, `--time-filter`, `--limit`,
  `--page-size`, `--no-id-match`, and `--format {table,json,csv}` round it out.

Search scope is the user + agent transcript only (matching the server
function); tool args/responses/variables are not searched server-side.

## Changes

- `core/conversation_history.py`: `list_conversations` gains `extra_filter`
  (ANDed with the time filter), a repeated `sources` list, and `page_size`.
- `core/traces.py`: new `Traces.search()`, `_build_search_filter`,
  `_extract_snippets`, and a shared `_row_from_convs` helper refactored out of
  `list()`.
- `cli/trace_cli.py`: new `search` subparser + handler reusing the list
  renderers.
- Docs: `AGENTS.md` CLI Features entry.

Fixes #236

## Test plan

- [x] `pytest tests/cxas_scrapi/core/test_traces.py tests/cxas_scrapi/cli/test_trace_cli.py tests/cxas_scrapi/core/test_conversation_history.py` — 110 passed
- [x] `ruff check` on changed source + test files — clean
- [x] Live smoke against a demo app:
  - `trace search crashing` → 1 match
  - `trace search "app crashing"` → 0 (phrase)
  - `trace search "app crashing" --match all` → 1
  - `trace search welcome --snippets` → matches agent text, shows excerpt
  - results match the console search box for the same queries
