### PR TITLE
feat(lint): add V100-V104 variable-reference rules

### DIFF
--- a/src/cxas_scrapi/utils/lint_rules/__init__.py
+++ b/src/cxas_scrapi/utils/lint_rules/__init__.py
@@ -22,4 +22,5 @@ from cxas_scrapi.utils.lint_rules import (  # noqa: F401
     schema,
     structure,
     tools,
+    variables,
 )

--- a/src/cxas_scrapi/utils/lint_rules/variables.py
+++ b/src/cxas_scrapi/utils/lint_rules/variables.py
@@ -1,0 +1,847 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Variable-reference lint rules (V100-V104).
+
+Surfaces state/instruction/eval references that target undeclared keys,
+mistyped nested children, or wrong parent objects after a flat→nested
+``variableDeclarations`` migration. See issue #291 for the bug catalogue.
+"""
+
+import ast
+import json
+import re
+from pathlib import Path
+
+import yaml
+
+from cxas_scrapi.utils.linter import (
+    LintContext,
+    LintResult,
+    Rule,
+    Severity,
+    rule,
+)
+
+# ── Schema loading & caching ─────────────────────────────────────────────
+
+_SCHEMA_CACHE: dict[str, dict] = {}
+
+# Maps declared schema.type → tuple of acceptable Python type names.
+SCHEMA_TYPE_TO_PY = {
+    "STRING": ("str",),
+    "BOOLEAN": ("bool",),
+    "INTEGER": ("int",),
+    "NUMBER": ("int", "float"),
+    "OBJECT": ("dict",),
+    "ARRAY": ("list",),
+}
+
+# Builtin instruction variables that bypass declaration checks.
+INSTRUCTION_BUILTINS = {"current_date"}
+
+# Template ref pattern — matches {var} and {var.child}. Excludes @TOOL/@AGENT
+# directives (those have a colon: {@TOOL: name}) and double-brace forms.
+TEMPLATE_RE = re.compile(r"(?<!\{)\{([a-zA-Z_][\w.]*)\}(?!\})")
+
+# Eval YAML keys that contain nested var assignments shaped like
+# ``{var_name: {nested_key: value, ...}, ...}``.
+EVAL_VAR_KEYS = ("variables", "session_parameters", "common_session_parameters")
+
+
+def _resolve_app_root(context: LintContext) -> Path | None:
+    """Locate the app root (dir containing app.json/app.yaml).
+
+    Prefers ``context.app_root`` when set, otherwise probes
+    ``context.app_dir`` directly and its immediate subdirectories
+    (mirroring ``Discovery._find_app_root``).
+    """
+    if context.app_root is not None:
+        return context.app_root
+    app_dir = context.app_dir
+    if app_dir is None or not app_dir.exists():
+        return None
+    for name in ("app.json", "app.yaml"):
+        if (app_dir / name).exists():
+            return app_dir
+    for d in app_dir.iterdir():
+        if d.is_dir() and not d.name.startswith("."):
+            if (d / "app.json").exists() or (d / "app.yaml").exists():
+                return d
+    return None
+
+
+def _load_app_config(app_root: Path) -> dict:
+    for name in ("app.json", "app.yaml"):
+        p = app_root / name
+        if not p.exists():
+            continue
+        try:
+            text = p.read_text()
+            if name.endswith(".yaml"):
+                return yaml.safe_load(text) or {}
+            return json.loads(text)
+        except (json.JSONDecodeError, yaml.YAMLError, OSError):
+            return {}
+    return {}
+
+
+def _load_var_schema(context: LintContext) -> dict:
+    """Return ``{var_name: schema_dict}`` for declared variables (cached)."""
+    app_root = _resolve_app_root(context)
+    if app_root is None:
+        return {}
+    key = str(app_root)
+    if key in _SCHEMA_CACHE:
+        return _SCHEMA_CACHE[key]
+    cfg = _load_app_config(app_root)
+    decls = cfg.get("variableDeclarations") or []
+    schema: dict[str, dict] = {}
+    for d in decls:
+        name = d.get("name")
+        if name:
+            schema[name] = d.get("schema") or {}
+    _SCHEMA_CACHE[key] = schema
+    return schema
+
+
+def _clear_schema_cache() -> None:
+    """Test helper — drop the schema cache so a new fixture is re-read."""
+    _SCHEMA_CACHE.clear()
+
+
+# ── Path resolver ────────────────────────────────────────────────────────
+
+
+def resolve_path(path: str, schema: dict) -> tuple:
+    """Resolve a dotted variable path against the declaration schema.
+
+    Returns a tagged tuple — caller dispatches on the first element:
+      ("ok", schema_type)             - leaf resolves cleanly
+      ("ok_object",)                  - resolves to a declared OBJECT
+      ("undeclared",)                 - top-level name is not declared
+      ("stale_flat", parent_var)      - top-level name lives nested under parent
+      ("not_object", parent_path)     - dotted access but parent isn't OBJECT
+      ("no_property", parent_path, child) - parent is OBJECT, child missing
+    """
+    parts = path.split(".")
+    head = parts[0]
+    if head not in schema:
+        for vname, vschema in schema.items():
+            if vschema.get("type") == "OBJECT":
+                props = vschema.get("properties") or {}
+                if head in props:
+                    return ("stale_flat", vname)
+        return ("undeclared",)
+
+    current = schema[head]
+    for i, child in enumerate(parts[1:], start=1):
+        if current.get("type") != "OBJECT":
+            return ("not_object", ".".join(parts[:i]))
+        props = current.get("properties") or {}
+        if child not in props:
+            return ("no_property", ".".join(parts[:i]), child)
+        current = props[child]
+
+    if current.get("type") == "OBJECT":
+        return ("ok_object",)
+    return ("ok", current.get("type", "UNKNOWN"))
+
+
+def _available_top_level(schema: dict) -> str:
+    return ", ".join(sorted(schema.keys())) or "(none declared)"
+
+
+def _available_properties(parent_schema: dict) -> str:
+    props = parent_schema.get("properties") or {}
+    return ", ".join(sorted(props.keys())) or "(none)"
+
+
+# ── State-access AST visitor (callbacks + tools) ────────────────────────
+
+
+class _StateAccessVisitor(ast.NodeVisitor):
+    """Extract reads/writes against ``state``-like attributes.
+
+    Matches both bare ``state`` (the common local-rebind convention,
+    e.g. ``state = callback_context.state``) and any attribute chain
+    ending in ``.state`` (``callback_context.state``, ``context.state``).
+
+    Emits records of ``(kind, key, lineno, rhs_type)``:
+      kind     - "read" | "write"
+      key      - the literal string key (or None if non-literal)
+      lineno   - 1-based line number
+      rhs_type - Python type name of the RHS literal for writes
+                 ("str"/"bool"/"int"/"float"/"dict"/"list"), or None
+                 if the RHS is a call/name/etc. (uninferable)
+    """
+
+    # Calls whose return type we can infer without semantic analysis.
+    KNOWN_CALL_RETURN_TYPES = {
+        "len": "int",
+        "str": "str",
+        "repr": "str",
+        "int": "int",
+        "float": "float",
+        "bool": "bool",
+        "list": "list",
+        "dict": "dict",
+        "tuple": "tuple",
+        "set": "set",
+        "frozenset": "set",
+    }
+
+    def __init__(self):
+        self.accesses: list[tuple[str, str, int, str | None]] = []
+        self._skip_subscripts: set[int] = set()
+
+    @staticmethod
+    def _is_state_target(node: ast.AST) -> bool:
+        if isinstance(node, ast.Name) and node.id == "state":
+            return True
+        if isinstance(node, ast.Attribute) and node.attr == "state":
+            return True
+        return False
+
+    @staticmethod
+    def _const_str(node: ast.AST) -> str | None:
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return node.value
+        return None
+
+    @classmethod
+    def _literal_type_name(cls, node: ast.AST) -> str | None:
+        if isinstance(node, ast.Constant):
+            v = node.value
+            if isinstance(v, bool):
+                return "bool"
+            if isinstance(v, str):
+                return "str"
+            if isinstance(v, int):
+                return "int"
+            if isinstance(v, float):
+                return "float"
+            return None
+        if isinstance(node, ast.Dict):
+            return "dict"
+        if isinstance(node, ast.List):
+            return "list"
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+            return cls._literal_type_name(node.operand)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            return cls.KNOWN_CALL_RETURN_TYPES.get(node.func.id)
+        return None
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        for target in node.targets:
+            if isinstance(target, ast.Subscript) and self._is_state_target(
+                target.value
+            ):
+                key = self._const_str(target.slice)
+                if key is not None:
+                    rhs_type = self._literal_type_name(node.value)
+                    self.accesses.append(
+                        ("write", key, target.lineno, rhs_type)
+                    )
+                self._skip_subscripts.add(id(target))
+        self.generic_visit(node)
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> None:
+        target = node.target
+        if isinstance(target, ast.Subscript) and self._is_state_target(
+            target.value
+        ):
+            key = self._const_str(target.slice)
+            if key is not None:
+                # AugAssign is both read+write; record as write for V100/V102.
+                self.accesses.append(("write", key, target.lineno, None))
+            self._skip_subscripts.add(id(target))
+        self.generic_visit(node)
+
+    def visit_Subscript(self, node: ast.Subscript) -> None:
+        if id(node) not in self._skip_subscripts and self._is_state_target(
+            node.value
+        ):
+            key = self._const_str(node.slice)
+            if key is not None:
+                self.accesses.append(("read", key, node.lineno, None))
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if isinstance(node.func, ast.Attribute):
+            method = node.func.attr
+            if self._is_state_target(node.func.value):
+                if method == "get" and node.args:
+                    key = self._const_str(node.args[0])
+                    if key is not None:
+                        self.accesses.append(("read", key, node.lineno, None))
+                elif method == "setdefault" and node.args:
+                    key = self._const_str(node.args[0])
+                    if key is not None:
+                        rhs_type = (
+                            self._literal_type_name(node.args[1])
+                            if len(node.args) >= 2
+                            else None
+                        )
+                        self.accesses.append(
+                            ("write", key, node.lineno, rhs_type)
+                        )
+                elif method == "update" and node.args:
+                    arg = node.args[0]
+                    if isinstance(arg, ast.Dict):
+                        for k_node, v_node in zip(
+                            arg.keys, arg.values, strict=False
+                        ):
+                            key = self._const_str(k_node)
+                            if key is not None:
+                                rhs_type = self._literal_type_name(v_node)
+                                self.accesses.append(
+                                    ("write", key, node.lineno, rhs_type)
+                                )
+        self.generic_visit(node)
+
+
+def _collect_state_accesses(
+    content: str,
+) -> list[tuple[str, str, int, str | None]]:
+    try:
+        tree = ast.parse(content)
+    except SyntaxError:
+        return []
+    visitor = _StateAccessVisitor()
+    visitor.visit(tree)
+    return visitor.accesses
+
+
+# ── Eval YAML traversal ─────────────────────────────────────────────────
+
+
+def _collect_eval_var_refs(content: str) -> list[tuple[str, int]]:
+    """Return ``[(dotted_path, line), ...]`` for keys under known eval var maps.
+
+    Walks any top-level ``variables`` / ``session_parameters`` /
+    ``common_session_parameters`` block plus their per-test/per-turn
+    siblings (recursive). YAML loaders don't preserve line numbers
+    without a custom Loader, so line is best-effort (defaults to 1).
+    """
+    try:
+        data = yaml.safe_load(content)
+    except yaml.YAMLError:
+        return []
+    if not data:
+        return []
+    refs: list[tuple[str, int]] = []
+    _walk_eval_for_var_keys(data, content, refs)
+    return refs
+
+
+def _walk_eval_for_var_keys(node, content: str, out: list) -> None:
+    if isinstance(node, dict):
+        for k, v in node.items():
+            if k in EVAL_VAR_KEYS and isinstance(v, dict):
+                _emit_var_paths(v, content, out, prefix="")
+            else:
+                _walk_eval_for_var_keys(v, content, out)
+    elif isinstance(node, list):
+        for item in node:
+            _walk_eval_for_var_keys(item, content, out)
+
+
+def _emit_var_paths(node: dict, content: str, out: list, prefix: str) -> None:
+    """Emit (path, line) for each leaf-bearing key in a nested var map."""
+    for k, v in node.items():
+        path = f"{prefix}.{k}" if prefix else str(k)
+        line = _find_key_line(content, k)
+        if isinstance(v, dict):
+            # Emit the parent path so resolver can confirm it's a declared
+            # OBJECT, then recurse for nested children.
+            out.append((path, line))
+            _emit_var_paths(v, content, out, prefix=path)
+        else:
+            out.append((path, line))
+
+
+def _find_key_line(content: str, key: str) -> int:
+    pattern = re.compile(rf"^\s*{re.escape(str(key))}\s*:", re.MULTILINE)
+    m = pattern.search(content)
+    return content[: m.start()].count("\n") + 1 if m else 1
+
+
+# ── Instruction template extraction ──────────────────────────────────────
+
+
+def _strip_inline_examples(content: str) -> str:
+    """Blank out ``<inline_example>...</inline_example>`` blocks.
+
+    Inline examples may contain literal ``{var}`` snippets that should
+    not be lint-checked. Replace them with same-length whitespace so
+    line numbers are preserved.
+    """
+    pattern = re.compile(
+        r"<inline_example\b[^>]*>.*?</inline_example>",
+        re.DOTALL | re.IGNORECASE,
+    )
+    return pattern.sub(lambda m: re.sub(r"[^\n]", " ", m.group(0)), content)
+
+
+def _collect_template_refs(content: str) -> list[tuple[str, int]]:
+    stripped = _strip_inline_examples(content)
+    refs = []
+    for m in TEMPLATE_RE.finditer(stripped):
+        ref = m.group(1)
+        if ref in INSTRUCTION_BUILTINS:
+            continue
+        line = stripped[: m.start()].count("\n") + 1
+        refs.append((ref, line))
+    return refs
+
+
+# ── Rules ────────────────────────────────────────────────────────────────
+
+
+@rule("callbacks")
+class CallbackVariableDeclared(Rule):
+    id = "V100"
+    name = "variable-declared"
+    description = (
+        "State reads/writes must reference a declared "
+        "variableDeclarations entry"
+    )
+    default_severity = Severity.ERROR
+
+    def check(
+        self, file_path: Path, content: str, context: LintContext
+    ) -> list[LintResult]:
+        return _check_v100_python(self, file_path, content, context)
+
+
+@rule("tools")
+class ToolVariableDeclared(Rule):
+    id = "V100"
+    name = "variable-declared"
+    description = (
+        "State reads/writes must reference a declared "
+        "variableDeclarations entry"
+    )
+    default_severity = Severity.ERROR
+
+    def check(
+        self, file_path: Path, content: str, context: LintContext
+    ) -> list[LintResult]:
+        return _check_v100_python(self, file_path, content, context)
+
+
+@rule("evals")
+class EvalVariableDeclared(Rule):
+    id = "V100"
+    name = "variable-declared"
+    description = (
+        "Eval session_parameters/variables must reference declared variables"
+    )
+    default_severity = Severity.ERROR
+
+    def check(
+        self, file_path: Path, content: str, context: LintContext
+    ) -> list[LintResult]:
+        if file_path.suffix not in (".yaml", ".yml"):
+            return []
+        schema = _load_var_schema(context)
+        if not schema:
+            return []
+        rel = str(file_path.relative_to(context.project_root))
+        results = []
+        for path, line in _collect_eval_var_refs(content):
+            verdict = resolve_path(path, schema)
+            if verdict[0] == "undeclared":
+                results.append(
+                    self.make_result(
+                        file=rel,
+                        line=line,
+                        message=(
+                            f"Eval variable '{path}' is not declared in "
+                            "app.json variableDeclarations"
+                        ),
+                        fix=(
+                            "Declare it under variableDeclarations, or "
+                            f"reference a known top-level var: "
+                            f"{_available_top_level(schema)}"
+                        ),
+                    )
+                )
+        return results
+
+
+def _check_v100_python(
+    rule_obj: Rule, file_path: Path, content: str, context: LintContext
+) -> list[LintResult]:
+    if file_path.suffix != ".py":
+        return []
+    schema = _load_var_schema(context)
+    if not schema:
+        return []
+    rel = str(file_path.relative_to(context.project_root))
+    results = []
+    seen: set[tuple[str, int]] = set()
+    for _kind, key, line, _rhs in _collect_state_accesses(content):
+        if (key, line) in seen:
+            continue
+        verdict = resolve_path(key, schema)
+        if verdict[0] != "undeclared":
+            continue
+        seen.add((key, line))
+        results.append(
+            rule_obj.make_result(
+                file=rel,
+                line=line,
+                message=(
+                    f"State key '{key}' is not declared in app.json "
+                    "variableDeclarations"
+                ),
+                fix=(
+                    "Declare it under variableDeclarations, or use a known "
+                    f"top-level var: {_available_top_level(schema)}"
+                ),
+            )
+        )
+    return results
+
+
+@rule("callbacks")
+class CallbackVariableTypeMatch(Rule):
+    id = "V101"
+    name = "variable-type-match"
+    description = (
+        "State write must match the declared schema type for the variable"
+    )
+    default_severity = Severity.ERROR
+
+    def check(
+        self, file_path: Path, content: str, context: LintContext
+    ) -> list[LintResult]:
+        return _check_v101_python(self, file_path, content, context)
+
+
+@rule("tools")
+class ToolVariableTypeMatch(Rule):
+    id = "V101"
+    name = "variable-type-match"
+    description = (
+        "State write must match the declared schema type for the variable"
+    )
+    default_severity = Severity.ERROR
+
+    def check(
+        self, file_path: Path, content: str, context: LintContext
+    ) -> list[LintResult]:
+        return _check_v101_python(self, file_path, content, context)
+
+
+def _check_v101_python(
+    rule_obj: Rule, file_path: Path, content: str, context: LintContext
+) -> list[LintResult]:
+    if file_path.suffix != ".py":
+        return []
+    schema = _load_var_schema(context)
+    if not schema:
+        return []
+    rel = str(file_path.relative_to(context.project_root))
+    results = []
+    for kind, key, line, rhs_type in _collect_state_accesses(content):
+        if kind != "write" or rhs_type is None:
+            continue
+        verdict = resolve_path(key, schema)
+        if verdict[0] != "ok":
+            continue
+        declared_type = verdict[1]
+        allowed = SCHEMA_TYPE_TO_PY.get(declared_type, ())
+        if not allowed or rhs_type in allowed:
+            continue
+        results.append(
+            rule_obj.make_result(
+                file=rel,
+                line=line,
+                message=(
+                    f"State key '{key}' is declared as {declared_type}, "
+                    f"but write assigns {rhs_type}"
+                ),
+                fix=(
+                    f"Assign a {' or '.join(allowed)} value, or change the "
+                    f"schema type of '{key}'"
+                ),
+            )
+        )
+    return results
+
+
+@rule("callbacks")
+class CallbackNestedPropertyExists(Rule):
+    id = "V102"
+    name = "nested-property-exists"
+    description = "Dotted state keys must resolve to declared OBJECT properties"
+    default_severity = Severity.ERROR
+
+    def check(
+        self, file_path: Path, content: str, context: LintContext
+    ) -> list[LintResult]:
+        return _check_v102_python(self, file_path, content, context)
+
+
+@rule("tools")
+class ToolNestedPropertyExists(Rule):
+    id = "V102"
+    name = "nested-property-exists"
+    description = "Dotted state keys must resolve to declared OBJECT properties"
+    default_severity = Severity.ERROR
+
+    def check(
+        self, file_path: Path, content: str, context: LintContext
+    ) -> list[LintResult]:
+        return _check_v102_python(self, file_path, content, context)
+
+
+def _check_v102_python(
+    rule_obj: Rule, file_path: Path, content: str, context: LintContext
+) -> list[LintResult]:
+    if file_path.suffix != ".py":
+        return []
+    schema = _load_var_schema(context)
+    if not schema:
+        return []
+    rel = str(file_path.relative_to(context.project_root))
+    results = []
+    seen: set[tuple[str, int]] = set()
+    for _kind, key, line, _rhs in _collect_state_accesses(content):
+        if "." not in key or (key, line) in seen:
+            continue
+        verdict = resolve_path(key, schema)
+        seen.add((key, line))
+        if verdict[0] == "no_property":
+            parent_path = verdict[1]
+            child = verdict[2]
+            parent_schema = _walk_to_schema(parent_path, schema)
+            results.append(
+                rule_obj.make_result(
+                    file=rel,
+                    line=line,
+                    message=(
+                        f"'{parent_path}' has no property '{child}' "
+                        f"(declared properties: "
+                        f"{_available_properties(parent_schema)})"
+                    ),
+                    fix=(
+                        f"Use one of the declared properties on "
+                        f"'{parent_path}', or add '{child}' to its schema"
+                    ),
+                )
+            )
+        elif verdict[0] == "not_object":
+            parent_path = verdict[1]
+            results.append(
+                rule_obj.make_result(
+                    file=rel,
+                    line=line,
+                    message=(
+                        f"'{parent_path}' is not an OBJECT — cannot access "
+                        f"nested key '{key}'"
+                    ),
+                    fix=(
+                        f"Change '{parent_path}' schema type to OBJECT, or "
+                        "use a flat reference"
+                    ),
+                )
+            )
+    return results
+
+
+def _walk_to_schema(path: str, schema: dict) -> dict:
+    parts = path.split(".")
+    current = schema.get(parts[0]) or {}
+    for child in parts[1:]:
+        props = current.get("properties") or {}
+        current = props.get(child) or {}
+    return current
+
+
+def _stale_flat_result(
+    rule_obj: Rule, rel: str, line: int, key: str, parent_var: str
+) -> LintResult:
+    suggested = f"{parent_var}.{key}"
+    return rule_obj.make_result(
+        file=rel,
+        line=line,
+        message=(
+            f"'{key}' is no longer a top-level variable — it lives nested "
+            f"under '{parent_var}' as '{suggested}'"
+        ),
+        fix=f"Replace '{key}' with '{suggested}'",
+    )
+
+
+@rule("callbacks")
+class CallbackStaleFlatVar(Rule):
+    id = "V103"
+    name = "no-stale-flat-var-regression"
+    description = (
+        "Top-level state key matches a nested property — likely a stale "
+        "flat-variable reference"
+    )
+    default_severity = Severity.WARNING
+
+    def check(
+        self, file_path: Path, content: str, context: LintContext
+    ) -> list[LintResult]:
+        return _check_v103_python(self, file_path, content, context)
+
+
+@rule("tools")
+class ToolStaleFlatVar(Rule):
+    id = "V103"
+    name = "no-stale-flat-var-regression"
+    description = (
+        "Top-level state key matches a nested property — likely a stale "
+        "flat-variable reference"
+    )
+    default_severity = Severity.WARNING
+
+    def check(
+        self, file_path: Path, content: str, context: LintContext
+    ) -> list[LintResult]:
+        return _check_v103_python(self, file_path, content, context)
+
+
+def _check_v103_python(
+    rule_obj: Rule, file_path: Path, content: str, context: LintContext
+) -> list[LintResult]:
+    if file_path.suffix != ".py":
+        return []
+    schema = _load_var_schema(context)
+    if not schema:
+        return []
+    rel = str(file_path.relative_to(context.project_root))
+    results = []
+    seen: set[tuple[str, int]] = set()
+    for _kind, key, line, _rhs in _collect_state_accesses(content):
+        if (key, line) in seen:
+            continue
+        verdict = resolve_path(key, schema)
+        if verdict[0] != "stale_flat":
+            continue
+        seen.add((key, line))
+        results.append(_stale_flat_result(rule_obj, rel, line, key, verdict[1]))
+    return results
+
+
+@rule("instructions")
+class InstructionStaleFlatVar(Rule):
+    id = "V103"
+    name = "no-stale-flat-var-regression"
+    description = (
+        "Instruction template reference matches a nested property — likely "
+        "a stale flat-variable reference"
+    )
+    default_severity = Severity.WARNING
+
+    def check(
+        self, file_path: Path, content: str, context: LintContext
+    ) -> list[LintResult]:
+        schema = _load_var_schema(context)
+        if not schema:
+            return []
+        rel = str(file_path.relative_to(context.project_root))
+        results = []
+        for ref, line in _collect_template_refs(content):
+            if "." in ref:
+                continue
+            verdict = resolve_path(ref, schema)
+            if verdict[0] != "stale_flat":
+                continue
+            results.append(_stale_flat_result(self, rel, line, ref, verdict[1]))
+        return results
+
+
+@rule("instructions")
+class InstructionVariableRef(Rule):
+    id = "V104"
+    name = "instruction-variable-ref"
+    description = (
+        "Instruction {var} references must resolve to a declared variable"
+    )
+    default_severity = Severity.ERROR
+
+    def check(
+        self, file_path: Path, content: str, context: LintContext
+    ) -> list[LintResult]:
+        schema = _load_var_schema(context)
+        if not schema:
+            return []
+        rel = str(file_path.relative_to(context.project_root))
+        results = []
+        for ref, line in _collect_template_refs(content):
+            verdict = resolve_path(ref, schema)
+            tag = verdict[0]
+            if tag in ("ok", "ok_object"):
+                continue
+            if tag in ("undeclared", "stale_flat"):
+                # Both surface as "not a declared top-level var".
+                results.append(
+                    self.make_result(
+                        file=rel,
+                        line=line,
+                        message=(
+                            f"Template ref '{{{ref}}}' is not a declared "
+                            "variable — it will silently resolve to empty "
+                            "string at runtime"
+                        ),
+                        fix=(
+                            "Use a declared top-level var: "
+                            f"{_available_top_level(schema)}"
+                        ),
+                    )
+                )
+            elif tag == "no_property":
+                parent_path = verdict[1]
+                child = verdict[2]
+                parent_schema = _walk_to_schema(parent_path, schema)
+                results.append(
+                    self.make_result(
+                        file=rel,
+                        line=line,
+                        message=(
+                            f"Template ref '{{{ref}}}' — '{parent_path}' "
+                            f"has no property '{child}' (declared: "
+                            f"{_available_properties(parent_schema)})"
+                        ),
+                        fix=(
+                            "Use a declared property, or add it to the "
+                            f"'{parent_path}' schema"
+                        ),
+                    )
+                )
+            elif tag == "not_object":
+                parent_path = verdict[1]
+                results.append(
+                    self.make_result(
+                        file=rel,
+                        line=line,
+                        message=(
+                            f"Template ref '{{{ref}}}' — '{parent_path}' "
+                            "is not an OBJECT; cannot access nested keys"
+                        ),
+                        fix=(
+                            f"Change '{parent_path}' schema type to OBJECT, "
+                            "or use a flat reference"
+                        ),
+                    )
+                )
+        return results

--- a/src/cxas_scrapi/utils/linter.py
+++ b/src/cxas_scrapi/utils/linter.py
@@ -214,14 +214,19 @@ class Rule(ABC):
 # ── Decorator-Based Auto-Registration ───────────────────────────────────
 
 _RULE_REGISTRY: dict[str, list[Rule]] = defaultdict(list)
-_REGISTERED_IDS: set[str] = set()
+# Dedup key is (rule_id, category) so the same id may register under
+# multiple categories (e.g. V100 across callbacks/tools/evals) while
+# repeated imports of the same rule still no-op.
+_REGISTERED_IDS: set[tuple[str, str]] = set()
 
 
 def rule(category: str):
     """Class decorator that auto-registers a Rule into its category.
 
-    Duplicate rule IDs are silently ignored so that repeated imports
-    (or test-time ``@rule`` usage) never produce duplicates.
+    Duplicate ``(rule_id, category)`` pairs are silently ignored so
+    that repeated imports (or test-time ``@rule`` usage) never produce
+    duplicates. The same ``rule_id`` MAY register under different
+    categories — useful for cross-surface rules.
 
     Usage::
 
@@ -234,8 +239,9 @@ def rule(category: str):
     def decorator(cls):
         cls.category = category
         instance = cls()
-        if instance.id not in _REGISTERED_IDS:
-            _REGISTERED_IDS.add(instance.id)
+        key = (instance.id, category)
+        if key not in _REGISTERED_IDS:
+            _REGISTERED_IDS.add(key)
             _RULE_REGISTRY[category].append(instance)
         return cls
 
@@ -272,6 +278,7 @@ class LintContext:
     )
     options: dict = field(default_factory=dict)
     bypass_tool_prefixes: set = field(default_factory=set)
+    app_root: Path | None = None
 
     @property
     def all_known_tools(self) -> set:
@@ -282,23 +289,32 @@ class LintContext:
 
 
 class RuleRegistry:
-    """Holds all registered rules and applies config overrides."""
+    """Holds all registered rules and applies config overrides.
+
+    Internally keyed by ``(rule_id, category)`` so the same id may
+    appear under multiple categories. ``get(rule_id)`` returns the
+    first match by id for back-compat with callers that expect
+    unique ids (V001-V007 single-resource validation).
+    """
 
     def __init__(self):
-        self._rules: dict[str, Rule] = {}
+        self._rules: dict[tuple[str, str], Rule] = {}
 
     def register(self, rule_obj: Rule):
-        self._rules[rule_obj.id] = rule_obj
+        self._rules[(rule_obj.id, rule_obj.category)] = rule_obj
 
     def register_all(self, rules: list[Rule]):
         for r in rules:
             self.register(r)
 
     def get(self, rule_id: str) -> Rule | None:
-        return self._rules.get(rule_id)
+        for (rid, _cat), r in self._rules.items():
+            if rid == rule_id:
+                return r
+        return None
 
     def all_rules(self) -> list[Rule]:
-        return sorted(self._rules.values(), key=lambda r: r.id)
+        return sorted(self._rules.values(), key=lambda r: (r.id, r.category))
 
     def rules_for_category(self, category: str) -> list[Rule]:
         return [r for r in self.all_rules() if r.category == category]
@@ -701,6 +717,7 @@ def build_context(
         all_tool_dirs={name: path.parent for name, path in tools.items()},
         options=config.options,
         bypass_tool_prefixes=bypass_tool_prefixes,
+        app_root=app_root,
     )
 
 

--- a/tests/cxas_scrapi/utils/test_lint_rules.py
+++ b/tests/cxas_scrapi/utils/test_lint_rules.py
@@ -1963,3 +1963,397 @@ def test_s006_tool_paths_invalid(tmp_path, context):
     results = rule.check(tool_dir, "", context)
     assert len(results) == 1
     assert "Tool pythonCode path" in results[0].message
+
+
+# ── Variable Rules (V100-V104) ───────────────────────────────────────────
+
+
+_VAR_APP_JSON = """\
+{
+  "name": "test-app",
+  "rootAgent": "Root_Agent",
+  "variableDeclarations": [
+    {
+      "name": "customer",
+      "schema": {
+        "type": "OBJECT",
+        "properties": {
+          "auth_status": {"type": "STRING"},
+          "api_failed": {"type": "STRING"},
+          "account_id": {"type": "STRING"}
+        }
+      }
+    },
+    {
+      "name": "_internal",
+      "schema": {
+        "type": "OBJECT",
+        "properties": {
+          "action_trigger": {"type": "STRING"},
+          "escalation_topic": {"type": "STRING"}
+        }
+      }
+    },
+    {"name": "flat_str", "schema": {"type": "STRING"}}
+  ]
+}
+"""
+
+
+@pytest.fixture
+def var_context(tmp_path):
+    """LintContext with an app.json containing variableDeclarations."""
+    from cxas_scrapi.utils.lint_rules.variables import _clear_schema_cache  # noqa: PLC0415,I001
+
+    (tmp_path / "app.json").write_text(_VAR_APP_JSON)
+    _clear_schema_cache()
+    return LintContext(
+        project_root=tmp_path,
+        app_dir=tmp_path,
+        evals_dir=tmp_path / "evals",
+        app_root=tmp_path,
+    )
+
+
+def test_resolve_path_ok_leaf(var_context):
+    from cxas_scrapi.utils.lint_rules.variables import (  # noqa: PLC0415,I001
+        _load_var_schema,
+        resolve_path,
+    )
+
+    schema = _load_var_schema(var_context)
+    assert resolve_path("customer.auth_status", schema) == ("ok", "STRING")
+    assert resolve_path("flat_str", schema) == ("ok", "STRING")
+
+
+def test_resolve_path_ok_object(var_context):
+    from cxas_scrapi.utils.lint_rules.variables import (  # noqa: PLC0415,I001
+        _load_var_schema,
+        resolve_path,
+    )
+
+    schema = _load_var_schema(var_context)
+    assert resolve_path("customer", schema) == ("ok_object",)
+
+
+def test_resolve_path_undeclared(var_context):
+    from cxas_scrapi.utils.lint_rules.variables import (  # noqa: PLC0415,I001
+        _load_var_schema,
+        resolve_path,
+    )
+
+    schema = _load_var_schema(var_context)
+    assert resolve_path("session_token", schema) == ("undeclared",)
+
+
+def test_resolve_path_stale_flat(var_context):
+    from cxas_scrapi.utils.lint_rules.variables import (  # noqa: PLC0415,I001
+        _load_var_schema,
+        resolve_path,
+    )
+
+    schema = _load_var_schema(var_context)
+    # auth_status is a property of customer — flat ref is "stale"
+    assert resolve_path("auth_status", schema) == ("stale_flat", "customer")
+
+
+def test_resolve_path_no_property(var_context):
+    from cxas_scrapi.utils.lint_rules.variables import (  # noqa: PLC0415,I001
+        _load_var_schema,
+        resolve_path,
+    )
+
+    schema = _load_var_schema(var_context)
+    assert resolve_path("customer.full_name", schema) == (
+        "no_property",
+        "customer",
+        "full_name",
+    )
+
+
+def test_resolve_path_not_object(var_context):
+    from cxas_scrapi.utils.lint_rules.variables import (  # noqa: PLC0415,I001
+        _load_var_schema,
+        resolve_path,
+    )
+
+    schema = _load_var_schema(var_context)
+    assert resolve_path("flat_str.child", schema) == ("not_object", "flat_str")
+
+
+def test_v100_callback_undeclared(tmp_path, var_context):
+    from cxas_scrapi.utils.lint_rules.variables import CallbackVariableDeclared  # noqa: PLC0415,I001
+
+    rule = CallbackVariableDeclared()
+    f = tmp_path / "python_code.py"
+    f.write_text(
+        "def before_model_callback(callback_context, llm_request):\n"
+        "    state = callback_context.state\n"
+        "    token = state.get('session_token', '')\n"
+    )
+    results = rule.check(f, f.read_text(), var_context)
+    assert len(results) == 1
+    assert results[0].rule_id == "V100"
+    assert "session_token" in results[0].message
+
+
+def test_v100_callback_declared_no_error(tmp_path, var_context):
+    from cxas_scrapi.utils.lint_rules.variables import CallbackVariableDeclared  # noqa: PLC0415,I001
+
+    rule = CallbackVariableDeclared()
+    f = tmp_path / "python_code.py"
+    f.write_text(
+        "def before_model_callback(callback_context, llm_request):\n"
+        "    state = callback_context.state\n"
+        "    x = state.get('customer.auth_status', '')\n"
+        "    state['_internal.action_trigger'] = 'go'\n"
+    )
+    results = rule.check(f, f.read_text(), var_context)
+    assert results == []
+
+
+def test_v100_tool_state_update(tmp_path, var_context):
+    from cxas_scrapi.utils.lint_rules.variables import ToolVariableDeclared  # noqa: PLC0415,I001
+
+    rule = ToolVariableDeclared()
+    f = tmp_path / "python_code.py"
+    f.write_text(
+        "def my_tool(context):\n"
+        "    context.state.update("
+        "{'missing_var': 1, 'customer.auth_status': 'ok'}"
+        ")\n"
+    )
+    results = rule.check(f, f.read_text(), var_context)
+    assert len(results) == 1
+    assert "missing_var" in results[0].message
+
+
+def test_v100_eval_undeclared(tmp_path, var_context):
+    from cxas_scrapi.utils.lint_rules.variables import EvalVariableDeclared  # noqa: PLC0415,I001
+
+    rule = EvalVariableDeclared()
+    f = tmp_path / "evals" / "goldens" / "g.yaml"
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text(
+        "common_session_parameters:\n"
+        "  customer:\n"
+        "    account_id: 'a1'\n"
+        "  missing_var:\n"
+        "    foo: 'bar'\n"
+    )
+    results = rule.check(f, f.read_text(), var_context)
+    rule_ids = [r.rule_id for r in results]
+    messages = [r.message for r in results]
+    assert "V100" in rule_ids
+    assert any("missing_var" in m for m in messages)
+    # The "customer" parent and "customer.account_id" leaf should be OK
+    assert not any("customer" in m and "missing" not in m for m in messages)
+
+
+def test_v101_type_mismatch_bool(tmp_path, var_context):
+    from cxas_scrapi.utils.lint_rules.variables import CallbackVariableTypeMatch  # noqa: PLC0415,I001
+
+    rule = CallbackVariableTypeMatch()
+    f = tmp_path / "python_code.py"
+    f.write_text(
+        "def before_model_callback(cb, llm):\n"
+        "    state = cb.state\n"
+        "    state['customer.api_failed'] = False\n"
+    )
+    results = rule.check(f, f.read_text(), var_context)
+    assert len(results) == 1
+    assert results[0].rule_id == "V101"
+    assert "STRING" in results[0].message and "bool" in results[0].message
+
+
+def test_v101_type_mismatch_len_call(tmp_path, var_context):
+    from cxas_scrapi.utils.lint_rules.variables import ToolVariableTypeMatch  # noqa: PLC0415,I001
+
+    rule = ToolVariableTypeMatch()
+    f = tmp_path / "python_code.py"
+    f.write_text(
+        "def my_tool(context):\n"
+        "    context.state['_internal.escalation_topic'] = len('abc')\n"
+    )
+    results = rule.check(f, f.read_text(), var_context)
+    assert len(results) == 1
+    assert results[0].rule_id == "V101"
+    assert "int" in results[0].message
+
+
+def test_v101_matching_type_no_error(tmp_path, var_context):
+    from cxas_scrapi.utils.lint_rules.variables import CallbackVariableTypeMatch  # noqa: PLC0415,I001
+
+    rule = CallbackVariableTypeMatch()
+    f = tmp_path / "python_code.py"
+    f.write_text(
+        "def before_model_callback(cb, llm):\n"
+        "    cb.state['customer.auth_status'] = 'ok'\n"
+    )
+    results = rule.check(f, f.read_text(), var_context)
+    assert results == []
+
+
+def test_v101_uninferable_rhs_skipped(tmp_path, var_context):
+    from cxas_scrapi.utils.lint_rules.variables import CallbackVariableTypeMatch  # noqa: PLC0415,I001
+
+    rule = CallbackVariableTypeMatch()
+    f = tmp_path / "python_code.py"
+    f.write_text(
+        "def before_model_callback(cb, llm):\n"
+        "    cb.state['customer.auth_status'] = some_helper()\n"
+    )
+    results = rule.check(f, f.read_text(), var_context)
+    assert results == []
+
+
+def test_v102_missing_nested_property(tmp_path, var_context):
+    from cxas_scrapi.utils.lint_rules.variables import ToolNestedPropertyExists  # noqa: PLC0415,I001
+
+    rule = ToolNestedPropertyExists()
+    f = tmp_path / "python_code.py"
+    f.write_text(
+        "def my_tool(context):\n    context.state['_internal.reason'] = 'x'\n"
+    )
+    results = rule.check(f, f.read_text(), var_context)
+    assert len(results) == 1
+    assert results[0].rule_id == "V102"
+    assert "_internal" in results[0].message and "reason" in results[0].message
+
+
+def test_v102_wrong_parent(tmp_path, var_context):
+    from cxas_scrapi.utils.lint_rules.variables import ToolNestedPropertyExists  # noqa: PLC0415,I001
+
+    rule = ToolNestedPropertyExists()
+    f = tmp_path / "python_code.py"
+    f.write_text(
+        "def my_tool(context):\n"
+        "    context.state['customer.action_trigger'] = 'x'\n"
+    )
+    results = rule.check(f, f.read_text(), var_context)
+    assert len(results) == 1
+    assert "customer" in results[0].message
+    assert "action_trigger" in results[0].message
+
+
+def test_v102_typo_on_declared_parent(tmp_path, var_context):
+    from cxas_scrapi.utils.lint_rules.variables import (  # noqa: PLC0415,I001
+        CallbackNestedPropertyExists,
+    )
+
+    rule = CallbackNestedPropertyExists()
+    f = tmp_path / "python_code.py"
+    f.write_text(
+        "def before_model_callback(cb, llm):\n"
+        "    x = cb.state.get('_internal.escalation_topik', 'g')\n"
+    )
+    results = rule.check(f, f.read_text(), var_context)
+    assert len(results) == 1
+    assert "escalation_topik" in results[0].message
+
+
+def test_v103_stale_flat_in_callback(tmp_path, var_context):
+    from cxas_scrapi.utils.lint_rules.variables import CallbackStaleFlatVar  # noqa: PLC0415,I001
+
+    rule = CallbackStaleFlatVar()
+    f = tmp_path / "python_code.py"
+    f.write_text(
+        "def before_model_callback(cb, llm):\n"
+        "    cb.state['auth_status'] = 'ok'\n"
+    )
+    results = rule.check(f, f.read_text(), var_context)
+    assert len(results) == 1
+    assert results[0].rule_id == "V103"
+    assert "customer.auth_status" in results[0].message
+
+
+def test_v103_no_match_no_warning(tmp_path, var_context):
+    from cxas_scrapi.utils.lint_rules.variables import CallbackStaleFlatVar  # noqa: PLC0415,I001
+
+    rule = CallbackStaleFlatVar()
+    f = tmp_path / "python_code.py"
+    # session_token isn't a nested property of any declared OBJECT
+    f.write_text(
+        "def before_model_callback(cb, llm):\n"
+        "    cb.state.get('session_token', '')\n"
+    )
+    results = rule.check(f, f.read_text(), var_context)
+    assert results == []
+
+
+def test_v104_undeclared_template_ref(tmp_path, var_context):
+    from cxas_scrapi.utils.lint_rules.variables import InstructionVariableRef  # noqa: PLC0415,I001
+
+    rule = InstructionVariableRef()
+    f = tmp_path / "instruction.txt"
+    f.write_text("Greet {auth_status} and {customer.full_name} today.")
+    results = rule.check(f, f.read_text(), var_context)
+    assert len(results) == 2
+    assert all(r.rule_id == "V104" for r in results)
+    assert any("auth_status" in r.message for r in results)
+    assert any("full_name" in r.message for r in results)
+
+
+def test_v104_skips_builtins_and_directives(tmp_path, var_context):
+    from cxas_scrapi.utils.lint_rules.variables import InstructionVariableRef  # noqa: PLC0415,I001
+
+    rule = InstructionVariableRef()
+    f = tmp_path / "instruction.txt"
+    f.write_text(
+        "Today is {current_date}. Use {@TOOL: get_balance} and "
+        "{@AGENT: billing agent}."
+    )
+    results = rule.check(f, f.read_text(), var_context)
+    assert results == []
+
+
+def test_v104_skips_inline_example_block(tmp_path, var_context):
+    from cxas_scrapi.utils.lint_rules.variables import InstructionVariableRef  # noqa: PLC0415,I001
+
+    rule = InstructionVariableRef()
+    f = tmp_path / "instruction.txt"
+    f.write_text(
+        "<inline_example>\n"
+        "Hello {undeclared_var}, your id is {bogus.path}.\n"
+        "</inline_example>\n"
+        "Otherwise, use {customer.auth_status}."
+    )
+    results = rule.check(f, f.read_text(), var_context)
+    assert results == []
+
+
+def test_v104_declared_object_ref_no_error(tmp_path, var_context):
+    from cxas_scrapi.utils.lint_rules.variables import InstructionVariableRef  # noqa: PLC0415,I001
+
+    rule = InstructionVariableRef()
+    f = tmp_path / "instruction.txt"
+    f.write_text("Customer object: {customer}.")
+    results = rule.check(f, f.read_text(), var_context)
+    assert results == []
+
+
+def test_state_visitor_skips_assignment_subscripts(tmp_path, var_context):
+    """Writes should be counted as writes, not double-counted as reads."""
+    from cxas_scrapi.utils.lint_rules.variables import _collect_state_accesses  # noqa: PLC0415,I001
+
+    src = "def f(cb):\n    cb.state['customer.api_failed'] = 'x'\n"
+    accesses = _collect_state_accesses(src)
+    kinds = [a[0] for a in accesses]
+    assert kinds == ["write"]
+
+
+def test_state_visitor_setdefault_is_write(tmp_path, var_context):
+    from cxas_scrapi.utils.lint_rules.variables import _collect_state_accesses  # noqa: PLC0415,I001
+
+    src = "def f(cb):\n    cb.state.setdefault('customer.account_id', '0')\n"
+    accesses = _collect_state_accesses(src)
+    assert accesses == [("write", "customer.account_id", 2, "str")]
+
+
+def test_state_visitor_update_with_literals(tmp_path, var_context):
+    from cxas_scrapi.utils.lint_rules.variables import _collect_state_accesses  # noqa: PLC0415,I001
+
+    src = "def f(cb):\n    cb.state.update({'a': True, 'b': 1})\n"
+    accesses = _collect_state_accesses(src)
+    assert ("write", "a", 2, "bool") in accesses
+    assert ("write", "b", 2, "int") in accesses

--- a/tests/cxas_scrapi/utils/test_linter.py
+++ b/tests/cxas_scrapi/utils/test_linter.py
@@ -187,7 +187,7 @@ def test_rule_decorator_deduplication():
     from cxas_scrapi.utils.linter import _REGISTERED_IDS  # noqa: PLC0415
 
     _RULE_REGISTRY["test_dedup"] = []
-    _REGISTERED_IDS.discard("XDUP001")
+    _REGISTERED_IDS.discard(("XDUP001", "test_dedup"))
 
 
 def test_reset_registry():
@@ -224,12 +224,15 @@ def test_reset_registry():
     import cxas_scrapi.utils.lint_rules.schema as mod_v  # noqa: PLC0415
     import cxas_scrapi.utils.lint_rules.structure as mod_s  # noqa: PLC0415
     import cxas_scrapi.utils.lint_rules.tools as mod_t  # noqa: PLC0415
+    import cxas_scrapi.utils.lint_rules.variables as mod_var  # noqa: PLC0415
 
-    for mod in [mod_i, mod_c, mod_t, mod_e, mod_a, mod_s, mod_v]:
+    for mod in [mod_i, mod_c, mod_t, mod_e, mod_a, mod_s, mod_v, mod_var]:
         importlib.reload(mod)
 
     registry_restored = build_registry()
-    assert len(registry_restored.all_rules()) == 66
+    # 66 baseline + 11 cross-surface V100-V104 registrations
+    # (V100 x3, V101 x2, V102 x2, V103 x3, V104 x1).
+    assert len(registry_restored.all_rules()) == 77
 
 
 # ── LintConfig ───────────────────────────────────────────────────────────
@@ -519,7 +522,9 @@ def test_discovery_filtering(tmp_path):
 def test_build_registry_all_rules():
     registry = build_registry()
     all_rules = registry.all_rules()
-    assert len(all_rules) == 66
+    # 66 baseline + 11 cross-surface V100-V104 registrations
+    # (V100 x3, V101 x2, V102 x2, V103 x3, V104 x1).
+    assert len(all_rules) == 77
 
 
 def test_build_context(tmp_path):
@@ -677,4 +682,4 @@ def test_structure_rules_dispatched_by_target(tmp_path):
     _RULE_REGISTRY["structure"] = [
         r for r in _RULE_REGISTRY["structure"] if r.id != "S999"
     ]
-    _REGISTERED_IDS.discard("S999")
+    _REGISTERED_IDS.discard(("S999", "structure"))


### PR DESCRIPTION
Closes #291.

## Summary

Five new variable-reference lint rules (`V100`–`V104`) that surface state writes/reads, instruction `{var}` templates, and eval `session_parameters` referencing undeclared keys, mistyped nested children, or wrong parent objects after a flat→nested `variableDeclarations` migration. These bug classes previously failed open at runtime (silent empty reads, wrong-key writes that persist, garbled prompt interpolations).

| Rule | Severity | Categories |
|---|---|---|
| **V100** `variable-declared` | ERROR | callbacks, tools, evals |
| **V101** `variable-type-match` | ERROR | callbacks, tools |
| **V102** `nested-property-exists` | ERROR | callbacks, tools |
| **V103** `no-stale-flat-var-regression` | WARNING | callbacks, tools, instructions |
| **V104** `instruction-variable-ref` | ERROR | instructions |

## Design notes

- **Shared resolver.** `resolve_path(path, schema)` returns a tagged tuple (`ok` / `ok_object` / `undeclared` / `stale_flat` / `not_object` / `no_property`). All five rules dispatch on it — one canonical source of truth across the three surfaces.
- **Three surfaces canonicalize to one.** Python dotted strings (`state["customer.auth_status"]`), instruction templates (`{customer.auth_status}`), and eval YAML nested maps (`customer: { auth_status: ... }`) all reduce to the same `(parent, child[, ...])` lookup.
- **AST visitor** (`_StateAccessVisitor`) catches `state[k]`, `state.get(k, …)`, `state[k] = v`, `state.update({k: v})`, `state.setdefault(k, v)`, plus `<x>.state` chains and `AugAssign`. Uses a skip-set to avoid double-counting assignment targets as reads.
- **V101 special-cases known-return-type calls** (`len`, `str`, `int`, `bool`, `list`, `dict`, …) so writes like `state[k] = len(x)` into a STRING field surface — without semantic analysis.
- **V104 skip-list:** `{@TOOL:…}`, `{@AGENT:…}`, `{current_date}`, double-brace `{{var}}`, and refs inside `<inline_example>` blocks (length-preserving blank-out to keep line numbers accurate).
- **Schema cached** per `app_root` to avoid re-parsing `app.json` for every file.

## Registry change (small + back-compatible)

Dedup key in `_REGISTERED_IDS` / `RuleRegistry._rules` switched from `id` to `(id, category)` so V100/V101/V102/V103 can register across multiple categories without losing emissions. `RuleRegistry.get(rule_id)` still returns first match by id (V001–V007 callers unchanged).

## Verification

Against the fixture app at `sample-agent-json/cxas_app/support_demo` (the 9 planted GAPs from #291):

```
[E] before_model_callbacks/.../python_code.py:8  [V100] State key 'session_token' is not declared
[E] before_model_callbacks/.../python_code.py:12 [V100] State key '_action_trigger' is not declared
[E] before_model_callbacks/.../python_code.py:16 [V102] '_internal' has no property 'escalation_topik'
[E] before_model_callbacks/.../python_code.py:21 [V101] 'customer.api_failed' declared STRING, write assigns bool
[E] tools/set_session_state/.../python_code.py:13 [V102] 'customer' has no property 'action_trigger'
[E] tools/set_session_state/.../python_code.py:19 [V102] '_internal' has no property 'reason'
[E] tools/set_session_state/.../python_code.py:25 [V101] '_internal.escalation_topic' declared STRING, write assigns int
[E] agents/Root_Agent/instruction.txt:30 [V104] Template ref '{auth_status}' is not a declared variable
[E] agents/Root_Agent/instruction.txt:31 [V104] Template ref '{customer.full_name}' — 'customer' has no property 'full_name'
[W] agents/Root_Agent/instruction.txt:30 [V103] 'auth_status' lives nested under 'customer' as 'customer.auth_status'
```

Exact GAP → rule mapping from issue #291.

## Test plan

- [x] `pytest tests/cxas_scrapi/utils/test_linter.py tests/cxas_scrapi/utils/test_lint_rules.py` — **187 passed** (26 new tests for V100–V104 + resolver + AST visitor).
- [x] `ruff check` + `ruff format --check` on changed paths — clean.
- [x] End-to-end `cxas lint` on the fixture app — all 9 GAPs surface at the expected lines.
- [x] Pre-existing failures in `test_llm_lint.py` / `test_deployments.py` confirmed unrelated (failing on `main` too).

## Out of scope (tracked in #291 follow-ups)

- V105 `unused-declared-variable`
- Eval-YAML V102 (nested-property checks on `session_parameters`)
- Flow JSON (`fixtures.initialVariables`, `implementation.variablesRead/Written`)
- `{{ var }}` double-brace templates (needs runtime confirmation first)
