### PR TITLE
fix(migration): avoid nested asyncio.run() in migration scripts

### DIFF
--- a/.agents/skills/cxas-dfcx-migration/scripts/migrate.py
+++ b/.agents/skills/cxas-dfcx-migration/scripts/migrate.py
@@ -146,7 +146,7 @@ def _build_parser() -> argparse.ArgumentParser:
 # ---------------------------------------------------------------------------
 
 
-async def _run(args) -> None:
+def _run(args) -> None:
     tracker = phase_tracker.PhaseTracker(console)
 
     # Phase 0: auth
@@ -253,7 +253,7 @@ async def _run(args) -> None:
     )
 
     with tracker.phase("Migration", "MigrationService.run_migration"):
-        await service.run_migration(source_cx_agent_id=agent_id, config=config)
+        asyncio.run(service.run_migration(source_cx_agent_id=agent_id, config=config))
 
     # Phase 6: persist IR bundle. service.persist_bundle handles the
     # IR snapshot + stage_history append + atomic file write.
@@ -327,7 +327,7 @@ def main() -> None:
         handlers=[RichHandler(console=console, rich_tracebacks=True)],
     )
     args = _build_parser().parse_args()
-    asyncio.run(_run(args))
+    _run(args)
 
 
 if __name__ == "__main__":

--- a/.agents/skills/cxas-dfcx-migration/scripts/stage_1.py
+++ b/.agents/skills/cxas-dfcx-migration/scripts/stage_1.py
@@ -109,7 +109,7 @@ def _make_grouping_callback(yes: bool):
     return cb
 
 
-async def _run(args) -> None:
+def _run(args) -> None:
     tracker = phase_tracker.PhaseTracker(console)
 
     if not _shared.auth_check(console):
@@ -133,7 +133,7 @@ async def _run(args) -> None:
         "Stage 1",
         "variable dedup + Gemini consolidation",
     ):
-        await service.run_stage_1(
+        asyncio.run(service.run_stage_1(
             bundle=bundle,
             grouping_callback=_make_grouping_callback(args.yes),
             grouping_json_path=args.grouping_json,
@@ -141,7 +141,7 @@ async def _run(args) -> None:
             dedup_version_label="0.0.2",
             persist_bundle_path=bundle_path,
             console=console,
-        )
+        ))
 
     console.print()
     console.print(tracker.summary_table())
@@ -165,7 +165,7 @@ def main() -> None:
         handlers=[RichHandler(console=console, rich_tracebacks=True)],
     )
     args = _build_parser().parse_args()
-    asyncio.run(_run(args))
+    _run(args)
 
 
 if __name__ == "__main__":

--- a/.agents/skills/cxas-dfcx-migration/scripts/stage_2.py
+++ b/.agents/skills/cxas-dfcx-migration/scripts/stage_2.py
@@ -85,7 +85,7 @@ def _resolve_bundle_path(args) -> str:
     return path
 
 
-async def _run(args) -> None:
+def _run(args) -> None:
     tracker = phase_tracker.PhaseTracker(console)
 
     if not _shared.auth_check(console):
@@ -116,7 +116,7 @@ async def _run(args) -> None:
         "Stage 2",
         "instruction state machines + tool mocks + redeploy",
     ):
-        await service.run_stage_2(
+        asyncio.run(service.run_stage_2(
             version_label="0.0.4",
             generate_unit_tests=not args.no_unit_tests,
             unit_tests_path=unit_tests_path,
@@ -125,7 +125,7 @@ async def _run(args) -> None:
             bundle=bundle,
             persist_bundle_path=bundle_path,
             console=console,
-        )
+        ))
 
     console.print()
     console.print(tracker.summary_table())
@@ -147,7 +147,7 @@ def main() -> None:
         handlers=[RichHandler(console=console, rich_tracebacks=True)],
     )
     args = _build_parser().parse_args()
-    asyncio.run(_run(args))
+    _run(args)
 
 
 if __name__ == "__main__":

--- a/.agents/skills/cxas-dfcx-migration/scripts/stage_3.py
+++ b/.agents/skills/cxas-dfcx-migration/scripts/stage_3.py
@@ -86,7 +86,7 @@ def _resolve_bundle_path(args) -> str:
     return path
 
 
-async def _run(args) -> None:
+def _run(args) -> None:
     tracker = phase_tracker.PhaseTracker(console)
 
     if not _shared.auth_check(console):
@@ -122,12 +122,12 @@ async def _run(args) -> None:
     mode_label = f"Architecture style: {args.architecture}"
 
     with tracker.phase("Stage 3 — apply topology", mode_label):
-        updated, skipped, failed = await service.run_stage_3(
+        updated, skipped, failed = asyncio.run(service.run_stage_3(
             bundle=bundle,
             mode=mode,
             version_label="0.0.5",
             persist_bundle_path=bundle_path,
-        )
+        ))
 
     console.print()
     console.print(tracker.summary_table())
@@ -143,7 +143,7 @@ def main() -> None:
         handlers=[RichHandler(console=console, rich_tracebacks=True)],
     )
     args = _build_parser().parse_args()
-    asyncio.run(_run(args))
+    _run(args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Problem: Running any migration script interactively crashed with:
```
RuntimeError: asyncio.run() cannot be called from a running event loop
```
This affected all 4 scripts (migrate.py, stage_1.py, stage_2.py, stage_3.py) because they all used asyncio.run(_run()) with async def _run(), and InquirerPy's prompt_toolkit calls its own asyncio.run() internally for interactive prompts — Python doesn't allow nesting those.

Fix: Across all 4 scripts:
  - _run() changed from async def to regular def
  - main() calls _run(args) directly instead of asyncio.run(_run(args))
  - The single async service call inside _run() gets its own asyncio.run(service.run_stage_*())

Interactive prompts now run outside any event loop, avoiding the nesting conflict.

Test:
```
python .agents/skills/cxas-dfcx-migration/scripts/migrate.py \
  --zip-file "<file_path>" \
  --project-id ces-deployment-dev \
  --location us \
  --target-name <target_name> \
  --skip-resource-selection \
  --skip-dependency-analysis \
  --yes
```