### PR TITLE
docs(cli): add llm-lint documentation and interactive help subcommand

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,9 @@ This workspace provides several specialized AI skills to assist with development
 
 ## CLI Features
 
-- **`cxas llm-lint`**: An AI-driven semantic linter for GECX sub-agent instructions. It reviews natural language rules and style guidelines using Gemini for a single sub-agent at a time. Run `cxas llm-lint --help` for details.
+- **`cxas help`**: Interactive terminal help documentation detailing all available CLI commands and sub-commands. Example: `cxas help llm-lint`.
+- **`cxas lint`**: Fast, deterministic static structural linter across 60+ structural, configuration, callback naming, and CES schema checks. Run this continuously while coding or in Git pre-commit hooks to ensure absolute structural validity before deployment.
+- **`cxas llm-lint`**: An AI-driven semantic prompt linter for GECX sub-agent instructions. Uses Gemini to deeply review natural language rules, tone, persona consistency, and dynamic instructions (`before_agent_callbacks`) for a single sub-agent at a time. Run this when authoring prompts or preparing qualitative reviews. Example: `cxas llm-lint --agent-dir <dir>`.
 - **`cxas trace search`**: Find conversations whose transcript contains a query, mirroring the console search box. Uses the server-side `ces_transcript.search(...)` full-text function (case-insensitive, substring/prefix; searches the user + agent transcript only). Use `--match {phrase,all,any}` for multi-word handling and `--snippets` to show highlighted excerpts. Example: `cxas trace search "app crashing" --app-name <app> --match all --snippets`. Run `cxas trace search --help` for details.
 
 *Note: For detailed development workflows, linter policies, and GECX-specific conventions, refer to the documentation within the respective skills (e.g., `.agents/skills/cxas-agent-foundry/SKILL.md`).*

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -54,7 +54,23 @@ When you pass a display name (e.g., `"My Support Agent"`) instead of a resource 
 | [`cxas ci-test`](ci-test.md) | Run the full CI test lifecycle against a temporary app. |
 | [`cxas local-test`](local-test.md) | Run the CI test lifecycle inside a local Docker container. |
 | [`cxas init-github-action`](init-github-action.md) | Generate a GitHub Actions workflow file for your agent. |
-| [`cxas lint`](lint.md) | Lint your app directory for best-practice violations. |
+| [`cxas lint`](lint.md) | Fast, deterministic structural and configuration linter across 60+ rules. |
+| [`cxas llm-lint`](llm-lint.md) | AI-driven semantic natural language prompt linter for sub-agent instructions using Gemini. |
+| [`cxas help`](index.md) | Show detailed help for the CLI or any specific subcommand. |
 | [`cxas init`](init.md) | Bootstrap a project with AI agent development skills. |
 | [`cxas insights`](insights.md) | Manage QA scorecards via the Insights API. |
 | [`cxas trace`](trace.md) | Inspect, analyze, and report on individual conversations (deployed/build/eval) — list, fetch report, merge Cloud Logs, download/analyze audio with Gemini, replay against current agent, aggregate stats, and flag platform bugs. |
+
+---
+
+## Static Linting vs AI Semantic Linting
+
+CXAS provides two complementary linting tools designed for different stages of your development workflow:
+
+1. **`cxas lint` (Static Structural Linter)**
+   - **What it does:** Runs deterministic checks against file layouts, YAML/JSON schemas, `app.yaml`/`app.json` configs, callback naming conventions, and basic instruction lengths.
+   - **When to run:** Continuously while coding, inside Git pre-commit hooks, and as a fast initial gate in local/CI test pipelines.
+
+2. **`cxas llm-lint` (AI Semantic Linter)**
+   - **What it does:** Uses Gemini to review the *actual meaning, tone, persona adherence, and logical consistency* of your natural language prompts (`instruction.txt`, `global_instruction.txt`, and dynamic state instructions in `before_agent_callbacks`).
+   - **When to run:** When authoring or refactoring prompt engineering instructions, conducting thorough prompt quality reviews, or preparing for high-stakes production deployments.

--- a/docs/cli/lint.md
+++ b/docs/cli/lint.md
@@ -114,6 +114,7 @@ cxas lint --json | jq 'if length > 0 then error else empty end'
 
 ## Related Commands
 
+- [`cxas llm-lint`](llm-lint.md) — AI-driven semantic prompt linter using Gemini. While `cxas lint` enforces deterministic structural, schema, and configuration rules across your directory tree, `cxas llm-lint` deeply analyzes the actual human language meaning, tone, persona consistency, and logical clarity of your sub-agent prompts.
 - [`cxas init`](init.md) — Bootstrap a project with the skills and configs that help you write lint-clean agents.
 - [`cxas push`](push.md) — Push your linted app to CX Agent Studio.
 - [`cxas ci-test`](ci-test.md) — Full CI lifecycle (add `cxas lint` as a step before `cxas ci-test` for maximum coverage).

--- a/docs/cli/llm-lint.md
+++ b/docs/cli/llm-lint.md
@@ -1,0 +1,78 @@
+# cxas llm-lint
+
+`cxas llm-lint` is an AI-driven semantic prompt linter that uses Gemini to review natural language rules, tone, persona consistency, style guidelines, and logical contradictions across your GECX sub-agent instructions.
+
+Unlike traditional static linters, `cxas llm-lint` understands the intent and nuances of human language, helping you craft robust, high-quality prompt engineering before deploying your conversational agents.
+
+---
+
+## Static Linting (`cxas lint`) vs AI Semantic Linting (`cxas llm-lint`)
+
+When developing agents in CX Agent Studio, you should use both linters at different stages of your workflow:
+
+| Feature | `cxas lint` (Static Structural Linter) | `cxas llm-lint` (AI Semantic Linter) |
+| :--- | :--- | :--- |
+| **Primary Focus** | File layout, YAML/JSON schemas, `app.yaml`/`app.json` configs, callback names, missing mandatory files. | Semantic meaning, clarity, persona adherence, tone, edge-case handling, logical prompt contradictions. |
+| **Mechanism** | Deterministic rule engine across 60+ static structural checks. | Advanced LLM analysis using Google Gemini (`gemini-2.5-flash` by default). |
+| **Speed** | Instantaneous (< 1 second). | A few seconds per agent/callback state. |
+| **Target Scope** | Entire application directory or individual components. | A single sub-agent directory (`instruction.txt`, `global_instruction.txt`, dynamic callbacks). |
+| **When to Run** | **Continuously** while authoring files, inside pre-commit hooks, and as an automated CI fast-fail gate. | **Iteratively** when writing/refactoring prompts, before peer code reviews, or during qualitative QA. |
+
+---
+
+## Usage
+
+```bash
+cxas llm-lint --agent-dir DIR
+              [--project-id ID]
+              [--location REGION]
+              [--model MODEL_NAME]
+              [--output FILE_PATH]
+```
+
+## Options
+
+| Option | Required | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `--agent-dir DIR` | **Yes** | — | Path to the specific sub-agent directory containing `instruction.txt`. |
+| `--project-id ID` | No | Auto-detected | GCP Project ID for Vertex AI Gemini queries. If omitted, checks environment variables or `gecx-config.json`. |
+| `--location REGION` | No | `us-central1` | GCP region for Vertex AI endpoints. |
+| `--model MODEL_NAME` | No | `gemini-2.5-flash` | Gemini model name to use for semantic analysis. |
+| `--output FILE_PATH`| No | `<agent_dir>/llm_lint_report.md` | Optional path to save the generated Markdown lint report. |
+
+---
+
+## How It Works
+
+When you invoke `cxas llm-lint` on a sub-agent directory, the tool performs a multi-stage semantic analysis:
+
+1. **Context Resolution:** Automatically walks up the directory tree to discover `global_instruction.txt` (if present) so Gemini understands overarching platform constraints and brand guidelines.
+2. **Base Prompt Review:** Deeply analyzes the sub-agent's primary `instruction.txt` against standard conversational AI best practices (such as avoiding negative prompts, ensuring clear turn-taking, and verifying robust escalation pathways).
+3. **Dynamic State Machine Review:** Discovers any dynamic state instructions defined inside Python callback files (`before_agent_callbacks`, `after_agent_callbacks`, etc.). It parses the Python abstract syntax tree (AST) to extract state-machine dictionary mappings and individually reviews each dynamic instruction state.
+4. **Architecture Guardrails:** Warns developers if dynamic prompt instructions are placed in non-standard callbacks outside of `before_agent_callbacks`.
+
+---
+
+## Examples
+
+### 1. Lint a Sub-Agent's Base Instructions
+Run a semantic check on the `support` sub-agent:
+
+```bash
+cxas llm-lint --agent-dir ./my-app/agents/support
+```
+*Outputs actionable critique to stdout and writes a full structured report to `./my-app/agents/support/llm_lint_report.md`.*
+
+### 2. Use a Advanced Model Tier
+For extremely complex reasoning or subtle tone checks, run with Gemini Pro or Flash Premium:
+
+```bash
+cxas llm-lint --agent-dir ./my-app/agents/billing --model gemini-2.5-pro
+```
+
+### 3. Specify a Custom Output Report Path
+Export the semantic analysis report directly to your team's QA artifacts directory:
+
+```bash
+cxas llm-lint --agent-dir ./my-app/agents/triage --output ./reports/triage_semantic_lint.md
+```

--- a/docs/patterns/index.md
+++ b/docs/patterns/index.md
@@ -61,7 +61,7 @@ deterministic, auditable, and testable.
 
 If you're new to SCRAPI, start with the [Slot Filling](slot-filling.md) pattern
 and the [Restaurant Reservation Tutorial](../tutorials/restaurant-reservation.md).
-The [`examples/bella_notte/`](../examples/bella_notte/) directory contains a
+The [`examples/bella_notte/`](https://github.com/GoogleCloudPlatform/cxas-scrapi/tree/main/examples/bella_notte/) directory contains a
 complete reference implementation.
 
 ---

--- a/docs/tutorials/restaurant-reservation.md
+++ b/docs/tutorials/restaurant-reservation.md
@@ -153,7 +153,7 @@ You are operating in SLOT FILLING mode. Follow these rules strictly:
 ```
 
 !!! warning "The concrete example is load-bearing"
-    The sentence *"if the user says 'table for 2 on June 20th under the name Johnson', call set_party_size, set_preferred_date, AND set_guest_name — all in one turn"* is what drives multi-slot batching. Removing it or making it abstract drops batching reliability significantly. See [Gotcha 3](../patterns/slot-filling.md#3-missing-concrete-example-in-the-batching-instruction) in the slot filling pattern.
+    The sentence *"if the user says 'table for 2 on June 20th under the name Johnson', call set_party_size, set_preferred_date, AND set_guest_name — all in one turn"* is what drives multi-slot batching. Removing it or making it abstract drops batching reliability significantly. See [Gotcha 3](../patterns/slot-filling.md#the-7-stabilization-gotchas) in the slot filling pattern.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -233,6 +233,7 @@ nav:
     - cxas llm-lint: cli/llm-lint.md
     - cxas init: cli/init.md
     - cxas insights: cli/insights.md
+    - cxas trace: cli/trace.md
   - API Reference:
     - api/index.md
     - Core:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -230,6 +230,7 @@ nav:
     - cxas local-test: cli/local-test.md
     - cxas init-github-action: cli/init-github-action.md
     - cxas lint: cli/lint.md
+    - cxas llm-lint: cli/llm-lint.md
     - cxas init: cli/init.md
     - cxas insights: cli/insights.md
   - API Reference:

--- a/src/cxas_scrapi/cli/main.py
+++ b/src/cxas_scrapi/cli/main.py
@@ -1072,21 +1072,24 @@ def cmd_help(args: argparse.Namespace) -> None:
 
 def get_parser() -> argparse.ArgumentParser:
     """Sets up the argument parser."""
-    description = """CXAS SCRAPI Command Line Interface — Full CI/CD & Agent Management Suite
-
-The cxas CLI puts the full power of CX Agent Studio in your terminal: pull/push apps, run evaluations, manage versions, analyze conversation traces, and lint configurations or natural language prompts.
-
---- Key Verification & Linting Tools — When to Run Which ---
-
-• cxas lint     : Fast, deterministic structural & configuration linter.
-                  Validates directory layout, YAML/JSON schemas, app.yaml/app.json correctness, and basic structure.
-                  When to run: Continuously during development, in pre-commit hooks, and as a first CI gate.
-
-• cxas llm-lint : AI-driven semantic natural language prompt linter using Gemini.
-                  Deeply analyzes natural language instructions (instruction.txt, global_instruction.txt,
-                  and dynamic state callbacks) for clarity, tone, persona adherence, and logical contradictions.
-                  When to run: When authoring or refactoring prompt engineering, before code reviews,
-                  or during qualitative prompt evaluations."""
+    description = (
+        "CXAS SCRAPI Command Line Interface — Full CI/CD Suite\n\n"
+        "The cxas CLI puts the full power of CX Agent Studio in your\n"
+        "terminal: pull/push apps, run evals, manage versions, analyze\n"
+        "conversation traces, and lint configurations or prompts.\n\n"
+        "--- Key Verification & Linting Tools — When to Run Which ---\n\n"
+        "• cxas lint     : Fast, deterministic structural linter.\n"
+        "                  Validates directory layout, YAML/JSON schemas,\n"
+        "                  app.yaml/app.json correctness, & basic structure.\n"
+        "                  When to run: Continuously during development,\n"
+        "                  in pre-commit hooks, and as a first CI gate.\n\n"
+        "• cxas llm-lint : AI semantic natural language prompt linter.\n"
+        "                  Analyzes instructions (instruction.txt,\n"
+        "                  global_instruction.txt, & dynamic callbacks)\n"
+        "                  for clarity, tone, persona, & contradictions.\n"
+        "                  When to run: When authoring prompt engineering,\n"
+        "                  before code reviews, or during qualitative QA."
+    )
 
     parser = argparse.ArgumentParser(
         description=description,

--- a/src/cxas_scrapi/cli/main.py
+++ b/src/cxas_scrapi/cli/main.py
@@ -1058,10 +1058,38 @@ def deployments_promote(args: argparse.Namespace) -> None:
         sys.exit(1)
 
 
+def cmd_help(args: argparse.Namespace) -> None:
+    """Handles the 'help' command."""
+    parser = get_parser()
+    if getattr(args, "help_command", None):
+        try:
+            parser.parse_args([args.help_command, "--help"])
+        except SystemExit:
+            pass
+    else:
+        parser.print_help()
+
+
 def get_parser() -> argparse.ArgumentParser:
     """Sets up the argument parser."""
+    description = """CXAS SCRAPI Command Line Interface — Full CI/CD & Agent Management Suite
+
+The cxas CLI puts the full power of CX Agent Studio in your terminal: pull/push apps, run evaluations, manage versions, analyze conversation traces, and lint configurations or natural language prompts.
+
+--- Key Verification & Linting Tools — When to Run Which ---
+
+• cxas lint     : Fast, deterministic structural & configuration linter.
+                  Validates directory layout, YAML/JSON schemas, app.yaml/app.json correctness, and basic structure.
+                  When to run: Continuously during development, in pre-commit hooks, and as a first CI gate.
+
+• cxas llm-lint : AI-driven semantic natural language prompt linter using Gemini.
+                  Deeply analyzes natural language instructions (instruction.txt, global_instruction.txt,
+                  and dynamic state callbacks) for clarity, tone, persona adherence, and logical contradictions.
+                  When to run: When authoring or refactoring prompt engineering, before code reviews,
+                  or during qualitative prompt evaluations."""
+
     parser = argparse.ArgumentParser(
-        description="CXAS SCRAPI Evaluation Runner for CI/CD.",
+        description=description,
         formatter_class=argparse.RawTextHelpFormatter,
     )
 
@@ -1969,6 +1997,17 @@ def get_parser() -> argparse.ArgumentParser:
         help="Optional path to write the markdown lint report.",
     )
     parser_llm_lint.set_defaults(func=llm_lint)
+
+    # Parser for 'help'
+    parser_help = subparsers.add_parser(
+        "help", help="Show help for the CLI or a specific command."
+    )
+    parser_help.add_argument(
+        "help_command",
+        nargs="?",
+        help="The command to show help for (e.g., lint, llm-lint, run).",
+    )
+    parser_help.set_defaults(func=cmd_help)
 
     # Parser for 'init'
     parser_init = subparsers.add_parser(

--- a/src/cxas_scrapi/utils/eval_utils.py
+++ b/src/cxas_scrapi/utils/eval_utils.py
@@ -68,7 +68,7 @@ class Conversations(BaseModel):
 class EvalUtils(Evaluations):
     """Utility class for processing and exporting CXAS Evaluation Results."""
 
-    def __init__(self, app_name: str, env: str = "PROD", **kwargs):
+    def __init__(self, app_name: str, env: str = "PROD", **kwargs: Any):
         """Initializes the EvalUtils class for processing Evaluation Results.
 
         Args:


### PR DESCRIPTION
Incorporates full llm-lint documentation, introduces the interactive cxas help subcommand, and contrasts static structural linting vs AI semantic prompt linting.