### PR TITLE
fix: Print trace when logging exception error messages to prevent silent errors.

### DIFF
--- a/src/cxas_scrapi/utils/gemini.py
+++ b/src/cxas_scrapi/utils/gemini.py
@@ -140,8 +140,8 @@ class GeminiGenerate:
             if response_mime_type == "application/json" and response_schema:
                 return response.parsed
             return response.text
-        except Exception as e:
-            logger.error(f"Gemini generation failed: {e}")
+        except Exception:
+            logger.exception("Gemini generation failed")
             return None
 
     def generate_with_parts(
@@ -196,8 +196,8 @@ class GeminiGenerate:
             if response_mime_type == "application/json" and response_schema:
                 return response.parsed
             return response.text
-        except Exception as e:
-            logger.error(f"Gemini multimodal generation failed: {e}")
+        except Exception:
+            logger.exception("Gemini multimodal generation failed")
             return None
 
     async def create_cache(
@@ -315,7 +315,7 @@ class GeminiGenerate:
                 logger.warning(f"  Attempt {attempt + 1} failed: {err_msg}")
 
                 if attempt == max_retries - 1:
-                    logger.error(
+                    logger.exception(
                         "  ❌ All retry attempts failed. Check GCP quota."
                     )
                     return None
@@ -351,6 +351,7 @@ class GeminiGenerate:
             )
             if response.embeddings is not None:
                 return [embedding.values for embedding in response.embeddings]
-        except Exception as e:
-            logger.error(f"Gemini embedding generation failed: {e}")
-        return []
+            return []
+        except Exception:
+            logger.exception("Gemini embedding generation failed")
+            return []


### PR DESCRIPTION
Trace is completely dropped if we just use 'error'.