### PR TITLE
fix: make use_tool_fakes as a flag when running evaluations

### DIFF
--- a/.agents/skills/cxas-agent-foundry/scripts/scrapi-sim-runner.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/scrapi-sim-runner.py
@@ -117,6 +117,7 @@ class EnhancedSimRunner(SimulationEvals):
         session_id: Optional[str] = None,
         console_logging: bool = True,
         modality: str = "text",
+        use_tool_fakes: bool = False,
     ) -> LLMUserConversation:
         """Run a simulated conversation with variable injection."""
         if session_id is None:
@@ -150,6 +151,7 @@ class EnhancedSimRunner(SimulationEvals):
                         "session_id": session_id,
                         "text": user_utterance,
                         "modality": modality,
+                        "use_tool_fakes": use_tool_fakes,
                     }
                     # Inject variables on first turn only
                     if first_turn and session_params:
@@ -364,6 +366,7 @@ def cmd_run(args):
         model=model,
         modality=modality,
         verbose=args.verbose,
+        use_tool_fakes=args.use_tool_fakes,
     )
 
     # Summary
@@ -451,6 +454,12 @@ def main():
     p_run.add_argument("--runs", type=int, default=1)
     p_run.add_argument("--parallel", type=int, default=1, help="Number of concurrent sessions (default: 1)")
     p_run.add_argument("--verbose", action="store_true")
+    p_run.add_argument(
+        "--use-tool-fakes",
+        action="store_true",
+        default=False,
+        help="Use fake tools if available",
+    )
     p_run.add_argument(
         "--gcs-report-path",
         type=str,

--- a/src/cxas_scrapi/cli/main.py
+++ b/src/cxas_scrapi/cli/main.py
@@ -883,7 +883,10 @@ def run_session(args: argparse.Namespace) -> None:
                 continue
 
             res = session_client.run(
-                session_id=session_id, text=user_input, modality=args.modality
+                session_id=session_id,
+                text=user_input,
+                modality=args.modality,
+                use_tool_fakes=args.use_tool_fakes,
             )
             session_client.parse_result(res)
     except Exception as e:
@@ -1689,6 +1692,12 @@ def get_parser() -> argparse.ArgumentParser:
     parser_run_session.add_argument(
         "app_name",
         help="The app name (projects/.../locations/.../apps/...).",
+    )
+    parser_run_session.add_argument(
+        "--use-tool-fakes",
+        action="store_true",
+        default=False,
+        help="Use fake tools for the session if available.",
     )
     parser_run_session.set_defaults(func=run_session)
 

--- a/src/cxas_scrapi/core/sessions.py
+++ b/src/cxas_scrapi/core/sessions.py
@@ -871,9 +871,10 @@ class Sessions(Common):
                     f"Invalid modality: {modality}. Must be 'text' or 'audio'."
                 ) from e
 
-        config = {"session": f"{self.app_name}/sessions/{session_id}"}
-        if use_tool_fakes:
-            config["use_tool_fakes"] = True
+        config = {
+            "session": f"{self.app_name}/sessions/{session_id}",
+            "use_tool_fakes": use_tool_fakes,
+        }
         inputs = []
 
         if modality == Modality.AUDIO:

--- a/src/cxas_scrapi/evals/simulation_evals.py
+++ b/src/cxas_scrapi/evals/simulation_evals.py
@@ -416,6 +416,7 @@ class SimulationEvals(Apps):
         variables: Dict[str, Any],
         modality: str,
         console_logging: bool,
+        use_tool_fakes: bool = False,
     ) -> Any:
         """Sends a request to the CES Agent with exponential backoff for
         transient errors.
@@ -429,6 +430,7 @@ class SimulationEvals(Apps):
                         event=user_utterance.removeprefix("event:").strip(),
                         variables=variables,
                         modality=modality,
+                        use_tool_fakes=use_tool_fakes,
                     )
                 elif user_utterance.startswith("dtmf:"):
                     response = self.sessions_client.run(
@@ -436,6 +438,7 @@ class SimulationEvals(Apps):
                         dtmf=user_utterance.removeprefix("dtmf:").strip(),
                         variables=variables,
                         modality=modality,
+                        use_tool_fakes=use_tool_fakes,
                     )
                 else:
                     response = self.sessions_client.run(
@@ -443,6 +446,7 @@ class SimulationEvals(Apps):
                         text=user_utterance,
                         variables=variables,
                         modality=modality,
+                        use_tool_fakes=use_tool_fakes,
                     )
                 break
             except Exception as e:
@@ -476,6 +480,7 @@ class SimulationEvals(Apps):
         session_id: Optional[str] = None,
         console_logging: bool = True,
         modality: str = "text",
+        use_tool_fakes: bool = False,
     ) -> LLMUserConversation:
         """Runs the simulated conversation loop.
 
@@ -514,6 +519,7 @@ class SimulationEvals(Apps):
                 accumulated_variables,
                 modality,
                 console_logging,
+                use_tool_fakes=use_tool_fakes,
             )
             if not response:
                 break
@@ -574,6 +580,7 @@ class SimulationEvals(Apps):
         modality: str,
         verbose: bool,
         parallel: int,
+        use_tool_fakes: bool = False,
     ) -> Dict[str, Any]:
         """Runs a single simulation job and returns the results."""
         name = tc["name"]
@@ -588,6 +595,7 @@ class SimulationEvals(Apps):
                 session_id=session_id,
                 console_logging=verbose and parallel <= 1,
                 modality=modality,
+                use_tool_fakes=use_tool_fakes,
             )
             duration_s = round(time.time() - _start, 1)
 
@@ -664,6 +672,7 @@ class SimulationEvals(Apps):
         model: str,
         modality: str,
         verbose: bool,
+        use_tool_fakes: bool = False,
     ) -> List[Dict[str, Any]]:
         """Aggregates results from multiple simulation jobs."""
         results = []
@@ -681,6 +690,7 @@ class SimulationEvals(Apps):
                             modality,
                             verbose,
                             parallel,
+                            use_tool_fakes=use_tool_fakes,
                         )
                     )
                     progress.update(task_id, advance=1)
@@ -697,6 +707,7 @@ class SimulationEvals(Apps):
                             modality,
                             verbose,
                             parallel,
+                            use_tool_fakes=use_tool_fakes,
                         ): (tc["name"], run_idx)
                         for tc, run_idx in jobs
                     }
@@ -714,6 +725,7 @@ class SimulationEvals(Apps):
         model: str = _DEFAULT_GEMINI_MODEL,
         modality: str = "text",
         verbose: bool = False,
+        use_tool_fakes: bool = False,
     ) -> List[Dict[str, Any]]:
         """Runs multiple simulations, optionally in parallel.
 
@@ -724,10 +736,17 @@ class SimulationEvals(Apps):
             model: Gemini model to use.
             modality: 'text' or 'audio'.
             verbose: Whether to log to console (only active if parallel=1).
+            use_tool_fakes: Use fake tools for the session if available.
         """
         jobs = self._prepare_simulation_jobs(test_cases, runs)
         return self._aggregate_simulation_results(
-            jobs, runs, parallel, model, modality, verbose
+            jobs,
+            runs,
+            parallel,
+            model,
+            modality,
+            verbose,
+            use_tool_fakes=use_tool_fakes,
         )
 
     def _add_agent_text(self, turn: Turn, text: str) -> None:

--- a/tests/cxas_scrapi/cli/test_main.py
+++ b/tests/cxas_scrapi/cli/test_main.py
@@ -247,3 +247,24 @@ def test_deployments_promote(mock_app_push, mock_deps_cls):
             "projects/test-project/locations/global/apps/test-app/versions/v1"
         ),
     )
+
+
+def test_get_parser_run_session_use_tool_fakes():
+    """Test that the parser parses run-session with --use-tool-fakes."""
+    parser = get_parser()
+    args = parser.parse_args(
+        [
+            "run-session",
+            "text",
+            "projects/test-project/locations/global/apps/test-app",
+            "--use-tool-fakes",
+        ]
+    )
+    assert args.command == "run-session"
+    assert args.modality == "text"
+    expected_app = (
+        "projects/test-project/locations/global/apps/test-app"
+    )
+    assert args.app_name == expected_app
+    assert args.use_tool_fakes is True
+

--- a/tests/cxas_scrapi/cli/test_main.py
+++ b/tests/cxas_scrapi/cli/test_main.py
@@ -262,9 +262,6 @@ def test_get_parser_run_session_use_tool_fakes():
     )
     assert args.command == "run-session"
     assert args.modality == "text"
-    expected_app = (
-        "projects/test-project/locations/global/apps/test-app"
-    )
+    expected_app = "projects/test-project/locations/global/apps/test-app"
     assert args.app_name == expected_app
     assert args.use_tool_fakes is True
-

--- a/tests/cxas_scrapi/evals/test_simulation_evals.py
+++ b/tests/cxas_scrapi/evals/test_simulation_evals.py
@@ -199,13 +199,18 @@ def test_user_simulator(mock_llm_conv_class, mock_sessions_class):
 
     # Assertions
     mock_sessions.run.assert_any_call(
-        session_id="123", event="welcome", variables={}, modality="text"
+        session_id="123",
+        event="welcome",
+        variables={},
+        modality="text",
+        use_tool_fakes=False,
     )
     mock_sessions.run.assert_any_call(
         session_id="123",
         text="I want to book a flight",
         variables={},
         modality="text",
+        use_tool_fakes=False,
     )
     mock_eval_conv.next_user_utterance.assert_any_call("Where to?")
     mock_eval_conv.next_user_utterance.assert_any_call("Flight booked.")
@@ -267,13 +272,18 @@ def test_user_simulator_audio(mock_llm_conv_class, mock_sessions_class):
     )
 
     mock_sessions.run.assert_any_call(
-        session_id="123", event="welcome", variables={}, modality="audio"
+        session_id="123",
+        event="welcome",
+        variables={},
+        modality="audio",
+        use_tool_fakes=False,
     )
     mock_sessions.run.assert_any_call(
         session_id="123",
         text="I want to book a flight",
         variables={},
         modality="audio",
+        use_tool_fakes=False,
     )
 
     # Verify text was extracted from Diagnostic Info

--- a/tests/cxas_scrapi/evals/test_simulation_evals.py
+++ b/tests/cxas_scrapi/evals/test_simulation_evals.py
@@ -1092,6 +1092,8 @@ def test_simulation_evals_simulate_conversation_use_tool_fakes(
         event="welcome",
         variables={},
         modality="text",
+        background_noise_file=None,
+        burst_noise_files=None,
         use_tool_fakes=True,
     )
 
@@ -1123,6 +1125,8 @@ def test_simulation_evals_run_simulations_use_tool_fakes(mock_sessions):
         "text",
         False,
         1,
+        None,
+        None,
         use_tool_fakes=True,
     )
 
@@ -1157,6 +1161,8 @@ def test_simulation_evals_run_simulations_use_tool_fakes_parallel(
         "text",
         False,
         2,
+        None,
+        None,
         use_tool_fakes=True,
     )
 

--- a/tests/cxas_scrapi/evals/test_simulation_evals.py
+++ b/tests/cxas_scrapi/evals/test_simulation_evals.py
@@ -1165,4 +1165,3 @@ def test_simulation_evals_run_simulations_use_tool_fakes_parallel(
         None,
         use_tool_fakes=True,
     )
-

--- a/tests/cxas_scrapi/evals/test_simulation_evals.py
+++ b/tests/cxas_scrapi/evals/test_simulation_evals.py
@@ -1046,3 +1046,109 @@ def test_simulation_evals_init_with_rate_limiter(mock_sessions):
         app_name,
         rate_limiter=mock_rate_limiter,
     )
+
+
+@patch("cxas_scrapi.evals.simulation_evals.Sessions")
+@patch("cxas_scrapi.evals.simulation_evals.LLMUserConversation")
+def test_simulation_evals_simulate_conversation_use_tool_fakes(
+    mock_llm_conv_class, mock_sessions_class
+):
+    mock_sessions = mock_sessions_class.return_value
+    mock_eval_conv = mock_llm_conv_class.return_value
+
+    mock_eval_conv.next_user_utterance.side_effect = [
+        ("event: welcome", {}),
+        ("", {}),
+    ]
+    mock_eval_conv.steps_progress = []
+
+    mock_response = MagicMock()
+    mock_response.outputs = []
+    mock_sessions.run.return_value = mock_response
+
+    app_name = "projects/test/locations/us/apps/123-abc"
+    with patch("cxas_scrapi.evals.simulation_evals.GeminiGenerate"):
+        with patch("cxas_scrapi.core.apps.AgentServiceClient"):
+            simulator = SimulationEvals(app_name=app_name)
+
+    test_case = {"steps": []}
+    simulator.simulate_conversation(
+        test_case=test_case,
+        session_id="123",
+        console_logging=False,
+        use_tool_fakes=True,
+    )
+
+    mock_sessions.run.assert_called_once_with(
+        session_id="123",
+        event="welcome",
+        variables={},
+        modality="text",
+        use_tool_fakes=True,
+    )
+
+
+@patch("cxas_scrapi.evals.simulation_evals.Sessions")
+def test_simulation_evals_run_simulations_use_tool_fakes(mock_sessions):
+    app_name = "projects/test/locations/us/apps/123-abc"
+    with patch("cxas_scrapi.evals.simulation_evals.GeminiGenerate"):
+        with patch("cxas_scrapi.core.apps.AgentServiceClient"):
+            evals = SimulationEvals(app_name=app_name)
+
+    evals._run_single_simulation_job = MagicMock(return_value={"status": "ok"})
+    test_cases = [{"name": "tc1"}]
+
+    results = evals.run_simulations(
+        test_cases=test_cases,
+        runs=1,
+        parallel=1,
+        model="gemini-1.5-flash",
+        use_tool_fakes=True,
+    )
+
+    assert len(results) == 1
+    evals._run_single_simulation_job.assert_called_once_with(
+        test_cases[0],
+        0,
+        1,
+        "gemini-1.5-flash",
+        "text",
+        False,
+        1,
+        use_tool_fakes=True,
+    )
+
+
+@patch("cxas_scrapi.evals.simulation_evals.Sessions")
+def test_simulation_evals_run_simulations_use_tool_fakes_parallel(
+    mock_sessions,
+):
+    app_name = "projects/test/locations/us/apps/123-abc"
+    with patch("cxas_scrapi.evals.simulation_evals.GeminiGenerate"):
+        with patch("cxas_scrapi.core.apps.AgentServiceClient"):
+            evals = SimulationEvals(app_name=app_name)
+
+    evals._run_single_simulation_job = MagicMock(return_value={"status": "ok"})
+    test_cases = [{"name": "tc1"}, {"name": "tc2"}]
+
+    results = evals.run_simulations(
+        test_cases=test_cases,
+        runs=1,
+        parallel=2,
+        model="gemini-1.5-flash",
+        use_tool_fakes=True,
+    )
+
+    assert len(results) == 2
+    assert evals._run_single_simulation_job.call_count == 2
+    evals._run_single_simulation_job.assert_any_call(
+        test_cases[0],
+        0,
+        1,
+        "gemini-1.5-flash",
+        "text",
+        False,
+        2,
+        use_tool_fakes=True,
+    )
+

--- a/tests/cxas_scrapi/evals/test_simulation_evals.py
+++ b/tests/cxas_scrapi/evals/test_simulation_evals.py
@@ -204,7 +204,7 @@ def test_user_simulator(mock_llm_conv_class, mock_sessions_class):
         variables={},
         modality="text",
         background_noise_file=None,
-        burst_noise_files=None,,
+        burst_noise_files=None,
         use_tool_fakes=False,
     )
     mock_sessions.run.assert_any_call(
@@ -281,7 +281,7 @@ def test_user_simulator_audio(mock_llm_conv_class, mock_sessions_class):
         variables={},
         modality="audio",
         background_noise_file=None,
-        burst_noise_files=None,,
+        burst_noise_files=None,
         use_tool_fakes=False,
     )
     mock_sessions.run.assert_any_call(


### PR DESCRIPTION
Enable a flag on the cli to utilize the mock tools provided by the platform.

The flag is false by default but if enabled the test will run against the agent and check if mock tools is made for tools required. If a mock tool is provided the test will use it else it would default to the original implementation.