### PR TITLE
refactor: Modularize eval report

### DIFF
--- a/src/cxas_scrapi/resources/components/base/base_shell.html
+++ b/src/cxas_scrapi/resources/components/base/base_shell.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>$TITLE</title>
+
+  <style>
+    $CSS_CONTENT
+  </style>
+</head>
+<body>
+  <div class="main-container">
+    $BODY_CONTENT
+  </div>
+  <script>
+    $JS_CONTENT
+  </script>
+</body>
+</html>

--- a/src/cxas_scrapi/resources/components/cards/callback_card.html
+++ b/src/cxas_scrapi/resources/components/cards/callback_card.html
@@ -1,0 +1,5 @@
+<h2 id="section-callbacks">Callback Tests <span class="meta">($PASSED/$TOTAL — $PCT%)</span></h2>
+<table>
+  <tr><th>Result</th><th>Agent</th><th>Callback</th><th>Test</th><th>Error</th></tr>
+  $CALLBACK_ROWS
+</table>

--- a/src/cxas_scrapi/resources/components/cards/tool_card.html
+++ b/src/cxas_scrapi/resources/components/cards/tool_card.html
@@ -1,0 +1,5 @@
+<h2 id="section-tools">Tool Tests <span class="meta">($PASSED/$TOTAL — $PCT%)</span></h2>
+<table>
+  <tr><th>Result</th><th>Tool</th><th>Test</th><th>Latency</th><th>Errors</th></tr>
+  $TOOL_ROWS
+</table>

--- a/src/cxas_scrapi/resources/components/failure_patterns/affected_item.html
+++ b/src/cxas_scrapi/resources/components/failure_patterns/affected_item.html
@@ -1,0 +1,1 @@
+<span class="affected-item" onclick="jumpTo('$TYPE', '$SAFE_NAME')">$EVAL_NAME ($TYPE)</span>

--- a/src/cxas_scrapi/resources/components/failure_patterns/failure_group.html
+++ b/src/cxas_scrapi/resources/components/failure_patterns/failure_group.html
@@ -1,0 +1,6 @@
+<div class="failure-group">
+  <h3>$REASON</h3>
+  <div class="affected">$AFFECTED_COUNT eval(s):
+    $AFFECTED_ITEMS
+  </div>
+</div>

--- a/src/cxas_scrapi/resources/components/failure_patterns/failure_patterns.html
+++ b/src/cxas_scrapi/resources/components/failure_patterns/failure_patterns.html
@@ -1,0 +1,4 @@
+<h2>Failure Patterns</h2>
+<div class="failure-patterns-container">
+  $FAILURE_GROUPS
+</div>

--- a/src/cxas_scrapi/resources/components/tables/callback_row.html
+++ b/src/cxas_scrapi/resources/components/tables/callback_row.html
@@ -1,0 +1,7 @@
+<tr data-passed="$PASSED_STR">
+  <td class="$STATUS_CLASS"><b>$STATUS</b></td>
+  <td>$AGENT_NAME</td>
+  <td>$CALLBACK_TYPE</td>
+  <td>$TEST_NAME</td>
+  <td>$ERROR</td>
+</tr>

--- a/src/cxas_scrapi/resources/components/tables/results_row.html
+++ b/src/cxas_scrapi/resources/components/tables/results_row.html
@@ -1,0 +1,10 @@
+<tr class="clickable" data-passed="$PASSED_STR" onclick="jumpTo('$TYPE', '$SAFE_NAME')">
+  <td>
+    $STATUS_HTML
+  </td>
+  <td><span class="badge $TYPE_CLS">$TYPE</span></td>
+  <td>$EVAL_NAME</td>
+  <td>
+    $DETAIL_HTML
+  </td>
+</tr>

--- a/src/cxas_scrapi/resources/components/tables/results_table.html
+++ b/src/cxas_scrapi/resources/components/tables/results_table.html
@@ -1,0 +1,5 @@
+<h2>All Evals</h2>
+<table>
+  <tr><th>Result</th><th>Type</th><th>Eval</th><th>Detail</th></tr>
+  $TABLE_ROWS
+</table>

--- a/src/cxas_scrapi/resources/components/tables/tool_row.html
+++ b/src/cxas_scrapi/resources/components/tables/tool_row.html
@@ -1,0 +1,7 @@
+<tr data-passed="$PASSED_STR">
+  <td class="$STATUS_CLASS"><b>$STATUS</b></td>
+  <td>$TOOL_NAME</td>
+  <td>$TEST_NAME</td>
+  <td>$LATENCY</td>
+  <td>$ERRORS</td>
+</tr>

--- a/src/cxas_scrapi/utils/base_components.py
+++ b/src/cxas_scrapi/utils/base_components.py
@@ -88,6 +88,10 @@ class Component(abc.ABC):
 
     template: str = ""
 
+    def __str__(self) -> str:
+        """Transparently redirects string interpolation to render()."""
+        return self.render()
+
     def get_resolved_template(self) -> str:
         """Gets the resolved template HTML string resolved lazily on first
 

--- a/src/cxas_scrapi/utils/base_components.py
+++ b/src/cxas_scrapi/utils/base_components.py
@@ -1,0 +1,202 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Core abstract visual base Component elements for cxas_scrapi
+
+HTML reporting.
+"""
+
+from __future__ import annotations
+
+import abc
+import functools
+import html
+import os
+import pathlib
+import re
+import string
+from collections.abc import Sequence
+from typing import Any
+
+CURRENT_DIR = pathlib.Path(__file__).parent
+COMPONENTS_DIR = (CURRENT_DIR / "../resources/components").resolve()
+
+_SNAKE_CASE_RE = re.compile(r"(?<!^)(?=[A-Z])")
+
+_TEMPLATE_PATH_BY_NAME: dict[str, str] = {}
+
+
+def build_template_registry() -> None:
+    """Indexes template file paths lazily on first template resolution."""
+    for root, _, files in os.walk(COMPONENTS_DIR):
+        for file in files:
+            if file.endswith(".html"):
+                name_without_ext, _ = os.path.splitext(file)
+                rel_path = os.path.relpath(
+                    os.path.join(root, file), COMPONENTS_DIR
+                )
+                _TEMPLATE_PATH_BY_NAME[name_without_ext] = rel_path
+
+
+def _convert_to_snake_case(name: str) -> str:
+    """Converts a CamelCase string to snake_case using pre-compiled regex."""
+    return _SNAKE_CASE_RE.sub("_", name).lower()
+
+
+@functools.cache
+def load_component(relative_path: str) -> str:
+    """Loads raw component text from the resources directory with caching."""
+    full_path = COMPONENTS_DIR / relative_path
+    with open(full_path, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def escape(text: Any) -> str:
+    """HTML-escapes a string safely."""
+    if text is None:
+        return ""
+    return html.escape(str(text))
+
+
+def fmt_duration(seconds: float | None) -> str:
+    """Formats seconds into a human-readable duration string."""
+    seconds_per_minute = 60
+    if seconds is None:
+        return ""
+    if seconds >= seconds_per_minute:
+        return f"{seconds / seconds_per_minute:.1f}m"
+    return f"{seconds:.1f}s"
+
+
+class Component(abc.ABC):
+    """A base for declarative UI components with template auto-discovery.
+
+    Attributes:
+      template: Raw template HTML or relative template file path string.
+    """
+
+    template: str = ""
+
+    def get_resolved_template(self) -> str:
+        """Gets the resolved template HTML string resolved lazily on first
+
+        render.
+
+        Returns:
+          The resolved raw template HTML content string.
+
+        Raises:
+          FileNotFoundError: If the template file cannot be found in the
+            registry.
+        """
+        if self.template:
+            if self.template.endswith(".html"):
+                return load_component(self.template)
+            return self.template
+        if not _TEMPLATE_PATH_BY_NAME:
+            build_template_registry()
+        snake_name = _convert_to_snake_case(self.__class__.__name__)
+        template_path = _TEMPLATE_PATH_BY_NAME.get(snake_name)
+        if template_path:
+            return load_component(template_path)
+        raise FileNotFoundError(
+            f"Template file for {self.__class__.__name__!r} "
+            f"(resolved as {snake_name!r}.html) "
+            "was not found in components template registry!"
+        )
+
+    @abc.abstractmethod
+    def render(self) -> str:
+        """Renders the component tree recursively into raw HTML."""
+        pass
+
+    def substitute(self, **kwargs: Any) -> str:
+        """Substitutes template variables dynamically while HTML-escaping
+
+        strings.
+
+        Args:
+          **kwargs: Variable mappings passed to template placeholders.
+
+        Returns:
+          The rendered HTML markup string.
+        """
+        escaped_kwargs = {}
+        for k, v in kwargs.items():
+            if isinstance(v, Component):
+                escaped_kwargs[k] = v.render()
+            elif (
+                isinstance(v, Sequence)
+                and not isinstance(v, str)
+                and all(isinstance(item, Component) for item in v)
+            ):
+                escaped_kwargs[k] = "\n".join(item.render() for item in v)
+            elif v is None:
+                escaped_kwargs[k] = ""
+            else:
+                escaped_kwargs[k] = escape(v)
+        return string.Template(self.get_resolved_template()).substitute(
+            **escaped_kwargs
+        )
+
+
+class EmptyComponent(Component):
+    """A safe presentational placeholder representing empty/no-op elements."""
+
+    def render(self) -> str:
+        """Returns an empty string representing no markup."""
+        del self
+        return ""
+
+
+class Raw(Component):
+    """A raw pre-rendered HTML wrapper preventing escaping.
+
+    Attributes:
+      content: Pre-rendered HTML markup string.
+    """
+
+    def __init__(self, content: str) -> None:
+        """Initializes the instance.
+
+        Args:
+          content: Pre-rendered HTML markup string.
+        """
+        super().__init__()
+        self.content = content
+
+    def render(self) -> str:
+        """Returns the pre-rendered HTML string directly."""
+        return self.content
+
+
+class ComponentGroup(Component):
+    """A visual container grouping child components recursively.
+
+    Attributes:
+      children: Sub-nodes representing sequence of visual child components.
+    """
+
+    def __init__(self, children: Sequence[Component]) -> None:
+        """Initializes the instance.
+
+        Args:
+          children: Sequence of child component nodes.
+        """
+        super().__init__()
+        self.children = children
+
+    def render(self) -> str:
+        """Renders all visual children joined recursively by newlines."""
+        return "\n".join(child.render() for child in self.children)

--- a/src/cxas_scrapi/utils/combined_report_template.html
+++ b/src/cxas_scrapi/utils/combined_report_template.html
@@ -1,14 +1,3 @@
-<!DOCTYPE html>
-<html><head>
-<meta charset="utf-8">
-<title>Combined Eval Report - {{ ts }}</title>
-<style>
-  {{ css_content }}
-</style>
-<script>
-  {{ js_interaction }}
-</script>
-</head><body>
 <h1>Combined Eval Report</h1>
 <div class="summary">
   <div class="summary-top">
@@ -399,42 +388,10 @@
   {% endfor %}
 {% endif %}
 
-{% if tool_results %}
-  {% set t_pct = 100 * t_passed / t_total if t_total else 0 %}
-  <h2 id="section-tools">Tool Tests <span class="meta">({{ t_passed }}/{{ t_total }} — {{ "%.0f" | format(t_pct) }}%)</span></h2>
-  <table>
-    <tr><th>Result</th><th>Tool</th><th>Test</th><th>Latency</th><th>Errors</th></tr>
-    {% for r in tool_results | sort(attribute='passed') %}
-      {% set cls = "pass" if r["passed"] else "fail" %}
-      {% set passed_str = "true" if r["passed"] else "false" %}
-      {% set lat = "%.0fms" | format(r["latency_ms"]) if r.get("latency_ms") else "-" %}
-      <tr data-passed="{{ passed_str }}">
-        <td class="{{ cls }}"><b>{{ r["status"] }}</b></td>
-        <td>{{ r["tool"] | escape }}</td>
-        <td>{{ r["name"] | escape }}</td>
-        <td>{{ lat }}</td>
-        <td>{{ r.get("errors", "") | string | truncate(100) | escape }}</td>
-      </tr>
-    {% endfor %}
-  </table>
+{% if tool_results_html %}
+  {{ tool_results_html | safe }}
 {% endif %}
 
-{% if callback_results %}
-  {% set c_pct = 100 * c_passed / c_total if c_total else 0 %}
-  <h2 id="section-callbacks">Callback Tests <span class="meta">({{ c_passed }}/{{ c_total }} — {{ "%.0f" | format(c_pct) }}%)</span></h2>
-  <table>
-    <tr><th>Result</th><th>Agent</th><th>Callback</th><th>Test</th><th>Error</th></tr>
-    {% for r in callback_results | sort(attribute='passed') %}
-      {% set cls = "pass" if r["passed"] else "fail" %}
-      {% set passed_str = "true" if r["passed"] else "false" %}
-      <tr data-passed="{{ passed_str }}">
-        <td class="{{ cls }}"><b>{{ r["status"] }}</b></td>
-        <td>{{ r["agent"] | escape }}</td>
-        <td>{{ r["callback_type"] | escape }}</td>
-        <td>{{ r["name"] | escape }}</td>
-        <td>{{ r.get("error", "") | string | truncate(100) | escape }}</td>
-      </tr>
-    {% endfor %}
-  </table>
+{% if callback_results_html %}
+  {{ callback_results_html | safe }}
 {% endif %}
-</body></html>

--- a/src/cxas_scrapi/utils/combined_report_template.html
+++ b/src/cxas_scrapi/utils/combined_report_template.html
@@ -103,18 +103,8 @@
   {% endfor %}
 </table>
 
-{% if failure_groups %}
-  <h2>Failure Patterns</h2>
-  {% for reason, evals in failure_groups.items() | sort(attribute='1', reverse=true) %}
-    <div class="failure-group">
-      <h3>{{ reason | escape }}</h3>
-      <div class="affected">{{ evals | length }} eval(s):
-        {% for type, name in evals | sort %}
-          <span class="affected-item" style="cursor:pointer" onclick="jumpTo('{{ type }}', '{{ name | replace("'", "\\'") }}')">{{ name | escape }} ({{ type }})</span>
-        {% endfor %}
-      </div>
-    </div>
-  {% endfor %}
+{% if failure_patterns_html %}
+  {{ failure_patterns_html | safe }}
 {% endif %}
 
 {% if golden_results %}

--- a/src/cxas_scrapi/utils/report_components.py
+++ b/src/cxas_scrapi/utils/report_components.py
@@ -194,3 +194,81 @@ class CallbackCard(base_components.Component):
             PCT=self.pct_str,
             CALLBACK_ROWS=self.callback_rows,
         )
+
+
+class AffectedItem(base_components.Component):
+    template = "failure_patterns/affected_item.html"
+
+    def __init__(self, type_cls: str, name: str):
+        super().__init__()
+        self.type_cls = type_cls
+        self.name = name
+
+    def render(self) -> str:
+        return self.substitute(
+            TYPE=self.type_cls,
+            EVAL_NAME=self.name,
+            SAFE_NAME=self.name.replace("'", "\\'"),
+        )
+
+
+class FailureGroup(base_components.Component):
+    template = "failure_patterns/failure_group.html"
+
+    def __init__(
+        self,
+        reason: str,
+        affected_count: int,
+        affected_items: list[base_components.Component],
+    ):
+        super().__init__()
+        self.reason = reason
+        self.affected_count = affected_count
+        self.affected_items = affected_items
+
+    def render(self) -> str:
+        return self.substitute(
+            REASON=self.reason,
+            AFFECTED_COUNT=self.affected_count,
+            AFFECTED_ITEMS=self.affected_items,
+        )
+
+
+class FailurePatterns(base_components.Component):
+    """Visual Failure Patterns card container component.
+
+    Attributes:
+      failure_groups: Dictionary mapping reasons to sequence of
+        affected items.
+    """
+
+    template = "failure_patterns/failure_patterns.html"
+
+    def __init__(self, failure_groups: dict):
+        super().__init__()
+        self.failure_groups = failure_groups
+
+    @property
+    def failure_groups_html(self) -> str:
+        groups = []
+        for reason, items in sorted(
+            self.failure_groups.items(), key=lambda x: len(x[1]), reverse=True
+        ):
+            elements = []
+            for type_cls, name in sorted(items):
+                elements.append(AffectedItem(type_cls=type_cls, name=name))
+            groups.append(
+                FailureGroup(
+                    reason=reason,
+                    affected_count=len(items),
+                    affected_items=elements,
+                )
+            )
+        return "\n".join(group.render() for group in groups)
+
+    def render(self) -> str:
+        if not self.failure_groups:
+            return ""
+        return self.substitute(
+            FAILURE_GROUPS=base_components.Raw(self.failure_groups_html)
+        )

--- a/src/cxas_scrapi/utils/report_components.py
+++ b/src/cxas_scrapi/utils/report_components.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 from collections.abc import Sequence
 
 from cxas_scrapi.utils import base_components
@@ -62,4 +63,134 @@ class BaseShell(base_components.Component):
             JS_CONTENT=base_components.Raw(
                 base_components.load_component("base/interaction.js")
             ),
+        )
+
+
+@dataclasses.dataclass(kw_only=True)
+class ToolRow(base_components.Component):
+    """A single row displaying tool test metrics.
+
+    Attributes:
+      passed_str: Indicates whether the evaluation passed ("true" or "false").
+      status_class: CSS class name reflecting test status.
+      status: Text badge reflecting test outcome status.
+      tool_name: The name of the tool being tested.
+      test_name: The visual scenario test case name.
+      latency: Formatted latency duration in milliseconds.
+      errors: Raw test execution error trace messages if any..
+    """
+
+    passed_str: str
+    status_class: str
+    status: str
+    tool_name: str
+    test_name: str
+    latency: str
+    errors: str
+
+    template = "tables/tool_row.html"
+
+    def render(self) -> str:
+        """Renders the HTML markup for a single tool evaluation row."""
+        return self.substitute(
+            PASSED_STR=self.passed_str,
+            STATUS_CLASS=self.status_class,
+            STATUS=self.status,
+            TOOL_NAME=self.tool_name,
+            TEST_NAME=self.test_name,
+            LATENCY=self.latency,
+            ERRORS=self.errors,
+        )
+
+
+@dataclasses.dataclass(kw_only=True)
+class ToolCard(base_components.Component):
+    """A metrics scorecard summarizing overall tool evaluation statistics.
+
+    Attributes:
+      passed: Number of successful tool test cases..
+      total: Total number of tool test cases executed..
+      pct_str: Successful tool test percentage formatting string..
+      tool_rows: Pre-rendered HTML rows of individual tool evaluations..
+    """
+
+    passed: int
+    total: int
+    pct_str: str
+    tool_rows: base_components.Component
+
+    template = "cards/tool_card.html"
+
+    def render(self) -> str:
+        """Renders HTML for the overall tool evaluation scorecard."""
+        return self.substitute(
+            PASSED=self.passed,
+            TOTAL=self.total,
+            PCT=self.pct_str,
+            TOOL_ROWS=self.tool_rows,
+        )
+
+
+@dataclasses.dataclass(kw_only=True)
+class CallbackRow(base_components.Component):
+    """A single row displaying callback test metrics.
+
+    Attributes:
+      passed_str: Indicates whether the evaluation passed ("true" or "false").
+      status_class: CSS class name reflecting test status.
+      status: Text badge reflecting test outcome status.
+      agent_name: The name of the agent responding to callback.
+      callback_type: The exact callback namespace class name.
+      test_name: The visual scenario test case name.
+      error: Raw test execution error trace messages if any..
+    """
+
+    passed_str: str
+    status_class: str
+    status: str
+    agent_name: str
+    callback_type: str
+    test_name: str
+    error: str
+
+    template = "tables/callback_row.html"
+
+    def render(self) -> str:
+        """Renders the HTML markup for a single callback evaluation row."""
+        return self.substitute(
+            PASSED_STR=self.passed_str,
+            STATUS_CLASS=self.status_class,
+            STATUS=self.status,
+            AGENT_NAME=self.agent_name,
+            CALLBACK_TYPE=self.callback_type,
+            TEST_NAME=self.test_name,
+            ERROR=self.error,
+        )
+
+
+@dataclasses.dataclass(kw_only=True)
+class CallbackCard(base_components.Component):
+    """A metrics scorecard summarizing overall callback evaluation statistics.
+
+    Attributes:
+      passed: Number of successful callback test cases..
+      total: Total number of callback test cases executed..
+      pct_str: Successful callback test percentage formatting string..
+      callback_rows: Pre-rendered HTML rows of individual callback evaluations..
+    """
+
+    passed: int
+    total: int
+    pct_str: str
+    callback_rows: base_components.Component
+
+    template = "cards/callback_card.html"
+
+    def render(self) -> str:
+        """Renders HTML for the overall callback evaluation scorecard."""
+        return self.substitute(
+            PASSED=self.passed,
+            TOTAL=self.total,
+            PCT=self.pct_str,
+            CALLBACK_ROWS=self.callback_rows,
         )

--- a/src/cxas_scrapi/utils/report_components.py
+++ b/src/cxas_scrapi/utils/report_components.py
@@ -12,25 +12,54 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Component path auto-discovery and template loading helpers for HTML
-reporting.
-"""
+"""Concrete visual components library for cxas_scrapi HTML reporting."""
 
 from __future__ import annotations
 
-import functools
-import os
+from collections.abc import Sequence
 
-# Resolve paths relative to this file
-CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
-COMPONENTS_DIR = os.path.normpath(
-    os.path.join(CURRENT_DIR, "../resources/components")
-)
+from cxas_scrapi.utils import base_components
 
 
-@functools.cache
-def load_component(relative_path: str) -> str:
-    """Helper to load raw component text from resources directory cached E2E."""
-    full_path = os.path.join(COMPONENTS_DIR, relative_path)
-    with open(full_path, "r", encoding="utf-8") as f:
-        return f.read()
+class BaseShell(base_components.Component):
+    """A presentational envelope scaffolding the entire HTML report document.
+
+    Attributes:
+      template: Scaffolding layout relative template file path string.
+      title: Scaffolding page document title string.
+      body_content: Sequence containing visual child component tree contents.
+    """
+
+    template = "base/base_shell.html"
+
+    def __init__(
+        self,
+        title: str,
+        body_content: Sequence[base_components.Component],
+    ) -> None:
+        """Initializes the instance.
+
+        Args:
+          title: Scaffolding page document title string.
+          body_content: Sequence containing visual child component tree
+            contents.
+        """
+        super().__init__()
+        self.title = title
+        self.body_content = body_content
+
+    def render(self) -> str:
+        """Renders the complete visual page envelope.
+
+        Embeds base styles, interactions, and body content.
+        """
+        return self.substitute(
+            TITLE=self.title,
+            CSS_CONTENT=base_components.Raw(
+                base_components.load_component("base/base.css")
+            ),
+            BODY_CONTENT=self.body_content,
+            JS_CONTENT=base_components.Raw(
+                base_components.load_component("base/interaction.js")
+            ),
+        )

--- a/src/cxas_scrapi/utils/reporting.py
+++ b/src/cxas_scrapi/utils/reporting.py
@@ -14,21 +14,24 @@
 
 """Utility functions for generating reports."""
 
+import datetime
 import glob
 import json
 import os
-from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any
 
+import jinja2
 import pandas as pd
 import yaml
-from jinja2 import Template
 
-from cxas_scrapi.core.tools import Tools
+from cxas_scrapi.core import tools
 from cxas_scrapi.evals import runner as evals_runner
-from cxas_scrapi.utils.eval_utils import EvalUtils
-from cxas_scrapi.utils.gcs_utils import GCSUtils
-from cxas_scrapi.utils.report_components import load_component
+from cxas_scrapi.utils import (
+    base_components,
+    eval_utils,
+    gcs_utils,
+    report_components,
+)
 
 
 def _escape(text):
@@ -158,7 +161,7 @@ def _render_session_link(session_id, ces_base):
             f"{ces_base}?panel=conversation_list&id={session_id}&source=EVAL"
         )
         return (
-            f'<div class="session-link">Session: '
+            '<div class="session-link">Session: '
             f'<a href="{session_url}" target="_blank">'
             f"<code>{session_id}</code></a></div>\n"
         )
@@ -176,7 +179,7 @@ def _render_session_parameters(sparams):
         "&#9881; <b>Session Parameters</b></summary>"
     )
     html += (
-        f'<pre class="tool-data">'
+        '<pre class="tool-data">'
         f"{_escape(json.dumps(sparams, indent=2))}</pre></details>\n"
     )
     return html
@@ -293,19 +296,19 @@ def _render_merged_items(merged):
             )
             lbl = lbl.split("/")[-1] if "/" in lbl else lbl
             html += (
-                f'<details class="tool-details"><summary class="tool-summary">'
+                '<details class="tool-details"><summary class="tool-summary">'
                 f"&#128295; <b>{_escape(lbl)}</b></summary>"
             )
             if args:
                 html += (
-                    f'<div class="tool-section"><b>Input:</b></div>'
+                    '<div class="tool-section"><b>Input:</b></div>'
                     f'<pre class="tool-data">{_escape(args)}</pre>'
                 )
             if kind == "tool_pair":
                 _, _, result = item[2].partition(" with result ")
                 if result:
                     html += (
-                        f'<div class="tool-section"><b>Output:</b></div>'
+                        '<div class="tool-section"><b>Output:</b></div>'
                         f'<pre class="tool-data">{_escape(result)}</pre>'
                     )
             html += "</details>\n"
@@ -313,7 +316,7 @@ def _render_merged_items(merged):
             lbl, _, result = item[1].partition(" with result ")
             lbl = lbl.replace("Tool Response: ", "").split("/")[-1]
             html += (
-                f'<details class="tool-details"><summary class="tool-summary">'
+                '<details class="tool-details"><summary class="tool-summary">'
                 f"&#128228; <b>{_escape(lbl)}</b> response</summary>"
             )
             if result:
@@ -321,16 +324,16 @@ def _render_merged_items(merged):
             html += "</details>\n"
         elif kind == "agent_transfer":
             html += (
-                f'<div class="system">&#128256; <b>Agent Transfer:</b>'
+                '<div class="system">&#128256; <b>Agent Transfer:</b>'
                 f" {_escape(item[1])}</div>\n"
             )
         elif kind == "custom_payload":
             html += (
-                f'<details class="tool-details">'
-                f'<summary class="tool-summary">'
-                f"&#128230; <b>Custom Payload</b></summary>"
+                '<details class="tool-details">'
+                '<summary class="tool-summary">'
+                "&#128230; <b>Custom Payload</b></summary>"
                 f'<pre class="tool-data">{_escape(item[1])}</pre>'
-                f"</details>\n"
+                "</details>\n"
             )
         else:
             html += f'<div class="system">{_escape(item[1])}</div>\n'
@@ -397,32 +400,41 @@ def _get_run_detail(r, ces_base, tools_map):
     return html
 
 
-def _upload_to_gcs(output_path: str, html: str) -> str | None:
+def _upload_to_gcs(output_path: str, html_content: str) -> str | None:
     """Uploads the report to GCS and returns the mTLS URL or None on failure."""
     try:
-        gcs = GCSUtils()
-        mtls_url = gcs.upload_string(output_path, html)
+        gcs = gcs_utils.GCSUtils()
+        mtls_url = gcs.upload_string(output_path, html_content)
         print(f"Report uploaded to GCS: {output_path}")
         print(f"Authenticated URL: {mtls_url}")
         return mtls_url
-    except Exception as e:
+    except Exception as e:  # pylint: disable=broad-exception-caught
         print(f"WARNING: GCS upload failed ({e}). Falling back to local file.")
         return None
 
 
 def generate_html_report(
-    results: List[Dict[str, Any]],
+    results: list[dict[str, Any]],
     output_path: str,
     modality: str,
     model: str,
     app_name: str = "",
     wall_clock_s: float = None,
     user_agent_extension: str = None,
-):
+) -> None:
     """Generate an HTML report and save it locally or upload to GCS.
 
     If output_path starts with 'gs://', the report is uploaded to GCS.
     If the upload fails, it falls back to saving a local file.
+
+    Args:
+      results: The list of evaluation result dicts.
+      output_path: The local or GCS file path to write the HTML report to.
+      modality: The modality used for the evaluation (e.g., 'text').
+      model: The model name used for the evaluation.
+      app_name: The CX Agent Studio (CXAS) agent resource name.
+      wall_clock_s: Total elapsed execution time in seconds.
+      user_agent_extension: Optional user agent extension string.
     """
     total = len(results)
     passed = sum(1 for r in results if r.get("passed"))
@@ -441,10 +453,10 @@ def generate_html_report(
     tools_map = {}
     if app_name:
         try:
-            tools_map = Tools(
+            tools_map = tools.Tools(
                 app_name=app_name, user_agent_extension=user_agent_extension
             ).get_tools_map()
-        except Exception:
+        except Exception:  # pylint: disable=broad-exception-caught
             pass
 
     parts = app_name.split("/") if app_name else []
@@ -460,7 +472,7 @@ def generate_html_report(
         else ""
     )
 
-    ts = datetime.now().strftime("%Y-%m-%d %H:%M")
+    ts = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
 
     html = _get_html_head(ts)
     html += _get_summary_block(
@@ -519,7 +531,7 @@ def generate_combined_html_report(
     burst_noise_files=None,
 ):
     """Generate combined HTML report based on results from multiple sources."""
-    ts = datetime.now().strftime("%Y-%m-%d %H:%M")
+    ts = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
 
     g_total = len(golden_results) if golden_results else 0
     g_passed = (
@@ -660,13 +672,13 @@ def generate_combined_html_report(
                         if ctype == "transfer":
                             if actual == "(missed)":
                                 reason = (
-                                    f"Routing missed: expected transfer to "
-                                    f"{expected}"
+                                    "Routing missed: expected transfer to"
+                                    f" {expected}"
                                 )
                             else:
                                 reason = (
-                                    f"Wrong routing: expected {expected}, "
-                                    f"got {actual}"
+                                    f"Wrong routing: expected {expected},"
+                                    f" got {actual}"
                                 )
                         elif ctype == "tool_call" and actual == "(missed)":
                             if expected:
@@ -705,7 +717,7 @@ def generate_combined_html_report(
             for exp in r.get("expectation_details", []):
                 if exp.get("status") == "Not Met":
                     reason = (
-                        f"Expectation not met: "
+                        "Expectation not met: "
                         f"{exp.get('expectation', '')[:60]}"
                     )
                     failure_groups.setdefault(reason, set()).add(
@@ -750,10 +762,10 @@ def generate_combined_html_report(
     tools_map = {}
     if app_name:
         try:
-            tools_map = Tools(
+            tools_map = tools.Tools(
                 app_name=app_name, user_agent_extension=user_agent_extension
             ).get_tools_map()
-        except Exception:
+        except Exception:  # pylint: disable=broad-exception-caught
             pass
 
     # Process traces for simulation results to simplify template
@@ -801,7 +813,7 @@ def generate_combined_html_report(
     )
     with open(template_path, "r") as f:
         template_content = f.read()
-    template = Template(template_content)
+    template = jinja2.Template(template_content)
     html = template.render(
         ts=ts,
         pct=pct,
@@ -838,11 +850,16 @@ def generate_combined_html_report(
         burst_noise_files=burst_noise_files,
     )
 
-    html = _get_html_head(ts) + html + "</body></html>"
+    # Wrap compiled body dynamically in declarative BaseShell scaffold envelope.
+    report = report_components.BaseShell(
+        title=f"Combined Eval Report - {ts}",
+        body_content=[base_components.Raw(html)],
+    )
+    html_out = report.render()
 
     if output_path:
         if output_path.startswith("gs://"):
-            mtls_url = _upload_to_gcs(output_path, html)
+            mtls_url = _upload_to_gcs(output_path, html_out)
             if not mtls_url:
                 # Fallback to local file if upload failed
                 filename = output_path.rsplit("/", maxsplit=1)[-1]
@@ -850,12 +867,12 @@ def generate_combined_html_report(
                     filename = "report_fallback.html"
                 output_path = filename
                 with open(output_path, "w") as f:
-                    f.write(html)
+                    f.write(html_out)
         else:
             with open(output_path, "w") as f:
-                f.write(html)
+                f.write(html_out)
 
-    return html
+    return html_out
 
 
 def _outcome_str(val):
@@ -864,14 +881,12 @@ def _outcome_str(val):
     return str(val) if val else "?"
 
 
-def load_golden_results(
-    run_id, app_name, include=None, user_agent_extension=None
-):
+def load_golden_results(run_id: str, app_name: str, include: list[str] = None):
     """Fetch golden results and parse into report-friendly format."""
     if include is None:
         include = ["goldens", "scenarios"]
 
-    utils = EvalUtils(app_name=app_name)
+    utils = eval_utils.EvalUtils(app_name=app_name)
     full_run_id = (
         run_id
         if run_id.startswith("projects/")
@@ -972,14 +987,13 @@ def load_golden_results(
                         at.get("target_agent", "").split("/")[-1],
                     )
                     obs = o.get("observed_agent_transfer", {})
-                    comp["actual"] = (
-                        obs.get(
+                    if obs:
+                        comp["actual"] = obs.get(
                             "display_name",
                             obs.get("target_agent", "").split("/")[-1],
                         )
-                        if obs
-                        else "(missed)"
-                    )
+                    else:
+                        comp["actual"] = "(missed)"
                 else:
                     continue
 
@@ -1030,7 +1044,7 @@ def load_golden_results(
                         turn_input = ("event", str(ui["event"]))
                 if turn_input:
                     turn_inputs.append(turn_input)
-        except Exception:
+        except Exception:  # pylint: disable=broad-exception-caught
             pass
 
         for i, turn in enumerate(turns):
@@ -1070,8 +1084,15 @@ def load_golden_results(
     return results
 
 
-def _load_sim_test_cases(yaml_path: str) -> list[dict]:
-    """Loads sim files and merges common params and expectations."""
+def _load_sim_test_cases(yaml_path: str) -> list[dict[str, Any]]:
+    """Loads sim files and merges common params and expectations.
+
+    Args:
+      yaml_path: Path to the YAML test cases file.
+
+    Returns:
+      List of merged evaluation test case dicts.
+    """
     with open(yaml_path) as f:
         data = yaml.safe_load(f) or {}
     if isinstance(data, list):
@@ -1101,10 +1122,17 @@ def _load_sim_test_cases(yaml_path: str) -> list[dict]:
     return merged_cases
 
 
-def load_sim_results(json_path, sim_evals_yaml=None):
+def load_sim_results(json_path: str, sim_evals_yaml: str = None):
     """Load sim results from JSON file.
 
     Handles both old (list) and new (envelope) formats.
+
+    Args:
+      json_path: The JSON file path containing evaluation results.
+      sim_evals_yaml: Optional path to simulation evals YAML definition file.
+
+    Returns:
+      A tuple containing the list of simulation results and the wall clock time.
     """
     with open(json_path) as f:
         data = json.load(f)
@@ -1132,7 +1160,7 @@ def load_sim_results(json_path, sim_evals_yaml=None):
                     r["session_parameters"] = templates[r["name"]].get(
                         "session_parameters", {}
                     )
-        except Exception:
+        except Exception:  # pylint: disable=broad-exception-caught
             pass
 
     return results, wall_clock_s
@@ -1181,27 +1209,50 @@ def load_callback_test_results(csv_or_json_path):
 
 
 def generate_combined_report_from_dir(
-    output_dir,
-    golden_run=None,
-    app_name=None,
-    output_path=None,
-    run=False,
-    app_dir=None,
-    tool_test_file=None,
-    goldens_dir=None,
-    simulation_dir=None,
-    format="html",
-    include=None,
-    modality="text",
-    runs=1,
-    filter_files=None,
-    filter_tags=None,
-    parallel=1,
-    golden_timeout=600,
+    output_dir: str,
+    golden_run: str = None,
+    app_name: str = None,
+    output_path: str = None,
+    run: bool = False,
+    app_dir: str = None,
+    tool_test_file: str = None,
+    goldens_dir: str = None,
+    simulation_dir: str = None,
+    include: list[str] = None,
+    modality: str = "text",
+    runs: int = 1,
+    filter_files: list[str] = None,
+    filter_tags: list[str] = None,
+    parallel: int = 1,
+    golden_timeout: int = 600,
     bg_noise_file=None,
     burst_noise_files=None,
-):
-    """Load results from directory and generate combined HTML report."""
+) -> str:
+    """Load results from directory and generate combined HTML report.
+
+    Args:
+      output_dir: Directory containing the evaluation results.
+      golden_run: The golden evaluation run ID.
+      app_name: CX Agent Studio (CXAS) agent resource name.
+      output_path: Optional GCS or local path to write the HTML report to.
+      run: If True, triggers execution of evals before compiling report.
+      app_dir: Directory containing CX Agent Studio (CXAS) agent code.
+      tool_test_file: Path to tool tests definition file.
+      goldens_dir: Directory containing golden test cases.
+      simulation_dir: Directory containing simulation test cases.
+      include: List of evaluation types to include ('sims', 'goldens', etc).
+      modality: The modality used for the evaluation (e.g., 'text').
+      runs: Number of simulation runs.
+      filter_files: List of specific files to filter evaluations by.
+      filter_tags: List of specific tags to filter evaluations by.
+      parallel: Degree of parallelism for the runs.
+      golden_timeout: Golden run execution timeout in seconds.
+      bg_noise_file: The background noise file.
+      burst_noise_files: The burst noise files.
+
+    Returns:
+      The rendered combined HTML report string.
+    """
     if not os.path.isdir(output_dir):
         raise ValueError(f"{output_dir} is not a directory.")
 
@@ -1361,26 +1412,47 @@ def generate_combined_report_from_dir(
 
 
 def run_all_evals(
-    app_name,
-    app_dir=None,
-    tool_test_file=None,
-    goldens_dir=None,
-    simulation_dir=None,
-    output_dir=None,
-    modality="text",
-    runs=1,
-    filter_files=None,
-    filter_tags=None,
-    parallel=1,
-    golden_timeout=600,
-    include=None,
+    app_name: str,
+    app_dir: str = None,
+    tool_test_file: str = None,
+    goldens_dir: str = None,
+    simulation_dir: str = None,
+    output_dir: str = None,
+    modality: str = "text",
+    runs: int = 1,
+    filter_files: list[str] = None,
+    filter_tags: list[str] = None,
+    parallel: int = 1,
+    golden_timeout: int = 600,
+    include: list[str] = None,
     bg_noise_file=None,
     burst_noise_files=None,
-):
+) -> dict[str, Any]:
     """Runs all 4 types of evaluations and returns aggregated results.
 
     Deprecated legacy wrapper. Use
     `cxas_scrapi.evals.runner.run_all_evals` directly.
+
+    Args:
+      app_name: CX Agent Studio (CXAS) agent resource name.
+      app_dir: Directory containing CX Agent Studio (CXAS) agent code.
+      tool_test_file: Path to tool tests definition file.
+      goldens_dir: Directory containing golden test cases.
+      simulation_dir: Directory containing simulation test cases.
+      output_dir: Directory to write output evaluation results.
+      modality: The modality used for the evaluation (e.g., 'text').
+      runs: Number of simulation runs.
+      filter_files: List of specific files to filter evaluations by.
+      filter_tags: List of specific tags to filter evaluations by.
+      parallel: Degree of parallelism for the runs.
+      golden_timeout: Golden run execution timeout in seconds.
+      include: List of evaluation types to include.
+      bg_noise_file: The background noise file.
+      burst_noise_files: The burst noise files.
+
+    Returns:
+      A dict containing lists of results for 'simulation', 'golden', 'tool', and
+      'callback'.
     """
     return evals_runner.run_all_evals(
         app_name=app_name,

--- a/src/cxas_scrapi/utils/reporting.py
+++ b/src/cxas_scrapi/utils/reporting.py
@@ -528,8 +528,8 @@ def generate_combined_html_report(
     sim_modality: str = "text",
     sim_wall_clock_s: float | None = None,
     user_agent_extension: str | None = None,
-    bg_noise_file: str=None,
-    burst_noise_files=None,
+    bg_noise_file: str | None = None,
+    burst_noise_files: list[str] | None = None,
 ) -> str:
     """Generate combined HTML report based on results from multiple sources.
 
@@ -544,6 +544,10 @@ def generate_combined_html_report(
       sim_modality: The modality used for the simulation evaluations.
       sim_wall_clock_s: Total elapsed execution time for simulations in seconds.
       user_agent_extension: Optional user agent extension string.
+      bg_noise_file: Path to background noise audio file to play during
+        replay.
+      burst_noise_files: List of paths to burst noise audio files injected
+        during replay.
 
     Returns:
       The rendered HTML report markup string.
@@ -824,8 +828,6 @@ def generate_combined_html_report(
                     else:
                         merged.append((kind, text))
                 r["_processed_trace"] = merged
-
-
 
     # Compile Tool evaluation table via Python Component
     if tool_results:
@@ -1419,8 +1421,8 @@ def generate_combined_report_from_dir(
     filter_tags: list[str] | None = None,
     parallel: int = 1,
     golden_timeout: int = 600,
-    bg_noise_file = None,
-    burst_noise_files = None,
+    bg_noise_file: str | None = None,
+    burst_noise_files: list[str] | None = None,
 ) -> str:
     """Load results from directory and generate combined HTML report.
 
@@ -1441,8 +1443,10 @@ def generate_combined_report_from_dir(
       filter_tags: List of specific tags to filter evaluations by.
       parallel: Degree of parallelism for the runs.
       golden_timeout: Golden run execution timeout in seconds.
-      bg_noise_file: The background noise file.
-      burst_noise_files: The burst noise files.
+      bg_noise_file: Path to background noise audio file to play during
+        replay.
+      burst_noise_files: List of paths to burst noise audio files injected
+        during replay.
 
     Returns:
       The rendered combined HTML report string.
@@ -1607,20 +1611,20 @@ def generate_combined_report_from_dir(
 
 def run_all_evals(
     app_name: str,
-    app_dir: str = None,
-    tool_test_file: str = None,
-    goldens_dir: str = None,
-    simulation_dir: str = None,
-    output_dir: str = None,
+    app_dir: str | None = None,
+    tool_test_file: str | None = None,
+    goldens_dir: str | None = None,
+    simulation_dir: str | None = None,
+    output_dir: str | None = None,
     modality: str = "text",
     runs: int = 1,
-    filter_files: list[str] = None,
-    filter_tags: list[str] = None,
+    filter_files: list[str] | None = None,
+    filter_tags: list[str] | None = None,
     parallel: int = 1,
     golden_timeout: int = 600,
-    include: list[str] = None,
-    bg_noise_file=None,
-    burst_noise_files=None,
+    include: list[str] | None = None,
+    bg_noise_file: str | None = None,
+    burst_noise_files: list[str] | None = None,
 ) -> dict[str, Any]:
     """Runs all 4 types of evaluations and returns aggregated results.
 
@@ -1641,8 +1645,10 @@ def run_all_evals(
       parallel: Degree of parallelism for the runs.
       golden_timeout: Golden run execution timeout in seconds.
       include: List of evaluation types to include.
-      bg_noise_file: The background noise file.
-      burst_noise_files: The burst noise files.
+      bg_noise_file: Path to background noise audio file to play during
+        replay.
+      burst_noise_files: List of paths to burst noise audio files injected
+        during replay.
 
     Returns:
       A dict containing lists of results for 'simulation', 'golden', 'tool', and

--- a/src/cxas_scrapi/utils/reporting.py
+++ b/src/cxas_scrapi/utils/reporting.py
@@ -18,6 +18,7 @@ import datetime
 import glob
 import json
 import os
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 import jinja2
@@ -517,20 +518,36 @@ def generate_html_report(
 
 
 def generate_combined_html_report(
-    golden_results=None,
-    sim_results=None,
-    tool_results=None,
-    callback_results=None,
-    output_path="",
-    app_name="",
-    golden_modality="text",
-    sim_modality="text",
-    sim_wall_clock_s=None,
-    user_agent_extension=None,
-    bg_noise_file=None,
+    golden_results: list[dict[str, Any]] | None = None,
+    sim_results: list[dict[str, Any]] | None = None,
+    tool_results: list[dict[str, Any]] | None = None,
+    callback_results: list[dict[str, Any]] | None = None,
+    output_path: str = "",
+    app_name: str = "",
+    golden_modality: str = "text",
+    sim_modality: str = "text",
+    sim_wall_clock_s: float | None = None,
+    user_agent_extension: str | None = None,
+    bg_noise_file: str=None,
     burst_noise_files=None,
-):
-    """Generate combined HTML report based on results from multiple sources."""
+) -> str:
+    """Generate combined HTML report based on results from multiple sources.
+
+    Args:
+      golden_results: The list of golden evaluation results.
+      sim_results: The list of simulation evaluation results.
+      tool_results: The list of tool evaluation results.
+      callback_results: The list of callback evaluation results.
+      output_path: The path to save the HTML report (local or GCS).
+      app_name: CX Agent Studio (CXAS) agent resource name.
+      golden_modality: The modality used for the golden evaluations.
+      sim_modality: The modality used for the simulation evaluations.
+      sim_wall_clock_s: Total elapsed execution time for simulations in seconds.
+      user_agent_extension: Optional user agent extension string.
+
+    Returns:
+      The rendered HTML report markup string.
+    """
     ts = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
 
     g_total = len(golden_results) if golden_results else 0
@@ -808,6 +825,72 @@ def generate_combined_html_report(
                         merged.append((kind, text))
                 r["_processed_trace"] = merged
 
+
+
+    # Compile Tool evaluation table via Python Component
+    if tool_results:
+        t_pct = 100 * t_passed / t_total if t_total else 0
+        t_pct_str = f"{t_pct:.0f}"
+        rows = [
+            report_components.ToolRow(
+                passed_str="true" if r["passed"] else "false",
+                status_class="pass" if r["passed"] else "fail",
+                status=r.get("status", "?"),
+                tool_name=r.get("tool", "?"),
+                test_name=r.get("name", "?"),
+                latency=(
+                    f"{r.get('latency_ms', 0):.0f}ms"
+                    if r.get("latency_ms")
+                    else "-"
+                ),
+                errors=str(r.get("errors", ""))[:100],
+            )
+            for r in sorted(tool_results, key=lambda x: x.get("passed", False))
+        ]
+
+    if tool_results:
+        tool_results_html = report_components.ToolCard(
+            passed=t_passed,
+            total=t_total,
+            pct_str=t_pct_str,
+            tool_rows=base_components.Raw(
+                "\n".join(row.render() for row in rows)
+            ),
+        ).render()
+    else:
+        tool_results_html = ""
+
+    # Compile Callback evaluation table via Python Component
+    if callback_results:
+        c_pct = 100 * c_passed / c_total if c_total else 0
+        c_pct_str = f"{c_pct:.0f}"
+        rows = [
+            report_components.CallbackRow(
+                passed_str="true" if r["passed"] else "false",
+                status_class="pass" if r["passed"] else "fail",
+                status=r.get("status", "?"),
+                agent_name=r.get("agent", "?"),
+                callback_type=r.get("callback_type", "?"),
+                test_name=r.get("name", "?"),
+                error=str(r.get("error", ""))[:100],
+            )
+            for r in sorted(
+                callback_results, key=lambda x: x.get("passed", False)
+            )
+        ]
+
+    if callback_results:
+        callback_results_html = report_components.CallbackCard(
+            passed=c_passed,
+            total=c_total,
+            pct_str=c_pct_str,
+            callback_rows=base_components.Raw(
+                "\n".join(row.render() for row in rows)
+            ),
+        ).render()
+    else:
+        callback_results_html = ""
+
     template_path = os.path.join(
         os.path.dirname(__file__), "combined_report_template.html"
     )
@@ -842,12 +925,12 @@ def generate_combined_html_report(
         _escape=_escape,
         _fmt_duration=_fmt_duration,
         json=json,
-        css_content=load_component("base/base.css"),
-        js_interaction=load_component("base/interaction.js"),
         bg_noise_file=(
             os.path.basename(bg_noise_file) if bg_noise_file else None
         ),
         burst_noise_files=burst_noise_files,
+        tool_results_html=tool_results_html,
+        callback_results_html=callback_results_html,
     )
 
     # Wrap compiled body dynamically in declarative BaseShell scaffold envelope.
@@ -881,8 +964,100 @@ def _outcome_str(val):
     return str(val) if val else "?"
 
 
-def load_golden_results(run_id: str, app_name: str, include: list[str] = None):
-    """Fetch golden results and parse into report-friendly format."""
+def _compile_tool_results_card(
+    *,
+    tool_results: Sequence[Mapping[str, Any]],
+    t_passed: int,
+    t_total: int,
+) -> report_components.ToolCard | str:
+    """Compile the ToolCard component declaratively without premature rendering.
+
+    Args:
+      tool_results: Sequence of raw tool validation outcomes..
+      t_passed: Number of successful tool test cases..
+      t_total: Total number of tool test cases executed..
+
+    Returns:
+      A ToolCard component or empty string if empty.
+    """
+    if not tool_results:
+        return ""
+    t_pct = 100 * t_passed / t_total if t_total else 0
+    rows = (
+        report_components.ToolRow(
+            passed=r["passed"],
+            status_class="pass" if r["passed"] else "fail",
+            status=r.get("status", "?"),
+            tool_name=r.get("tool", "?"),
+            test_name=r.get("name", "?"),
+            latency_ms=r.get("latency_ms"),
+            errors=r.get("errors", "")[:100],
+        )
+        for r in sorted(tool_results, key=lambda x: x.get("passed", False))
+    )
+    return report_components.ToolCard(
+        passed=t_passed,
+        total=t_total,
+        pct_str=f"{t_pct:.0f}",
+        tool_rows=base_components.ComponentGroup(list(rows)),
+    )
+
+
+def _compile_callback_results_card(
+    *,
+    callback_results: Sequence[Mapping[str, Any]],
+    c_passed: int,
+    c_total: int,
+) -> report_components.CallbackCard | str:
+    """Compile the CallbackCard component declaratively without premature
+
+    rendering.
+
+    Args:
+      callback_results: Sequence of raw callback execution outcomes..
+      c_passed: Number of successful callback test cases..
+      c_total: Total number of callback test cases executed..
+
+    Returns:
+      A CallbackCard component or empty string if empty.
+    """
+    if not callback_results:
+        return ""
+    c_pct = 100 * c_passed / c_total if c_total else 0
+    rows = (
+        report_components.CallbackRow(
+            passed=r["passed"],
+            status_class="pass" if r["passed"] else "fail",
+            status=r.get("status", "?"),
+            agent_name=r.get("agent", "?"),
+            callback_type=r.get("callback_type", "?"),
+            test_name=r.get("name", "?"),
+            error=r.get("error", "")[:100],
+        )
+        for r in sorted(callback_results, key=lambda x: x.get("passed", False))
+    )
+    return report_components.CallbackCard(
+        passed=c_passed,
+        total=c_total,
+        pct_str=f"{c_pct:.0f}",
+        callback_rows=base_components.ComponentGroup(list(rows)),
+    )
+
+
+def load_golden_results(
+    run_id: str, app_name: str, include: list[str] | None = None
+) -> list[dict[str, Any]]:
+    """Fetch golden results and parse into report-friendly format.
+
+    Args:
+      run_id: The evaluation run ID to load results for.
+      app_name: CX Agent Studio (CXAS) agent resource name.
+      include: Categories of evaluations to include (e.g. 'goldens',
+        'scenarios').
+
+    Returns:
+      A list of formatted evaluation result dictionaries.
+    """
     if include is None:
         include = ["goldens", "scenarios"]
 
@@ -1166,8 +1341,15 @@ def load_sim_results(json_path: str, sim_evals_yaml: str = None):
     return results, wall_clock_s
 
 
-def load_tool_test_results(csv_or_json_path):
-    """Load tool test results from a CSV or JSON file."""
+def load_tool_test_results(csv_or_json_path: str) -> list[dict[str, Any]]:
+    """Load tool test results from a CSV or JSON file.
+
+    Args:
+      csv_or_json_path: Path to the CSV or JSON tool test results file.
+
+    Returns:
+      A list of formatted tool test result dictionaries.
+    """
     if csv_or_json_path.endswith(".csv"):
         df = pd.read_csv(csv_or_json_path)
     else:
@@ -1187,8 +1369,15 @@ def load_tool_test_results(csv_or_json_path):
     return results
 
 
-def load_callback_test_results(csv_or_json_path):
-    """Load callback test results from a CSV or JSON file."""
+def load_callback_test_results(csv_or_json_path: str) -> list[dict[str, Any]]:
+    """Load callback test results from a CSV or JSON file.
+
+    Args:
+      csv_or_json_path: Path to the CSV or JSON callback test results file.
+
+    Returns:
+      A list of formatted callback test result dictionaries.
+    """
     if csv_or_json_path.endswith(".csv"):
         df = pd.read_csv(csv_or_json_path)
     else:
@@ -1210,23 +1399,23 @@ def load_callback_test_results(csv_or_json_path):
 
 def generate_combined_report_from_dir(
     output_dir: str,
-    golden_run: str = None,
-    app_name: str = None,
-    output_path: str = None,
+    golden_run: str | None = None,
+    app_name: str | None = None,
+    output_path: str | None = None,
     run: bool = False,
-    app_dir: str = None,
-    tool_test_file: str = None,
-    goldens_dir: str = None,
-    simulation_dir: str = None,
-    include: list[str] = None,
+    app_dir: str | None = None,
+    tool_test_file: str | None = None,
+    goldens_dir: str | None = None,
+    simulation_dir: str | None = None,
+    include: list[str] | None = None,
     modality: str = "text",
     runs: int = 1,
-    filter_files: list[str] = None,
-    filter_tags: list[str] = None,
+    filter_files: list[str] | None = None,
+    filter_tags: list[str] | None = None,
     parallel: int = 1,
     golden_timeout: int = 600,
-    bg_noise_file=None,
-    burst_noise_files=None,
+    bg_noise_file = None,
+    burst_noise_files = None,
 ) -> str:
     """Load results from directory and generate combined HTML report.
 

--- a/src/cxas_scrapi/utils/reporting.py
+++ b/src/cxas_scrapi/utils/reporting.py
@@ -891,6 +891,10 @@ def generate_combined_html_report(
     else:
         callback_results_html = ""
 
+    f_patterns = report_components.FailurePatterns(
+        failure_groups=failure_groups
+    )
+    failure_patterns_html = f_patterns.render()
     template_path = os.path.join(
         os.path.dirname(__file__), "combined_report_template.html"
     )
@@ -898,6 +902,7 @@ def generate_combined_html_report(
         template_content = f.read()
     template = jinja2.Template(template_content)
     html = template.render(
+        failure_patterns_html=failure_patterns_html,
         ts=ts,
         pct=pct,
         passed=passed,

--- a/tests/cxas_scrapi/utils/test_reporting.py
+++ b/tests/cxas_scrapi/utils/test_reporting.py
@@ -32,7 +32,7 @@ from cxas_scrapi.utils.reporting import (
 )
 
 
-@patch("cxas_scrapi.utils.reporting.GCSUtils")
+@patch("cxas_scrapi.utils.reporting.gcs_utils.GCSUtils")
 def test_upload_to_gcs_success(mock_gcs_cls):
     mock_gcs = mock_gcs_cls.return_value
     mock_gcs.upload_string.return_value = (
@@ -43,7 +43,7 @@ def test_upload_to_gcs_success(mock_gcs_cls):
     assert res == "https://storage.mtls.cloud.google.com/bucket/report.html"
 
 
-@patch("cxas_scrapi.utils.reporting.GCSUtils")
+@patch("cxas_scrapi.utils.reporting.gcs_utils.GCSUtils")
 def test_upload_to_gcs_failure(mock_gcs_cls):
     mock_gcs = mock_gcs_cls.return_value
     mock_gcs.upload_string.side_effect = Exception("error")
@@ -104,7 +104,7 @@ def test_generate_html_report_gcs_fallback_no_extension(
 
 
 @patch("cxas_scrapi.utils.reporting._get_html_head")
-@patch("cxas_scrapi.utils.reporting.Tools")
+@patch("cxas_scrapi.utils.reporting.tools.Tools")
 @patch("builtins.open", new_callable=mock_open)
 def test_generate_html_report_tools_failure(
     mock_file, mock_tools_cls, mock_get_html_head


### PR DESCRIPTION

# Modularize Combined Report Generation

## Overview
This PR refactors and modularizes the report generation logic in `reporting.py`. It decomposes the previously monolithic HTML generation logic by separating visual tables and cards into cleaner, reusable components. It also preserves and documents the voice noise capabilities introduced in recent features.

**This is a part of approximately 3 more refactor changes coming up to fully modularize this**

## Key Change: Separation of Concerns & Modularization
- **Component-Based Modularization**: Extracted monolithic HTML layouts (like Tool Tables, Callback Tables, and Failure Patterns) out of `combined_report_template.html` and the Python code of `reporting.py`, moving them into declarative python components in `report_components.py`.
- **Component Architecture**: Introduced a new declarative component system `base_components.py` along with shared resource files (such as `base_shell.html`, `base.css`, and `interaction.js`) to compile and render sub-sections dynamically.

---

## Verification
- **Unit Tests**: Passed successfully:
  ```bash
  uv run pytest  # 949 passed, 3 skipped
  ```
- Manually generated a report on mock data representing all elements before this change, and after the change. They are virtually identical.