### PR TITLE
chore: implement random automated PR reviewer assignment

### DIFF
--- a/.github/maintainers.txt
+++ b/.github/maintainers.txt
@@ -1,0 +1,9 @@
+# Add GitHub handles of reviewers here (one per line, no @ symbol)
+# The auto-assign workflow will randomly pick a reviewer from this list.
+
+PatrickMarlow
+ygupta
+alexyu
+kranthikiran01
+deniscalin
+vishalghorpade

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,54 +1,51 @@
-name: "Auto Assign Reviewer"
+name: Auto Assign Reviewer
 
+# Use pull_request_target to ensure the workflow has write permissions
+# even when the PR originates from a fork.
 on:
   pull_request_target:
     types: [opened, ready_for_review, reopened]
 
+# Explicitly grant the required write permissions
 permissions:
   pull-requests: write
 
 jobs:
-  assign:
-    name: Assign Random Reviewer
+  assign-reviewer:
+    # Do not assign reviewers to Draft PRs
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout maintainers file
+      - name: Checkout base repository
         uses: actions/checkout@v4
-        with:
-          sparse-checkout: |
-            .github/maintainers.txt
-          sparse-checkout-cone-mode: false
+        # We checkout the base repository (main) to securely read maintainers.txt.
+        # This prevents executing untrusted code from the fork.
 
-      - name: Pick and Assign
+      - name: Assign Random Reviewer
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          # 1. Read maintainers from file, ignoring empty lines and comments
-          mapfile -t reviewer_array < <(grep -v '^#' .github/maintainers.txt | grep -v '^\s*$')
+          # 1. Check if reviewers are already assigned
+          EXISTING_REVIEWERS=$(gh pr view "$PR_URL" --json reviewRequests -q '.reviewRequests | length')
 
-          # 2. Identify the author of the PR
-          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
-
-          # 3. Create a pool of reviewers excluding the author
-          pool=()
-          for r in "${reviewer_array[@]}"; do
-            # Trim whitespace
-            r=$(echo "$r" | xargs)
-            if [ "$r" != "$PR_AUTHOR" ]; then
-              pool+=("$r")
-            fi
-          done
-
-          if [ ${#pool[@]} -eq 0 ]; then
-            echo "No eligible reviewers found."
+          if [ "$EXISTING_REVIEWERS" -gt 0 ]; then
+            echo "Reviewer already requested. Exiting."
             exit 0
           fi
 
-          # 4. Pick a random index
-          RANDOM_INDEX=$(( RANDOM % ${#pool[@]} ))
-          SELECTED_REVIEWER=${pool[$RANDOM_INDEX]}
+          # 2. Read maintainers and filter out the author
+          # Ignores comments (#), empty lines, and the author (case-insensitive)
+          MAINTAINERS=$(grep -v "^#" .github/maintainers.txt | grep -v "^$" | grep -v -i "^${AUTHOR}$" || true)
 
-          echo "Selected $SELECTED_REVIEWER for review."
+          if [ -z "$MAINTAINERS" ]; then
+            echo "No eligible maintainers found after filtering out the author."
+            exit 0
+          fi
 
-          # 5. Use GitHub CLI to add the reviewer
-          gh pr edit ${{ github.event.pull_request.html_url }} --add-reviewer "$SELECTED_REVIEWER"
+          # 3. Pick a random reviewer using shuf
+          REVIEWER=$(echo "$MAINTAINERS" | shuf -n 1)
+
+          echo "Assigning @$REVIEWER as reviewer..."
+          gh pr edit "$PR_URL" --add-reviewer "$REVIEWER"

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,54 @@
+name: "Auto Assign Reviewer"
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign:
+    name: Assign Random Reviewer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout maintainers file
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/maintainers.txt
+          sparse-checkout-cone-mode: false
+
+      - name: Pick and Assign
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # 1. Read maintainers from file, ignoring empty lines and comments
+          mapfile -t reviewer_array < <(grep -v '^#' .github/maintainers.txt | grep -v '^\s*$')
+
+          # 2. Identify the author of the PR
+          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+
+          # 3. Create a pool of reviewers excluding the author
+          pool=()
+          for r in "${reviewer_array[@]}"; do
+            # Trim whitespace
+            r=$(echo "$r" | xargs)
+            if [ "$r" != "$PR_AUTHOR" ]; then
+              pool+=("$r")
+            fi
+          done
+
+          if [ ${#pool[@]} -eq 0 ]; then
+            echo "No eligible reviewers found."
+            exit 0
+          fi
+
+          # 4. Pick a random index
+          RANDOM_INDEX=$(( RANDOM % ${#pool[@]} ))
+          SELECTED_REVIEWER=${pool[$RANDOM_INDEX]}
+
+          echo "Selected $SELECTED_REVIEWER for review."
+
+          # 5. Use GitHub CLI to add the reviewer
+          gh pr edit ${{ github.event.pull_request.html_url }} --add-reviewer "$SELECTED_REVIEWER"


### PR DESCRIPTION
This PR introduces a GitHub Actions workflow to automatically and randomly assign PR reviewers from a designated list of maintainers (will be expanded later to reduce review bottleneck).

### Why not use `CODEOWNERS`?
The original plan was to use a standard GitHub `.github/CODEOWNERS` file to route reviews to maintainers. However, `CODEOWNERS` has several critical limitations in this environment:
1. **Lack of Load Balancing / Random Assignment**: When multiple individual handles are configured in `CODEOWNERS` (e.g., `* @PatrickMarlow @ygupta @alexyu ...`), GitHub automatically requests a review from *every* listed person simultaneously. This results in heavy notification spam for all maintainers on every single PR.
2. **Access Restrictions for Teams**: The standard GitHub way to solve the notification spam is to assign the PR to a GitHub Team and configure the team's "Code review auto-assignment" to distribute reviews (e.g., round-robin). However, we are hosting in the `@GoogleCloudPlatform` organization, where creating and managing GitHub Teams requires administrative access that may require additional approvals.
3. **Friction for Authors**: `CODEOWNERS` automatically assigns the author if they are in the file and modify their own domains, whereas the GitHub Actions workflow dynamically filters out the PR author from the pool of eligible reviewers.

### Proposed Solution
To bypass these limitations, we introduced:
1. `.github/maintainers.txt`: A simple, flat file listing all eligible reviewers.
2. `.github/workflows/auto-assign.yml`: An automated workflow that:
   - Reads the list of maintainers.
   - Dynamically excludes the PR author.
   - Randomly selects a reviewer from the remaining pool.
   - Assigns them as a reviewer using the GitHub CLI (`gh pr edit`).