### PR TITLE
fix(linter): False positive V006 linter error on deterministic golden evaluations

### DIFF
--- a/src/cxas_scrapi/utils/lint_rules/schema.py
+++ b/src/cxas_scrapi/utils/lint_rules/schema.py
@@ -290,6 +290,14 @@ class SchemaValid(Rule):
             if key.startswith("_comment_"):
                 data.pop(key)
 
+        # For evaluations, if it's a golden/deterministic evaluation,
+        # bypass scenario validation
+        if self.target == "evaluation_config" and (
+            "golden" in data or "Golden" in data
+        ):
+            data.pop("scenario", None)
+            data.pop("Scenario", None)
+
         try:
             _validate_fields(data, self._proto_type, path=str(resource_dir))
         except ValueError as e:

--- a/src/cxas_scrapi/utils/lint_rules/schema.py
+++ b/src/cxas_scrapi/utils/lint_rules/schema.py
@@ -290,13 +290,28 @@ class SchemaValid(Rule):
             if key.startswith("_comment_"):
                 data.pop(key)
 
-        # For evaluations, if it's a golden/deterministic evaluation,
-        # bypass scenario validation
-        if self.target == "evaluation_config" and (
-            "golden" in data or "Golden" in data
-        ):
-            data.pop("scenario", None)
-            data.pop("Scenario", None)
+        if self.target == "evaluation_config":
+            lower_keys = {k.lower() for k in data.keys()}
+            if "turns" in lower_keys or "expectations" in lower_keys:
+                # TODO: Deprecate this block of logic if the backend no longer
+                # supports these legacy root-level keys (turns/expectations).
+                turns = data.pop("turns", None) or data.pop("Turns", None) or []
+                expectations = (
+                    data.pop("expectations", None)
+                    or data.pop("Expectations", None)
+                    or []
+                )
+                data["golden"] = {
+                    "turns": turns,
+                    "evaluationExpectations": expectations,
+                }
+                lower_keys.add("golden")
+
+            # Bypass scenario validation if it's a deterministic
+            # (golden) evaluation
+            if "golden" in lower_keys:
+                data.pop("scenario", None)
+                data.pop("Scenario", None)
 
         try:
             _validate_fields(data, self._proto_type, path=str(resource_dir))

--- a/tests/cxas_scrapi/utils/test_lint_rules.py
+++ b/tests/cxas_scrapi/utils/test_lint_rules.py
@@ -1617,6 +1617,49 @@ def test_v006_evaluation_invalid_field(tmp_path, context):
     assert "Proto schema" in msg or "validation failed" in msg
 
 
+def test_v006_golden_with_empty_scenario_passes(tmp_path, context):
+    from cxas_scrapi.utils.linter import build_registry  # noqa: PLC0415
+
+    registry = build_registry()
+    rule = registry.get("V006")
+
+    eval_dir = tmp_path / "evaluations" / "MyEval"
+    eval_dir.mkdir(parents=True)
+    (eval_dir / "MyEval.yaml").write_text(
+        "displayName: MyEval\n"
+        "golden:\n"
+        "  turns:\n"
+        "    - steps:\n"
+        "        - userInput:\n"
+        "            text: hello\n"
+        "scenario: {}\n"
+    )
+
+    results = rule.check(eval_dir, "", context)
+    assert len(results) == 0, results[0].message
+
+
+def test_v006_deterministic_evaluation_passes(tmp_path, context):
+    from cxas_scrapi.utils.linter import build_registry  # noqa: PLC0415
+
+    registry = build_registry()
+    rule = registry.get("V006")
+
+    eval_dir = tmp_path / "evaluations" / "MyEval"
+    eval_dir.mkdir(parents=True)
+    (eval_dir / "MyEval.yaml").write_text(
+        "displayName: MyEval\n"
+        "golden:\n"
+        "  turns:\n"
+        "    - steps:\n"
+        "        - userInput:\n"
+        "            text: hello\n"
+    )
+
+    results = rule.check(eval_dir, "", context)
+    assert len(results) == 0, results[0].message
+
+
 def test_schema_missing_referenced_file(tmp_path, context):
     from cxas_scrapi.utils.linter import build_registry  # noqa: PLC0415
 

--- a/tests/cxas_scrapi/utils/test_lint_rules.py
+++ b/tests/cxas_scrapi/utils/test_lint_rules.py
@@ -1660,6 +1660,146 @@ def test_v006_deterministic_evaluation_passes(tmp_path, context):
     assert len(results) == 0, results[0].message
 
 
+def test_v006_generative_scenario_without_required_scenario_expectations_fails(
+    tmp_path, context
+):
+    from cxas_scrapi.utils.linter import build_registry  # noqa: PLC0415,I001
+
+    registry = build_registry()
+    rule = registry.get("V006")
+
+    eval_dir = tmp_path / "evaluations" / "ScenarioNoExpectations"
+    eval_dir.mkdir(parents=True)
+    (eval_dir / "ScenarioNoExpectations.yaml").write_text(
+        "displayName: Scenario No Expectations\n"
+        "scenario:\n"
+        "  task: Perform a transaction.\n"
+        "  rubrics:\n"
+        "    - The transaction must succeed.\n"
+    )
+    results = rule.check(eval_dir, "", context)
+    assert len(results) == 1, f"Expected 1 failure, got: {results}"
+    assert "Missing required fields" in results[0].message
+
+
+def test_v006_deterministic_standard_golden_passes(tmp_path, context):
+    from cxas_scrapi.utils.linter import build_registry  # noqa: PLC0415,I001
+
+    registry = build_registry()
+    rule = registry.get("V006")
+
+    eval_dir = tmp_path / "evaluations" / "StandardGolden"
+    eval_dir.mkdir(parents=True)
+    (eval_dir / "StandardGolden.yaml").write_text(
+        "displayName: Standard Golden\n"
+        "golden:\n"
+        "  turns:\n"
+        "    - steps:\n"
+        "        - userInput:\n"
+        "            text: hello\n"
+        "        - expectation:\n"
+        "            agentResponse:\n"
+        "              chunks:\n"
+        "                - text: Hi\n"
+    )
+    results = rule.check(eval_dir, "", context)
+    assert len(results) == 0, f"Standard Golden failed: {results}"
+
+
+def test_v006_deterministic_legacy_keys_passes(tmp_path, context):
+    from cxas_scrapi.utils.linter import build_registry  # noqa: PLC0415,I001
+
+    registry = build_registry()
+    rule = registry.get("V006")
+
+    eval_dir = tmp_path / "evaluations" / "LegacyKeys"
+    eval_dir.mkdir(parents=True)
+    (eval_dir / "LegacyKeys.yaml").write_text(
+        "displayName: Legacy Keys\n"
+        "turns:\n"
+        "  - steps:\n"
+        "      - userInput:\n"
+        "          text: hello\n"
+        "      - expectation:\n"
+        "          agentResponse:\n"
+        "            chunks:\n"
+        "              - text: Hi\n"
+        "expectations:\n"
+        "  - projects/p/locations/l/apps/a/evaluationExpectations/e1\n"
+    )
+    results = rule.check(eval_dir, "", context)
+    assert len(results) == 0, f"Legacy Keys failed: {results}"
+
+
+def test_v006_deterministic_hybrid_evaluation_passes(tmp_path, context):
+    from cxas_scrapi.utils.linter import build_registry  # noqa: PLC0415,I001
+
+    registry = build_registry()
+    rule = registry.get("V006")
+
+    eval_dir = tmp_path / "evaluations" / "HybridKeys"
+    eval_dir.mkdir(parents=True)
+    (eval_dir / "HybridKeys.yaml").write_text(
+        "displayName: Hybrid Keys\n"
+        "scenario:\n"
+        "  task: Perform a transaction.\n"
+        "expectations:\n"
+        "  - projects/p/locations/l/apps/a/evaluationExpectations/e1\n"
+    )
+    results = rule.check(eval_dir, "", context)
+    assert len(results) == 0, f"Hybrid Keys failed: {results}"
+
+
+def test_v006_generative_scenario_without_required_rubrics_fails(
+    tmp_path, context
+):
+    from cxas_scrapi.utils.linter import build_registry  # noqa: PLC0415,I001
+
+    registry = build_registry()
+    rule = registry.get("V006")
+
+    eval_dir = tmp_path / "evaluations" / "InvalidScenario"
+    eval_dir.mkdir(parents=True)
+    (eval_dir / "InvalidScenario.yaml").write_text(
+        "displayName: Invalid Scenario\n"
+        "scenario:\n"
+        "  task: Perform a transaction.\n"
+    )
+    results = rule.check(eval_dir, "", context)
+    assert len(results) == 1, f"Expected 1 failure, got: {results}"
+    assert "Missing required fields" in results[0].message
+
+
+def test_v006_generative_scenario_with_required_fields_passes(
+    tmp_path, context
+):
+    from cxas_scrapi.utils.linter import build_registry  # noqa: PLC0415,I001
+
+    registry = build_registry()
+    rule = registry.get("V006")
+
+    eval_dir = tmp_path / "evaluations" / "ValidScenario"
+    eval_dir.mkdir(parents=True)
+    (eval_dir / "ValidScenario.yaml").write_text(
+        "displayName: Valid Scenario\n"
+        "scenario:\n"
+        "  task: Perform a transaction.\n"
+        "  rubrics:\n"
+        "    - The transaction must succeed.\n"
+        "  scenarioExpectations:\n"
+        "    - toolExpectation:\n"
+        "        expectedToolCall:\n"
+        "          tool: projects/p/locations/l/apps/a/tools/finish\n"
+        "        mockToolResponse:\n"
+        "          tool: projects/p/locations/l/apps/a/tools/finish\n"
+        "          response:\n"
+        "            output:\n"
+        "              status: SUCCESS\n"
+    )
+    results = rule.check(eval_dir, "", context)
+    assert len(results) == 0, f"Valid Scenario failed: {results}"
+
+
 def test_schema_missing_referenced_file(tmp_path, context):
     from cxas_scrapi.utils.linter import build_registry  # noqa: PLC0415
 


### PR DESCRIPTION
## Problem
When running `cxas lint`, deterministic Golden evaluations (which use the `"golden": {"turns": [...]}` structure) were incorrectly flagged with validation error `[V006] Missing required fields for Scenario: ['rubrics']`

This happens because some tools or export scripts generate Golden evaluation files include empty scenario blocks (e.g., `scenario: {}`). The linter schema validator (`_validate_fields`) was unconditionally recursing into the `scenario` dictionary if it was present, even when the `golden` block was also present (and thus, it was a deterministic test).

## Solution
Modified `src/cxas_scrapi/utils/lint_rules/schema.py` (`SchemaValid.check`) to normalize legacy/hybrid deterministic configs:
   - Uses case-insensitive key lookups (`lower_keys = {k.lower() for k in data.keys()}`) to inspect the schema.
   - If the configuration uses traditional deterministic keys (`turns` or `expectations` at root), it is normalized into a standard `golden` block format.
   - If the config is deterministic (has `golden` or is normalized to have one), we pop `scenario` and `Scenario` blocks to bypass Generative Scenario validation.
   - Added a `TODO` comment to track deprecating this validation bypass logic if the backend no longer supports legacy root-level keys.

## Testing
- Added comprehensive unit tests in `tests/cxas_scrapi/utils/test_lint_rules.py` covering:
  - `test_v006_deterministic_standard_golden_passes` (Standard Golden format)
  - `test_v006_deterministic_legacy_keys_passes` (Legacy root-level turns and expectations format)
  - `test_v006_deterministic_hybrid_evaluation_passes` (Hybrid format with Scenario and root-level expectations)
  - `test_v006_generative_scenario_without_required_rubrics_fails` (Invalid Generative Scenario missing rubrics)
  - `test_v006_generative_scenario_without_required_scenario_expectations_fails` (Invalid Generative Scenario missing scenarioExpectations)
  - `test_v006_generative_scenario_with_required_fields_passes` (Valid Generative Scenario with rubrics & expectations)
- Verified that all 966 tests in the project pass successfully using pytest.
- Verified code formatting and linting rules using `ruff check` and `ruff format`.

Fixes #250 