### PR TITLE
feat: add --app-dir-name option to cxas pull

### DIFF
--- a/src/cxas_scrapi/cli/app.py
+++ b/src/cxas_scrapi/cli/app.py
@@ -126,8 +126,11 @@ def _app_pull(
             if export_members:
                 top_dir = export_members[0].split("/")[0]
                 for info in z.infolist():
-                    if app_dir_name and info.filename.startswith(top_dir + "/"):
-                        info.filename = app_dir_name + "/" + info.filename[len(top_dir) + 1:]
+                    if app_dir_name and info.filename.startswith(
+                        top_dir + "/"
+                    ):
+                        suffix = info.filename[len(top_dir) + 1 :]
+                        info.filename = f"{app_dir_name}/{suffix}"
                     elif app_dir_name and info.filename == top_dir:
                         info.filename = app_dir_name
                     z.extract(info, path=target_dir)

--- a/src/cxas_scrapi/cli/app.py
+++ b/src/cxas_scrapi/cli/app.py
@@ -126,9 +126,7 @@ def _app_pull(
             if export_members:
                 top_dir = export_members[0].split("/")[0]
                 for info in z.infolist():
-                    if app_dir_name and info.filename.startswith(
-                        top_dir + "/"
-                    ):
+                    if app_dir_name and info.filename.startswith(top_dir + "/"):
                         suffix = info.filename[len(top_dir) + 1 :]
                         info.filename = f"{app_dir_name}/{suffix}"
                     elif app_dir_name and info.filename == top_dir:

--- a/src/cxas_scrapi/cli/app.py
+++ b/src/cxas_scrapi/cli/app.py
@@ -98,6 +98,7 @@ def app_pull(args: argparse.Namespace) -> None:
         app_name,
         args.target_dir,
         getattr(args, "overwrite", False),
+        getattr(args, "app_dir_name", None),
     )
 
 
@@ -106,6 +107,7 @@ def _app_pull(
     app_name: str,
     target_dir: str,
     overwrite: bool = False,
+    app_dir_name: Optional[str] = None,
 ) -> None:
     """Helper to pull an app from CXAS."""
     try:
@@ -121,13 +123,21 @@ def _app_pull(
         # Extract content to target directory.
         with zipfile.ZipFile(io.BytesIO(response.app_content)) as z:
             export_members = z.namelist()
-            z.extractall(target_dir)
+            if export_members:
+                top_dir = export_members[0].split("/")[0]
+                for info in z.infolist():
+                    if app_dir_name and info.filename.startswith(top_dir + "/"):
+                        info.filename = app_dir_name + "/" + info.filename[len(top_dir) + 1:]
+                    elif app_dir_name and info.filename == top_dir:
+                        info.filename = app_dir_name
+                    z.extract(info, path=target_dir)
 
         # Handle overwrite logic if requested
         if overwrite and export_members:
             # Find the top level directory name in the zip (app name)
             top_dir = export_members[0].split("/")[0]
-            app_root = os.path.join(target_dir, top_dir)
+            final_dir_name = app_dir_name if app_dir_name else top_dir
+            app_root = os.path.join(target_dir, final_dir_name)
 
             if os.path.exists(app_root):
                 # Build set of exported paths relative to app_root

--- a/src/cxas_scrapi/cli/main.py
+++ b/src/cxas_scrapi/cli/main.py
@@ -1797,6 +1797,10 @@ def get_parser() -> argparse.ArgumentParser:
             "the exported app will be deleted."
         ),
     )
+    parser_pull.add_argument(
+        "--app-dir-name",
+        help="Override the top-level folder name of the exported app.",
+    )
     _add_project_location_args(parser_pull, required=False)
     parser_pull.set_defaults(func=app_pull)
 

--- a/tests/cxas_scrapi/cli/test_app.py
+++ b/tests/cxas_scrapi/cli/test_app.py
@@ -230,8 +230,14 @@ def test_app_pull_with_app_dir_name(
         app_name="projects/test-project/locations/us/apps/123"
     )
     # Check that the files were extracted under the overridden name
-    assert os.path.exists(os.path.join(args.target_dir, "my_custom_folder", "app.yaml"))
-    assert os.path.exists(os.path.join(args.target_dir, "my_custom_folder", "agents", "agent1.json"))
+    assert os.path.exists(
+        os.path.join(args.target_dir, "my_custom_folder", "app.yaml")
+    )
+    assert os.path.exists(
+        os.path.join(
+            args.target_dir, "my_custom_folder", "agents", "agent1.json"
+        )
+    )
     # Check that original 123 folder does not exist
     assert not os.path.exists(os.path.join(args.target_dir, "123"))
 
@@ -278,10 +284,23 @@ def test_app_pull_overwrite_with_app_dir_name(
     cli_app.app_pull(args)
 
     # Check that the files were extracted under the overridden name
-    assert os.path.exists(os.path.join(args.target_dir, "my_custom_folder", "app.yaml"))
-    assert os.path.exists(os.path.join(args.target_dir, "my_custom_folder", "agents", "agent1.json"))
+    assert os.path.exists(
+        os.path.join(args.target_dir, "my_custom_folder", "app.yaml")
+    )
+    assert os.path.exists(
+        os.path.join(
+            args.target_dir, "my_custom_folder", "agents", "agent1.json"
+        )
+    )
     # Check that the extra file was deleted by the overwrite logic
-    assert not os.path.exists(os.path.join(args.target_dir, "my_custom_folder", "agents", "extra_file.json"))
+    assert not os.path.exists(
+        os.path.join(
+            args.target_dir,
+            "my_custom_folder",
+            "agents",
+            "extra_file.json",
+        )
+    )
 
 
 def test_app_push(mock_apps_client, tmp_path):

--- a/tests/cxas_scrapi/cli/test_app.py
+++ b/tests/cxas_scrapi/cli/test_app.py
@@ -191,6 +191,99 @@ def test_app_pull(
     assert os.path.exists(os.path.join(args.target_dir, "app.yaml"))
 
 
+def test_app_pull_with_app_dir_name(
+    mock_apps_client,
+    mock_common_get_project_id,
+    mock_common_get_location,
+    tmp_path,
+):
+    args = argparse.Namespace(
+        app="Test App",
+        target_dir=str(tmp_path / "pulled_app"),
+        app_dir_name="my_custom_folder",
+        project_id="test-project",
+        location="us",
+        overwrite=True,
+    )
+
+    # Mock resolving display name to resource name
+    mock_app = mock.MagicMock()
+    mock_app.name = "projects/test-project/locations/us/apps/123"
+    mock_apps_client.get_app_by_display_name.return_value = mock_app
+
+    # Create a dummy zip file in memory representing the LRO response
+    dummy_zip_io = io.BytesIO()
+    with zipfile.ZipFile(dummy_zip_io, "w") as zf:
+        zf.writestr("123/app.yaml", "name: Test App")
+        zf.writestr("123/agents/agent1.json", "{}")
+    dummy_zip_bytes = dummy_zip_io.getvalue()
+
+    mock_lro = mock.MagicMock()
+    mock_response = mock.MagicMock()
+    mock_response.app_content = dummy_zip_bytes
+    mock_lro.result.return_value = mock_response
+    mock_apps_client.export_app.return_value = mock_lro
+
+    cli_app.app_pull(args)
+
+    mock_apps_client.export_app.assert_called_once_with(
+        app_name="projects/test-project/locations/us/apps/123"
+    )
+    # Check that the files were extracted under the overridden name
+    assert os.path.exists(os.path.join(args.target_dir, "my_custom_folder", "app.yaml"))
+    assert os.path.exists(os.path.join(args.target_dir, "my_custom_folder", "agents", "agent1.json"))
+    # Check that original 123 folder does not exist
+    assert not os.path.exists(os.path.join(args.target_dir, "123"))
+
+
+def test_app_pull_overwrite_with_app_dir_name(
+    mock_apps_client,
+    mock_common_get_project_id,
+    mock_common_get_location,
+    tmp_path,
+):
+    args = argparse.Namespace(
+        app="Test App",
+        target_dir=str(tmp_path / "pulled_app"),
+        app_dir_name="my_custom_folder",
+        project_id="test-project",
+        location="us",
+        overwrite=True,
+    )
+
+    # Mock resolving display name to resource name
+    mock_app = mock.MagicMock()
+    mock_app.name = "projects/test-project/locations/us/apps/123"
+    mock_apps_client.get_app_by_display_name.return_value = mock_app
+
+    # Pre-create the custom folder with an extra file that should be deleted
+    custom_folder = tmp_path / "pulled_app" / "my_custom_folder"
+    os.makedirs(custom_folder / "agents", exist_ok=True)
+    with open(custom_folder / "agents" / "extra_file.json", "w") as f:
+        f.write("{}")
+
+    # Create a dummy zip file in memory representing the LRO response
+    dummy_zip_io = io.BytesIO()
+    with zipfile.ZipFile(dummy_zip_io, "w") as zf:
+        zf.writestr("123/app.yaml", "name: Test App")
+        zf.writestr("123/agents/agent1.json", "{}")
+    dummy_zip_bytes = dummy_zip_io.getvalue()
+
+    mock_lro = mock.MagicMock()
+    mock_response = mock.MagicMock()
+    mock_response.app_content = dummy_zip_bytes
+    mock_lro.result.return_value = mock_response
+    mock_apps_client.export_app.return_value = mock_lro
+
+    cli_app.app_pull(args)
+
+    # Check that the files were extracted under the overridden name
+    assert os.path.exists(os.path.join(args.target_dir, "my_custom_folder", "app.yaml"))
+    assert os.path.exists(os.path.join(args.target_dir, "my_custom_folder", "agents", "agent1.json"))
+    # Check that the extra file was deleted by the overwrite logic
+    assert not os.path.exists(os.path.join(args.target_dir, "my_custom_folder", "agents", "extra_file.json"))
+
+
 def test_app_push(mock_apps_client, tmp_path):
     args = argparse.Namespace(
         app_dir=str(tmp_path),


### PR DESCRIPTION
# PR Description: Add `--app-dir-name` argument to `cxas pull` CLI command

## Summary
This Pull Request introduces a new CLI argument, `--app-dir-name`, to the `cxas pull` command. This allows users to specify a custom folder name for the extracted app, overriding the default behavior which extracts the app into a folder named after the exported app's resource name (or ID).

## Details of Changes
- **CLI parser update** ([src/cxas_scrapi/cli/main.py](file:///Users/raycai/fde/cxas-scrapi/src/cxas_scrapi/cli/main.py)):
  - Registered `--app-dir-name` to `parser_pull`.
- **Implementation logic** ([src/cxas_scrapi/cli/app.py](file:///Users/raycai/fde/cxas-scrapi/src/cxas_scrapi/cli/app.py)):
  - Updated `app_pull` and `_app_pull` to accept the optional `app_dir_name` argument.
  - Intercepted zipfile extraction to dynamically rename `ZipInfo.filename` entries matching the top-level directory (`top_dir`) to `app_dir_name`.
  - Updated overwrite/sync detection logic to use the custom folder name (`app_root`) to ensure that stale files inside the customized directory are correctly identified and cleaned up.
- **Unit testing** ([tests/cxas_scrapi/cli/test_app.py](file:///Users/raycai/fde/cxas-scrapi/tests/cxas_scrapi/cli/test_app.py)):
  - Added `test_app_pull_with_app_dir_name` to test basic extraction into a custom folder.
  - Added `test_app_pull_overwrite_with_app_dir_name` to test file deletion/overwrite logic inside the custom folder.

## Verification
Ran pytest tests successfully:
```bash
.venv/bin/pytest tests/cxas_scrapi/cli/test_app.py
```
Output:
```
======================== 22 passed, 2 warnings in 3.37s ========================
```
