### PR TITLE
chore: Add backticks to commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,9 +186,9 @@ mkdocs build --strict # also fails on warnings (used in CI)
 We welcome any contributions or feature requests you would like to submit!
 
 1. Fork the Project
-2. Create your Feature Branch (git checkout -b feature/AmazingFeature)
-3. Commit your Changes (git commit -m 'Add some AmazingFeature')
-4. Push to the Branch (git push origin feature/AmazingFeature)
+2. Create your Feature Branch (`git checkout -b feature/AmazingFeature`)
+3. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
+4. Push to the Branch (`git push origin feature/AmazingFeature`)
 5. Open a Pull Request
 
 <!-- LICENSE -->


### PR DESCRIPTION
This minor change adds backticks to the git commands in the ReadMe, for better readability. 