### PR TITLE
chore(skills): add mdformat linter and format cxas-sim-eval SKILL.md

### DIFF
--- a/.agents/skills/cxas-sim-eval/SKILL.md
+++ b/.agents/skills/cxas-sim-eval/SKILL.md
@@ -10,41 +10,51 @@ description: >-
 
 This skill helps convert turn-by-turn CXAS golden evaluations into high-level, goal-oriented test cases for the SCRAPI `SimulationEvals` framework. It analyzes the agent's tools to enrich expectations with specific tool calls.
 
----
+______________________________________________________________________
 
 ## Steps
 
 ### 1. Check Environment
+
 Ensure `cxas_scrapi` is installed as a python package. You can check this by running:
+
 ```bash
 python -c "import cxas_scrapi"
 ```
 
 Ensure `gcloud` is authenticated properly:
+
 ```bash
 gcloud auth list
 ```
+
 If needed, login with:
+
 ```bash
 gcloud auth login
 ```
 
 ### 2. Get App Name and Output Directory
+
 > [!IMPORTANT]
 > You MUST ask the user for the full resource name of the app/agent (e.g., `projects/.../locations/.../apps/...`) and the base output directory before proceeding with any execution steps.
 
 Ask the user for these values.
 
 ### 3. Fetch Evaluations
+
 Fetch the list of evaluations using the CES API. Save each evaluation as a JSON file named after its display name under `[output_dir]/golden_evals/`.
 
 ### 4. Fetch Tool Schemas
+
 Fetch the full schemas for all tools available in the app and save them under `[output_dir]/tools/`.
 
 ### 5. Fetch Agent Tools Configuration
+
 Fetch the list of tools and toolsets used by the agent and save the configuration (e.g., to `[output_dir]/agent_tools.json`).
 
 ### 6. Convert Evaluations
+
 Run the conversion script (`convert_eval.py`) to process the fetched evaluations and save the converted test cases under `[output_dir]/sim_evals/`.
 
 ## Automation Scripts
@@ -52,11 +62,13 @@ Run the conversion script (`convert_eval.py`) to process the fetched evaluations
 Three scripts are available to automate the process:
 
 ### 1. Fetch Evaluations and Agent Config
+
 `scripts/fetch_app_data.py`
 
 Fetches evaluations and the list of tools used by the agent from the CES API.
 
 Usage:
+
 ```bash
 python .agents/skills/cxas-sim-eval/scripts/fetch_app_data.py \
   --app-name "projects/.../locations/.../apps/..." \
@@ -64,11 +76,13 @@ python .agents/skills/cxas-sim-eval/scripts/fetch_app_data.py \
 ```
 
 ### 2. Fetch Tool Schemas
+
 `scripts/fetch_tool_schemas.py`
 
 Fetches the full schemas for all tools available in the app.
 
 Usage:
+
 ```bash
 python .agents/skills/cxas-sim-eval/scripts/fetch_tool_schemas.py \
   --app-name "projects/.../locations/.../apps/..." \
@@ -76,11 +90,13 @@ python .agents/skills/cxas-sim-eval/scripts/fetch_tool_schemas.py \
 ```
 
 ### 3. Convert Evaluations
+
 `scripts/convert_eval.py`
 
 Converts the fetched evaluations to simulation test cases, using the fetched tool schemas to infer expectations.
 
 Usage:
+
 ```bash
 python .agents/skills/cxas-sim-eval/scripts/convert_eval.py \
   --output-dir /path/to/output_directory \
@@ -88,6 +104,7 @@ python .agents/skills/cxas-sim-eval/scripts/convert_eval.py \
 ```
 
 ### 4. Run Evaluations
+
 `scripts/run_evals.py`
 
 Runs the simulation evaluations, logs raw results, and generates a combined HTML report.
@@ -96,6 +113,7 @@ Runs the simulation evaluations, logs raw results, and generates a combined HTML
 If the agent has the `intercept_and_score_reasoning` tool enabled, this script will automatically extract and analyze the agent's internal monologue for failed evaluations. It detects issues like overthinking, hesitation, and backtracking. Furthermore, it correlates these diagnostics with the agent's instructions to generate **actionable suggestions** for improvement directly in the HTML report.
 
 Usage:
+
 ```bash
 python .agents/skills/cxas-sim-eval/scripts/run_evals.py \
   --app-name "projects/.../locations/.../apps/..." \
@@ -112,17 +130,19 @@ When running evaluations with the `intercept_and_score_reasoning` tool enabled, 
 ### Key Signals
 
 1. **Overthinking (Verbosity)**
+
    - **Symptom**: Internal monologue exceeds 350 or 600 characters.
    - **Meaning**: The agent is struggling to process complex or circular instructions.
    - **Fix**: Simplify instructions. Break down complex tasks into smaller, linear steps.
 
-2. **Hedging**
+1. **Hedging**
+
    - **Symptom**: Use of words like "might be", "guess", "unsure", "assume".
    - **Meaning**: The agent is uncertain about its next action, often due to missing edge case handling.
    - **Fix**: Add explicit instructions for the scenario the agent is unsure about.
 
-3. **Backtracking**
+1. **Backtracking**
+
    - **Symptom**: Use of words like "wait", "actually", "on second thought".
    - **Meaning**: The agent is abandoning a plan mid-turn or correcting itself, indicating unclear triggers.
    - **Fix**: Clarify triggers and state transitions in instructions.
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,8 +18,6 @@ repos:
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
-#    -   id: check-yaml
-#    -   id: check-added-large-files
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.12
@@ -30,15 +28,20 @@ repos:
 
 -   repo: local
     hooks:
+    # Ensure SKILL.md files adhere to mdformat standards for optimal markdown
+    # consumption by agents without degraded structure.
+    -   id: mdformat
+        name: mdformat
+        entry: uv run mdformat
+        language: system
+        files: SKILL\.md$
+
+    # Run pytest only on modified test files.
     -   id: pytest
         name: pytest
         entry: pytest
         language: system
-        types: [python]
-        args:
-            - tests/
-        always_run: true
-        pass_filenames: false
+        files: ^tests/.*test_.*\.py$
 
     # Block third-party brand / company names in added diff lines.
     # Implemented via a Gemini call in scripts/check_brands.py — only

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,10 @@ dev = [
   "ruff",
   "twine",
   "pre-commit",
+  "mdformat>=0.7.21",
+  "mdformat-gfm",
+  "mdformat-frontmatter",
+  "mdformat-gfm-alerts",
 ]
 docs = [
   "mkdocs-material[imaging]>=9.5",

--- a/uv.lock
+++ b/uv.lock
@@ -644,6 +644,10 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "mdformat" },
+    { name = "mdformat-frontmatter" },
+    { name = "mdformat-gfm" },
+    { name = "mdformat-gfm-alerts" },
     { name = "pre-commit" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -681,6 +685,10 @@ requires-dist = [
     { name = "jinja2" },
     { name = "json5" },
     { name = "jsonpath-ng" },
+    { name = "mdformat", marker = "extra == 'dev'", specifier = ">=0.7.21" },
+    { name = "mdformat-frontmatter", marker = "extra == 'dev'" },
+    { name = "mdformat-gfm", marker = "extra == 'dev'" },
+    { name = "mdformat-gfm-alerts", marker = "extra == 'dev'" },
     { name = "mike", marker = "extra == 'docs'", specifier = ">=2.0" },
     { name = "mkdocs-git-revision-date-localized-plugin", marker = "extra == 'docs'", specifier = ">=1.2" },
     { name = "mkdocs-material", extras = ["imaging"], marker = "extra == 'docs'", specifier = ">=9.5" },
@@ -1703,6 +1711,73 @@ wheels = [
 ]
 
 [[package]]
+name = "mdformat"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/05/32b5e14b192b0a8a309f32232c580aefedd9d06017cb8fe8fce34bec654c/mdformat-1.0.0.tar.gz", hash = "sha256:4954045fcae797c29f86d4ad879e43bb151fa55dbaf74ac6eaeacf1d45bb3928", size = 56953, upload-time = "2025-10-16T12:05:03.695Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/9a/8fe71b95985ca7a4001effbcc58e5a07a1f2a2884203f74dcf48a3b08315/mdformat-1.0.0-py3-none-any.whl", hash = "sha256:bca015d65a1d063a02e885a91daee303057bc7829c2cd37b2075a50dbb65944b", size = 53288, upload-time = "2025-10-16T12:05:02.607Z" },
+]
+
+[[package]]
+name = "mdformat-frontmatter"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdformat" },
+    { name = "mdit-py-plugins" },
+    { name = "ruamel-yaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/90/ae8a3d20066295367d9048ad480bcde3afe694eb592fec9c35bbdb7d68eb/mdformat_frontmatter-2.1.2.tar.gz", hash = "sha256:9c9c3159c38407f47e567202749c74ce7680017516cd158c82400f015c6a01d1", size = 9425, upload-time = "2026-05-23T05:14:26.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/a0/20b6f53593139d8b64fa8e7f750033fbb580c096c241cd551b59907e6abe/mdformat_frontmatter-2.1.2-py3-none-any.whl", hash = "sha256:bcbb1dd7e35ce4387603acd32f2c092dd4518bbfaa2a4b801a0f29a4e69bf2ca", size = 4927, upload-time = "2026-05-23T05:14:24.747Z" },
+]
+
+[[package]]
+name = "mdformat-gfm"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "mdformat" },
+    { name = "mdit-py-plugins" },
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/6f/a626ebb142a290474401b67e2d61e73ce096bf7798ee22dfe6270f924b3f/mdformat_gfm-1.0.0.tar.gz", hash = "sha256:d1d49a409a6acb774ce7635c72d69178df7dce1dc8cdd10e19f78e8e57b72623", size = 10112, upload-time = "2025-10-16T09:12:22.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/18/6bc2189b744dd383cad03764f41f30352b1278d2205096f77a29c0b327ad/mdformat_gfm-1.0.0-py3-none-any.whl", hash = "sha256:7305a50efd2a140d7c83505b58e3ac5df2b09e293f9bbe72f6c7bee8c678b005", size = 10970, upload-time = "2025-10-16T09:12:21.276Z" },
+]
+
+[[package]]
+name = "mdformat-gfm-alerts"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdformat" },
+    { name = "mdit-py-plugins" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/33/70619cf9e2b9e35857ebcf7e947e8f5370df2ff2a4ab666895783f8fab6c/mdformat_gfm_alerts-2.0.0.tar.gz", hash = "sha256:eb2b3189ad44ae28a6b6b714609dd3a30d6e3b898f02b1e6473d7b08df8bb3c0", size = 9687, upload-time = "2025-06-05T20:49:46.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/ea/22e093bb2ef3e25dc3ccc9d8392c14b069a007ae394a12e058d9e1f51c00/mdformat_gfm_alerts-2.0.0-py3-none-any.whl", hash = "sha256:e003422cc003bc6e936d0797553f23201095a1d1e8602c5062296d223f2ae516", size = 6752, upload-time = "2025-06-05T20:49:45.539Z" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2340,7 +2415,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3116,6 +3191,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Add mdformat check in pre-commit hook to address SKILL.md standardization
- Applied fix to 1 file for now `.agents/skills/cxas-sim-eval/SKILL.md` (cl/933548293 for ref)
- Modified the pytest pre-commit hook to only run on modified pytest files instead of ALL files; this was causing pre-commit runs that were 6+ minutes; pre-commit should now run in under 2 seconds on average