### PR TITLE
fix: catch missing graphviz dependency and exit gracefully

### DIFF
--- a/src/cxas_scrapi/migration/main_visualizer.py
+++ b/src/cxas_scrapi/migration/main_visualizer.py
@@ -47,10 +47,6 @@ from cxas_scrapi.migration.graph_visualizer import HighLevelGraphVisualizer
 from cxas_scrapi.migration.playbook_visualizer import PlaybookTreeVisualizer
 
 
-class VisualizationError(Exception):
-    """Raised when visualization fails (e.g. missing external dependency)."""
-
-
 class MainVisualizer:
     """Coordinates topology graph and detailed Rich trees with an
     interactive zoom UI (designed for Jupyter / Colab environments).

--- a/src/cxas_scrapi/migration/main_visualizer.py
+++ b/src/cxas_scrapi/migration/main_visualizer.py
@@ -338,13 +338,15 @@ class MainVisualizer:
         Args:
             prefix: Filename prefix for exported files.
         """
+        svg_filename = f"{prefix}_topology.svg"
+        svg_exported = False
         try:
             dot = HighLevelGraphVisualizer(self.data).build(
                 show_code_blocks=False
             )
-            svg_filename = f"{prefix}_topology.svg"
             dot.render(outfile=svg_filename, format="svg", cleanup=True)
-        except graphviz.backend.execute.ExecutableNotFound as e:
+            svg_exported = True
+        except graphviz.backend.execute.ExecutableNotFound:
             self.console.print(
                 "\n[bold red]Error: Graphviz executable 'dot' not found.[/]\n"
                 "The topology graph could not be rendered. Please install "
@@ -356,9 +358,6 @@ class MainVisualizer:
                 "Download from https://graphviz.org/download/\n"
                 "Ensure the 'dot' executable is added to your system PATH.\n"
             )
-            raise VisualizationError(
-                "Graphviz executable 'dot' not found."
-            ) from e
 
         buf = io.StringIO()
         capture_console = Console(file=buf, force_terminal=False, width=120)
@@ -399,7 +398,10 @@ class MainVisualizer:
             md_file.write(buf.getvalue())
 
         if HAS_COLAB:
-            files.download(svg_filename)
+            if svg_exported:
+                files.download(svg_filename)
             files.download(md_filename)
-        else:
+        elif svg_exported:
             print(f"Files saved locally: {svg_filename}, {md_filename}")
+        else:
+            print(f"Files saved locally: {md_filename}")

--- a/src/cxas_scrapi/migration/main_visualizer.py
+++ b/src/cxas_scrapi/migration/main_visualizer.py
@@ -15,8 +15,11 @@
 """Master visualizer coordinating topology graph and detailed Rich trees."""
 
 import io
+import sys
 import uuid
 from typing import Any, Dict
+
+import graphviz
 
 try:
     from IPython.display import HTML, display
@@ -332,9 +335,25 @@ class MainVisualizer:
         Args:
             prefix: Filename prefix for exported files.
         """
-        dot = HighLevelGraphVisualizer(self.data).build(show_code_blocks=False)
-        svg_filename = f"{prefix}_topology.svg"
-        dot.render(outfile=svg_filename, format="svg", cleanup=True)
+        try:
+            dot = HighLevelGraphVisualizer(self.data).build(
+                show_code_blocks=False
+            )
+            svg_filename = f"{prefix}_topology.svg"
+            dot.render(outfile=svg_filename, format="svg", cleanup=True)
+        except graphviz.backend.execute.ExecutableNotFound:
+            self.console.print(
+                "\n[bold red]Error: Graphviz executable 'dot' not found.[/]\n"
+                "The topology graph could not be rendered. Please install "
+                "the actual Graphviz software on your system:\n"
+                "  - [bold cyan]macOS[/]: brew install graphviz\n"
+                "  - [bold cyan]Ubuntu/Debian[/]: "
+                "sudo apt-get install graphviz\n"
+                "  - [bold cyan]Windows/Other[/]: "
+                "Download from https://graphviz.org/download/\n"
+                "Ensure the 'dot' executable is added to your system PATH.\n"
+            )
+            sys.exit(1)
 
         buf = io.StringIO()
         capture_console = Console(file=buf, force_terminal=False, width=120)

--- a/src/cxas_scrapi/migration/main_visualizer.py
+++ b/src/cxas_scrapi/migration/main_visualizer.py
@@ -15,7 +15,6 @@
 """Master visualizer coordinating topology graph and detailed Rich trees."""
 
 import io
-import sys
 import uuid
 from typing import Any, Dict
 
@@ -46,6 +45,10 @@ from cxas_scrapi.migration.flow_visualizer import (
 )
 from cxas_scrapi.migration.graph_visualizer import HighLevelGraphVisualizer
 from cxas_scrapi.migration.playbook_visualizer import PlaybookTreeVisualizer
+
+
+class VisualizationError(Exception):
+    """Raised when visualization fails (e.g. missing external dependency)."""
 
 
 class MainVisualizer:
@@ -341,7 +344,7 @@ class MainVisualizer:
             )
             svg_filename = f"{prefix}_topology.svg"
             dot.render(outfile=svg_filename, format="svg", cleanup=True)
-        except graphviz.backend.execute.ExecutableNotFound:
+        except graphviz.backend.execute.ExecutableNotFound as e:
             self.console.print(
                 "\n[bold red]Error: Graphviz executable 'dot' not found.[/]\n"
                 "The topology graph could not be rendered. Please install "
@@ -353,7 +356,9 @@ class MainVisualizer:
                 "Download from https://graphviz.org/download/\n"
                 "Ensure the 'dot' executable is added to your system PATH.\n"
             )
-            sys.exit(1)
+            raise VisualizationError(
+                "Graphviz executable 'dot' not found."
+            ) from e
 
         buf = io.StringIO()
         capture_console = Console(file=buf, force_terminal=False, width=120)

--- a/tests/cxas_scrapi/migration/test_main_visualizer.py
+++ b/tests/cxas_scrapi/migration/test_main_visualizer.py
@@ -17,6 +17,7 @@
 import os
 from unittest.mock import MagicMock, patch
 
+import graphviz
 from rich.console import Console
 from rich.tree import Tree
 
@@ -252,3 +253,28 @@ class TestMainVisualizerExport:
         md_file = f"{prefix}_detailed_resources.md"
         content = open(md_file).read()
         assert "Agent Tools" in content
+
+    @patch("cxas_scrapi.migration.main_visualizer.sys.exit")
+    @patch(
+        "cxas_scrapi.migration.graph_visualizer.HighLevelGraphVisualizer.build"
+    )
+    def test_export_handles_executable_not_found(
+        self, mock_build, mock_exit, tmp_path
+    ):
+        mock_dot = MagicMock()
+        mock_dot.render.side_effect = (
+            graphviz.backend.execute.ExecutableNotFound("dot")
+        )
+        mock_build.return_value = mock_dot
+
+        prefix = str(tmp_path / "test_agent")
+        mv = MainVisualizer(DFCXAgentIR(**EMPTY_DATA))
+
+        with patch.object(mv.console, "print") as mock_print:
+            mv.export_visualizations(prefix=prefix)
+
+            mock_print.assert_called_once()
+            args, _ = mock_print.call_args
+            assert "Graphviz executable 'dot' not found" in args[0]
+
+        mock_exit.assert_called_once_with(1)

--- a/tests/cxas_scrapi/migration/test_main_visualizer.py
+++ b/tests/cxas_scrapi/migration/test_main_visualizer.py
@@ -18,15 +18,11 @@ import os
 from unittest.mock import MagicMock, patch
 
 import graphviz
-import pytest
 from rich.console import Console
 from rich.tree import Tree
 
 from cxas_scrapi.migration.data_models import DFCXAgentIR
-from cxas_scrapi.migration.main_visualizer import (
-    MainVisualizer,
-    VisualizationError,
-)
+from cxas_scrapi.migration.main_visualizer import MainVisualizer
 
 # ---------------------------------------------------------------------------
 # Shared data
@@ -272,10 +268,10 @@ class TestMainVisualizerExport:
         mv = MainVisualizer(DFCXAgentIR(**EMPTY_DATA))
 
         with patch.object(mv.console, "print") as mock_print:
-            with pytest.raises(VisualizationError) as exc_info:
-                mv.export_visualizations(prefix=prefix)
-
-            assert "Graphviz executable 'dot' not found" in str(exc_info.value)
+            mv.export_visualizations(prefix=prefix)
             mock_print.assert_called_once()
             args, _ = mock_print.call_args
             assert "Graphviz executable 'dot' not found" in args[0]
+
+            md_file = f"{prefix}_detailed_resources.md"
+            assert os.path.exists(md_file)

--- a/tests/cxas_scrapi/migration/test_main_visualizer.py
+++ b/tests/cxas_scrapi/migration/test_main_visualizer.py
@@ -18,11 +18,15 @@ import os
 from unittest.mock import MagicMock, patch
 
 import graphviz
+import pytest
 from rich.console import Console
 from rich.tree import Tree
 
 from cxas_scrapi.migration.data_models import DFCXAgentIR
-from cxas_scrapi.migration.main_visualizer import MainVisualizer
+from cxas_scrapi.migration.main_visualizer import (
+    MainVisualizer,
+    VisualizationError,
+)
 
 # ---------------------------------------------------------------------------
 # Shared data
@@ -254,13 +258,10 @@ class TestMainVisualizerExport:
         content = open(md_file).read()
         assert "Agent Tools" in content
 
-    @patch("cxas_scrapi.migration.main_visualizer.sys.exit")
     @patch(
         "cxas_scrapi.migration.graph_visualizer.HighLevelGraphVisualizer.build"
     )
-    def test_export_handles_executable_not_found(
-        self, mock_build, mock_exit, tmp_path
-    ):
+    def test_export_handles_executable_not_found(self, mock_build, tmp_path):
         mock_dot = MagicMock()
         mock_dot.render.side_effect = (
             graphviz.backend.execute.ExecutableNotFound("dot")
@@ -271,10 +272,10 @@ class TestMainVisualizerExport:
         mv = MainVisualizer(DFCXAgentIR(**EMPTY_DATA))
 
         with patch.object(mv.console, "print") as mock_print:
-            mv.export_visualizations(prefix=prefix)
+            with pytest.raises(VisualizationError) as exc_info:
+                mv.export_visualizations(prefix=prefix)
 
+            assert "Graphviz executable 'dot' not found" in str(exc_info.value)
             mock_print.assert_called_once()
             args, _ = mock_print.call_args
             assert "Graphviz executable 'dot' not found" in args[0]
-
-        mock_exit.assert_called_once_with(1)


### PR DESCRIPTION
I got a "raise ExecutableNotFound(cmd) from e
graphviz.backend.execute.ExecutableNotFound: failed to execute PosixPath('dot'), make sure the Graphviz executables are on your systems' PATH" error when I first tried to run the migration cmd. This change allows the script to exit more gracefully while providing actionable items to users on how to resolve the error. 