### PR TITLE
feat: add --version-id flag to cxas pull

### DIFF
--- a/src/cxas_scrapi/cli/app.py
+++ b/src/cxas_scrapi/cli/app.py
@@ -98,6 +98,7 @@ def app_pull(args: argparse.Namespace) -> None:
         app_name,
         args.target_dir,
         getattr(args, "overwrite", False),
+        version_id=getattr(args, "version_id", None),
     )
 
 
@@ -106,12 +107,27 @@ def _app_pull(
     app_name: str,
     target_dir: str,
     overwrite: bool = False,
+    version_id: str = None,
 ) -> None:
-    """Helper to pull an app from CXAS."""
+    """Helper to pull an app from CXAS.
+
+    If ``version_id`` is provided, exports that specific version instead of the
+    live app. Accepts either a bare version ID (e.g. ``"0.0.3"``) or a fully
+    qualified resource name (``"projects/.../apps/{app}/versions/{v}"``).
+    """
     try:
         # Export the app
-        print("Exporting app from CXAS...")
-        lro = apps_client.export_app(app_name=app_name)
+        export_kwargs = {"app_name": app_name}
+        if version_id:
+            if "/" in version_id:
+                app_version = version_id
+            else:
+                app_version = f"{app_name}/versions/{version_id}"
+            export_kwargs["app_version"] = app_version
+            print(f"Exporting app from CXAS (version {version_id})...")
+        else:
+            print("Exporting app from CXAS...")
+        lro = apps_client.export_app(**export_kwargs)
         response = lro.result()
 
         # Determine the target directory

--- a/src/cxas_scrapi/cli/main.py
+++ b/src/cxas_scrapi/cli/main.py
@@ -1797,6 +1797,16 @@ def get_parser() -> argparse.ArgumentParser:
             "the exported app will be deleted."
         ),
     )
+    parser_pull.add_argument(
+        "--version-id",
+        default=None,
+        help=(
+            "Optional. Export a specific app version instead of the live app. "
+            "Accepts a bare version ID (e.g. '0.0.3') or a fully qualified "
+            "resource name "
+            "(projects/.../apps/{app}/versions/{version})."
+        ),
+    )
     _add_project_location_args(parser_pull, required=False)
     parser_pull.set_defaults(func=app_pull)
 

--- a/src/cxas_scrapi/core/apps.py
+++ b/src/cxas_scrapi/core/apps.py
@@ -171,6 +171,7 @@ class Apps(Common):
         gcs_uri: str = None,
         local_path: str = None,
         export_format: str = "JSON",
+        app_version: str = None,
     ) -> Any:
         # Wait for long-running operation to complete.
         """Exports the specified app.
@@ -181,6 +182,10 @@ class Apps(Common):
             local_path: Optional. Local file path to write the exported zip
                 archive.
             export_format: The format to export the app in ('JSON' or 'YAML').
+            app_version: Optional. Full resource name of the app version to
+                export, e.g.
+                ``projects/{p}/locations/{l}/apps/{app}/versions/{version}``.
+                If omitted, the live app is exported.
         """
         # Validate that exactly one source is provided if both are given
         if gcs_uri and local_path:
@@ -192,6 +197,7 @@ class Apps(Common):
             name=app_name,
             gcs_uri=gcs_uri if gcs_uri else None,
             export_format=export_format,
+            app_version=app_version,
         )
 
         operation = self.client.export_app(request=request)

--- a/tests/cxas_scrapi/cli/test_app.py
+++ b/tests/cxas_scrapi/cli/test_app.py
@@ -191,6 +191,106 @@ def test_app_pull(
     assert os.path.exists(os.path.join(args.target_dir, "app.yaml"))
 
 
+def _make_pull_zip_response(mock_apps_client):
+    """Helper to wire mock_apps_client.export_app to return a dummy zip LRO."""
+    dummy_zip_io = io.BytesIO()
+    with zipfile.ZipFile(dummy_zip_io, "w") as zf:
+        zf.writestr("app.yaml", "name: Test App")
+    mock_lro = mock.MagicMock()
+    mock_response = mock.MagicMock()
+    mock_response.app_content = dummy_zip_io.getvalue()
+    mock_lro.result.return_value = mock_response
+    mock_apps_client.export_app.return_value = mock_lro
+
+
+def test_app_pull_with_version_id_bare(
+    mock_apps_client,
+    mock_common_get_project_id,
+    mock_common_get_location,
+    tmp_path,
+):
+    """Bare --version-id is expanded to a full resource name on the request."""
+    args = argparse.Namespace(
+        app="Test App",
+        target_dir=str(tmp_path / "pulled_app"),
+        project_id="test-project",
+        location="us",
+        version_id="0.0.3",
+    )
+    mock_app = mock.MagicMock()
+    mock_app.name = "projects/test-project/locations/us/apps/123"
+    mock_apps_client.get_app_by_display_name.return_value = mock_app
+    _make_pull_zip_response(mock_apps_client)
+
+    cli_app.app_pull(args)
+
+    mock_apps_client.export_app.assert_called_once_with(
+        app_name="projects/test-project/locations/us/apps/123",
+        app_version=(
+            "projects/test-project/locations/us/apps/123/versions/0.0.3"
+        ),
+    )
+
+
+def test_app_pull_with_version_id_full_resource_name(
+    mock_apps_client,
+    mock_common_get_project_id,
+    mock_common_get_location,
+    tmp_path,
+):
+    """A fully qualified --version-id is passed through unchanged."""
+    full_version = (
+        "projects/test-project/locations/us/apps/123/versions/0.0.3"
+    )
+    args = argparse.Namespace(
+        app="Test App",
+        target_dir=str(tmp_path / "pulled_app"),
+        project_id="test-project",
+        location="us",
+        version_id=full_version,
+    )
+    mock_app = mock.MagicMock()
+    mock_app.name = "projects/test-project/locations/us/apps/123"
+    mock_apps_client.get_app_by_display_name.return_value = mock_app
+    _make_pull_zip_response(mock_apps_client)
+
+    cli_app.app_pull(args)
+
+    mock_apps_client.export_app.assert_called_once_with(
+        app_name="projects/test-project/locations/us/apps/123",
+        app_version=full_version,
+    )
+
+
+def test_app_pull_without_version_id_omits_app_version(
+    mock_apps_client,
+    mock_common_get_project_id,
+    mock_common_get_location,
+    tmp_path,
+):
+    """When --version-id is not provided, export_app is called without it.
+
+    Guards against regressing the live-app pull path.
+    """
+    args = argparse.Namespace(
+        app="Test App",
+        target_dir=str(tmp_path / "pulled_app"),
+        project_id="test-project",
+        location="us",
+        version_id=None,
+    )
+    mock_app = mock.MagicMock()
+    mock_app.name = "projects/test-project/locations/us/apps/123"
+    mock_apps_client.get_app_by_display_name.return_value = mock_app
+    _make_pull_zip_response(mock_apps_client)
+
+    cli_app.app_pull(args)
+
+    mock_apps_client.export_app.assert_called_once_with(
+        app_name="projects/test-project/locations/us/apps/123"
+    )
+
+
 def test_app_push(mock_apps_client, tmp_path):
     args = argparse.Namespace(
         app_dir=str(tmp_path),

--- a/tests/cxas_scrapi/cli/test_main.py
+++ b/tests/cxas_scrapi/cli/test_main.py
@@ -39,6 +39,43 @@ def test_get_parser():
     assert args.location == "us"
 
 
+def test_get_parser_pull_with_version_id():
+    """Parser accepts --version-id on the pull subcommand."""
+    parser = get_parser()
+    args = parser.parse_args(
+        [
+            "pull",
+            "Test App",
+            "--version-id",
+            "0.0.3",
+            "--project-id",
+            "test-project",
+            "--location",
+            "us",
+        ]
+    )
+    assert args.command == "pull"
+    assert args.app == "Test App"
+    assert args.version_id == "0.0.3"
+
+
+def test_get_parser_pull_without_version_id():
+    """--version-id is optional; defaults to None."""
+    parser = get_parser()
+    args = parser.parse_args(
+        [
+            "pull",
+            "Test App",
+            "--project-id",
+            "test-project",
+            "--location",
+            "us",
+        ]
+    )
+    assert args.command == "pull"
+    assert args.version_id is None
+
+
 def test_get_parser_llm_lint():
     """Test that the parser can parse the llm-lint command."""
     parser = get_parser()

--- a/tests/cxas_scrapi/core/test_apps.py
+++ b/tests/cxas_scrapi/core/test_apps.py
@@ -283,6 +283,49 @@ def test_export_app_validation(mock_client_cls):
         )
 
 
+@patch("cxas_scrapi.core.apps.types.ExportAppRequest")
+@patch("cxas_scrapi.core.apps.AgentServiceClient")
+def test_export_app_with_app_version(mock_client_cls, mock_export_app_req):
+    """app_version is forwarded to ExportAppRequest as the full resource name."""
+    apps_client = Apps(
+        project_id="mock-project", location="us", creds=MagicMock()
+    )
+    mock_operation = MagicMock()
+    apps_client.client.export_app.return_value = mock_operation
+
+    version_name = (
+        "projects/mock-project/locations/us/apps/test-app/versions/0.0.3"
+    )
+    result = apps_client.export_app(
+        app_name="projects/mock-project/locations/us/apps/test-app",
+        app_version=version_name,
+    )
+
+    kwargs = mock_export_app_req.call_args[1]
+    assert kwargs.get("app_version") == version_name
+    assert (
+        kwargs.get("name") == "projects/mock-project/locations/us/apps/test-app"
+    )
+    assert result == mock_operation
+
+
+@patch("cxas_scrapi.core.apps.types.ExportAppRequest")
+@patch("cxas_scrapi.core.apps.AgentServiceClient")
+def test_export_app_without_app_version(mock_client_cls, mock_export_app_req):
+    """Omitting app_version produces a request without it (live-app export)."""
+    apps_client = Apps(
+        project_id="mock-project", location="us", creds=MagicMock()
+    )
+    apps_client.client.export_app.return_value = MagicMock()
+
+    apps_client.export_app(
+        app_name="projects/mock-project/locations/us/apps/test-app",
+    )
+
+    kwargs = mock_export_app_req.call_args[1]
+    assert kwargs.get("app_version") is None
+
+
 @patch("cxas_scrapi.core.apps.types.UpdateAppRequest")
 @patch("cxas_scrapi.core.apps.AgentServiceClient")
 def test_update_app_sparse(mock_client_cls, mock_update_app_req):


### PR DESCRIPTION
# Add `--version-id` argument to `cxas pull` CLI command

Closes #252.

## Summary

Adds an optional `--version-id` flag to `cxas pull` so users (and CI/CD pipelines) can deterministically export a specific, immutable app version instead of whatever the live app happens to look like at the moment of the call. The underlying `ces.v1beta.ExportAppRequest` proto already exposes an `app_version` field — this PR plumbs it through `Apps.export_app`, `_app_pull` / `app_pull`, and the `pull` subparser.

```bash
# Existing (unchanged): live app
cxas pull "Support Agent" --project-id p --location us

# New: pin to a specific version (bare ID)
cxas pull "Support Agent" --version-id 0.0.3 --project-id p --location us

# New: pin to a specific version (full resource name, e.g. from `cxas versions list`)
cxas pull "Support Agent" \
  --version-id projects/p/locations/us/apps/123/versions/0.0.3 \
  --project-id p --location us
```

Bare IDs are expanded to `{app_name}/versions/{version_id}` using the resolved app resource name — matching the convention already used by `cxas versions get/delete/revert`. Fully qualified resource names are passed through unchanged.

## Details of Changes

- **CLI parser update** (`src/cxas_scrapi/cli/main.py`):
  - Registered `--version-id` on `parser_pull` (optional, defaults to `None`).
- **CLI implementation** (`src/cxas_scrapi/cli/app.py`):
  - `app_pull` reads `args.version_id` and forwards it to `_app_pull`.
  - `_app_pull` accepts `version_id`; expands bare IDs to a full resource name when needed and passes `app_version` to `Apps.export_app`. When the flag is omitted the existing live-app path is preserved exactly.
- **Core SDK** (`src/cxas_scrapi/core/apps.py`):
  - `Apps.export_app` accepts an optional `app_version` kwarg and forwards it to `types.ExportAppRequest`.
- **Unit tests** (added):
  - `tests/cxas_scrapi/core/test_apps.py`: `test_export_app_with_app_version`, `test_export_app_without_app_version`.
  - `tests/cxas_scrapi/cli/test_app.py`: `test_app_pull_with_version_id_bare`, `test_app_pull_with_version_id_full_resource_name`, `test_app_pull_without_version_id_omits_app_version`.
  - `tests/cxas_scrapi/cli/test_main.py`: `test_get_parser_pull_with_version_id`, `test_get_parser_pull_without_version_id`.

## Verification

Built tests TDD-style (failing tests first, then minimal implementation):

```bash
python -m pytest tests/cxas_scrapi/cli/test_app.py \
                 tests/cxas_scrapi/cli/test_main.py \
                 tests/cxas_scrapi/core/test_apps.py
# ======================== 48 passed, 4 warnings in 18.06s ========================
```

Full non-migration suite (754 passed) is green. Migration tests have pre-existing failures on `main` unrelated to this change (verified via `git stash`).

## Notes

- No proto / server-side changes required — the API already supports it; this PR is pure CLI/SDK plumbing.
- Backward compatible: existing `cxas pull` invocations are unaffected; the new flag is optional.