### PR TITLE
refactor: bypass LLM for static utterances in simulation evals

### DIFF
--- a/src/cxas_scrapi/evals/simulation_evals.py
+++ b/src/cxas_scrapi/evals/simulation_evals.py
@@ -213,18 +213,12 @@ class LLMUserConversation(Conversation):
 
         return True
 
-    def _handle_first_turn(self) -> Optional[tuple[str, Dict[str, Any]]]:
-        """Handles the special logic for the first turn."""
-        if self.current_turn != 0:
-            return None
-
-        session_params = self.test_case.get("session_parameters", {})
-        if not self.test_case["steps"][0].get("static_utterance", None):
-            return _FIRST_UTTERANCE, session_params
-
-        inject_vars = self.test_case["steps"][0].get("inject_variables", {})
-        merged_vars = {**session_params, **inject_vars}
-        return self.test_case["steps"][0]["static_utterance"], merged_vars
+    def _get_active_step_index(self) -> Optional[int]:
+        """Finds the index of the first step that is not completed."""
+        for i, prog in enumerate(self.steps_progress):
+            if prog.status != StepStatus.COMPLETED:
+                return i
+        return None
 
     def _prepare_llm_prompt(self) -> str:
         """Prepares the prompt for the LLM user."""
@@ -265,9 +259,27 @@ class LLMUserConversation(Conversation):
         if not self._check_conversation_status():
             return "", {}
 
-        first_turn = self._handle_first_turn()
-        if first_turn:
-            return first_turn
+        active_idx = self._get_active_step_index()
+        if active_idx is not None:
+            active_step_prog = self.steps_progress[active_idx]
+            if active_step_prog.step.static_utterance:
+                # Mark static step as completed
+                active_step_prog.status = StepStatus.COMPLETED
+                active_step_prog.justification = (
+                    "Static utterance sent (bypassed LLM)."
+                )
+
+                utterance = active_step_prog.step.static_utterance
+                session_params = self.test_case.get("session_parameters", {})
+                inject_vars = self.test_case["steps"][active_idx].get(
+                    "inject_variables", {}
+                )
+                merged_vars = {**session_params, **inject_vars}
+                return utterance, merged_vars
+
+        if self.current_turn == 0:
+            session_params = self.test_case.get("session_parameters", {})
+            return _FIRST_UTTERANCE, session_params
 
         prompt = self._prepare_llm_prompt()
 

--- a/tests/cxas_scrapi/evals/test_simulation_evals.py
+++ b/tests/cxas_scrapi/evals/test_simulation_evals.py
@@ -482,16 +482,62 @@ def test_llm_user_check_conversation_status_max_turns():
     assert conv._check_conversation_status() is False
 
 
-def test_llm_user_handle_first_turn():
+def test_llm_user_get_active_step_index():
     mock_genai_client = MagicMock()
     test_case = {
-        "steps": [{"goal": "greet", "static_utterance": "Hello"}],
+        "steps": [{"goal": "greet"}, {"goal": "ask_hours"}],
+    }
+    conv = LLMUserConversation(mock_genai_client, "model", test_case)
+    # Initially first step is active (index 0)
+    assert conv._get_active_step_index() == 0
+
+    # Mark first step as completed
+    conv.steps_progress[0].status = StepStatus.COMPLETED
+    assert conv._get_active_step_index() == 1
+
+    # Mark second step as completed
+    conv.steps_progress[1].status = StepStatus.COMPLETED
+    assert conv._get_active_step_index() is None
+
+
+def test_llm_user_next_user_utterance_static_utterance_bypass():
+    mock_genai_client = MagicMock()
+    test_case = {
+        "steps": [
+            {
+                "goal": "greet",
+                "static_utterance": "Hello First Step",
+                "inject_variables": {"var1": "val1"},
+            },
+            {"goal": "ask_hours", "static_utterance": "What are the hours?"},
+        ],
         "session_parameters": {"user_id": "123"},
     }
     conv = LLMUserConversation(mock_genai_client, "model", test_case)
-    utterance, params = conv._handle_first_turn()
-    assert utterance == "Hello"
-    assert params["user_id"] == "123"
+
+    # 1. First Turn (Turn 0): Should bypass LLM and return first step's
+    # static utterance
+    utterance, variables = conv.next_user_utterance()
+    assert utterance == "Hello First Step"
+    assert variables == {"user_id": "123", "var1": "val1"}
+    assert conv.steps_progress[0].status == StepStatus.COMPLETED
+    assert conv.steps_progress[0].justification == (
+        "Static utterance sent (bypassed LLM)."
+    )
+    mock_genai_client.generate.assert_not_called()
+
+    # 2. Second Turn (Turn 1): Active step is now index 1 which is also
+    # static. Should bypass LLM again.
+    utterance, variables = conv.next_user_utterance(
+        "Agent response to first step"
+    )
+    assert utterance == "What are the hours?"
+    assert variables == {"user_id": "123"}
+    assert conv.steps_progress[1].status == StepStatus.COMPLETED
+    assert conv.steps_progress[1].justification == (
+        "Static utterance sent (bypassed LLM)."
+    )
+    mock_genai_client.generate.assert_not_called()
 
 
 def test_simulation_evals_add_agent_text():


### PR DESCRIPTION
Currently, steps with a `static_utterance` are orchestrated by prompting the LLM to robotically repeat them. This is redundant, incurs extra tokens and latency, and can introduce instruction-following errors.

This change bypasses the LLM entirely for any active step that has a `static_utterance`. The simulator now directly marks the step as completed in the python class, sets its justification, and returns the static utterance and session/injected parameters.