### PR TITLE
feat(curator): implement cxas-turn-eval-curator skill and extractor s…

### DIFF
--- a/.agents/skills/cxas-turn-eval-curator/SKILL.md
+++ b/.agents/skills/cxas-turn-eval-curator/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: cxas-turn-eval-curator
+description: >-
+  Generates curated, deterministic AUDIO turn-eval probes from SCRAPI
+  SimulationEvals runs. Use when converting simulation trajectories into
+  single-turn turn evals for fast instruction iteration or to build the
+  train/val eval set for the instruction optimizer (cxas_scrapi.optimize).
+  A deterministic script extracts a draft (tool calls, transfers, inputs,
+  outputs) from each sim turn; the agent then curates it — pruning incidental
+  assertions, flagging observed bugs, reconstructing missing tool outputs from
+  the spoken answer plus the test fixture, and converting free-text
+  expectations to deterministic operators. Triggers: "turn evals from
+  simulations", "convert sim evals to turn evals", "curate harvested
+  assertions", "build the eval set for the optimizer".
+---
+
+# CXAS Simulation → Curated Turn-Eval Builder
+
+Turn a few expensive simulation runs into many cheap, deterministic, single-turn
+**audio** turn-eval probes. The split is deliberate:
+
+- **Extraction is deterministic** (`scripts/sim_to_turn_evals.py`) — parse
+  trajectories, harvest `tool_called` / `tool_input` / `tool_output` /
+  `agent_transfer`, build `historical_contexts` + `turn_count`.
+- **Curation is agent judgment** (this skill) — decide which observed behaviors
+  are *required* vs incidental, flag bugs, and strengthen assertions.
+
+The agent runs at AUTHORING time only. Output is static deterministic YAML; the
+eval-runtime loop stays LLM-free. Curated probes feed `cxas sxs` (run) and
+`cxas_scrapi.optimize.reflective_loop` (instruction optimization gate).
+
+Read `references/operators.md` for operator semantics, `historical_contexts`
+forms, audio gotchas, and the full curation heuristics. Read it before curating.
+
+## Steps
+
+### 1. Check environment
+```bash
+python -c "import cxas_scrapi" && gcloud auth list
+```
+
+### 2. Get inputs
+Ask the user for: the App resource name (`projects/.../apps/...`); the
+simulation source — either an existing sim results JSON or a sim YAML to capture
+from; and the output path. Confirm the agent is audio-native (default
+`modality: AUDIO`).
+
+### 3. Generate the draft (deterministic)
+Run the extractor with `--review` so the harvested assertions print for
+inspection. Default `--capture-modality audio` honors the audio constraint.
+```bash
+python .agents/skills/cxas-turn-eval-curator/scripts/sim_to_turn_evals.py \
+  --app-name "projects/.../apps/..." \
+  --eval-file evals/simulations/<sims>.yaml --run --capture-modality audio \
+  --output <draft>.yaml --review
+```
+Use `--sim-results <results.json>` instead of `--eval-file --run` to convert a
+prior run. Key flags: `--context session|utterances`, `--input-keys`,
+`--output-keys`, `--carry-expectations`, `--min-assertions`, `--fetch-retries`.
+
+If the run reports "falling back to local trace", tool **outputs** are
+unavailable for those scenarios (the conversation read flapped) — plan to
+reconstruct them in curation (Step 4).
+
+### 4. Curate (agent judgment — the point of this skill)
+Read `references/operators.md` first. For each probe in the draft, apply
+judgment the script cannot. Fetch the agent's tool schemas and the scenario's
+`test_accounts_data` fixture as needed for grounding:
+- **Prune** incidental tool assertions; keep the load-bearing ones.
+- **Flag, do not encode, suspected bugs** — captures from FAILED sims or clearly
+  wrong behavior must be surfaced to the user, never asserted as expected.
+- **Reconstruct missing `tool_output`** from the spoken answer + fixture when the
+  trace lacked outputs.
+- **Convert** free-text expectations to deterministic operators where possible;
+  keep only genuinely subjective ones as bare strings.
+- **Fix audio-form assertions** (`"152.10"` → `"152 10"`).
+- **Name and tag** probes by intent.
+
+Present the curated changes as a diff and get user sign-off before trusting the
+file.
+
+### 5. Use the curated probes
+```bash
+# Run side-by-side (baseline vs candidate deployment), audio:
+cxas sxs --app-name-a <baseline> --app-name-b <candidate> --eval-file <curated>.yaml
+
+# Or feed the optimizer as its train/val gate:
+python -m cxas_scrapi.optimize.reflective_loop \
+  --candidate-app <scratch-app> --agent-name <.../agents/root_agent> \
+  --eval-file <curated>.yaml --rounds 6 --output best_instruction.txt
+```
+
+## Notes
+- Curation quality is load-bearing: un-curated assertions can make the optimizer
+  optimize toward a captured bug. Always complete Step 4.
+- Pairs with `cxas-sim-eval` (golden → sim) and `cxas-loss-analysis` (failure
+  analysis). This skill is sim → curated turn-eval.

--- a/.agents/skills/cxas-turn-eval-curator/references/operators.md
+++ b/.agents/skills/cxas-turn-eval-curator/references/operators.md
@@ -1,0 +1,85 @@
+# Turn-eval reference: operators, context, audio, curation heuristics
+
+Table of contents:
+- Deterministic operators (what each asserts)
+- historical_contexts (prefix replay) forms
+- Audio gotchas
+- Conversation-fetch reliability (why drafts sometimes lack tool outputs)
+- Curation heuristics (the agent's judgment job)
+
+## Deterministic operators
+
+A turn-eval probe is one user input asserted against the agent's response. The
+response is decomposed into five signals: `full_text`, `called_tools`,
+`tool_inputs`, `tool_outputs`, `target_agent`. Operators (all ANDed):
+
+| `type` | Asserts | Match semantics |
+|---|---|---|
+| `agent_transfer` | `target_agent` | exact OR suffix |
+| `tool_called` | a tool ran | exact OR suffix on name |
+| `no_tools_called` | nothing ran | `value: null` |
+| `tool_input` | call args | **dict subset** — list only the args that matter |
+| `tool_output` | call response | dict subset; `{tool: {}}` = "tool returned at all" |
+| `contains` | `full_text` | case-insensitive substring |
+| `equals` | `full_text` | exact (whitespace-trimmed) |
+| `fuzzy_match` | `full_text` | embedding cosine ≥ 0.75 (paraphrase-tolerant) |
+| *bare string* | full trace | LLM-judged (flash-lite) — subjective only |
+
+Prefer structural operators (`agent_transfer`, `tool_called`, `tool_input`,
+`tool_output`) over prose (`contains`/`equals`) — they survive rewording.
+
+## historical_contexts (prefix replay) forms
+
+Order of preference (most faithful first):
+1. `test_name: <other-test>` — chain; child inherits the parent's real session.
+2. `session_id: <id>` + `turn_count: <k>` — replay the REAL recorded
+   conversation's first k turns; restores real session state. Needs the
+   platform conversation fetch to succeed.
+3. `utterances: [{user: ...}, {agent: ..., name: ...}]` — inline fabricated
+   prefix. Does NOT re-run prior tools, so resulting session state (e.g.
+   `auth_status`, `account_id`) MUST be injected via the probe's `variables:`.
+
+The generator emits form 2 when it can fetch the conversation, else form 3 +
+`variables`.
+
+## Audio gotchas
+
+The agent under test is audio-native; probes run with `config: {modality: AUDIO}`.
+- STT drops formatting: `"152.10"` is transcribed as `"152 10"`. Write
+  `contains`/`equals` against the SPOKEN form, or assert `tool_output` instead.
+- Favor structural checks; avoid asserting long verbatim sentences.
+- `use_tool_fakes: true` keeps the audio model the only quota-bound call.
+
+## Conversation-fetch reliability
+
+Full fidelity (tool args + **outputs** + real `session_id` replay) requires the
+CES `get_conversation` read. The API IS available (ces_v1beta, global
+`ces.googleapis.com`) and returns tool_call + tool_response chunks — no GCS
+bucket or API-version change needed. But in some projects the read **flaps**
+(same call returns full data one moment, `501/"status 404"` the next). The
+generator retries (`--fetch-retries`) then falls back to the local
+`detailed_trace`, which has tool calls + args but NOT outputs (so no
+`tool_output` assertions; uses `utterances`+`variables` instead of replay).
+If outputs are unavailable, curation can RECONSTRUCT them (see below).
+
+## Curation heuristics (the agent's job)
+
+The script harvests everything observed; the agent decides what is *required*:
+
+- **Prune incidental calls.** Keep load-bearing tools (`billing_account_lookup`,
+  `service_diagnostics_lookup`, the transfer). Drop bookkeeping (`set_session_state`,
+  `end_session`) unless the scenario is specifically about them.
+- **Flag suspected bugs — do not encode them.** If the capture came from a
+  FAILED sim, or shows wrong behavior (e.g. authenticated as TEL-1003 but the
+  agent looked up TEL-1001), do NOT turn that into an assertion. Surface it.
+- **Pick semantic `tool_input` keys.** Pin identifiers/decision args
+  (`account_id`, `line_id`), not volatile ones.
+- **Reconstruct missing `tool_output`.** When the trace lacks outputs, ground an
+  assertion from the spoken answer + the `test_accounts_data` fixture: agent says
+  balance is "152 10" and fixture says TEL-1003 balance is "152.10" → emit
+  `tool_output {billing_account_lookup: {current_balance: '152.10'}}` (or a
+  `contains` on the spoken form).
+- **Convert free-text to deterministic where possible.** "Must not reveal another
+  account" → `tool_input {account_id: <authenticated>}`. Keep genuinely
+  subjective ones as bare strings.
+- **Name + tag** probes by intent so `cxas sxs --tags` can slice them.

--- a/.agents/skills/cxas-turn-eval-curator/scripts/sim_to_turn_evals.py
+++ b/.agents/skills/cxas-turn-eval-curator/scripts/sim_to_turn_evals.py
@@ -45,6 +45,18 @@ python .agents/skills/cxas-turn-eval-curator/scripts/sim_to_turn_evals.py \
     --output evals/turn_tests/from_sims.yaml --review
 """
 
+# Force urllib3 to use python's standard ssl module even if pyopenssl is installed.
+# This prevents ValueError: "Context has already been used to create a Connection".
+import os
+os.environ["GOOGLE_API_USE_CLIENT_CERTIFICATE"] = "false"
+
+try:
+    import urllib3.contrib.pyopenssl
+    urllib3.contrib.pyopenssl.inject_into_urllib3 = lambda: None
+    urllib3.contrib.pyopenssl.extract_from_urllib3()
+except ImportError:
+    pass
+
 import argparse
 import ast
 import json

--- a/.agents/skills/cxas-turn-eval-curator/scripts/sim_to_turn_evals.py
+++ b/.agents/skills/cxas-turn-eval-curator/scripts/sim_to_turn_evals.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generate TurnEvals probes from SimulationEvals runs.
+
+Run the (expensive) simulation loop ONCE, then slice each scenario's
+trajectory into single-turn, deterministic, AUDIO turn-eval probes you can
+iterate on cheaply. Expectations are harvested from what the agent actually
+did (tool calls + transfers) so observed-good behavior gets locked in.
+
+This script changes NO harness code; it only consumes the public
+``SimulationEvals`` API and emits a YAML the ``TurnEvals`` runner accepts
+(run it with ``cxas sxs``).
+
+IMPORTANT: generation bakes in observed behavior, INCLUDING bugs. Always
+review the harvested assertions (use --review) and keep only the ones that
+represent *required* behavior before trusting the file. Never generate from a
+failing run without curating.
+
+Examples
+--------
+# Re-use a prior `cxas evals report` run, slice into audio probes:
+python .agents/skills/cxas-turn-eval-curator/scripts/sim_to_turn_evals.py \
+    --app-name projects/.../apps/<id> \
+    --sim-results eval-out/sim_results.json \
+    --output evals/turn_tests/from_sims.yaml --review
+
+# Capture fresh (audio) then convert:
+python .agents/skills/cxas-turn-eval-curator/scripts/sim_to_turn_evals.py \
+    --app-name projects/.../apps/<id> \
+    --eval-file evals/simulations/simulations.yaml --run \
+    --capture-modality audio \
+    --output evals/turn_tests/from_sims.yaml --review
+"""
+
+import argparse
+import ast
+import json
+import re
+import sys
+import time
+from typing import Any, Dict, List, Optional
+
+
+# Transfers are surfaced by the harness as this synthetic tool call.
+_TRANSFER_ACTION = "transfer_to_agent"
+_TRANSFER_TARGET_KEYS = ("agent", "agent_name", "target_agent")
+# Default arg keys worth pinning as tool_input assertions (stable identifiers).
+_DEFAULT_INPUT_KEYS = ("account_id", "customer_id", "ticket_id", "line_id")
+
+# The local sim trace embeds tool calls / transfers as lines INSIDE the
+# multi-line "Agent Text: ... blocks, which the library's own line-start
+# parser misses. We parse them directly so conversion works without the
+# platform conversation fetch (which may be unavailable / not retained).
+_TOOLCALL_RE = re.compile(r"Tool Call:\s*(?P<name>\S+)\s+with args\s+(?P<args>\{.*\})\s*$")
+_TRANSFER_RE = re.compile(r"Agent Transfer:\s*(?P<target>.+?)\s*$")
+
+
+def _parse_local_trace(trace_lines):
+    """Parse SimulationEvals detailed_trace into Turn objects WITH tool calls.
+
+    Richer than SimulationEvals._get_turns_from_local_trace, which only reads
+    line starts and therefore drops embedded ``Tool Call:`` lines.
+    """
+    from cxas_scrapi.utils.eval_utils import Turn, ToolCall  # noqa: PLC0415
+
+    turns: List[Any] = []
+    cur = None
+    for block in trace_lines:
+        for line in str(block).split("\n"):
+            line = line.rstrip()
+            if line.startswith("User: "):
+                cur = Turn(user=line[6:].strip(), tool_calls=[])
+                turns.append(cur)
+                continue
+            if line.startswith("Agent Text: "):  # excludes "Agent Text (Diag):"
+                if cur is None:
+                    cur = Turn(tool_calls=[])
+                    turns.append(cur)
+                txt = line[len("Agent Text: "):].strip()
+                cur.agent = f"{cur.agent} {txt}".strip() if cur.agent else txt
+                continue
+            if cur is None:
+                continue
+            m = _TOOLCALL_RE.search(line)
+            if m:
+                try:
+                    args = ast.literal_eval(m.group("args"))
+                except (ValueError, SyntaxError):
+                    args = {}
+                cur.tool_calls.append(
+                    ToolCall(
+                        action=m.group("name"),
+                        args=args if isinstance(args, dict) else {},
+                    )
+                )
+                continue
+            mt = _TRANSFER_RE.search(line)
+            if mt:
+                target = mt.group("target").removeprefix("Transferred to ").strip()
+                cur.tool_calls.append(
+                    ToolCall(action=_TRANSFER_ACTION, args={"agent": target})
+                )
+                continue
+    return turns
+
+
+def _agent_text(turn) -> str:
+    """Join a Turn.agent value (str | list | None) into one string."""
+    a = getattr(turn, "agent", None)
+    if a is None:
+        return ""
+    if isinstance(a, list):
+        return " ".join(str(x) for x in a if x).strip()
+    return str(a).strip()
+
+
+def _as_utterance(turn) -> List[Dict[str, Any]]:
+    """Render a reconstructed Turn as historical_contexts.utterances entries."""
+    out = []
+    user = getattr(turn, "user", None)
+    if user:
+        user = str(user).strip()
+        # Normalize "event: welcome" back to the <event>...</event> form.
+        if user.lower().startswith("event:"):
+            user = f"<event>{user.split(':', 1)[1].strip()}</event>"
+        out.append({"user": user})
+    text = _agent_text(turn)
+    if text:
+        out.append({"agent": text})
+    return out
+
+
+def _harvest_expectations(
+    turn, input_keys, output_keys, want_output
+) -> List[Dict[str, Any]]:
+    """Turn observed tool calls / transfers into deterministic expectations.
+
+    ``want_output`` emits tool_output assertions when the captured turn carries
+    tool responses (only available from the real platform record, not the local
+    trace). ``output_keys`` pins specific response keys; empty -> existence-only.
+    """
+    exps: List[Dict[str, Any]] = []
+    seen = set()
+    for tc in getattr(turn, "tool_calls", []) or []:
+        action = tc.action
+        args = tc.args or {}
+        if action == _TRANSFER_ACTION:
+            target = next(
+                (args[k] for k in _TRANSFER_TARGET_KEYS if args.get(k)),
+                "unknown",
+            )
+            key = ("agent_transfer", target)
+            if key not in seen:
+                seen.add(key)
+                exps.append({"type": "agent_transfer", "value": target})
+            continue
+
+        key = ("tool_called", action)
+        if key not in seen:
+            seen.add(key)
+            exps.append({"type": "tool_called", "value": action})
+
+        pinned = {k: args[k] for k in input_keys if k in args}
+        if pinned:
+            pkey = ("tool_input", json.dumps(pinned, sort_keys=True, default=str))
+            if pkey not in seen:
+                seen.add(pkey)
+                exps.append({"type": "tool_input", "value": pinned})
+
+        out = getattr(tc, "output", None)
+        if want_output and isinstance(out, dict):
+            pinned_out = {k: out[k] for k in output_keys if k in out}
+            value = {action: pinned_out}  # {} => assert the tool returned
+            okey = ("tool_output", json.dumps(value, sort_keys=True, default=str))
+            if okey not in seen:
+                seen.add(okey)
+                exps.append({"type": "tool_output", "value": value})
+    return exps
+
+
+def _fetch_conversation_dict(app_name, creds, sid, attempts, delay):
+    """Fetch the real platform conversation, retrying past the read-after-write
+    eventual-consistency window (a fresh sim's conversation can briefly 404)."""
+    from cxas_scrapi.core.conversation_history import ConversationHistory  # noqa: PLC0415
+
+    ch = ConversationHistory(app_name=app_name, creds=creds)
+    last = None
+    for a in range(attempts):
+        try:
+            conv = ch.get_conversation(sid)
+            return type(conv).to_dict(conv)
+        except Exception as e:  # noqa: BLE001
+            last = e
+            if a < attempts - 1:
+                time.sleep(delay * (a + 1))
+    raise last
+
+
+def _parse_conversation_turns(conv_dict):
+    """Parse a platform conversation dict into native turns (1:1 with
+    conv_dict['turns'], so the index doubles as turn_count) WITH tool outputs."""
+    from cxas_scrapi.core.sessions import Sessions  # noqa: PLC0415
+    from cxas_scrapi.utils.eval_utils import Turn, ToolCall  # noqa: PLC0415
+
+    turns = []
+    for p_turn in conv_dict.get("turns", []):
+        users, agents, tcs = [], [], []
+        for m in p_turn.get("messages", []):
+            role = m.get("role", "")
+            for ch in m.get("chunks", []):
+                if ch.get("text"):
+                    (users if role == "user" else agents).append(ch["text"])
+                elif "tool_call" in ch:
+                    tc = ch["tool_call"]
+                    nm = tc.get("display_name") or tc.get("tool")
+                    args = Sessions._expand_pb_struct(tc.get("args", {}))  # noqa: SLF001
+                    tcs.append(ToolCall(action=nm, args=args))
+                elif "tool_response" in ch:
+                    tr = ch["tool_response"]
+                    nm = tr.get("display_name") or tr.get("tool")
+                    resp = Sessions._expand_pb_struct(tr.get("response", {}))  # noqa: SLF001
+                    match = next(
+                        (t for t in reversed(tcs)
+                         if t.action == nm and t.output is None),
+                        None,
+                    )
+                    if match:
+                        match.output = resp
+                    else:
+                        tcs.append(ToolCall(action=nm, args={}, output=resp))
+                elif "agent_transfer" in ch:
+                    at = ch["agent_transfer"]
+                    tgt = at.get("display_name") or at.get(
+                        "target_agent", "unknown"
+                    )
+                    tcs.append(
+                        ToolCall(action=_TRANSFER_ACTION, args={"agent": tgt})
+                    )
+        turns.append(
+            Turn(
+                user=" ".join(users).strip() or None,
+                agent=" ".join(agents).strip() or None,
+                tool_calls=tcs,
+            )
+        )
+    return turns
+
+
+def _reconstruct(app_name, creds, res, args):
+    """Return (turns, effective_context). Prefer the real platform conversation
+    (full tool args+outputs, faithful session replay); fall back to the local
+    trace (text + tool args + transfers, no outputs) only if the fetch fails."""
+    sid = res.get("session_id")
+    if sid and args.context in ("auto", "session"):
+        try:
+            cd = _fetch_conversation_dict(
+                app_name, creds, sid, args.fetch_retries, args.fetch_delay
+            )
+            return _parse_conversation_turns(cd), "session"
+        except Exception as e:  # noqa: BLE001
+            print(
+                f"  ! platform fetch failed for {res.get('name')} after "
+                f"{args.fetch_retries} tries ({type(e).__name__}); "
+                f"falling back to local trace (no tool outputs, no replay).",
+                file=sys.stderr,
+            )
+
+    return _parse_local_trace(res.get("detailed_trace", [])), "utterances"
+
+
+def _build_probes(app_name, creds, results, args) -> List[Dict[str, Any]]:
+    input_keys = [k.strip() for k in args.input_keys.split(",") if k.strip()]
+    output_keys = [k.strip() for k in args.output_keys.split(",") if k.strip()]
+    want_output = not args.no_tool_output
+    probes: List[Dict[str, Any]] = []
+
+    for res in results:
+        name = res.get("name", "sim")
+        if args.only_passing and not res.get("passed", False):
+            print(f"  - skip {name}: sim did not pass (--only-passing)")
+            continue
+
+        turns, effective = _reconstruct(app_name, creds, res, args)
+        if not turns:
+            print(f"  - skip {name}: no turns reconstructed")
+            continue
+
+        sparams = res.get("session_parameters", {}) or {}
+        carried = (
+            [e["expectation"] for e in res.get("expectation_details", [])]
+            if args.carry_expectations
+            else []
+        )
+
+        scenario_probes = []
+        for i, turn in enumerate(turns):
+            user_i = getattr(turn, "user", None)
+            if not user_i:
+                continue  # need a user input to probe this turn
+            exps = _harvest_expectations(
+                turn, input_keys, output_keys,
+                want_output and effective == "session",
+            )
+            if args.include_text:
+                text = _agent_text(turn)
+                if text:
+                    exps.append(
+                        {"type": "fuzzy_match", "value": text[:200]}
+                    )
+            if len(exps) < args.min_assertions:
+                continue
+
+            probe: Dict[str, Any] = {
+                "conversation": f"{name}__t{i}",
+                "tags": ["from-sim", args.modality.lower(), name],
+            }
+            # Prefix context: turns before this user input.
+            prefix = turns[:i]
+            if effective == "session":
+                probe["historical_contexts"] = {"session_id": res["session_id"]}
+                probe["turn_count"] = i  # include i prior turns
+            else:
+                utts: List[Dict[str, Any]] = []
+                for t in prefix:
+                    utts.extend(_as_utterance(t))
+                if utts:
+                    probe["historical_contexts"] = {"utterances": utts}
+                # Fabricated prefix can't re-run prior tools -> inject state.
+                if sparams:
+                    probe["variables"] = sparams
+
+            probe["user"] = str(user_i).strip()
+            probe["expectations"] = exps
+            scenario_probes.append(probe)
+
+        # Carry scenario-level (LLM-judged) expectations onto the last probe.
+        if carried and scenario_probes:
+            scenario_probes[-1]["expectations"].extend(carried)
+
+        if not scenario_probes:
+            print(f"  - skip {name}: no assertion-bearing turns "
+                  f"(context={effective})")
+        probes.extend(scenario_probes)
+
+    return probes
+
+
+def _write_yaml(probes, args) -> str:
+    import yaml
+
+    doc = {
+        "config": {"modality": args.modality},
+        "conversations": probes,
+    }
+    if args.use_tool_fakes:
+        doc["config"]["use_tool_fakes"] = True
+
+    header = (
+        "# AUTO-GENERATED from simulation runs by scripts/sim_to_turn_evals.py.\n"
+        "# Each probe replays a frozen prefix and asserts ONE turn deterministically.\n"
+        "# REVIEW before trusting: generation bakes in observed behavior incl. bugs.\n"
+        f"# Run:  cxas sxs --app-name-a <baseline> --app-name-b <candidate> \\\n"
+        f"#               --eval-file {args.output}\n\n"
+    )
+    body = yaml.safe_dump(doc, sort_keys=False, default_flow_style=False, width=100)
+    out = header + body
+    with open(args.output, "w", encoding="utf-8") as f:
+        f.write(out)
+    return out
+
+
+def _review(probes) -> None:
+    print("\n===== REVIEW: harvested probes (curate before trusting) =====")
+    if not probes:
+        print("  (none — likely no tool/transfer detail; see warnings above)")
+    for p in probes:
+        hc = p.get("historical_contexts", {})
+        ctx = (
+            f"session_id+turn_count={p.get('turn_count')}"
+            if "session_id" in hc
+            else f"utterances({len(hc.get('utterances', []))})"
+        )
+        print(f"\n  • {p['conversation']}  [{ctx}]")
+        print(f"      user: {p['user'][:80]}")
+        for e in p["expectations"]:
+            if isinstance(e, str):
+                print(f"      expect (LLM): {e[:80]}")
+            else:
+                print(f"      expect: {e['type']} = {e['value']}")
+
+
+def _local_load_sim_test_cases(yaml_path: str) -> list[dict]:
+    """Fallback parser when cxas_scrapi.utils.reporting is not available."""
+    import yaml
+    with open(yaml_path) as f:
+        data = yaml.safe_load(f) or {}
+    if isinstance(data, list):
+        return data
+
+    common_params = data.get("common_session_parameters", {}) or {}
+    common_expectations = data.get("common_expectations", []) or []
+    cases = data.get("evals", [])
+    if not isinstance(cases, list):
+        return []
+
+    merged_cases = []
+    for c in cases:
+        if isinstance(c, dict):
+            case_copy = c.copy()
+            # Merge session parameters
+            case_params = case_copy.get("session_parameters", {}) or {}
+            merged = common_params.copy()
+            merged.update(case_params)
+            case_copy["session_parameters"] = merged
+
+            # Merge expectations
+            case_expectations = case_copy.get("expectations", []) or []
+            case_copy["expectations"] = common_expectations + case_expectations
+
+            merged_cases.append(case_copy)
+    return merged_cases
+
+
+def _load_results(sim, args) -> List[Dict[str, Any]]:
+    if args.sim_results:
+        with open(args.sim_results, encoding="utf-8") as f:
+            data = json.load(f)
+        # Accept either a bare list or {"simulation": [...]} / {"results": [...]}
+        if isinstance(data, dict):
+            data = data.get("simulation") or data.get("results") or data.get(
+                "sims", []
+            )
+        print(f"Loaded {len(data)} sim results from {args.sim_results}")
+        return data
+
+    # Capture fresh.
+    if sim is None:
+        raise ValueError("SimulationEvals client is not initialized.")
+
+    try:
+        from cxas_scrapi.utils.reporting import _load_sim_test_cases  # noqa: PLC0415
+    except (ImportError, ModuleNotFoundError):
+        _load_sim_test_cases = _local_load_sim_test_cases
+
+    cases = _load_sim_test_cases(args.eval_file)
+    print(
+        f"Running {len(cases)} simulations (modality={args.capture_modality}, "
+        f"runs={args.runs}) to capture trajectories..."
+    )
+    return sim.run_simulations(
+        cases, runs=args.runs, modality=args.capture_modality
+    )
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--app-name", required=True,
+                   help="CXAS App resource (projects/.../apps/...).")
+    src = p.add_mutually_exclusive_group(required=True)
+    src.add_argument("--sim-results",
+                     help="Path to a saved sim results JSON to convert.")
+    src.add_argument("--eval-file",
+                     help="Simulation YAML to capture from (use with --run).")
+    p.add_argument("--run", action="store_true",
+                     help="Run sims from --eval-file before converting.")
+    p.add_argument("--capture-modality", choices=["audio", "text"],
+                   default="audio",
+                   help="Modality for the capture run (default: audio).")
+    p.add_argument("--runs", type=int, default=1,
+                   help="Runs per scenario during capture (default: 1).")
+    p.add_argument("--output", required=True, help="Output turn-eval YAML path.")
+
+    p.add_argument("--modality", default="AUDIO",
+                   help="Modality the GENERATED probes run in (default: AUDIO).")
+    p.add_argument("--use-tool-fakes", action="store_true", default=True,
+                   help="Set use_tool_fakes in the generated config (default).")
+    p.add_argument("--no-tool-fakes", dest="use_tool_fakes",
+                   action="store_false")
+    p.add_argument("--context", choices=["auto", "session", "utterances"],
+                   default="session",
+                   help="Prefix replay strategy (default: session — replay the "
+                        "REAL conversation via session_id+turn_count; falls back "
+                        "to inline utterances only if the fetch fails).")
+    p.add_argument("--fetch-retries", type=int, default=5,
+                   help="Attempts to fetch each conversation, to ride out "
+                        "read-after-write consistency (default: 5).")
+    p.add_argument("--fetch-delay", type=float, default=2.0,
+                   help="Base seconds between fetch retries (linear backoff).")
+    p.add_argument("--input-keys", default=",".join(_DEFAULT_INPUT_KEYS),
+                   help="Comma-separated tool-arg keys to pin as tool_input "
+                        "assertions.")
+    p.add_argument("--output-keys", default="status",
+                   help="Comma-separated tool-response keys to pin as tool_output "
+                        "assertions (empty -> existence-only). Session mode only.")
+    p.add_argument("--no-tool-output", action="store_true",
+                   help="Do not emit tool_output assertions.")
+    p.add_argument("--carry-expectations", action="store_true", default=True,
+                   help="Attach the sim's free-text expectations (LLM-judged) "
+                        "to each scenario's last probe (default).")
+    p.add_argument("--no-carry-expectations", dest="carry_expectations",
+                   action="store_false")
+    p.add_argument("--include-text", action="store_true",
+                   help="Also add a fuzzy_match on the agent's text (brittle; "
+                        "off by default).")
+    p.add_argument("--min-assertions", type=int, default=1,
+                   help="Skip turns with fewer than N deterministic assertions "
+                        "(default: 1).")
+    p.add_argument("--only-passing", action="store_true",
+                   help="Only convert scenarios whose sim run passed.")
+    p.add_argument("--review", action="store_true",
+                   help="Print harvested assertions for curation.")
+    args = p.parse_args()
+
+    if args.eval_file and not args.run:
+        p.error("--eval-file requires --run (to capture trajectories).")
+
+    sim = None
+    if args.run:
+        from cxas_scrapi.evals.simulation_evals import SimulationEvals  # noqa: PLC0415
+        sim = SimulationEvals(app_name=args.app_name)
+
+    results = _load_results(sim, args)
+    if not results:
+        print("No sim results to convert.", file=sys.stderr)
+        sys.exit(1)
+
+    print("Building turn-eval probes...")
+    creds = getattr(sim, "creds", None) if sim else None
+    probes = _build_probes(args.app_name, creds, results, args)
+    _write_yaml(probes, args)
+    print(f"\nWrote {len(probes)} probes to {args.output}")
+    if args.review:
+        _review(probes)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/cxas-turn-eval-curator/scripts/sim_to_turn_evals.py
+++ b/.agents/skills/cxas-turn-eval-curator/scripts/sim_to_turn_evals.py
@@ -71,6 +71,7 @@ _TRANSFER_ACTION = "transfer_to_agent"
 _TRANSFER_TARGET_KEYS = ("agent", "agent_name", "target_agent")
 # Default arg keys worth pinning as tool_input assertions (stable identifiers).
 _DEFAULT_INPUT_KEYS = ("account_id", "customer_id", "ticket_id", "line_id")
+_NOISY_INPUT_KEYS = {"reason", "issueDescription", "customerConfirmationText", "summary", "requestBody"}
 
 # The local sim trace embeds tool calls / transfers as lines INSIDE the
 # multi-line "Agent Text: ... blocks, which the library's own line-start
@@ -133,10 +134,7 @@ def _parse_local_trace(trace_lines):
                     None,
                 )
                 if match:
-                    if isinstance(res_val, dict) and "result" in res_val:
-                        match.output = res_val["result"]
-                    else:
-                        match.output = res_val
+                    match.output = res_val
                 continue
             mt = _TRANSFER_RE.search(line)
             if mt:
@@ -185,10 +183,20 @@ def _harvest_expectations(
     """
     exps: List[Dict[str, Any]] = []
     seen = set()
-    for tc in getattr(turn, "tool_calls", []) or []:
+    tool_calls = getattr(turn, "tool_calls", []) or []
+    
+    # Identify the last transfer to avoid asserting intermediate transfers
+    last_transfer_idx = -1
+    for idx, tc in enumerate(tool_calls):
+        if tc.action == _TRANSFER_ACTION:
+            last_transfer_idx = idx
+
+    for idx, tc in enumerate(tool_calls):
         action = tc.action
         args = tc.args or {}
         if action == _TRANSFER_ACTION:
+            if idx != last_transfer_idx:
+                continue
             target = next(
                 (args[k] for k in _TRANSFER_TARGET_KEYS if args.get(k)),
                 "unknown",
@@ -204,10 +212,11 @@ def _harvest_expectations(
             seen.add(key)
             exps.append({"type": "tool_called", "value": action})
 
+        # Filter out noisy keys from input assertions to prevent flakiness
         if "*" in input_keys:
-            pinned = args
+            pinned = {k: v for k, v in args.items() if k not in _NOISY_INPUT_KEYS}
         else:
-            pinned = {k: args[k] for k in input_keys if k in args}
+            pinned = {k: args[k] for k in input_keys if k in args and k not in _NOISY_INPUT_KEYS}
         if pinned:
             pkey = ("tool_input", json.dumps(pinned, sort_keys=True, default=str))
             if pkey not in seen:
@@ -219,7 +228,13 @@ def _harvest_expectations(
             if "*" in output_keys:
                 pinned_out = out
             else:
-                pinned_out = {k: out[k] for k in output_keys if k in out}
+                pinned_out = {}
+                if "result" in out and isinstance(out["result"], dict):
+                    inner_pinned = {k: out["result"][k] for k in output_keys if k in out["result"]}
+                    if inner_pinned:
+                        pinned_out["result"] = inner_pinned
+                top_pinned = {k: out[k] for k in output_keys if k in out}
+                pinned_out.update(top_pinned)
             value = {action: pinned_out}  # {} => assert the tool returned
             okey = ("tool_output", json.dumps(value, sort_keys=True, default=str))
             if okey not in seen:
@@ -558,9 +573,9 @@ def main() -> None:
                         "assertions (empty -> existence-only). Session mode only.")
     p.add_argument("--no-tool-output", action="store_true",
                    help="Do not emit tool_output assertions.")
-    p.add_argument("--carry-expectations", action="store_true", default=True,
+    p.add_argument("--carry-expectations", action="store_true", default=False,
                    help="Attach the sim's free-text expectations (LLM-judged) "
-                        "to each scenario's last probe (default).")
+                        "to each scenario's last probe.")
     p.add_argument("--no-carry-expectations", dest="carry_expectations",
                    action="store_false")
     p.add_argument("--include-text", action="store_true",

--- a/.agents/skills/cxas-turn-eval-curator/scripts/sim_to_turn_evals.py
+++ b/.agents/skills/cxas-turn-eval-curator/scripts/sim_to_turn_evals.py
@@ -45,9 +45,11 @@ python .agents/skills/cxas-turn-eval-curator/scripts/sim_to_turn_evals.py \
     --output evals/turn_tests/from_sims.yaml --review
 """
 
-# Force urllib3 to use python's standard ssl module even if pyopenssl is installed.
-# This prevents ValueError: "Context has already been used to create a Connection".
+# Force urllib3 to use python's standard ssl module even if pyopenssl is
+# installed. This prevents ValueError: "Context has already been used to create
+# a Connection".
 import os
+
 os.environ["GOOGLE_API_USE_CLIENT_CERTIFICATE"] = "false"
 
 try:
@@ -63,39 +65,56 @@ import json
 import re
 import sys
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any
 
+import yaml
+
+from cxas_scrapi.core.conversation_history import ConversationHistory
+from cxas_scrapi.core.sessions import Sessions
+from cxas_scrapi.evals.simulation_evals import SimulationEvals
+from cxas_scrapi.utils.eval_utils import ToolCall, Turn
 
 # Transfers are surfaced by the harness as this synthetic tool call.
 _TRANSFER_ACTION = "transfer_to_agent"
 _TRANSFER_TARGET_KEYS = ("agent", "agent_name", "target_agent")
 # Default arg keys worth pinning as tool_input assertions (stable identifiers).
 _DEFAULT_INPUT_KEYS = ("account_id", "customer_id", "ticket_id", "line_id")
-_NOISY_INPUT_KEYS = {"reason", "issueDescription", "customerConfirmationText", "summary", "requestBody"}
+_NOISY_INPUT_KEYS = {
+    "reason",
+    "issueDescription",
+    "customerConfirmationText",
+    "summary",
+    "requestBody",
+}
 
 # The local sim trace embeds tool calls / transfers as lines INSIDE the
 # multi-line "Agent Text: ... blocks, which the library's own line-start
 # parser misses. We parse them directly so conversion works without the
 # platform conversation fetch (which may be unavailable / not retained).
-_TOOLCALL_RE = re.compile(r"Tool Call:\s*(?P<name>\S+)\s+with args\s+(?P<args>\{.*\})\s*$")
-_TOOLRESPONSE_RE = re.compile(r"Tool Response:\s*(?P<name>\S+)\s+with result\s+(?P<result>\{.*\})\s*$")
+_TOOLCALL_RE = re.compile(
+    r"Tool Call:\s*(?P<name>\S+)\s+with args\s+(?P<args>\{.*\})\s*$"
+)
+_TOOLRESPONSE_RE = re.compile(
+    r"Tool Response:\s*(?P<name>\S+)\s+with result\s+(?P<result>\{.*\})\s*$"
+)
 _TRANSFER_RE = re.compile(r"Agent Transfer:\s*(?P<target>.+?)\s*$")
 
 
 def _parse_local_trace(trace_lines):
-    """Parse SimulationEvals detailed_trace into Turn objects WITH tool calls and outputs.
+    """Parse SimulationEvals detailed_trace into Turn objects.
 
-    Richer than SimulationEvals._get_turns_from_local_trace, which only reads
-    line starts and therefore drops embedded ``Tool Call:`` lines.
+    Includes tool calls and outputs. Richer than
+    SimulationEvals._get_turns_from_local_trace, which only reads line starts
+    and therefore drops embedded ``Tool Call:`` lines.
     """
-    from cxas_scrapi.utils.eval_utils import Turn, ToolCall  # noqa: PLC0415
 
-    turns: List[Any] = []
+
+    turns: list[Any] = []
     cur = None
     in_agent_text = False
     for block in trace_lines:
-        for line in str(block).split("\n"):
-            line = line.rstrip()
+        for raw_line in str(block).split("\n"):
+            line = raw_line.rstrip()
             if line.startswith("User: "):
                 cur = Turn(user=line[6:].strip(), tool_calls=[])
                 turns.append(cur)
@@ -144,7 +163,11 @@ def _parse_local_trace(trace_lines):
             mt = _TRANSFER_RE.search(line)
             if mt:
                 in_agent_text = False
-                target = mt.group("target").removeprefix("Transferred to ").strip()
+                target = (
+                    mt.group("target")
+                    .removeprefix("Transferred to ")
+                    .strip()
+                )
                 cur.tool_calls.append(
                     ToolCall(action=_TRANSFER_ACTION, args={"agent": target})
                 )
@@ -165,7 +188,7 @@ def _agent_text(turn) -> str:
     return str(a).strip()
 
 
-def _as_utterance(turn) -> List[Dict[str, Any]]:
+def _as_utterance(turn) -> list[dict[str, Any]]:
     """Render a reconstructed Turn as historical_contexts.utterances entries."""
     out = []
     user = getattr(turn, "user", None)
@@ -183,17 +206,18 @@ def _as_utterance(turn) -> List[Dict[str, Any]]:
 
 def _harvest_expectations(
     turn, input_keys, output_keys, want_output
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """Turn observed tool calls / transfers into deterministic expectations.
 
     ``want_output`` emits tool_output assertions when the captured turn carries
     tool responses (only available from the real platform record, not the local
-    trace). ``output_keys`` pins specific response keys; empty -> existence-only.
+    trace). ``output_keys`` pins specific response keys; empty ->
+    existence-only.
     """
-    exps: List[Dict[str, Any]] = []
+    exps: list[dict[str, Any]] = []
     seen = set()
     tool_calls = getattr(turn, "tool_calls", []) or []
-    
+
     # Identify the last transfer to avoid asserting intermediate transfers
     last_transfer_idx = -1
     for idx, tc in enumerate(tool_calls):
@@ -223,11 +247,20 @@ def _harvest_expectations(
 
         # Filter out noisy keys from input assertions to prevent flakiness
         if "*" in input_keys:
-            pinned = {k: v for k, v in args.items() if k not in _NOISY_INPUT_KEYS}
+            pinned = {
+                k: v for k, v in args.items() if k not in _NOISY_INPUT_KEYS
+            }
         else:
-            pinned = {k: args[k] for k in input_keys if k in args and k not in _NOISY_INPUT_KEYS}
+            pinned = {
+                k: args[k]
+                for k in input_keys
+                if k in args and k not in _NOISY_INPUT_KEYS
+            }
         if pinned:
-            pkey = ("tool_input", json.dumps(pinned, sort_keys=True, default=str))
+            pkey = (
+                "tool_input",
+                json.dumps(pinned, sort_keys=True, default=str),
+            )
             if pkey not in seen:
                 seen.add(pkey)
                 exps.append({"type": "tool_input", "value": pinned})
@@ -239,13 +272,20 @@ def _harvest_expectations(
             else:
                 pinned_out = {}
                 if "result" in out and isinstance(out["result"], dict):
-                    inner_pinned = {k: out["result"][k] for k in output_keys if k in out["result"]}
+                    inner_pinned = {
+                        k: out["result"][k]
+                        for k in output_keys
+                        if k in out["result"]
+                    }
                     if inner_pinned:
                         pinned_out["result"] = inner_pinned
                 top_pinned = {k: out[k] for k in output_keys if k in out}
                 pinned_out.update(top_pinned)
             value = {action: pinned_out}  # {} => assert the tool returned
-            okey = ("tool_output", json.dumps(value, sort_keys=True, default=str))
+            okey = (
+                "tool_output",
+                json.dumps(value, sort_keys=True, default=str),
+            )
             if okey not in seen:
                 seen.add(okey)
                 exps.append({"type": "tool_output", "value": value})
@@ -255,8 +295,6 @@ def _harvest_expectations(
 def _fetch_conversation_dict(app_name, creds, sid, attempts, delay):
     """Fetch the real platform conversation, retrying past the read-after-write
     eventual-consistency window (a fresh sim's conversation can briefly 404)."""
-    from cxas_scrapi.core.conversation_history import ConversationHistory  # noqa: PLC0415
-
     ch = ConversationHistory(app_name=app_name, creds=creds)
     last = None
     for a in range(attempts):
@@ -271,10 +309,11 @@ def _fetch_conversation_dict(app_name, creds, sid, attempts, delay):
 
 
 def _parse_conversation_turns(conv_dict):
-    """Parse a platform conversation dict into native turns (1:1 with
-    conv_dict['turns'], so the index doubles as turn_count) WITH tool outputs."""
-    from cxas_scrapi.core.sessions import Sessions  # noqa: PLC0415
-    from cxas_scrapi.utils.eval_utils import Turn, ToolCall  # noqa: PLC0415
+    """Parse a platform conversation dict into native turns.
+
+    The turns map 1:1 with conv_dict['turns'], so the index doubles as
+    turn_count. Includes tool outputs.
+    """
 
     turns = []
     for p_turn in conv_dict.get("turns", []):
@@ -343,11 +382,11 @@ def _reconstruct(app_name, creds, res, args):
     return _parse_local_trace(res.get("detailed_trace", [])), "local"
 
 
-def _build_probes(app_name, creds, results, args) -> List[Dict[str, Any]]:
+def _build_probes(app_name, creds, results, args) -> list[dict[str, Any]]:
     input_keys = [k.strip() for k in args.input_keys.split(",") if k.strip()]
     output_keys = [k.strip() for k in args.output_keys.split(",") if k.strip()]
     want_output = not args.no_tool_output
-    probes: List[Dict[str, Any]] = []
+    probes: list[dict[str, Any]] = []
 
     for res in results:
         name = res.get("name", "sim")
@@ -385,17 +424,18 @@ def _build_probes(app_name, creds, results, args) -> List[Dict[str, Any]]:
             if len(exps) < args.min_assertions:
                 continue
 
-            probe: Dict[str, Any] = {
+            probe: dict[str, Any] = {
                 "conversation": f"{name}__t{i}",
                 "tags": ["from-sim", args.modality.lower(), name],
             }
             # Prefix context: turns before this user input.
             prefix = turns[:i]
-            
+
             # Determine if we should generate session_id context:
             # We use session_id context IF:
             # 1. User requested "session" or "auto"
-            # 2. AND we successfully got platform conversation (source == "platform")
+            # 2. AND we successfully got platform conversation (source ==
+            #    "platform")
             # 3. AND session_id is present in the results
             use_session_context = (
                 args.context in ("session", "auto")
@@ -407,7 +447,7 @@ def _build_probes(app_name, creds, results, args) -> List[Dict[str, Any]]:
                 probe["historical_contexts"] = {"session_id": res["session_id"]}
                 probe["turn_count"] = i  # include i prior turns
             else:
-                utts: List[Dict[str, Any]] = []
+                utts: list[dict[str, Any]] = []
                 for t in prefix:
                     utts.extend(_as_utterance(t))
                 if utts:
@@ -433,7 +473,6 @@ def _build_probes(app_name, creds, results, args) -> List[Dict[str, Any]]:
 
 
 def _write_yaml(probes, args) -> str:
-    import yaml
 
     doc = {
         "config": {"modality": args.modality},
@@ -443,13 +482,19 @@ def _write_yaml(probes, args) -> str:
         doc["config"]["use_tool_fakes"] = True
 
     header = (
-        "# AUTO-GENERATED from simulation runs by scripts/sim_to_turn_evals.py.\n"
-        "# Each probe replays a frozen prefix and asserts ONE turn deterministically.\n"
-        "# REVIEW before trusting: generation bakes in observed behavior incl. bugs.\n"
-        f"# Run:  cxas sxs --app-name-a <baseline> --app-name-b <candidate> \\\n"
+        "# AUTO-GENERATED from simulation runs by "
+        "scripts/sim_to_turn_evals.py.\n"
+        "# Each probe replays a frozen prefix and asserts ONE turn "
+        "deterministically.\n"
+        "# REVIEW before trusting: generation bakes in observed behavior "
+        "incl. bugs.\n"
+        f"# Run:  cxas sxs --app-name-a <baseline> "
+        f"--app-name-b <candidate> \\\n"
         f"#               --eval-file {args.output}\n\n"
     )
-    body = yaml.safe_dump(doc, sort_keys=False, default_flow_style=False, width=100)
+    body = yaml.safe_dump(
+        doc, sort_keys=False, default_flow_style=False, width=100
+    )
     out = header + body
     with open(args.output, "w", encoding="utf-8") as f:
         f.write(out)
@@ -478,7 +523,6 @@ def _review(probes) -> None:
 
 def _local_load_sim_test_cases(yaml_path: str) -> list[dict]:
     """Fallback parser when cxas_scrapi.utils.reporting is not available."""
-    import yaml
     with open(yaml_path) as f:
         data = yaml.safe_load(f) or {}
     if isinstance(data, list):
@@ -508,14 +552,17 @@ def _local_load_sim_test_cases(yaml_path: str) -> list[dict]:
     return merged_cases
 
 
-def _load_results(sim, args) -> List[Dict[str, Any]]:
+def _load_results(sim, args) -> list[dict[str, Any]]:
     if args.sim_results:
         with open(args.sim_results, encoding="utf-8") as f:
             data = json.load(f)
-        # Accept either a bare list or {"simulation": [...]} / {"results": [...]}
+        # Accept either a bare list or {"simulation": [...]} /
+        # {"results": [...]}
         if isinstance(data, dict):
-            data = data.get("simulation") or data.get("results") or data.get(
-                "sims", []
+            data = (
+                data.get("simulation")
+                or data.get("results")
+                or data.get("sims", [])
             )
         print(f"Loaded {len(data)} sim results from {args.sim_results}")
         return data
@@ -525,7 +572,9 @@ def _load_results(sim, args) -> List[Dict[str, Any]]:
         raise ValueError("SimulationEvals client is not initialized.")
 
     try:
-        from cxas_scrapi.utils.reporting import _load_sim_test_cases  # noqa: PLC0415
+        from cxas_scrapi.utils.reporting import (  # noqa: PLC0415
+            _load_sim_test_cases,
+        )
     except (ImportError, ModuleNotFoundError):
         _load_sim_test_cases = _local_load_sim_test_cases
 
@@ -555,31 +604,36 @@ def main() -> None:
                    help="Modality for the capture run (default: audio).")
     p.add_argument("--runs", type=int, default=1,
                    help="Runs per scenario during capture (default: 1).")
-    p.add_argument("--output", required=True, help="Output turn-eval YAML path.")
+    p.add_argument("--output", required=True,
+                   help="Output turn-eval YAML path.")
 
     p.add_argument("--modality", default="AUDIO",
-                   help="Modality the GENERATED probes run in (default: AUDIO).")
+                   help="Modality the GENERATED probes run in "
+                        "(default: AUDIO).")
     p.add_argument("--use-tool-fakes", action="store_true", default=True,
-                   help="Set use_tool_fakes in the generated config (default).")
+                   help="Set use_tool_fakes in the generated config "
+                        "(default).")
     p.add_argument("--no-tool-fakes", dest="use_tool_fakes",
                    action="store_false")
     p.add_argument("--context", choices=["auto", "session", "utterances"],
                    default="utterances",
-                   help="Prefix replay strategy (default: utterances — replay using "
-                        "inline utterances and variables; session replays the "
-                        "REAL conversation via session_id+turn_count; auto uses "
-                        "session if platform fetch succeeds, else utterances).")
+                   help="Prefix replay strategy (default: utterances — replay "
+                        "using inline utterances and variables; session "
+                        "replays the REAL conversation via "
+                        "session_id+turn_count; auto uses session if platform "
+                        "fetch succeeds, else utterances).")
     p.add_argument("--fetch-retries", type=int, default=5,
                    help="Attempts to fetch each conversation, to ride out "
                         "read-after-write consistency (default: 5).")
     p.add_argument("--fetch-delay", type=float, default=2.0,
                    help="Base seconds between fetch retries (linear backoff).")
     p.add_argument("--input-keys", default="*",
-                   help="Comma-separated tool-arg keys to pin as tool_input "
-                        "assertions (default: * to include all).")
+                   help="Comma-separated tool-arg keys to pin as "
+                        "tool_input assertions (default: * to include all).")
     p.add_argument("--output-keys", default="status",
-                   help="Comma-separated tool-response keys to pin as tool_output "
-                        "assertions (empty -> existence-only). Session mode only.")
+                   help="Comma-separated tool-response keys to pin as "
+                        "tool_output assertions (empty -> existence-only). "
+                        "Session mode only.")
     p.add_argument("--no-tool-output", action="store_true",
                    help="Do not emit tool_output assertions.")
     p.add_argument("--carry-expectations", action="store_true", default=False,
@@ -596,7 +650,8 @@ def main() -> None:
     p.add_argument("--only-passing", action="store_true",
                    help="Only convert scenarios whose sim run passed.")
     p.add_argument("--write-results",
-                   help="Save the raw captured sim results (trajectories) JSON to this path.")
+                   help="Save the raw captured sim results (trajectories) "
+                        "JSON to this path.")
     p.add_argument("--review", action="store_true",
                    help="Print harvested assertions for curation.")
     args = p.parse_args()
@@ -606,7 +661,6 @@ def main() -> None:
 
     sim = None
     if args.run:
-        from cxas_scrapi.evals.simulation_evals import SimulationEvals  # noqa: PLC0415
         sim = SimulationEvals(app_name=args.app_name)
 
     results = _load_results(sim, args)
@@ -615,7 +669,6 @@ def main() -> None:
         sys.exit(1)
 
     if args.write_results:
-        import json
         with open(args.write_results, "w", encoding="utf-8") as f:
             json.dump(results, f, indent=2, default=str)
         print(f"Saved raw sim results (trajectories) to {args.write_results}")

--- a/.agents/skills/cxas-turn-eval-curator/scripts/sim_to_turn_evals.py
+++ b/.agents/skills/cxas-turn-eval-curator/scripts/sim_to_turn_evals.py
@@ -92,12 +92,14 @@ def _parse_local_trace(trace_lines):
 
     turns: List[Any] = []
     cur = None
+    in_agent_text = False
     for block in trace_lines:
         for line in str(block).split("\n"):
             line = line.rstrip()
             if line.startswith("User: "):
                 cur = Turn(user=line[6:].strip(), tool_calls=[])
                 turns.append(cur)
+                in_agent_text = False
                 continue
             if line.startswith("Agent Text: "):  # excludes "Agent Text (Diag):"
                 if cur is None:
@@ -105,11 +107,13 @@ def _parse_local_trace(trace_lines):
                     turns.append(cur)
                 txt = line[len("Agent Text: "):].strip()
                 cur.agent = f"{cur.agent} {txt}".strip() if cur.agent else txt
+                in_agent_text = True
                 continue
             if cur is None:
                 continue
             m = _TOOLCALL_RE.search(line)
             if m:
+                in_agent_text = False
                 try:
                     args = ast.literal_eval(m.group("args"))
                 except (ValueError, SyntaxError):
@@ -123,6 +127,7 @@ def _parse_local_trace(trace_lines):
                 continue
             mr = _TOOLRESPONSE_RE.search(line)
             if mr:
+                in_agent_text = False
                 name = mr.group("name")
                 try:
                     res_val = ast.literal_eval(mr.group("result"))
@@ -138,11 +143,15 @@ def _parse_local_trace(trace_lines):
                 continue
             mt = _TRANSFER_RE.search(line)
             if mt:
+                in_agent_text = False
                 target = mt.group("target").removeprefix("Transferred to ").strip()
                 cur.tool_calls.append(
                     ToolCall(action=_TRANSFER_ACTION, args={"agent": target})
                 )
                 continue
+            if in_agent_text and line.strip():
+                txt = line.strip()
+                cur.agent = f"{cur.agent} {txt}".strip() if cur.agent else txt
     return turns
 
 

--- a/.agents/skills/cxas-turn-eval-curator/scripts/sim_to_turn_evals.py
+++ b/.agents/skills/cxas-turn-eval-curator/scripts/sim_to_turn_evals.py
@@ -185,7 +185,10 @@ def _harvest_expectations(
             seen.add(key)
             exps.append({"type": "tool_called", "value": action})
 
-        pinned = {k: args[k] for k in input_keys if k in args}
+        if "*" in input_keys:
+            pinned = args
+        else:
+            pinned = {k: args[k] for k in input_keys if k in args}
         if pinned:
             pkey = ("tool_input", json.dumps(pinned, sort_keys=True, default=str))
             if pkey not in seen:
@@ -194,7 +197,10 @@ def _harvest_expectations(
 
         out = getattr(tc, "output", None)
         if want_output and isinstance(out, dict):
-            pinned_out = {k: out[k] for k in output_keys if k in out}
+            if "*" in output_keys:
+                pinned_out = out
+            else:
+                pinned_out = {k: out[k] for k in output_keys if k in out}
             value = {action: pinned_out}  # {} => assert the tool returned
             okey = ("tool_output", json.dumps(value, sort_keys=True, default=str))
             if okey not in seen:
@@ -272,25 +278,26 @@ def _parse_conversation_turns(conv_dict):
 
 
 def _reconstruct(app_name, creds, res, args):
-    """Return (turns, effective_context). Prefer the real platform conversation
-    (full tool args+outputs, faithful session replay); fall back to the local
-    trace (text + tool args + transfers, no outputs) only if the fetch fails."""
+    """Return (turns, source). Prefer the real platform conversation
+    (full tool args+outputs) to get rich expectations; fall back to the local
+    trace (text + tool args + transfers, no outputs) only if the fetch fails or
+    no session_id is available."""
     sid = res.get("session_id")
-    if sid and args.context in ("auto", "session"):
+    if sid:
         try:
             cd = _fetch_conversation_dict(
                 app_name, creds, sid, args.fetch_retries, args.fetch_delay
             )
-            return _parse_conversation_turns(cd), "session"
+            return _parse_conversation_turns(cd), "platform"
         except Exception as e:  # noqa: BLE001
             print(
                 f"  ! platform fetch failed for {res.get('name')} after "
                 f"{args.fetch_retries} tries ({type(e).__name__}); "
-                f"falling back to local trace (no tool outputs, no replay).",
+                f"falling back to local trace (no tool outputs).",
                 file=sys.stderr,
             )
 
-    return _parse_local_trace(res.get("detailed_trace", [])), "utterances"
+    return _parse_local_trace(res.get("detailed_trace", [])), "local"
 
 
 def _build_probes(app_name, creds, results, args) -> List[Dict[str, Any]]:
@@ -305,7 +312,7 @@ def _build_probes(app_name, creds, results, args) -> List[Dict[str, Any]]:
             print(f"  - skip {name}: sim did not pass (--only-passing)")
             continue
 
-        turns, effective = _reconstruct(app_name, creds, res, args)
+        turns, source = _reconstruct(app_name, creds, res, args)
         if not turns:
             print(f"  - skip {name}: no turns reconstructed")
             continue
@@ -324,7 +331,7 @@ def _build_probes(app_name, creds, results, args) -> List[Dict[str, Any]]:
                 continue  # need a user input to probe this turn
             exps = _harvest_expectations(
                 turn, input_keys, output_keys,
-                want_output and effective == "session",
+                want_output and source == "platform",
             )
             if args.include_text:
                 text = _agent_text(turn)
@@ -341,7 +348,19 @@ def _build_probes(app_name, creds, results, args) -> List[Dict[str, Any]]:
             }
             # Prefix context: turns before this user input.
             prefix = turns[:i]
-            if effective == "session":
+            
+            # Determine if we should generate session_id context:
+            # We use session_id context IF:
+            # 1. User requested "session" or "auto"
+            # 2. AND we successfully got platform conversation (source == "platform")
+            # 3. AND session_id is present in the results
+            use_session_context = (
+                args.context in ("session", "auto")
+                and source == "platform"
+                and res.get("session_id") is not None
+            )
+
+            if use_session_context:
                 probe["historical_contexts"] = {"session_id": res["session_id"]}
                 probe["turn_count"] = i  # include i prior turns
             else:
@@ -364,7 +383,7 @@ def _build_probes(app_name, creds, results, args) -> List[Dict[str, Any]]:
 
         if not scenario_probes:
             print(f"  - skip {name}: no assertion-bearing turns "
-                  f"(context={effective})")
+                  f"(context={source})")
         probes.extend(scenario_probes)
 
     return probes
@@ -502,10 +521,11 @@ def main() -> None:
     p.add_argument("--no-tool-fakes", dest="use_tool_fakes",
                    action="store_false")
     p.add_argument("--context", choices=["auto", "session", "utterances"],
-                   default="session",
-                   help="Prefix replay strategy (default: session — replay the "
-                        "REAL conversation via session_id+turn_count; falls back "
-                        "to inline utterances only if the fetch fails).")
+                   default="utterances",
+                   help="Prefix replay strategy (default: utterances — replay using "
+                        "inline utterances and variables; session replays the "
+                        "REAL conversation via session_id+turn_count; auto uses "
+                        "session if platform fetch succeeds, else utterances).")
     p.add_argument("--fetch-retries", type=int, default=5,
                    help="Attempts to fetch each conversation, to ride out "
                         "read-after-write consistency (default: 5).")

--- a/.agents/skills/cxas-turn-eval-curator/scripts/sim_to_turn_evals.py
+++ b/.agents/skills/cxas-turn-eval-curator/scripts/sim_to_turn_evals.py
@@ -532,6 +532,8 @@ def main() -> None:
                         "(default: 1).")
     p.add_argument("--only-passing", action="store_true",
                    help="Only convert scenarios whose sim run passed.")
+    p.add_argument("--write-results",
+                   help="Save the raw captured sim results (trajectories) JSON to this path.")
     p.add_argument("--review", action="store_true",
                    help="Print harvested assertions for curation.")
     args = p.parse_args()
@@ -548,6 +550,12 @@ def main() -> None:
     if not results:
         print("No sim results to convert.", file=sys.stderr)
         sys.exit(1)
+
+    if args.write_results:
+        import json
+        with open(args.write_results, "w", encoding="utf-8") as f:
+            json.dump(results, f, indent=2, default=str)
+        print(f"Saved raw sim results (trajectories) to {args.write_results}")
 
     print("Building turn-eval probes...")
     creds = getattr(sim, "creds", None) if sim else None

--- a/.agents/skills/cxas-turn-eval-curator/scripts/sim_to_turn_evals.py
+++ b/.agents/skills/cxas-turn-eval-curator/scripts/sim_to_turn_evals.py
@@ -77,11 +77,12 @@ _DEFAULT_INPUT_KEYS = ("account_id", "customer_id", "ticket_id", "line_id")
 # parser misses. We parse them directly so conversion works without the
 # platform conversation fetch (which may be unavailable / not retained).
 _TOOLCALL_RE = re.compile(r"Tool Call:\s*(?P<name>\S+)\s+with args\s+(?P<args>\{.*\})\s*$")
+_TOOLRESPONSE_RE = re.compile(r"Tool Response:\s*(?P<name>\S+)\s+with result\s+(?P<result>\{.*\})\s*$")
 _TRANSFER_RE = re.compile(r"Agent Transfer:\s*(?P<target>.+?)\s*$")
 
 
 def _parse_local_trace(trace_lines):
-    """Parse SimulationEvals detailed_trace into Turn objects WITH tool calls.
+    """Parse SimulationEvals detailed_trace into Turn objects WITH tool calls and outputs.
 
     Richer than SimulationEvals._get_turns_from_local_trace, which only reads
     line starts and therefore drops embedded ``Tool Call:`` lines.
@@ -118,6 +119,24 @@ def _parse_local_trace(trace_lines):
                         args=args if isinstance(args, dict) else {},
                     )
                 )
+                continue
+            mr = _TOOLRESPONSE_RE.search(line)
+            if mr:
+                name = mr.group("name")
+                try:
+                    res_val = ast.literal_eval(mr.group("result"))
+                except (ValueError, SyntaxError):
+                    res_val = {}
+                match = next(
+                    (t for t in reversed(cur.tool_calls)
+                     if t.action == name and t.output is None),
+                    None,
+                )
+                if match:
+                    if isinstance(res_val, dict) and "result" in res_val:
+                        match.output = res_val["result"]
+                    else:
+                        match.output = res_val
                 continue
             mt = _TRANSFER_RE.search(line)
             if mt:
@@ -331,7 +350,7 @@ def _build_probes(app_name, creds, results, args) -> List[Dict[str, Any]]:
                 continue  # need a user input to probe this turn
             exps = _harvest_expectations(
                 turn, input_keys, output_keys,
-                want_output and source == "platform",
+                want_output,
             )
             if args.include_text:
                 text = _agent_text(turn)
@@ -531,9 +550,9 @@ def main() -> None:
                         "read-after-write consistency (default: 5).")
     p.add_argument("--fetch-delay", type=float, default=2.0,
                    help="Base seconds between fetch retries (linear backoff).")
-    p.add_argument("--input-keys", default=",".join(_DEFAULT_INPUT_KEYS),
+    p.add_argument("--input-keys", default="*",
                    help="Comma-separated tool-arg keys to pin as tool_input "
-                        "assertions.")
+                        "assertions (default: * to include all).")
     p.add_argument("--output-keys", default="status",
                    help="Comma-separated tool-response keys to pin as tool_output "
                         "assertions (empty -> existence-only). Session mode only.")

--- a/src/cxas_scrapi/core/sessions.py
+++ b/src/cxas_scrapi/core/sessions.py
@@ -54,6 +54,7 @@ except ImportError:
 from cxas_scrapi.core.common import DEFAULT_API_ENDPOINT, Common
 from cxas_scrapi.core.conversation_history import ConversationHistory
 from cxas_scrapi.core.response_parser import ParsedSessionResponse
+from cxas_scrapi.core.agents import Agents
 
 logger = logging.getLogger(__name__)
 
@@ -925,6 +926,7 @@ class Sessions(Common):
         input_audio_config: dict[str, Any] | None = None,
         output_audio_config: dict[str, Any] | None = None,
         deployment_id: str | None = None,
+        entry_agent: str | None = None,
         historical_contexts: list[dict[str, Any]] | str | None = None,
         turn_count: int | None = None,
         modality: Modality | str = Modality.TEXT,
@@ -981,6 +983,17 @@ class Sessions(Common):
             "session": f"{self.app_name}/sessions/{session_id}",
             "use_tool_fakes": use_tool_fakes,
         }
+        if entry_agent:
+            if not entry_agent.startswith("projects/"):
+                agents_client = Agents(app_name=self.app_name, creds=self.creds)
+                agents_map = agents_client.get_agents_map(reverse=True)
+                if entry_agent in agents_map:
+                    entry_agent = agents_map[entry_agent]
+                else:
+                    logger.warning(
+                        f"Could not resolve entry_agent display name: {entry_agent}"
+                    )
+            config["entry_agent"] = entry_agent
         inputs = []
 
         if modality == Modality.AUDIO:

--- a/src/cxas_scrapi/core/sessions.py
+++ b/src/cxas_scrapi/core/sessions.py
@@ -51,10 +51,10 @@ try:
     from pydub import AudioSegment
 except ImportError:
     AudioSegment = None
+from cxas_scrapi.core.agents import Agents
 from cxas_scrapi.core.common import DEFAULT_API_ENDPOINT, Common
 from cxas_scrapi.core.conversation_history import ConversationHistory
 from cxas_scrapi.core.response_parser import ParsedSessionResponse
-from cxas_scrapi.core.agents import Agents
 
 logger = logging.getLogger(__name__)
 
@@ -991,7 +991,8 @@ class Sessions(Common):
                     entry_agent = agents_map[entry_agent]
                 else:
                     logger.warning(
-                        f"Could not resolve entry_agent display name: {entry_agent}"
+                        "Could not resolve entry_agent display name: %s",
+                        entry_agent,
                     )
             config["entry_agent"] = entry_agent
         inputs = []

--- a/src/cxas_scrapi/evals/turn_evals.py
+++ b/src/cxas_scrapi/evals/turn_evals.py
@@ -244,8 +244,19 @@ class TurnEvals:
                 except json.JSONDecodeError:
                     pass
 
-            # Recursive check if both are dicts
-            if isinstance(v, dict) and isinstance(super_val, dict):
+            if isinstance(super_val, list):
+                if isinstance(v, dict):
+                    match_found = False
+                    for item in super_val:
+                        if isinstance(item, dict) and self._check_dict_subset(v, item):
+                            match_found = True
+                            break
+                    if not match_found:
+                        return False
+                else:
+                    if v not in super_val and str(v) not in [str(x) for x in super_val]:
+                        return False
+            elif isinstance(v, dict) and isinstance(super_val, dict):
                 if not self._check_dict_subset(v, super_val):
                     return False
             elif super_val != v:
@@ -268,10 +279,10 @@ class TurnEvals:
                 if tool_name not in called_tools:
                     called_tools.append(tool_name)
 
-                if "args" in attrs and tool_name not in tool_inputs:
-                    tool_inputs[tool_name] = attrs["args"]
-                if "response" in attrs and tool_name not in tool_outputs:
-                    tool_outputs[tool_name] = attrs["response"]
+                if "args" in attrs:
+                    tool_inputs.setdefault(tool_name, []).append(attrs["args"])
+                if "response" in attrs:
+                    tool_outputs.setdefault(tool_name, []).append(attrs["response"])
 
         for child in span.get("childSpans", []):
             self._extract_tools_from_span(
@@ -309,8 +320,7 @@ class TurnEvals:
                 tool_name = tc.get("displayName", tc.get("tool", ""))
                 if tool_name and tool_name not in called_tools:
                     called_tools.append(tool_name)
-                if tool_name not in tool_inputs:
-                    tool_inputs[tool_name] = tc.get("args", {})
+                tool_inputs.setdefault(tool_name, []).append(tc.get("args", {}))
 
         def add_snippet(snippet: str):
             nonlocal full_text
@@ -352,13 +362,11 @@ class TurnEvals:
                         tool_name = tc.get("displayName", tc.get("tool", ""))
                         if tool_name and tool_name not in called_tools:
                             called_tools.append(tool_name)
-                        if tool_name not in tool_inputs:
-                            tool_inputs[tool_name] = tc.get("args", {})
+                        tool_inputs.setdefault(tool_name, []).append(tc.get("args", {}))
                     if "toolResponse" in chunk:
                         tr = chunk["toolResponse"]
                         tool_name = tr.get("displayName", tr.get("tool", ""))
-                        if tool_name not in tool_outputs:
-                            tool_outputs[tool_name] = tr.get("response", {})
+                        tool_outputs.setdefault(tool_name, []).append(tr.get("response", {}))
                     if "agentTransfer" in chunk:
                         at = chunk["agentTransfer"]
                         target_agent = at.get("displayName", "")
@@ -382,8 +390,7 @@ class TurnEvals:
                     tool_name = tc.get("displayName", tc.get("tool", ""))
                     if tool_name and tool_name not in called_tools:
                         called_tools.append(tool_name)
-                    if tool_name not in tool_inputs:
-                        tool_inputs[tool_name] = tc.get("args", {})
+                    tool_inputs.setdefault(tool_name, []).append(tc.get("args", {}))
 
         return {
             "full_text": full_text,
@@ -553,9 +560,12 @@ class TurnEvals:
                     # 2) Fallback to checking nested argument dicts for
                     # any tool
                     match_found = False
-                    for _t_name, t_args in tool_inputs.items():
-                        if self._check_dict_subset(expected, t_args):
-                            match_found = True
+                    for _t_name, args_list in tool_inputs.items():
+                        for t_args in args_list:
+                            if isinstance(t_args, dict) and self._check_dict_subset(expected, t_args):
+                                match_found = True
+                                break
+                        if match_found:
                             break
                     if not match_found:
                         status = "FAILURE"
@@ -580,9 +590,12 @@ class TurnEvals:
                     # 2) Fallback to checking nested response dicts for
                     # any tool
                     match_found = False
-                    for _t_name, t_resp in tool_outputs.items():
-                        if self._check_dict_subset(expected, t_resp):
-                            match_found = True
+                    for _t_name, resp_list in tool_outputs.items():
+                        for t_resp in resp_list:
+                            if isinstance(t_resp, dict) and self._check_dict_subset(expected, t_resp):
+                                match_found = True
+                                break
+                        if match_found:
                             break
                     if not match_found:
                         status = "FAILURE"

--- a/src/cxas_scrapi/evals/turn_evals.py
+++ b/src/cxas_scrapi/evals/turn_evals.py
@@ -248,14 +248,17 @@ class TurnEvals:
                 if isinstance(v, dict):
                     match_found = False
                     for item in super_val:
-                        if isinstance(item, dict) and self._check_dict_subset(v, item):
+                        if isinstance(
+                            item, dict
+                        ) and self._check_dict_subset(v, item):
                             match_found = True
                             break
                     if not match_found:
                         return False
-                else:
-                    if v not in super_val and str(v) not in [str(x) for x in super_val]:
-                        return False
+                elif v not in super_val and str(v) not in [
+                    str(x) for x in super_val
+                ]:
+                    return False
             elif isinstance(v, dict) and isinstance(super_val, dict):
                 if not self._check_dict_subset(v, super_val):
                     return False
@@ -282,7 +285,9 @@ class TurnEvals:
                 if "args" in attrs:
                     tool_inputs.setdefault(tool_name, []).append(attrs["args"])
                 if "response" in attrs:
-                    tool_outputs.setdefault(tool_name, []).append(attrs["response"])
+                    tool_outputs.setdefault(tool_name, []).append(
+                        attrs["response"]
+                    )
 
         for child in span.get("childSpans", []):
             self._extract_tools_from_span(
@@ -362,11 +367,15 @@ class TurnEvals:
                         tool_name = tc.get("displayName", tc.get("tool", ""))
                         if tool_name and tool_name not in called_tools:
                             called_tools.append(tool_name)
-                        tool_inputs.setdefault(tool_name, []).append(tc.get("args", {}))
+                        tool_inputs.setdefault(tool_name, []).append(
+                            tc.get("args", {})
+                        )
                     if "toolResponse" in chunk:
                         tr = chunk["toolResponse"]
                         tool_name = tr.get("displayName", tr.get("tool", ""))
-                        tool_outputs.setdefault(tool_name, []).append(tr.get("response", {}))
+                        tool_outputs.setdefault(tool_name, []).append(
+                            tr.get("response", {})
+                        )
                     if "agentTransfer" in chunk:
                         at = chunk["agentTransfer"]
                         target_agent = at.get("displayName", "")
@@ -390,7 +399,9 @@ class TurnEvals:
                     tool_name = tc.get("displayName", tc.get("tool", ""))
                     if tool_name and tool_name not in called_tools:
                         called_tools.append(tool_name)
-                    tool_inputs.setdefault(tool_name, []).append(tc.get("args", {}))
+                    tool_inputs.setdefault(tool_name, []).append(
+                        tc.get("args", {})
+                    )
 
         return {
             "full_text": full_text,
@@ -562,7 +573,9 @@ class TurnEvals:
                     match_found = False
                     for _t_name, args_list in tool_inputs.items():
                         for t_args in args_list:
-                            if isinstance(t_args, dict) and self._check_dict_subset(expected, t_args):
+                            if isinstance(
+                                t_args, dict
+                            ) and self._check_dict_subset(expected, t_args):
                                 match_found = True
                                 break
                         if match_found:
@@ -592,7 +605,9 @@ class TurnEvals:
                     match_found = False
                     for _t_name, resp_list in tool_outputs.items():
                         for t_resp in resp_list:
-                            if isinstance(t_resp, dict) and self._check_dict_subset(expected, t_resp):
+                            if isinstance(
+                                t_resp, dict
+                            ) and self._check_dict_subset(expected, t_resp):
                                 match_found = True
                                 break
                         if match_found:

--- a/src/cxas_scrapi/utils/gemini.py
+++ b/src/cxas_scrapi/utils/gemini.py
@@ -140,7 +140,7 @@ class GeminiGenerate:
             if response_mime_type == "application/json" and response_schema:
                 return response.parsed
             return response.text
-        except Exception as e:
+        except Exception:
             logger.exception("Gemini generation failed")
             return None
 
@@ -196,7 +196,7 @@ class GeminiGenerate:
             if response_mime_type == "application/json" and response_schema:
                 return response.parsed
             return response.text
-        except Exception as e:
+        except Exception:
             logger.exception("Gemini multimodal generation failed")
             return None
 

--- a/src/cxas_scrapi/utils/gemini.py
+++ b/src/cxas_scrapi/utils/gemini.py
@@ -141,7 +141,7 @@ class GeminiGenerate:
                 return response.parsed
             return response.text
         except Exception as e:
-            logger.error(f"Gemini generation failed: {e}")
+            logger.exception("Gemini generation failed")
             return None
 
     def generate_with_parts(
@@ -197,7 +197,7 @@ class GeminiGenerate:
                 return response.parsed
             return response.text
         except Exception as e:
-            logger.error(f"Gemini multimodal generation failed: {e}")
+            logger.exception("Gemini multimodal generation failed")
             return None
 
     async def generate_async(

--- a/tests/cxas_scrapi/evals/test_turn_evals.py
+++ b/tests/cxas_scrapi/evals/test_turn_evals.py
@@ -203,7 +203,7 @@ def test_extract_signals(mock_message_to_dict, mock_turn_evals):
 
     assert signals["full_text"] == "Hello there!"
     assert signals["called_tools"] == ["my_tool"]
-    assert signals["tool_inputs"] == {"my_tool": {"param": "value"}}
+    assert signals["tool_inputs"] == {"my_tool": [{"param": "value"}]}
 
 
 @patch("cxas_scrapi.evals.turn_evals.MessageToDict")


### PR DESCRIPTION
Implements a deterministic extractor and curation workflow skill that translates expensive multi-turn SimulationEvals runs into cheap single-turn audio TurnEvals.

Command to generate draft turn-evals from simulations: python .agents/skills/cxas-turn-eval-curator/scripts/sim_to_turn_evals.py \
  --app-name <app_project_path> \
  --eval-file simulations.yaml \
  --run --capture-modality audio \
  --output draft_turn_evals.yaml --review

