### PR TITLE
fix: eval cmd remove dead format flag

### DIFF
--- a/src/cxas_scrapi/cli/main.py
+++ b/src/cxas_scrapi/cli/main.py
@@ -611,7 +611,6 @@ def combined_evals_report_cmd(args: argparse.Namespace) -> None:
         tool_test_file=args.tool_test_file,
         goldens_dir=args.goldens_dir,
         simulation_dir=args.simulation_dir,
-        format=args.format,
         include=include_list,
         modality=args.modality,
         runs=args.runs,

--- a/src/cxas_scrapi/cli/main.py
+++ b/src/cxas_scrapi/cli/main.py
@@ -1580,11 +1580,6 @@ def get_parser() -> argparse.ArgumentParser:
         help="Optional: GCS path to store the combined report (starts with gs://).",
     )
     parser_report.add_argument(
-        "--format",
-        default="html",
-        help="Output format (default: html).",
-    )
-    parser_report.add_argument(
         "--runs",
         type=int,
         default=1,

--- a/tests/cxas_scrapi/cli/test_cli_reporting.py
+++ b/tests/cxas_scrapi/cli/test_cli_reporting.py
@@ -54,7 +54,6 @@ def test_combined_evals_report_cmd(tmp_path):
             self.tool_test_file = None
             self.goldens_dir = None
             self.simulation_dir = None
-            self.format = "html"
             self.include = "sims,goldens,scenarios"
             self.input_dir = None
             self.modality = "text"
@@ -78,7 +77,6 @@ def test_combined_evals_report_cmd(tmp_path):
             tool_test_file=None,
             goldens_dir=None,
             simulation_dir=None,
-            format="html",
             include=["sims", "goldens", "scenarios"],
             modality="text",
             runs=1,
@@ -108,7 +106,6 @@ def test_combined_evals_report_cmd_with_modality_and_runs(tmp_path):
             self.tool_test_file = None
             self.goldens_dir = None
             self.simulation_dir = None
-            self.format = "html"
             self.include = "sims,goldens,scenarios"
             self.input_dir = None
             self.modality = "audio"
@@ -132,7 +129,6 @@ def test_combined_evals_report_cmd_with_modality_and_runs(tmp_path):
             tool_test_file=None,
             goldens_dir=None,
             simulation_dir=None,
-            format="html",
             include=["sims", "goldens", "scenarios"],
             modality="audio",
             runs=5,


### PR DESCRIPTION
# Summary

Fixes a broken `cxas evals report` command and removes the dead CLI flag that caused the regression.

`combined_evals_report_cmd` forwarded `format=args.format` into `generate_combined_report_from_dir`, but that function has no `format` parameter — every invocation died with:

TypeError: generate_combined_report_from_dir() got an unexpected keyword argument 'format'



The combined report is hardcoded to HTML (`combined_report_template.html`, `.html` output, fallback `report_fallback.html`), and `git log -G "format"` on `reporting.py` shows the `format` parameter was never wired into the function. The CLI flag was speculative and never functional for this subcommand.
