### PR TITLE
fix(eval-utils): Propagate credentials to internal Evaluations client

### DIFF
--- a/src/cxas_scrapi/utils/eval_utils.py
+++ b/src/cxas_scrapi/utils/eval_utils.py
@@ -68,15 +68,17 @@ class Conversations(BaseModel):
 class EvalUtils(Evaluations):
     """Utility class for processing and exporting CXAS Evaluation Results."""
 
-    def __init__(self, app_name: str, env: str = "PROD"):
+    def __init__(self, app_name: str, env: str = "PROD", **kwargs):
         """Initializes the EvalUtils class for processing Evaluation Results.
 
         Args:
             app_name: CXAS App ID
                 (projects/{project}/locations/{location}/apps/{app}).
             env: Environment override (default: PROD).
+            **kwargs: Additional arguments passed to the parent class
+                (Evaluations).
         """
-        super().__init__(app_name=app_name, env=env)
+        super().__init__(app_name=app_name, env=env, **kwargs)
         self.app_name = app_name
         self.tools_client = Tools(app_name=self.app_name, creds=self.creds)
         self.var_client = Variables(app_name=self.app_name, creds=self.creds)
@@ -104,7 +106,9 @@ class EvalUtils(Evaluations):
         self.ch_client = ConversationHistory(
             app_name=self.app_name, creds=self.creds
         )
-        self.eval_client = Evaluations(app_name=self.app_name, env=env)
+        self.eval_client = Evaluations(
+            app_name=self.app_name, env=env, creds=self.creds
+        )
 
     @staticmethod
     def parse_variables_input(v: Any) -> Dict[str, Any]:

--- a/tests/cxas_scrapi/utils/test_eval_utils.py
+++ b/tests/cxas_scrapi/utils/test_eval_utils.py
@@ -430,3 +430,33 @@ def test_process_conversation_expectations():
         mock_find.assert_any_call(
             llm_prompt="Dict prompt", display_name="My Name"
         )
+
+
+def test_eval_utils_credentials_propagation():
+    """Test that custom credentials and kwargs propagate down to all
+    sub-clients.
+    """
+    mock_creds = MagicMock()
+
+    # We mock out internal calls and dependencies during initialization to
+    # prevent actual side effects
+    with (
+        patch("cxas_scrapi.core.evaluations.EvaluationServiceClient"),
+        patch("cxas_scrapi.core.tools.Tools.get_tools_map") as mock_tools_map,
+        patch(
+            "cxas_scrapi.core.agents.Agents.get_agents_map"
+        ) as mock_agents_map,
+    ):
+        mock_tools_map.return_value = {}
+        mock_agents_map.return_value = {}
+
+        utils = EvalUtils(
+            app_name="projects/p/locations/l/apps/a", creds=mock_creds
+        )
+
+        assert utils.creds == mock_creds
+        assert utils.tools_client.creds == mock_creds
+        assert utils.var_client.creds == mock_creds
+        assert utils.agents_client.creds == mock_creds
+        assert utils.ch_client.creds == mock_creds
+        assert utils.eval_client.creds == mock_creds


### PR DESCRIPTION
EvalUtils was instantiating self.eval_client Evaluations instance without propagating custom credentials, causing auto-resolution failures in on-premise environments.

This updates the EvalUtils constructor to accept **kwargs and propagates resolved credentials down to all sub-clients, including the internal evaluations client. Added comprehensive unit test coverage.

Fixes https://github.com/GoogleCloudPlatform/cxas-scrapi/issues/244