### PR TITLE
chore: migrate legacy polysynth terminology to cxas

### DIFF
--- a/src/cxas_scrapi/migration/ai_augment.py
+++ b/src/cxas_scrapi/migration/ai_augment.py
@@ -37,7 +37,7 @@ class AIAugment:
     async def generate_agent_description(
         self, playbook_data: dict[str, Any]
     ) -> str | None:
-        """Generates a concise, one-sentence description for a Polysynth agent
+        """Generates a concise, one-sentence description for a CXAS agent
 
         based on its source DFCX Playbook's goal and instructions.
 

--- a/src/cxas_scrapi/migration/code_block_migrator.py
+++ b/src/cxas_scrapi/migration/code_block_migrator.py
@@ -414,7 +414,7 @@ class GlobalStateTransformer(ast.NodeTransformer):
 
 
 class CodeBlockMigrator:
-    """Handles the migration of DFCX Code Blocks to Polysynth components."""
+    """Handles the migration of DFCX Code Blocks to CXAS components."""
 
     TYPING_MAP = {
         "Dict": "from typing import Dict",
@@ -532,7 +532,7 @@ class CodeBlockMigrator:
     def _sanitize_resource_id(
         self, name: str, min_len: int = 5, max_len: int = 36
     ) -> str:
-        """Sanitizes a string to be a valid Polysynth resource ID."""
+        """Sanitizes a string to be a valid CXAS resource ID."""
         # Replace spaces and other invalid characters with underscores
         sanitized = re.sub(r"[^a-zA-Z0-9_.-]", "_", name)
 

--- a/src/cxas_scrapi/migration/data_models.py
+++ b/src/cxas_scrapi/migration/data_models.py
@@ -90,10 +90,10 @@ class DFCXAgentIR(BaseModel):
 class IRMetadata(BaseModel):
     """Metadata for the migration target."""
 
-    app_name: str  # The display name of the target Polysynth app
-    app_id: str | None = None  # The UUID generated for the new Polysynth app
+    app_name: str  # The display name of the target CXAS app
+    app_id: str | None = None  # The UUID generated for the new CXAS app
     app_resource_name: str | None = (
-        None  # The full resource name of the Polysynth app
+        None  # The full resource name of the CXAS app
     )
     default_model: str = "gemini-2.5-flash-001"
 

--- a/src/cxas_scrapi/migration/dfcx_migration_reporter.py
+++ b/src/cxas_scrapi/migration/dfcx_migration_reporter.py
@@ -180,11 +180,11 @@ migration process,
     def generate_markdown(self) -> str:
         timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
         md = [
-            "# Polysynth Migration Audit Report",
+            "# CXAS Migration Audit Report",
             f"**Generated:** `{timestamp}`\n",
             "## 📦 App Details",
             f"- **Source DFCX Agent:** `{self.app_info.get('source', 'N/A')}`",
-            f"- **Target Polysynth App:** "
+            f"- **Target CXAS App:** "
             f"`{self.app_info.get('target_name', 'N/A')}`",
             f"- **Target App ID:** `{self.app_info.get('target_id', 'N/A')}`\n",
         ]
@@ -217,7 +217,7 @@ migration process,
         md.extend(
             [
                 "## 🔠 App Variables Migrated",
-                "| Original Name | Polysynth Name | Type |",
+                "| Original Name | CXAS Name | Type |",
                 "|---|---|---|",
             ]
         )
@@ -231,7 +231,7 @@ migration process,
         md.extend(
             [
                 "\n## 🛠️ Tools & Toolsets Migrated",
-                "| Type | Original Name | Polysynth ID | Operations / Notes |",
+                "| Type | Original Name | CXAS ID | Operations / Notes |",
                 "|---|---|---|---|",
             ]
         )
@@ -247,7 +247,7 @@ migration process,
         md.extend(
             [
                 "\n## 🤖 Agents Migrated",
-                "| Original Playbook/Flow | Polysynth Agent ID | "
+                "| Original Playbook/Flow | CXAS Agent ID | "
                 "Model | Generated Description |",
                 "|---|---|---|---|",
             ]
@@ -305,7 +305,7 @@ migration process,
                 "The following items are not covered by this tool and must "
                 "be migrated manually:",
                 "1. **Examples:** If the source app has any examples, they "
-                "need to be recreated in Polysynth.",
+                "need to be recreated in CXAS.",
                 "2. **Flows:** If the source app has any flows, they need "
                 "to be manually transitioned or implemented.",
             ]

--- a/src/cxas_scrapi/migration/dfcx_tool_converter.py
+++ b/src/cxas_scrapi/migration/dfcx_tool_converter.py
@@ -324,7 +324,7 @@ class DFCXToolConverter:
     def convert_webhook_to_openapi_toolset(
         self, cx_webhook: dict[str, Any]
     ) -> dict[str, Any] | None:
-        """Converts a DFCX Webhook into a generalized Polysynth OpenAPI
+        """Converts a DFCX Webhook into a generalized CXAS OpenAPI
         Toolset payload.
         """
         display_name = cx_webhook.get("displayName", "unnamed_webhook")

--- a/src/cxas_scrapi/migration/prompts.py
+++ b/src/cxas_scrapi/migration/prompts.py
@@ -305,7 +305,7 @@ Expected_Behavior
         "system": """You are the Principal Conversational AI Systems \
 Architect.
     Your role is to analyze a legacy Dialogflow CX (DFCX) Flow and design a
-    modern Polysynth/CXAS Agent Architecture Blueprint.
+    modern CXAS Agent Architecture Blueprint.
 
     ### ENTERPRISE ARCHITECTURE STANDARDS
     1. **Hub-and-Spoke / Specialization**: Every agent must have a specific,
@@ -415,7 +415,7 @@ returns 500'",
 
     STEP_2B_INSTRUCTIONS_EXPERT = {
         "system": """You are a Principal Conversational AI Prompt Engineer \
-and CXAS/Polysynth Architect.
+and CXAS Architect.
     Your task: translate a deterministic DFCX Flow into a CANONICAL CXAS
     instruction file (lowercase taskflow XML) for a generative AI agent.
 
@@ -781,7 +781,7 @@ here using the patterns provided\n    return None"
         "system": """You are the Principal Conversational AI Systems \
 Architect.
     Your role is to analyze a legacy Dialogflow CX (DFCX) Flow and design a
-    modern Polysynth/CXAS Agent Architecture Blueprint.
+    modern CXAS Agent Architecture Blueprint.
 
     ### ENTERPRISE ARCHITECTURE STANDARDS
     1. **Hub-and-Spoke / Specialization**: Every agent must have a specific,
@@ -975,7 +975,7 @@ returns 500'",
 
     STEP_3B_CONSOLIDATION_INSTRUCTIONS = {
         "system": """You are a Principal Conversational AI Prompt Engineer \
-and CXAS/Polysynth Architect.
+and CXAS Architect.
     Your task: translate a deterministic DFCX Flow into a CANONICAL CXAS
     instruction file (lowercase taskflow XML) for a generative AI agent.
 
@@ -1225,7 +1225,7 @@ and CXAS/Polysynth Architect.
 
     AGENT_DESCRIPTION = {
         "system": """You are an expert AI agent architect.
-        Your task is to create a concise, one-sentence description for a Polysynth agent based on its detailed instructions and goal.
+        Your task is to create a concise, one-sentence description for a CXAS agent based on its detailed instructions and goal.
         The generated description will be used by either a parent 'router' agent to decide when to transfer a user to this specialist agent, or by other LLM agents to determine if they should route a task to this agent. The description must be clear, accurate, and focus on the agent's primary capability.
         Do not use conversational language. Output only the single sentence description.""",
         "template": """
@@ -1319,14 +1319,14 @@ and CXAS/Polysynth Architect.
 
         The input JSON contains two top-level keys:
         1.  `golden_set`: The ground-truth test script, detailing scenarios and the expected agent actions (text or tool calls) for each turn.
-        2.  `conversation_results`: The actual turn-by-turn logs from running the `golden_set` against two agents: a source 'DFCX' agent and a target 'Polysynth' agent.
+        2.  `conversation_results`: The actual turn-by-turn logs from running the `golden_set` against two agents: a source 'DFCX' agent and a target 'CXAS' agent.
 
         Your report MUST have two sections:
 
         **1. Per-Scenario Analysis:**
         Iterate through each conversation scenario. For each one:
         - Announce the scenario's goal (e.g., `### Scenario 1: Full happy path...`).
-        - For EACH agent (DFCX and Polysynth), provide a sub-section with the following evaluations based on the metrics library:
+        - For EACH agent (DFCX and CXAS), provide a sub-section with the following evaluations based on the metrics library:
             - **Conversation Correctness (Score 1-5):** Did the agent follow the expected conversational flow and achieve the scenario's goal? (1=Completely failed, 5=Perfectly achieved).
             - **Agent Response Agreement (Score 1-5):** How semantically similar were the agent's text responses to the golden responses? (1=Totally different, 5=Identical meaning).
             - **Conversation Fluency (Score 1-5):** Was the conversation natural, coherent, and not repetitive? (1=Confusing/robotic, 5=Very natural).
@@ -1334,8 +1334,8 @@ and CXAS/Polysynth Architect.
 
         **2. Overall Summary & Recommendations:**
         - **High-Level Summary:** Write a paragraph comparing the two agents' overall performance based on the qualitative metrics you just scored.
-        - **Key Findings:** Provide a bulleted list of the most important observations (e.g., "Polysynth struggled with multi-turn context," or "DFCX was less fluent").
-        - **Final Recommendation:** Conclude with a clear recommendation. Is the Polysynth agent ready, ready with conditions, or does it need significant work?
+        - **Key Findings:** Provide a bulleted list of the most important observations (e.g., "CXAS struggled with multi-turn context," or "DFCX was less fluent").
+        - **Final Recommendation:** Conclude with a clear recommendation. Is the CXAS agent ready, ready with conditions, or does it need significant work?
 
         Generate ONLY the Markdown report. Do not include any other text or conversational filler.
         """,

--- a/src/cxas_scrapi/migration/service.py
+++ b/src/cxas_scrapi/migration/service.py
@@ -1549,7 +1549,7 @@ class MigrationService:
         # 2. Deploy Consolidated App Configurations (Timeout, Variables)
         app_updates = {}
 
-        # A. Speech Silence / Inactivity Timeout (WAI for CXAS/Polysynth)
+        # A. Speech Silence / Inactivity Timeout (WAI for CXAS)
         if (
             not self.deployment_state.get("app_timeout_configured")
             or is_update_pass

--- a/tests/cxas_scrapi/migration/test_dfcx_migration_reporter.py
+++ b/tests/cxas_scrapi/migration/test_dfcx_migration_reporter.py
@@ -99,7 +99,7 @@ async def test_generate_markdown(mock_gemini):
 
     markdown = reporter.generate_markdown()
 
-    assert "# Polysynth Migration Audit Report" in markdown
+    assert "# CXAS Migration Audit Report" in markdown
     assert "dfcx-123" in markdown
     assert "cxas-app" in markdown
     assert "Mocked detailed description." in markdown


### PR DESCRIPTION
# Summary
Migrated all legacy internal references of "Polysynth" / "polysynth" terminology to the approved product terminology "CXAS" / "cxas".

# Changes
- Replaced 24 occurrences of Polysynth/polysynth with CXAS/cxas across 7 source files and 1 test file.
- Cleaned up duplicate and awkward CXAS/CXAS patterns that resulted from the migration.
- Updated unit test assertions in `test_dfcx_migration_reporter.py` to match the new terminology.

# Verification
- Ran all migration unit tests successfully: 232 passed, 2 skipped.