### PR TITLE
feat: add --no-app-folder option to cxas pull

### DIFF
--- a/src/cxas_scrapi/cli/app.py
+++ b/src/cxas_scrapi/cli/app.py
@@ -98,6 +98,7 @@ def app_pull(args: argparse.Namespace) -> None:
         app_name,
         args.target_dir,
         getattr(args, "overwrite", False),
+        getattr(args, "no_app_folder", False),
     )
 
 
@@ -106,6 +107,7 @@ def _app_pull(
     app_name: str,
     target_dir: str,
     overwrite: bool = False,
+    no_app_folder: bool = False,
 ) -> None:
     """Helper to pull an app from CXAS."""
     try:
@@ -121,13 +123,29 @@ def _app_pull(
         # Extract content to target directory.
         with zipfile.ZipFile(io.BytesIO(response.app_content)) as z:
             export_members = z.namelist()
-            z.extractall(target_dir)
+            if no_app_folder and export_members:
+                top_dir = export_members[0].split("/")[0]
+                for info in z.infolist():
+                    if (
+                        info.filename == top_dir
+                        or info.filename == top_dir + "/"
+                    ):
+                        continue
+                    if info.filename.startswith(top_dir + "/"):
+                        info.filename = info.filename[len(top_dir) + 1 :]
+                    z.extract(info, path=target_dir)
+            else:
+                z.extractall(target_dir)
 
         # Handle overwrite logic if requested
         if overwrite and export_members:
             # Find the top level directory name in the zip (app name)
             top_dir = export_members[0].split("/")[0]
-            app_root = os.path.join(target_dir, top_dir)
+            app_root = (
+                target_dir
+                if no_app_folder
+                else os.path.join(target_dir, top_dir)
+            )
 
             if os.path.exists(app_root):
                 # Build set of exported paths relative to app_root

--- a/src/cxas_scrapi/cli/main.py
+++ b/src/cxas_scrapi/cli/main.py
@@ -1805,6 +1805,14 @@ def get_parser() -> argparse.ArgumentParser:
             "the exported app will be deleted."
         ),
     )
+    parser_pull.add_argument(
+        "--no-app-folder",
+        action="store_true",
+        help=(
+            "Do not create a subdirectory with the app's name; extract "
+            "contents directly into target-dir."
+        ),
+    )
     _add_project_location_args(parser_pull, required=False)
     parser_pull.set_defaults(func=app_pull)
 

--- a/tests/cxas_scrapi/cli/test_app.py
+++ b/tests/cxas_scrapi/cli/test_app.py
@@ -191,6 +191,105 @@ def test_app_pull(
     assert os.path.exists(os.path.join(args.target_dir, "app.yaml"))
 
 
+def test_app_pull_no_app_folder(
+    mock_apps_client,
+    mock_common_get_project_id,
+    mock_common_get_location,
+    tmp_path,
+):
+    args = argparse.Namespace(
+        app="Test App",
+        target_dir=str(tmp_path / "pulled_app"),
+        no_app_folder=True,
+        project_id="test-project",
+        location="us",
+    )
+
+    # Mock resolving display name to resource name
+    mock_app = mock.MagicMock()
+    mock_app.name = "projects/test-project/locations/us/apps/123"
+    mock_apps_client.get_app_by_display_name.return_value = mock_app
+
+    # Create a dummy zip file nested under app ID directory
+    dummy_zip_io = io.BytesIO()
+    with zipfile.ZipFile(dummy_zip_io, "w") as zf:
+        zf.writestr("123/app.yaml", "name: Test App")
+        zf.writestr("123/agents/agent1.json", "{}")
+    dummy_zip_bytes = dummy_zip_io.getvalue()
+
+    mock_lro = mock.MagicMock()
+    mock_response = mock.MagicMock()
+    mock_response.app_content = dummy_zip_bytes
+    mock_lro.result.return_value = mock_response
+    mock_apps_client.export_app.return_value = mock_lro
+
+    cli_app.app_pull(args)
+
+    mock_apps_client.export_app.assert_called_once_with(
+        app_name="projects/test-project/locations/us/apps/123"
+    )
+    # Check that the files were extracted directly under target_dir (pulled_app)
+    assert os.path.exists(os.path.join(args.target_dir, "app.yaml"))
+    assert os.path.exists(
+        os.path.join(args.target_dir, "agents", "agent1.json")
+    )
+    # Check that the nesting 123 folder does not exist
+    assert not os.path.exists(os.path.join(args.target_dir, "123"))
+
+
+def test_app_pull_overwrite_no_app_folder(
+    mock_apps_client,
+    mock_common_get_project_id,
+    mock_common_get_location,
+    tmp_path,
+):
+    args = argparse.Namespace(
+        app="Test App",
+        target_dir=str(tmp_path / "pulled_app"),
+        no_app_folder=True,
+        project_id="test-project",
+        location="us",
+        overwrite=True,
+    )
+
+    # Mock resolving display name to resource name
+    mock_app = mock.MagicMock()
+    mock_app.name = "projects/test-project/locations/us/apps/123"
+    mock_apps_client.get_app_by_display_name.return_value = mock_app
+
+    # Pre-create a file in a subdirectory that should be deleted during
+    # overwrite logic
+    agents_dir = tmp_path / "pulled_app" / "agents"
+    os.makedirs(agents_dir, exist_ok=True)
+    with open(agents_dir / "extra_file.json", "w") as f:
+        f.write("{}")
+
+    # Create a dummy zip file nested under app ID directory
+    dummy_zip_io = io.BytesIO()
+    with zipfile.ZipFile(dummy_zip_io, "w") as zf:
+        zf.writestr("123/app.yaml", "name: Test App")
+        zf.writestr("123/agents/agent1.json", "{}")
+    dummy_zip_bytes = dummy_zip_io.getvalue()
+
+    mock_lro = mock.MagicMock()
+    mock_response = mock.MagicMock()
+    mock_response.app_content = dummy_zip_bytes
+    mock_lro.result.return_value = mock_response
+    mock_apps_client.export_app.return_value = mock_lro
+
+    cli_app.app_pull(args)
+
+    # Check that the files were extracted directly under target_dir (pulled_app)
+    assert os.path.exists(os.path.join(args.target_dir, "app.yaml"))
+    assert os.path.exists(
+        os.path.join(args.target_dir, "agents", "agent1.json")
+    )
+    # Check that the extra file was deleted by the overwrite logic
+    assert not os.path.exists(
+        os.path.join(args.target_dir, "agents", "extra_file.json")
+    )
+
+
 def test_app_push(mock_apps_client, tmp_path):
     args = argparse.Namespace(
         app_dir=str(tmp_path),


### PR DESCRIPTION
# PR Description: Add `--no-app-folder` argument to `cxas pull` CLI command

## Summary
This Pull Request introduces a new CLI argument, `--no-app-folder`, to the `cxas pull` command. This allows users to extract the contents of an exported app directly into the specified target directory without nesting it inside a subfolder named after the app.

## Details of Changes
- **CLI parser update** ([src/cxas_scrapi/cli/main.py](file:///Users/raycai/fde/cxas-scrapi/src/cxas_scrapi/cli/main.py)):
  - Registered `--no-app-folder` as a boolean option (`action="store_true"`) to `parser_pull`.
- **Implementation logic** ([src/cxas_scrapi/cli/app.py](file:///Users/raycai/fde/cxas-scrapi/src/cxas_scrapi/cli/app.py)):
  - Updated `app_pull` and `_app_pull` to accept the `no_app_folder` flag.
  - When `no_app_folder` is `True`, the zip archive's top-level subdirectory path prefix (e.g., `123/`) is stripped during extraction.
  - Adjusted `app_root` to target the base `target_dir` instead of `target_dir/top_dir`, allowing the overwrite/cleanup logic to cleanly scan for non-exported files inside target subdirectories (like `agents/` and `tools/`).
- **Unit testing** ([tests/cxas_scrapi/cli/test_app.py](file:///Users/raycai/fde/cxas-scrapi/tests/cxas_scrapi/cli/test_app.py)):
  - Added `test_app_pull_no_app_folder` to test direct extraction when pulling.
  - Added `test_app_pull_overwrite_no_app_folder` to ensure that stale files under extracted subdirectories are correctly deleted when `--overwrite` and `--no-app-folder` are combined.

## Verification
Ran pytest tests successfully:
```bash
.venv/bin/pytest tests/cxas_scrapi/cli/test_app.py
```
Output:
```
======================== 22 passed, 2 warnings in 3.04s ========================
```
