### PR TITLE
fix: fix goal progress status on session end in SimulationEvals

### DIFF
--- a/src/cxas_scrapi/evals/simulation_evals.py
+++ b/src/cxas_scrapi/evals/simulation_evals.py
@@ -547,6 +547,9 @@ class SimulationEvals(Apps):
             if session_ended:
                 if agent_text:
                     eval_conv._add_agent_response(agent_text)
+                # Ensure the final agent response is evaluated
+                # so that steps_progress is updated on session end.
+                eval_conv._next_user_utterance()
                 if console_logging:
                     print(
                         "\nSession has been closed by the Agent via "

--- a/tests/cxas_scrapi/evals/test_simulation_evals.py
+++ b/tests/cxas_scrapi/evals/test_simulation_evals.py
@@ -1038,6 +1038,8 @@ def test_simulation_evals_adds_final_agent_response_on_session_ended(
     mock_eval_conv._add_agent_response.assert_any_call(
         "Transferring to associate now."
     )
+    # Verify that final agent response triggers evaluation
+    mock_eval_conv._next_user_utterance.assert_called_once()
 
 
 @patch("cxas_scrapi.evals.simulation_evals.Sessions")


### PR DESCRIPTION
When the agent closed the session (triggering session_ended), the simulation loop terminated immediately. While the final agent response was recorded to the transcript, the step progress was not evaluated on the final turn. This left the final goal status stuck in "In Progress" in the evaluation report even when the success criteria had been met.

This change invokes the existing private `_next_user_utterance` method on session end. This ensures the LLM evaluator analyzes the final conversation turn to update the steps progress status before the loop exits.

Tested:
Command  `pytest tests/cxas_scrapi/evals/test_simulation_evals.py`
Result
```
============================= test session starts ==============================
platform linux -- Python 3.13.12, pytest-9.0.3, pluggy-1.6.0
rootdir: 
configfile: pytest.ini
plugins: anyio-4.13.0, asyncio-1.4.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collecting ...
collecting 1 item
collected 36 items
tests/cxas_scrapi/evals/test_simulation_evals.py
.............                                                            [100%]
============================== 36 passed in 3.01s ==============================```
