### PR TITLE
fix: remove duplicate agent response in turn evals

### DIFF
--- a/src/cxas_scrapi/evals/turn_evals.py
+++ b/src/cxas_scrapi/evals/turn_evals.py
@@ -374,8 +374,6 @@ class TurnEvals:
 
             # Fallback to high-level outputs if no diagnostic trace is available
             if not messages:
-                if "text" in out:
-                    full_text += str(out["text"]) + " "
                 # Check top-level toolCalls and agentTransfers
                 tcs_msg = out.get("toolCalls", {})
                 for tc in tcs_msg.get("toolCalls", []):


### PR DESCRIPTION
In line 329, add_snippet(out["text"]) is called once. In is called again in the fallback which results in duplicate agent response