### PR TITLE
feat(migration): convert DFCX test cases to CXAS TurnTestCase simulations

### DIFF
--- a/.agents/skills/cxas-dfcx-migration/scripts/convert_dfcx_tests.py
+++ b/.agents/skills/cxas-dfcx-migration/scripts/convert_dfcx_tests.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+
+"""Convert DFCX test cases to CXAS TurnTestCase YAML files.
+
+Can read test cases from either an IR bundle or a raw test case directory.
+
+Usage:
+    # From an IR bundle (has flow-to-agent mapping built in)
+    python convert_dfcx_tests.py --ir-bundle <target>_ir.json
+
+    # From a raw test case directory (needs explicit flow mapping)
+    python convert_dfcx_tests.py \
+        --source-dir /tmp/dfcx_compare/source/testCases \
+        --flow-map flow_map.json
+
+    # Override output directory
+    python convert_dfcx_tests.py \
+        --ir-bundle <target>_ir.json \
+        --output-dir my_evals/simulations
+"""
+
+import argparse
+import json
+import logging
+import os
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from cxas_scrapi.migration.data_models import (
+    DFCXAgentIR,
+    IRAgent,
+    IRBundle,
+    IRMetadata,
+    MigrationIR,
+)
+from cxas_scrapi.migration.dfcx_test_converter import DFCXTestConverter
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Convert DFCX test cases to CXAS simulation YAML files."
+    )
+
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument(
+        "--ir-bundle",
+        help=(
+            "Path to IR bundle JSON "
+            "(contains source test cases and agent mapping)"
+        ),
+    )
+    source.add_argument(
+        "--source-dir",
+        help="Path to directory containing DFCX test case JSON files",
+    )
+
+    parser.add_argument(
+        "--flow-map",
+        help=(
+            "Path to JSON file mapping DFCX flow names to CXAS agent names. "
+            "Required when using --source-dir. "
+            'Format: {"Default Start Flow": "RootAgent", ...}'
+        ),
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=None,
+        help=(
+            "Output directory for YAML files "
+            "(default: <target>_evals/simulations)"
+        ),
+    )
+    return parser.parse_args()
+
+
+def load_from_bundle(path: str):
+    """Load test cases and build converter from an IR bundle."""
+    bundle = IRBundle.load(path)
+    source = bundle.source_agent_data
+    ir = bundle.ir
+
+    flow_map = None
+    if bundle.grouping:
+        flow_map = {
+            flow: group
+            for group, entry in bundle.grouping.items()
+            for flow in entry.get("agents", [])
+        }
+
+    target_name = bundle.config.target_name
+    return source, ir, flow_map, target_name
+
+
+def load_from_directory(source_dir: str, flow_map_path: str | None):
+    """Load test cases from a directory of JSON files."""
+    test_cases = []
+    for filename in sorted(os.listdir(source_dir)):
+        if filename.endswith(".json"):
+            filepath = os.path.join(source_dir, filename)
+            with open(filepath) as test_file:
+                test_cases.append(json.load(test_file))
+
+    if not test_cases:
+        return None, None, None, None
+
+    source = DFCXAgentIR(
+        name="local",
+        display_name="local",
+        default_language_code="en",
+        test_cases=test_cases,
+    )
+
+    flow_map = None
+    if flow_map_path:
+        with open(flow_map_path) as f:
+            flow_map = json.load(f)
+
+    # Build IR from flow map agent names, or from test case flow names
+    if flow_map:
+        agent_names = set(flow_map.values())
+    else:
+        agent_names = {
+            tc.get("testConfig", {}).get("flow")
+            for tc in test_cases
+            if tc.get("testConfig", {}).get("flow")
+        }
+
+    ir = MigrationIR(
+        metadata=IRMetadata(app_name="local"),
+        agents={
+            name: IRAgent(type="FLOW", display_name=name, instruction="")
+            for name in agent_names
+        },
+    )
+
+    return source, ir, flow_map, "converted"
+
+
+def main():
+    args = parse_args()
+    console = Console()
+
+    if args.source_dir and not args.flow_map:
+        console.print(
+            "[yellow]Warning: no --flow-map provided. "
+            "Tests will be grouped by source flow name.[/]"
+        )
+
+    # Load
+    if args.ir_bundle:
+        console.print(f"Loading IR bundle: {args.ir_bundle}")
+        source, ir, flow_map, target_name = load_from_bundle(args.ir_bundle)
+    else:
+        console.print(f"Loading test cases from: {args.source_dir}")
+        source, ir, flow_map, target_name = load_from_directory(
+            args.source_dir, args.flow_map
+        )
+
+    if source is None or not source.test_cases:
+        console.print("[red]No test cases found.[/]")
+        sys.exit(1)
+
+    console.print(f"Found {len(source.test_cases)} DFCX test cases")
+
+    # Convert
+    converter = DFCXTestConverter(ir, flow_to_agent_map=flow_map)
+    tests_by_agent, report = converter.convert_all(source)
+
+    # Report
+    table = Table(title="Conversion Report")
+    table.add_column("Metric", style="bold")
+    table.add_column("Value", justify="right")
+    table.add_row("Source test cases", str(report["total_source_tests"]))
+    table.add_row("Converted", f"[green]{report['converted']}[/]")
+    table.add_row("Skipped", f"[yellow]{report['skipped']}[/]")
+    table.add_row(
+        "Behavioral assertions",
+        str(report["behavioral_assertions"]),
+    )
+    table.add_row(
+        "Fuzzy-match assertions",
+        str(report["fuzzy_match_assertions"]),
+    )
+    table.add_row(
+        "AGENT_TRANSFER assertions",
+        str(report["agent_transfer_assertions"]),
+    )
+    table.add_row("DTMF-as-text turns", str(report["dtmf_as_text_count"]))
+    console.print(table)
+
+    if report.get("tests_per_agent"):
+        agent_table = Table(title="Tests per Agent")
+        agent_table.add_column("Agent")
+        agent_table.add_column("Tests", justify="right")
+        for agent, count in sorted(report["tests_per_agent"].items()):
+            agent_table.add_row(agent, str(count))
+        console.print(agent_table)
+
+    # Write YAML
+    out_dir = args.output_dir or f"{target_name}_evals/simulations"
+    os.makedirs(out_dir, exist_ok=True)
+
+    yamls = DFCXTestConverter.serialize_to_yaml(tests_by_agent)
+    for agent_name, yaml_str in yamls.items():
+        path = os.path.join(out_dir, f"{agent_name}.yaml")
+        with open(path, "w") as f:
+            f.write(yaml_str)
+        console.print(f"  Wrote {path} ({len(yaml_str):,} bytes)")
+
+    # Write report
+    report_path = os.path.join(out_dir, "_conversion_report.json")
+    with open(report_path, "w") as f:
+        json.dump(report, f, indent=2, default=str)
+    console.print(f"  Wrote {report_path}")
+
+    console.print(
+        f"\n[bold green]Done.[/] Run simulations with:\n"
+        f"  python run_simulations.py "
+        f"--app-name projects/<project>/locations/<loc>/apps/<app-id> "
+        f"--sim-dir {out_dir}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/cxas-dfcx-migration/scripts/run_simulations.py
+++ b/.agents/skills/cxas-dfcx-migration/scripts/run_simulations.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+
+"""Run converted DFCX test simulations against a deployed CXAS agent.
+
+Usage:
+    python run_simulations.py \
+        --app-name projects/<project>/locations/<loc>/apps/<app-id> \
+        --sim-dir <target_name>_evals/simulations \
+        [--filter <glob>] \
+        [--tags <tag1,tag2>] \
+        [--limit <N>] \
+        [--debug]
+
+Examples:
+    # Run all simulations
+    python run_simulations.py \
+        --app-name projects/my-proj/locations/us/apps/abc123 \
+        --sim-dir tong_wf_dfcx_migration_evals/simulations
+
+    # Run only tests tagged #happy_path, limit to 10
+    python run_simulations.py \
+        --app-name projects/my-proj/locations/us/apps/abc123 \
+        --sim-dir tong_wf_dfcx_migration_evals/simulations \
+        --tags '#happy_path' --limit 10
+
+    # Run tests from a single agent file
+    python run_simulations.py \
+        --app-name projects/my-proj/locations/us/apps/abc123 \
+        --sim-dir tong_wf_dfcx_migration_evals/simulations \
+        --filter 'RootAgent*'
+"""
+
+import argparse
+import fnmatch
+import logging
+import os
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from cxas_scrapi.evals.turn_evals import TurnEvals
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Run converted DFCX test simulations against a CXAS agent."
+    )
+    parser.add_argument(
+        "--app-name",
+        required=True,
+        help="Full CXAS app resource name (projects/.../apps/...)",
+    )
+    parser.add_argument(
+        "--sim-dir",
+        required=True,
+        help="Directory containing simulation YAML files",
+    )
+    parser.add_argument(
+        "--filter",
+        default="*.yaml",
+        help="Glob pattern to filter YAML files (default: *.yaml)",
+    )
+    parser.add_argument(
+        "--tags",
+        default=None,
+        help="Comma-separated tags to filter tests (e.g. '#happy_path,#bug')",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Max number of tests to run",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Path to write results CSV",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug output for each turn",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    console = Console()
+
+    if not os.path.isdir(args.sim_dir):
+        console.print(f"[red]Directory not found: {args.sim_dir}[/]")
+        sys.exit(1)
+
+    # Discover YAML files
+    yaml_files = sorted(
+        f
+        for f in os.listdir(args.sim_dir)
+        if fnmatch.fnmatch(f, args.filter)
+        and (f.endswith(".yaml") or f.endswith(".yml"))
+    )
+    if not yaml_files:
+        msg = f"No YAML files matching '{args.filter}' in {args.sim_dir}"
+        console.print(f"[yellow]{msg}[/]")
+        sys.exit(0)
+
+    console.print(
+        f"Found {len(yaml_files)} simulation file(s): {', '.join(yaml_files)}"
+    )
+
+    # Initialize TurnEvals
+    evals = TurnEvals(app_name=args.app_name)
+
+    # Load tests
+    all_tests = []
+    for yf in yaml_files:
+        path = os.path.join(args.sim_dir, yf)
+        tests = evals.load_turn_test_cases_from_file(path)
+        console.print(f"  Loaded {len(tests)} tests from {yf}")
+        all_tests.extend(tests)
+
+    if not all_tests:
+        console.print("[yellow]No tests loaded.[/]")
+        sys.exit(0)
+
+    # Filter by tags
+    if args.tags:
+        tag_set = {t.strip() for t in args.tags.split(",")}
+        all_tests = [t for t in all_tests if tag_set & set(t.tags)]
+        console.print(f"After tag filter ({args.tags}): {len(all_tests)} tests")
+
+    # Apply limit
+    if args.limit and args.limit < len(all_tests):
+        all_tests = all_tests[: args.limit]
+        console.print(f"Limited to {args.limit} tests")
+
+    if not all_tests:
+        console.print("[yellow]No tests after filtering.[/]")
+        sys.exit(0)
+
+    n = len(all_tests)
+    console.print(
+        f"\n[bold]Running {n} simulations against {args.app_name}[/]\n"
+    )
+
+    # Run tests
+    results_df = evals.run_turn_tests(all_tests, debug=args.debug)
+
+    # Summary
+    console.print()
+    total = len(results_df)
+    passed = len(results_df[results_df["status"] == "SUCCESS"])
+    failed = len(results_df[results_df["status"] == "FAILURE"])
+    skipped = len(results_df[results_df["status"] == "SKIPPED"])
+
+    table = Table(title="Simulation Results Summary")
+    table.add_column("Metric", style="bold")
+    table.add_column("Count", justify="right")
+    table.add_row("Total assertions", str(total))
+    table.add_row("Passed", f"[green]{passed}[/]")
+    table.add_row("Failed", f"[red]{failed}[/]")
+    if skipped:
+        table.add_row("Skipped", f"[yellow]{skipped}[/]")
+    table.add_row(
+        "Pass rate", f"{passed / total * 100:.1f}%" if total else "N/A"
+    )
+    console.print(table)
+
+    # Show failures
+    failures = results_df[results_df["status"] == "FAILURE"]
+    if not failures.empty:
+        console.print(f"\n[red bold]Failed assertions ({len(failures)}):[/]\n")
+        for _, row in failures.head(20).iterrows():
+            console.print(f"  [bold]{row['test_name']}[/] / {row['turn']}")
+            console.print(f"    User: {row['user']}")
+            console.print(f"    Error: {row['errors']}")
+            if row.get("expected"):
+                console.print(f"    Expected: {row['expected']}")
+            if row.get("actual"):
+                console.print(f"    Actual: {str(row['actual'])[:200]}")
+            console.print()
+        if len(failures) > 20:
+            console.print(f"  ... and {len(failures) - 20} more failures")
+
+    # Write CSV
+    if args.output:
+        results_df.to_csv(args.output, index=False)
+        console.print(f"\nResults written to {args.output}")
+
+    sys.exit(1 if failed > 0 else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cxas_scrapi/migration/dfcx_test_converter.py
+++ b/src/cxas_scrapi/migration/dfcx_test_converter.py
@@ -1,0 +1,412 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Converts DFCX test cases to CXAS TurnTestCase format."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from cxas_scrapi.evals.turn_evals import (
+    TurnExpectation,
+    TurnOperator,
+    TurnStep,
+    TurnTestCase,
+)
+from cxas_scrapi.migration.data_models import DFCXAgentIR, MigrationIR
+
+if TYPE_CHECKING:
+    from cxas_scrapi.utils.gemini import GeminiGenerate
+
+logger = logging.getLogger(__name__)
+
+SSML_TAG_RE = re.compile(r"<[^>]+>")
+WHITESPACE_RE = re.compile(r"\s+")
+FUZZY_MAX_LEN = 100
+RESPONSE_MIN_LEN = 10
+
+SUMMARIZE_RESPONSE_PROMPT = (
+    "Summarize what this agent response accomplishes in one short sentence. "
+    "Focus on the BEHAVIOR or ACTION, not exact wording. "
+    "The summary will be used to verify that a different version of this "
+    "agent behaves equivalently.\n\n"
+    'User said: "{user_input}"\n'
+    'Agent responded: "{agent_response}"\n\n'
+    'Write one sentence starting with "Agent " that describes what the agent '
+    "does in this turn."
+)
+
+
+class DFCXTestConverter:
+    """Converts DFCX test cases into CXAS TurnTestCase objects.
+
+    Args:
+        ir: The MigrationIR with compiled agents.
+        flow_to_agent_map: Optional explicit mapping from source flow names
+            to target agent names. If not provided, uses ir.agents keys
+            directly (correct for pre-consolidation Stage 0).
+    """
+
+    def __init__(
+        self,
+        ir: MigrationIR,
+        flow_to_agent_map: dict[str, str] | None = None,
+        gemini_client: GeminiGenerate | None = None,
+    ):
+        self.ir = ir
+        self._agent_names = set(ir.agents.keys())
+        self._flow_map = flow_to_agent_map or {}
+        self._gemini = gemini_client
+        self._summarize_cache: dict[str, str] = {}
+
+    def convert_all(
+        self, source: DFCXAgentIR
+    ) -> tuple[dict[str, list[TurnTestCase]], dict[str, Any]]:
+        """Convert all DFCX test cases and return (tests_by_agent, report)."""
+        tests_by_agent: dict[str, list[TurnTestCase]] = {}
+        skipped: list[dict[str, str]] = []
+        seen_names: dict[str, int] = {}
+        dtmf_count = 0
+        empty_text_count = 0
+        transfer_count = 0
+        behavioral_count = 0
+        fuzzy_match_count = 0
+
+        for tc in source.test_cases:
+            agent_name = self._route_test_to_agent(tc)
+            if agent_name is None:
+                skipped.append(
+                    {
+                        "name": tc.get("displayName", "unknown"),
+                        "reason": self._skip_reason(tc),
+                    }
+                )
+                continue
+
+            result = self._convert_single_test(tc)
+            if result is None:
+                skipped.append(
+                    {
+                        "name": tc.get("displayName", "unknown"),
+                        "reason": "no_assertions",
+                    }
+                )
+                continue
+
+            test_case, notes = result
+            base_name = test_case.name
+            key = f"{agent_name}::{base_name}"
+            if key in seen_names:
+                seen_names[key] += 1
+                test_case.name = f"{base_name} ({seen_names[key]})"
+            else:
+                seen_names[key] = 1
+
+            tests_by_agent.setdefault(agent_name, []).append(test_case)
+            dtmf_count += notes.get("dtmf_turns", 0)
+            empty_text_count += notes.get("empty_text_turns", 0)
+            transfer_count += notes.get("transfer_assertions", 0)
+            behavioral_count += notes.get("behavioral_assertions", 0)
+            fuzzy_match_count += notes.get("fuzzy_match_assertions", 0)
+
+        report = {
+            "total_source_tests": len(source.test_cases),
+            "converted": sum(len(v) for v in tests_by_agent.values()),
+            "skipped": len(skipped),
+            "skipped_details": skipped[:20],
+            "tests_per_agent": {k: len(v) for k, v in tests_by_agent.items()},
+            "dtmf_as_text_count": dtmf_count,
+            "empty_text_turns_collapsed": empty_text_count,
+            "agent_transfer_assertions": transfer_count,
+            "behavioral_assertions": behavioral_count,
+            "fuzzy_match_assertions": fuzzy_match_count,
+        }
+
+        logger.info(
+            "[TestConverter] Converted %d/%d tests (%d skipped)",
+            report["converted"],
+            report["total_source_tests"],
+            report["skipped"],
+        )
+
+        return tests_by_agent, report
+
+    def _route_test_to_agent(self, test_case: dict) -> str | None:
+        flow_name = test_case.get("testConfig", {}).get("flow")
+        if not flow_name:
+            return None
+        if flow_name in self._flow_map:
+            return self._flow_map[flow_name]
+        if flow_name in self._agent_names:
+            return flow_name
+        sanitized = self._sanitize_name(flow_name)
+        for agent_name in self._agent_names:
+            if self._sanitize_name(agent_name) == sanitized:
+                return agent_name
+        return None
+
+    def _skip_reason(self, test_case: dict) -> str:
+        flow = test_case.get("testConfig", {}).get("flow")
+        if not flow:
+            return "no_flow"
+        return f"unknown_flow:{flow}"
+
+    def _convert_single_test(
+        self, test_case: dict
+    ) -> tuple[TurnTestCase, dict[str, int]] | None:
+        display_name = test_case.get("displayName", "unnamed")
+        source_tags = test_case.get("tags", [])
+        turns_data = test_case.get("testCaseConversationTurns", [])
+        if not turns_data:
+            return None
+
+        steps: list[TurnStep] = []
+        notes: dict[str, int] = {
+            "dtmf_turns": 0,
+            "transfer_assertions": 0,
+            "behavioral_assertions": 0,
+            "fuzzy_match_assertions": 0,
+        }
+        prev_flow: str | None = None
+        conversion_tags: set[str] = set()
+
+        for i, turn in enumerate(turns_data):
+            user_input = turn.get("userInput", {})
+            agent_output = turn.get("virtualAgentOutput", {})
+
+            if self._is_empty_text_turn(user_input):
+                notes["empty_text_turns"] = notes.get("empty_text_turns", 0) + 1
+                current_flow = agent_output.get("currentFlow", {}).get("name")
+                prev_flow = current_flow or prev_flow
+                continue
+
+            user, event, variables = self._map_user_input(user_input, i)
+            expectations = self._map_expectations(
+                agent_output, prev_flow, user_text=user or ""
+            )
+
+            if user_input.get("input", {}).get("dtmf"):
+                notes["dtmf_turns"] += 1
+                conversion_tags.add("#dtmf-as-text")
+
+            for exp in expectations:
+                if isinstance(exp, str):
+                    notes["behavioral_assertions"] += 1
+                    conversion_tags.add("#behavioral")
+                elif isinstance(exp, TurnExpectation):
+                    if exp.type == TurnOperator.AGENT_TRANSFER:
+                        notes["transfer_assertions"] += 1
+                    elif exp.type == TurnOperator.FUZZY_MATCH:
+                        notes["fuzzy_match_assertions"] += 1
+
+            current_flow = agent_output.get("currentFlow", {}).get("name")
+            prev_flow = current_flow or prev_flow
+
+            step = TurnStep(
+                turn=f"Turn {len(steps) + 1}",
+                user=user,
+                event=event,
+                variables=variables,
+                expectations=expectations,
+            )
+            steps.append(step)
+
+        has_assertions = any(step.expectations for step in steps)
+        if not has_assertions:
+            return None
+
+        tags = list({*source_tags, "#migrated-dfcx", *conversion_tags})
+
+        test = TurnTestCase(
+            name=display_name,
+            tags=tags,
+            turns=steps,
+        )
+        return test, notes
+
+    @staticmethod
+    def _is_empty_text_turn(user_input: dict) -> bool:
+        """Detect DFCX auto-advance turns: {"text": {}, "languageCode": "en"}.
+        These have no user input and are used to advance flows in DFCX."""
+        inp = user_input.get("input", {})
+        if "event" in inp or "dtmf" in inp:
+            return False
+        text_obj = inp.get("text")
+        if not isinstance(text_obj, dict):
+            return False
+        return not text_obj.get("text")
+
+    def _map_user_input(
+        self, user_input: dict, turn_index: int
+    ) -> tuple[str | None, str | None, dict[str, Any]]:
+        inp = user_input.get("input", {})
+        user: str | None = None
+        event: str | None = None
+        variables: dict[str, Any] = {}
+
+        if "text" in inp:
+            text_obj = inp["text"]
+            user = (
+                text_obj.get("text", "") if isinstance(text_obj, dict) else ""
+            )
+        if "event" in inp:
+            event = (
+                inp["event"].get("event")
+                if isinstance(inp["event"], dict)
+                else None
+            )
+        if "dtmf" in inp:
+            dtmf = inp["dtmf"]
+            digits = dtmf.get("digits", "") if isinstance(dtmf, dict) else ""
+            if digits:
+                user = digits
+
+        if turn_index == 0:
+            injected = user_input.get("injectedParameters", {})
+            if injected:
+                variables = dict(injected)
+
+        return user, event, variables
+
+    def _map_expectations(
+        self,
+        output: dict,
+        prev_flow: str | None,
+        user_text: str = "",
+    ) -> list[TurnExpectation | str]:
+        expectations: list[TurnExpectation | str] = []
+
+        # Tier 1: AGENT_TRANSFER (structural)
+        current_flow = output.get("currentFlow", {}).get("name")
+        if current_flow and prev_flow and current_flow != prev_flow:
+            target_agent = self._flow_to_agent(current_flow)
+            if target_agent:
+                expectations.append(
+                    TurnExpectation(
+                        type=TurnOperator.AGENT_TRANSFER,
+                        value=target_agent,
+                    )
+                )
+
+        # Tier 2 / 3: response text → behavioral string or FUZZY_MATCH
+        response_text = self._extract_response_text(output)
+        if response_text:
+            if self._gemini is not None:
+                summary = self._summarize_response(response_text, user_text)
+                expectations.append(summary)
+            else:
+                expectations.append(
+                    TurnExpectation(
+                        type=TurnOperator.FUZZY_MATCH,
+                        value=response_text[:FUZZY_MAX_LEN],
+                    )
+                )
+
+        return expectations
+
+    def _extract_response_text(self, output: dict) -> str:
+        """Extract the first usable response text from a DFCX turn output."""
+        for resp_group in output.get("textResponses", []):
+            for text in resp_group.get("text", []):
+                clean = self._strip_ssml(text)
+                if clean and len(clean) >= RESPONSE_MIN_LEN:
+                    return clean
+        return ""
+
+    def _summarize_response(
+        self, response_text: str, user_text: str = ""
+    ) -> str:
+        """Use Gemini to summarize a DFCX response into a behavioral
+        description suitable for LLM-judged evaluation."""
+        cache_key = f"{user_text}|||{response_text}"
+        if cache_key in self._summarize_cache:
+            return self._summarize_cache[cache_key]
+
+        prompt = SUMMARIZE_RESPONSE_PROMPT.format(
+            user_input=user_text or "(conversation start)",
+            agent_response=response_text,
+        )
+        result = self._gemini.generate(prompt, temperature=0.0)
+        summary = (
+            result.strip()
+            if result
+            else f"Agent responds appropriately to: {user_text or 'user'}"
+        )
+        self._summarize_cache[cache_key] = summary
+        return summary
+
+    def _flow_to_agent(self, flow_name: str) -> str | None:
+        if flow_name in self._flow_map:
+            return self._flow_map[flow_name]
+        if flow_name in self._agent_names:
+            return flow_name
+        sanitized = self._sanitize_name(flow_name)
+        for agent_name in self._agent_names:
+            if self._sanitize_name(agent_name) == sanitized:
+                return agent_name
+        return None
+
+    @staticmethod
+    def _strip_ssml(text: str) -> str:
+        stripped = SSML_TAG_RE.sub("", text)
+        return WHITESPACE_RE.sub(" ", stripped).strip()
+
+    @staticmethod
+    def _sanitize_name(name: str) -> str:
+        return re.sub(r"[^a-zA-Z0-9]", "", name).lower()
+
+    @staticmethod
+    def serialize_to_yaml(
+        tests_by_agent: dict[str, list[TurnTestCase]],
+    ) -> dict[str, str]:
+        result: dict[str, str] = {}
+        for agent_name, tests in tests_by_agent.items():
+            data = {
+                "tests": [
+                    t.model_dump(
+                        mode="json", exclude_none=True, exclude_defaults=True
+                    )
+                    for t in tests
+                ]
+            }
+            result[agent_name] = yaml.dump(
+                data,
+                default_flow_style=False,
+                sort_keys=False,
+                allow_unicode=True,
+            )
+        return result
+
+    @staticmethod
+    def reroute_after_consolidation(
+        test_cases: dict[str, Any],
+        grouping: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Re-route test cases from pre-consolidation agent names to
+        post-consolidation group names. Works with both TurnTestCase
+        objects and serialized dicts."""
+        flow_to_group = {
+            flow: group_name
+            for group_name, entry in grouping.items()
+            for flow in entry.get("agents", [])
+        }
+        new_tests: dict[str, list] = {}
+        for agent_name, tests in test_cases.items():
+            target = flow_to_group.get(agent_name, agent_name)
+            new_tests.setdefault(target, []).extend(tests)
+        return new_tests

--- a/src/cxas_scrapi/migration/dfcx_test_converter.py
+++ b/src/cxas_scrapi/migration/dfcx_test_converter.py
@@ -51,6 +51,21 @@ SUMMARIZE_RESPONSE_PROMPT = (
     "does in this turn."
 )
 
+BATCH_SUMMARIZE_PROMPT = (
+    "For each numbered interaction below, summarize what the agent "
+    "response accomplishes in one short sentence. Focus on the "
+    "BEHAVIOR or ACTION, not exact wording. Each summary will be "
+    "used to verify that a different version of this agent behaves "
+    "equivalently.\n\n"
+    "{interactions}\n\n"
+    "Return exactly one summary per interaction, numbered to match. "
+    'Each summary must start with "Agent ". Example format:\n'
+    "1. Agent greets the user and offers help.\n"
+    "2. Agent transfers the call to billing.\n"
+)
+
+BATCH_SIZE = 20
+
 
 class DFCXTestConverter:
     """Converts DFCX test cases into CXAS TurnTestCase objects.
@@ -78,6 +93,9 @@ class DFCXTestConverter:
         self, source: DFCXAgentIR
     ) -> tuple[dict[str, list[TurnTestCase]], dict[str, Any]]:
         """Convert all DFCX test cases and return (tests_by_agent, report)."""
+        if self._gemini is not None:
+            self._batch_summarize(source.test_cases)
+
         tests_by_agent: dict[str, list[TurnTestCase]] = {}
         skipped: list[dict[str, str]] = []
         seen_names: dict[str, int] = {}
@@ -349,6 +367,100 @@ class DFCXTestConverter:
         )
         self._summarize_cache[cache_key] = summary
         return summary
+
+    def _collect_summarization_pairs(
+        self, test_cases: list[dict]
+    ) -> list[tuple[str, str]]:
+        """Extract unique (user_text, response_text) pairs from all
+        test case turns that would need Gemini summarization."""
+        seen: set[str] = set()
+        pairs: list[tuple[str, str]] = []
+        for tc in test_cases:
+            turns = tc.get("testCaseConversationTurns", [])
+            for turn in turns:
+                user_input = turn.get("userInput", {})
+                if self._is_empty_text_turn(user_input):
+                    continue
+                output = turn.get("virtualAgentOutput", {})
+                response_text = self._extract_response_text(output)
+                if not response_text:
+                    continue
+                inp = user_input.get("input", {})
+                user_text = ""
+                if "text" in inp:
+                    text_obj = inp["text"]
+                    user_text = (
+                        text_obj.get("text", "")
+                        if isinstance(text_obj, dict)
+                        else ""
+                    )
+                elif "dtmf" in inp:
+                    dtmf = inp["dtmf"]
+                    user_text = (
+                        dtmf.get("digits", "") if isinstance(dtmf, dict) else ""
+                    )
+                cache_key = f"{user_text}|||{response_text}"
+                if cache_key not in seen:
+                    seen.add(cache_key)
+                    pairs.append((user_text, response_text))
+        return pairs
+
+    def _batch_summarize(self, test_cases: list[dict]) -> None:
+        """Pre-fill the summarization cache using batched Gemini
+        calls. Each call summarizes up to BATCH_SIZE interactions."""
+        pairs = self._collect_summarization_pairs(test_cases)
+        if not pairs:
+            return
+
+        total_batches = (len(pairs) + BATCH_SIZE - 1) // BATCH_SIZE
+        logger.info(
+            "[TestConverter] Batch-summarizing %d unique responses "
+            "in %d calls (batch_size=%d)",
+            len(pairs),
+            total_batches,
+            BATCH_SIZE,
+        )
+
+        for batch_idx in range(0, len(pairs), BATCH_SIZE):
+            batch = pairs[batch_idx : batch_idx + BATCH_SIZE]
+            interactions = "\n".join(
+                f'{i + 1}. User: "{u or "(conversation start)"}"\n'
+                f'   Agent: "{r}"'
+                for i, (u, r) in enumerate(batch)
+            )
+            prompt = BATCH_SUMMARIZE_PROMPT.format(interactions=interactions)
+            result = self._gemini.generate(prompt, temperature=0.0)
+            summaries = self._parse_batch_response(result, len(batch))
+            for (user_text, response_text), summary in zip(
+                batch, summaries, strict=True
+            ):
+                cache_key = f"{user_text}|||{response_text}"
+                self._summarize_cache[cache_key] = summary
+
+        logger.info(
+            "[TestConverter] Cache pre-filled with %d summaries",
+            len(self._summarize_cache),
+        )
+
+    @staticmethod
+    def _parse_batch_response(
+        response: str | None, expected_count: int
+    ) -> list[str]:
+        """Parse numbered lines from a batch summarization response.
+        Falls back to generic summaries for unparseable lines."""
+        if not response:
+            return ["Agent responds appropriately to the user"] * expected_count
+
+        lines = response.strip().splitlines()
+        summaries: list[str] = []
+        for line in lines:
+            cleaned = re.sub(r"^\d+[\.\)]\s*", "", line.strip())
+            if cleaned:
+                summaries.append(cleaned)
+
+        while len(summaries) < expected_count:
+            summaries.append("Agent responds appropriately to the user")
+        return summaries[:expected_count]
 
     def _flow_to_agent(self, flow_name: str) -> str | None:
         if flow_name in self._flow_map:

--- a/src/cxas_scrapi/migration/service.py
+++ b/src/cxas_scrapi/migration/service.py
@@ -59,6 +59,7 @@ from cxas_scrapi.migration.dfcx_parameter_extractor import (
     DFCXParameterExtractor,
 )
 from cxas_scrapi.migration.dfcx_playbook_converter import DFCXPlaybookConverter
+from cxas_scrapi.migration.dfcx_test_converter import DFCXTestConverter
 from cxas_scrapi.migration.dfcx_tool_converter import DFCXToolConverter
 from cxas_scrapi.migration.eval_generator import DeterministicEvalGenerator
 from cxas_scrapi.migration.flow_visualizer import (
@@ -444,6 +445,21 @@ class MigrationService:
                 f"Consolidated to {len(accepted_groupings)} CXAS group(s); "
                 f"{len(self.ir.agents)} agents in final IR.",
             )
+
+            # Re-route converted DFCX tests to consolidated agent names
+            if self.ir.test_cases:
+                try:
+                    self.ir.test_cases = (
+                        DFCXTestConverter.reroute_after_consolidation(
+                            self.ir.test_cases, accepted_groupings
+                        )
+                    )
+                    logger.info(
+                        "Re-routed test cases to %d consolidated agents",
+                        len(self.ir.test_cases),
+                    )
+                except Exception as exc:
+                    logger.warning("Test re-routing failed: %s", exc)
 
         # --- CXAS Version checkpoint: Post-Consolidation --------------------
         if accepted_groupings:
@@ -1434,6 +1450,37 @@ class MigrationService:
             f"Wired parent-child topology; "
             f"{len(self.ir.routing_edges or [])} routing edges in graph.",
         )
+
+        # --- 10.5. Convert DFCX Test Cases → CXAS TurnTestCases ---
+        if self.source_agent_data.test_cases:
+            try:
+                tc_converter = DFCXTestConverter(self.ir)
+                converted_tests, tc_report = tc_converter.convert_all(
+                    self.source_agent_data
+                )
+                self.ir.test_cases = {
+                    agent: [t.model_dump(mode="json") for t in cases]
+                    for agent, cases in converted_tests.items()
+                }
+                # Write YAML files to evals/simulations/
+                sim_dir = os.path.join(
+                    f"{config.target_name}_evals", "simulations"
+                )
+                os.makedirs(sim_dir, exist_ok=True)
+                yamls = DFCXTestConverter.serialize_to_yaml(converted_tests)
+                for agent_name, yaml_str in yamls.items():
+                    yaml_path = os.path.join(sim_dir, f"{agent_name}.yaml")
+                    with open(yaml_path, "w") as f:
+                        f.write(yaml_str)
+                logger.info(
+                    "Converted %d/%d DFCX test cases (%d skipped) → %s",
+                    tc_report["converted"],
+                    tc_report["total_source_tests"],
+                    tc_report["skipped"],
+                    sim_dir,
+                )
+            except Exception as exc:
+                logger.warning("DFCX test case conversion failed: %s", exc)
 
         # Create initial 1:1 transpile version snapshot unconditionally!
         logger.info("\n--- Creating Initial Migrated Version 0.0.1 ---")

--- a/tests/cxas_scrapi/migration/test_dfcx_test_converter.py
+++ b/tests/cxas_scrapi/migration/test_dfcx_test_converter.py
@@ -102,7 +102,7 @@ def _empty_text_turn(flow=None):
 
 def _mock_gemini(summary="Agent greets the user"):
     mock = MagicMock()
-    mock.generate.return_value = summary
+    mock.generate.return_value = f"1. {summary}"
     return mock
 
 
@@ -269,6 +269,57 @@ def test_behavioral_fallback_on_gemini_failure():
     exp = tc.turns[0].expectations[0]
     assert isinstance(exp, str)
     assert "Agent responds appropriately" in exp
+
+
+def test_batch_summarize_multiple_unique():
+    ir = _make_ir("RootAgent")
+    source = _make_source(
+        {
+            "displayName": "test1",
+            "testConfig": {"flow": "RootAgent"},
+            "testCaseConversationTurns": [
+                _text_turn(
+                    "hello",
+                    responses=["Welcome! How can I help?"],
+                    flow="RootAgent",
+                ),
+            ],
+        },
+        {
+            "displayName": "test2",
+            "testConfig": {"flow": "RootAgent"},
+            "testCaseConversationTurns": [
+                _text_turn(
+                    "check balance",
+                    responses=["Your balance is $100."],
+                    flow="RootAgent",
+                ),
+            ],
+        },
+    )
+    gemini = MagicMock()
+    gemini.generate.return_value = (
+        "1. Agent greets the user and offers help.\n"
+        "2. Agent reports the account balance."
+    )
+    converter = DFCXTestConverter(ir, gemini_client=gemini)
+    tests_by_agent, _ = converter.convert_all(source)
+
+    assert gemini.generate.call_count == 1
+    tc1 = tests_by_agent["RootAgent"][0]
+    tc2 = tests_by_agent["RootAgent"][1]
+    assert tc1.turns[0].expectations[0] == (
+        "Agent greets the user and offers help."
+    )
+    assert tc2.turns[0].expectations[0] == (
+        "Agent reports the account balance."
+    )
+
+
+def test_parse_batch_response_fallback():
+    result = DFCXTestConverter._parse_batch_response(None, 3)
+    assert len(result) == 3
+    assert all("Agent responds" in s for s in result)
 
 
 # --- Event input ---

--- a/tests/cxas_scrapi/migration/test_dfcx_test_converter.py
+++ b/tests/cxas_scrapi/migration/test_dfcx_test_converter.py
@@ -1,0 +1,763 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for DFCX test case converter."""
+
+from unittest.mock import MagicMock
+
+import yaml
+
+from cxas_scrapi.evals.turn_evals import (
+    TurnExpectation,
+    TurnOperator,
+    TurnStep,
+    TurnTestCase,
+)
+from cxas_scrapi.migration.data_models import (
+    DFCXAgentIR,
+    IRAgent,
+    IRMetadata,
+    MigrationIR,
+)
+from cxas_scrapi.migration.dfcx_test_converter import DFCXTestConverter
+
+
+def _make_ir(*agent_names: str) -> MigrationIR:
+    return MigrationIR(
+        metadata=IRMetadata(app_name="test"),
+        agents={
+            name: IRAgent(type="FLOW", display_name=name, instruction="")
+            for name in agent_names
+        },
+    )
+
+
+def _make_source(*test_cases: dict) -> DFCXAgentIR:
+    return DFCXAgentIR(
+        name="test",
+        display_name="test",
+        default_language_code="en",
+        test_cases=list(test_cases),
+    )
+
+
+def _text_turn(text, responses=None, flow=None, prev_flow=None, params=None):
+    turn = {
+        "userInput": {"input": {"text": {"text": text}}},
+        "virtualAgentOutput": {},
+    }
+    if responses:
+        turn["virtualAgentOutput"]["textResponses"] = [{"text": responses}]
+    if flow:
+        turn["virtualAgentOutput"]["currentFlow"] = {"name": flow}
+    if params:
+        turn["userInput"]["injectedParameters"] = params
+    return turn
+
+
+def _event_turn(event, responses=None, flow=None):
+    turn = {
+        "userInput": {"input": {"event": {"event": event}}},
+        "virtualAgentOutput": {},
+    }
+    if responses:
+        turn["virtualAgentOutput"]["textResponses"] = [{"text": responses}]
+    if flow:
+        turn["virtualAgentOutput"]["currentFlow"] = {"name": flow}
+    return turn
+
+
+def _dtmf_turn(digits, responses=None, flow=None):
+    turn = {
+        "userInput": {"input": {"dtmf": {"digits": digits}}},
+        "virtualAgentOutput": {},
+    }
+    if responses:
+        turn["virtualAgentOutput"]["textResponses"] = [{"text": responses}]
+    if flow:
+        turn["virtualAgentOutput"]["currentFlow"] = {"name": flow}
+    return turn
+
+
+def _empty_text_turn(flow=None):
+    turn = {
+        "userInput": {"input": {"text": {}}},
+        "virtualAgentOutput": {},
+    }
+    if flow:
+        turn["virtualAgentOutput"]["currentFlow"] = {"name": flow}
+    return turn
+
+
+def _mock_gemini(summary="Agent greets the user"):
+    mock = MagicMock()
+    mock.generate.return_value = summary
+    return mock
+
+
+# --- Routing ---
+
+
+def test_route_to_agent_direct_match():
+    ir = _make_ir("MainMenu", "RootAgent")
+    converter = DFCXTestConverter(ir)
+    tc = {"testConfig": {"flow": "MainMenu"}}
+    assert converter._route_test_to_agent(tc) == "MainMenu"
+
+
+def test_route_to_agent_via_flow_map():
+    ir = _make_ir("NavigationAgent")
+    flow_map = {"Main Menu": "NavigationAgent"}
+    converter = DFCXTestConverter(ir, flow_to_agent_map=flow_map)
+    tc = {"testConfig": {"flow": "Main Menu"}}
+    assert converter._route_test_to_agent(tc) == "NavigationAgent"
+
+
+def test_route_to_agent_sanitized_fallback():
+    ir = _make_ir("DefaultStartFlow")
+    converter = DFCXTestConverter(ir)
+    tc = {"testConfig": {"flow": "Default Start Flow"}}
+    assert converter._route_test_to_agent(tc) == "DefaultStartFlow"
+
+
+def test_route_to_agent_no_flow():
+    ir = _make_ir("RootAgent")
+    converter = DFCXTestConverter(ir)
+    tc = {"testConfig": {}}
+    assert converter._route_test_to_agent(tc) is None
+
+
+def test_route_to_agent_unknown_flow():
+    ir = _make_ir("RootAgent")
+    converter = DFCXTestConverter(ir)
+    tc = {"testConfig": {"flow": "NonexistentFlow"}}
+    assert converter._route_test_to_agent(tc) is None
+
+
+# --- Fuzzy match mode (no gemini_client) ---
+
+
+def test_convert_text_produces_fuzzy_match():
+    ir = _make_ir("RootAgent")
+    source = _make_source(
+        {
+            "displayName": "greeting test",
+            "tags": ["#smoke"],
+            "testConfig": {"flow": "RootAgent"},
+            "testCaseConversationTurns": [
+                _text_turn(
+                    "hello",
+                    responses=["Welcome! How can I help you today?"],
+                    flow="RootAgent",
+                ),
+            ],
+        }
+    )
+    converter = DFCXTestConverter(ir)
+    tests_by_agent, report = converter.convert_all(source)
+
+    assert "RootAgent" in tests_by_agent
+    assert len(tests_by_agent["RootAgent"]) == 1
+
+    tc = tests_by_agent["RootAgent"][0]
+    assert tc.name == "greeting test"
+    assert "#migrated-dfcx" in tc.tags
+    assert "#smoke" in tc.tags
+    assert len(tc.turns) == 1
+    assert tc.turns[0].user == "hello"
+
+    exps = tc.turns[0].expectations
+    assert len(exps) == 1
+    assert exps[0].type == TurnOperator.FUZZY_MATCH
+    assert "Welcome! How can I help you today?" in exps[0].value
+    assert report["fuzzy_match_assertions"] == 1
+
+
+# --- Behavioral mode (with gemini_client) ---
+
+
+def test_convert_text_produces_behavioral_string():
+    ir = _make_ir("RootAgent")
+    source = _make_source(
+        {
+            "displayName": "greeting test",
+            "testConfig": {"flow": "RootAgent"},
+            "testCaseConversationTurns": [
+                _text_turn(
+                    "hello",
+                    responses=["Welcome! How can I help you today?"],
+                    flow="RootAgent",
+                ),
+            ],
+        }
+    )
+    gemini = _mock_gemini("Agent greets the user and offers help")
+    converter = DFCXTestConverter(ir, gemini_client=gemini)
+    tests_by_agent, report = converter.convert_all(source)
+
+    tc = tests_by_agent["RootAgent"][0]
+    exps = tc.turns[0].expectations
+    assert len(exps) == 1
+    assert isinstance(exps[0], str)
+    assert exps[0] == "Agent greets the user and offers help"
+    assert "#behavioral" in tc.tags
+    assert report["behavioral_assertions"] == 1
+    assert report["fuzzy_match_assertions"] == 0
+
+
+def test_behavioral_caches_identical_responses():
+    ir = _make_ir("RootAgent")
+    source = _make_source(
+        {
+            "displayName": "test1",
+            "testConfig": {"flow": "RootAgent"},
+            "testCaseConversationTurns": [
+                _text_turn(
+                    "hello", responses=["Same response."], flow="RootAgent"
+                ),
+            ],
+        },
+        {
+            "displayName": "test2",
+            "testConfig": {"flow": "RootAgent"},
+            "testCaseConversationTurns": [
+                _text_turn(
+                    "hello", responses=["Same response."], flow="RootAgent"
+                ),
+            ],
+        },
+    )
+    gemini = _mock_gemini("Agent gives same response")
+    converter = DFCXTestConverter(ir, gemini_client=gemini)
+    converter.convert_all(source)
+
+    assert gemini.generate.call_count == 1
+
+
+def test_behavioral_fallback_on_gemini_failure():
+    ir = _make_ir("RootAgent")
+    source = _make_source(
+        {
+            "displayName": "test",
+            "testConfig": {"flow": "RootAgent"},
+            "testCaseConversationTurns": [
+                _text_turn(
+                    "hello",
+                    responses=["Welcome to our service!"],
+                    flow="RootAgent",
+                ),
+            ],
+        }
+    )
+    gemini = MagicMock()
+    gemini.generate.return_value = None
+    converter = DFCXTestConverter(ir, gemini_client=gemini)
+    tests_by_agent, _ = converter.convert_all(source)
+
+    tc = tests_by_agent["RootAgent"][0]
+    exp = tc.turns[0].expectations[0]
+    assert isinstance(exp, str)
+    assert "Agent responds appropriately" in exp
+
+
+# --- Event input ---
+
+
+def test_convert_event_input():
+    ir = _make_ir("RootAgent")
+    source = _make_source(
+        {
+            "displayName": "welcome event",
+            "testConfig": {"flow": "RootAgent"},
+            "testCaseConversationTurns": [
+                _event_turn(
+                    "welcome",
+                    responses=["Hi there, how can I assist?"],
+                    flow="RootAgent",
+                ),
+            ],
+        }
+    )
+    converter = DFCXTestConverter(ir)
+    tests_by_agent, _ = converter.convert_all(source)
+
+    tc = tests_by_agent["RootAgent"][0]
+    assert tc.turns[0].event == "welcome"
+    assert tc.turns[0].user is None
+
+
+# --- DTMF as text ---
+
+
+def test_convert_dtmf_as_text():
+    ir = _make_ir("RootAgent")
+    source = _make_source(
+        {
+            "displayName": "dtmf test",
+            "testConfig": {"flow": "RootAgent"},
+            "testCaseConversationTurns": [
+                _dtmf_turn(
+                    "*7",
+                    responses=["You pressed star seven. Connecting you now."],
+                    flow="RootAgent",
+                ),
+            ],
+        }
+    )
+    converter = DFCXTestConverter(ir)
+    tests_by_agent, report = converter.convert_all(source)
+
+    tc = tests_by_agent["RootAgent"][0]
+    assert tc.turns[0].user == "*7"
+    assert "#dtmf-as-text" in tc.tags
+    assert report["dtmf_as_text_count"] == 1
+
+
+# --- Multi-turn with flow change / agent_transfer ---
+
+
+def test_convert_multi_turn_with_agent_transfer():
+    ir = _make_ir("RootAgent", "BillingAgent")
+    flow_map = {"Default Start Flow": "RootAgent", "Billing": "BillingAgent"}
+    source = _make_source(
+        {
+            "displayName": "transfer to billing",
+            "testConfig": {"flow": "Default Start Flow"},
+            "testCaseConversationTurns": [
+                _text_turn(
+                    "hello",
+                    responses=["Welcome! How can I help?"],
+                    flow="Default Start Flow",
+                ),
+                _text_turn(
+                    "check my bill",
+                    responses=["Let me transfer you to billing."],
+                    flow="Billing",
+                ),
+            ],
+        }
+    )
+    converter = DFCXTestConverter(ir, flow_to_agent_map=flow_map)
+    tests_by_agent, report = converter.convert_all(source)
+
+    tc = tests_by_agent["RootAgent"][0]
+    assert len(tc.turns) == 2
+
+    turn2_exps = tc.turns[1].expectations
+    types = [
+        e.type if isinstance(e, TurnExpectation) else "str" for e in turn2_exps
+    ]
+    assert TurnOperator.AGENT_TRANSFER in types
+    assert TurnOperator.FUZZY_MATCH in types
+    transfer = next(
+        e
+        for e in turn2_exps
+        if isinstance(e, TurnExpectation)
+        and e.type == TurnOperator.AGENT_TRANSFER
+    )
+    assert transfer.value == "BillingAgent"
+    assert report["agent_transfer_assertions"] >= 1
+
+
+def test_agent_transfer_with_behavioral():
+    ir = _make_ir("RootAgent", "BillingAgent")
+    flow_map = {"Root": "RootAgent", "Billing": "BillingAgent"}
+    source = _make_source(
+        {
+            "displayName": "transfer behavioral",
+            "testConfig": {"flow": "Root"},
+            "testCaseConversationTurns": [
+                _text_turn("hello", responses=["Welcome!"], flow="Root"),
+                _text_turn(
+                    "billing",
+                    responses=["Transferring to billing now."],
+                    flow="Billing",
+                ),
+            ],
+        }
+    )
+    gemini = _mock_gemini("Agent confirms transfer to billing")
+    converter = DFCXTestConverter(
+        ir, flow_to_agent_map=flow_map, gemini_client=gemini
+    )
+    tests_by_agent, report = converter.convert_all(source)
+
+    tc = tests_by_agent["RootAgent"][0]
+    turn2_exps = tc.turns[1].expectations
+    has_transfer = any(
+        isinstance(e, TurnExpectation) and e.type == TurnOperator.AGENT_TRANSFER
+        for e in turn2_exps
+    )
+    has_behavioral = any(isinstance(e, str) for e in turn2_exps)
+    assert has_transfer
+    assert has_behavioral
+    assert report["agent_transfer_assertions"] >= 1
+    assert report["behavioral_assertions"] >= 1
+
+
+# --- SSML stripping ---
+
+
+def test_ssml_stripping():
+    ssml = (
+        "<speak>Thank you for calling "
+        '<prosody rate="slow">support</prosody>.</speak>'
+    )
+    assert DFCXTestConverter._strip_ssml(ssml) == (
+        "Thank you for calling support."
+    )
+
+
+def test_ssml_stripping_plain_text():
+    assert DFCXTestConverter._strip_ssml("Hello world") == "Hello world"
+
+
+# --- Empty text turn skipping ---
+
+
+def test_empty_text_turns_skipped():
+    ir = _make_ir("RootAgent")
+    source = _make_source(
+        {
+            "displayName": "with empty turn",
+            "testConfig": {"flow": "RootAgent"},
+            "testCaseConversationTurns": [
+                _text_turn(
+                    "hi",
+                    responses=["Hello! How can I help?"],
+                    flow="RootAgent",
+                ),
+                _empty_text_turn(flow="RootAgent"),
+                _text_turn(
+                    "check balance",
+                    responses=["Your balance is $100."],
+                    flow="RootAgent",
+                ),
+            ],
+        }
+    )
+    converter = DFCXTestConverter(ir)
+    tests_by_agent, report = converter.convert_all(source)
+
+    tc = tests_by_agent["RootAgent"][0]
+    assert len(tc.turns) == 2
+    assert tc.turns[0].user == "hi"
+    assert tc.turns[1].user == "check balance"
+    assert report["empty_text_turns_collapsed"] == 1
+
+
+# --- Post-consolidation rerouting ---
+
+
+def test_reroute_after_consolidation():
+    test_cases = {
+        "FlowA": [{"name": "test1"}],
+        "FlowB": [{"name": "test2"}],
+        "FlowC": [{"name": "test3"}],
+    }
+    grouping = {
+        "AgentAlpha": {"agents": ["FlowA", "FlowB"]},
+        "AgentBeta": {"agents": ["FlowC"]},
+    }
+
+    result = DFCXTestConverter.reroute_after_consolidation(test_cases, grouping)
+
+    assert set(result.keys()) == {"AgentAlpha", "AgentBeta"}
+    assert len(result["AgentAlpha"]) == 2
+    assert len(result["AgentBeta"]) == 1
+
+
+# --- Skip cases ---
+
+
+def test_skip_test_no_assertions():
+    ir = _make_ir("RootAgent")
+    source = _make_source(
+        {
+            "displayName": "no response test",
+            "testConfig": {"flow": "RootAgent"},
+            "testCaseConversationTurns": [
+                _text_turn("hi", responses=[], flow="RootAgent"),
+            ],
+        }
+    )
+    converter = DFCXTestConverter(ir)
+    tests_by_agent, report = converter.convert_all(source)
+    assert report["skipped"] == 1
+    assert not tests_by_agent
+
+
+def test_skip_test_short_response():
+    ir = _make_ir("RootAgent")
+    source = _make_source(
+        {
+            "displayName": "short response",
+            "testConfig": {"flow": "RootAgent"},
+            "testCaseConversationTurns": [
+                _text_turn("hi", responses=["OK"], flow="RootAgent"),
+            ],
+        }
+    )
+    converter = DFCXTestConverter(ir)
+    _, report = converter.convert_all(source)
+    assert report["skipped"] == 1
+
+
+# --- Serialize to YAML ---
+
+
+def test_serialize_to_yaml_fuzzy_match():
+    tests_by_agent = {
+        "RootAgent": [
+            TurnTestCase(
+                name="yaml test",
+                tags=["#migrated-dfcx"],
+                turns=[
+                    TurnStep(
+                        turn="Turn 1",
+                        user="hello",
+                        expectations=[
+                            TurnExpectation(
+                                type=TurnOperator.FUZZY_MATCH, value="Welcome"
+                            )
+                        ],
+                    )
+                ],
+            )
+        ]
+    }
+    yamls = DFCXTestConverter.serialize_to_yaml(tests_by_agent)
+    assert "RootAgent" in yamls
+    parsed = yaml.safe_load(yamls["RootAgent"])
+    assert len(parsed["tests"]) == 1
+    assert parsed["tests"][0]["name"] == "yaml test"
+    assert parsed["tests"][0]["turns"][0]["user"] == "hello"
+
+
+def test_serialize_to_yaml_behavioral():
+    tests_by_agent = {
+        "RootAgent": [
+            TurnTestCase(
+                name="behavioral test",
+                tags=["#migrated-dfcx", "#behavioral"],
+                turns=[
+                    TurnStep(
+                        turn="Turn 1",
+                        user="hello",
+                        expectations=[
+                            "Agent greets the user and offers help",
+                            TurnExpectation(
+                                type=TurnOperator.AGENT_TRANSFER,
+                                value="BillingAgent",
+                            ),
+                        ],
+                    )
+                ],
+            )
+        ]
+    }
+    yamls = DFCXTestConverter.serialize_to_yaml(tests_by_agent)
+    parsed = yaml.safe_load(yamls["RootAgent"])
+    exps = parsed["tests"][0]["turns"][0]["expectations"]
+    assert "Agent greets the user and offers help" in exps
+    assert any(
+        isinstance(e, dict) and e.get("type") == "agent_transfer" for e in exps
+    )
+
+
+# --- Deduplication ---
+
+
+def test_duplicate_names_deduplicated():
+    ir = _make_ir("RootAgent")
+    source = _make_source(
+        {
+            "displayName": "same name",
+            "testConfig": {"flow": "RootAgent"},
+            "testCaseConversationTurns": [
+                _text_turn(
+                    "hello",
+                    responses=["Welcome to our service!"],
+                    flow="RootAgent",
+                ),
+            ],
+        },
+        {
+            "displayName": "same name",
+            "testConfig": {"flow": "RootAgent"},
+            "testCaseConversationTurns": [
+                _text_turn(
+                    "hi",
+                    responses=["Hello, how can I help you?"],
+                    flow="RootAgent",
+                ),
+            ],
+        },
+    )
+    converter = DFCXTestConverter(ir)
+    tests_by_agent, _ = converter.convert_all(source)
+
+    names = [tc.name for tc in tests_by_agent["RootAgent"]]
+    assert len(names) == 2
+    assert len(set(names)) == 2
+
+
+# --- Injected parameters ---
+
+
+def test_first_turn_injected_parameters():
+    ir = _make_ir("RootAgent")
+    source = _make_source(
+        {
+            "displayName": "params test",
+            "testConfig": {"flow": "RootAgent"},
+            "testCaseConversationTurns": [
+                _text_turn(
+                    "hello",
+                    responses=["Welcome, credit card holder!"],
+                    flow="RootAgent",
+                    params={"account-type": "credit card"},
+                ),
+                _text_turn(
+                    "check balance",
+                    responses=["Your balance is one hundred dollars."],
+                    flow="RootAgent",
+                ),
+            ],
+        }
+    )
+    converter = DFCXTestConverter(ir)
+    tests_by_agent, _ = converter.convert_all(source)
+
+    tc = tests_by_agent["RootAgent"][0]
+    assert tc.turns[0].variables == {"account-type": "credit card"}
+    assert tc.turns[1].variables == {}
+
+
+# --- Report ---
+
+
+def test_report_counts():
+    ir = _make_ir("RootAgent", "BillingAgent")
+    flow_map = {"Root": "RootAgent", "Billing": "BillingAgent"}
+    source = _make_source(
+        {
+            "displayName": "test1",
+            "testConfig": {"flow": "Root"},
+            "testCaseConversationTurns": [
+                _text_turn(
+                    "hi",
+                    responses=["Hello, welcome to support!"],
+                    flow="Root",
+                ),
+                _text_turn(
+                    "billing",
+                    responses=["Transferring to billing now."],
+                    flow="Billing",
+                ),
+            ],
+        },
+        {
+            "displayName": "test2",
+            "testConfig": {},
+            "testCaseConversationTurns": [
+                _text_turn("hi", responses=["hello"], flow="Root"),
+            ],
+        },
+    )
+    converter = DFCXTestConverter(ir, flow_to_agent_map=flow_map)
+    _, report = converter.convert_all(source)
+
+    assert report["total_source_tests"] == 2
+    assert report["converted"] == 1
+    assert report["skipped"] == 1
+    assert report["fuzzy_match_assertions"] >= 1
+    assert report["agent_transfer_assertions"] >= 1
+
+
+def test_report_counts_behavioral():
+    ir = _make_ir("RootAgent")
+    source = _make_source(
+        {
+            "displayName": "test1",
+            "testConfig": {"flow": "RootAgent"},
+            "testCaseConversationTurns": [
+                _text_turn(
+                    "hi",
+                    responses=["Hello, welcome to support!"],
+                    flow="RootAgent",
+                ),
+            ],
+        }
+    )
+    gemini = _mock_gemini("Agent greets user")
+    converter = DFCXTestConverter(ir, gemini_client=gemini)
+    _, report = converter.convert_all(source)
+
+    assert report["behavioral_assertions"] == 1
+    assert report["fuzzy_match_assertions"] == 0
+
+
+# --- FUZZY_MATCH truncation ---
+
+
+def test_fuzzy_match_truncated_to_max_length():
+    ir = _make_ir("RootAgent")
+    long_response = "A" * 200
+    source = _make_source(
+        {
+            "displayName": "long response",
+            "testConfig": {"flow": "RootAgent"},
+            "testCaseConversationTurns": [
+                _text_turn("hi", responses=[long_response], flow="RootAgent"),
+            ],
+        }
+    )
+    converter = DFCXTestConverter(ir)
+    tests_by_agent, _ = converter.convert_all(source)
+
+    tc = tests_by_agent["RootAgent"][0]
+    assert len(tc.turns[0].expectations[0].value) == 100
+
+
+# --- Extract response text ---
+
+
+def test_extract_response_text():
+    converter = DFCXTestConverter(_make_ir("RootAgent"))
+    output = {
+        "textResponses": [{"text": ["Hello, how can I help?"]}],
+    }
+    assert converter._extract_response_text(output) == "Hello, how can I help?"
+
+
+def test_extract_response_text_strips_ssml():
+    converter = DFCXTestConverter(_make_ir("RootAgent"))
+    output = {
+        "textResponses": [{"text": ["<speak>Hello world</speak>"]}],
+    }
+    assert converter._extract_response_text(output) == "Hello world"
+
+
+def test_extract_response_text_skips_short():
+    converter = DFCXTestConverter(_make_ir("RootAgent"))
+    output = {
+        "textResponses": [{"text": ["OK"]}],
+    }
+    assert converter._extract_response_text(output) == ""
+
+
+def test_extract_response_text_empty():
+    converter = DFCXTestConverter(_make_ir("RootAgent"))
+    assert converter._extract_response_text({}) == ""


### PR DESCRIPTION
- Add DFCXTestConverter that maps DFCX test case conversations to CXAS TurnTestCase YAML files.
- Handles text/event/DTMF inputs, SSML stripping, flow-to-agent routing with post-consolidation remapping, and CONTAINS/AGENT_TRANSFER assertion generation.
- Integrates into Stage 0 of the migration pipeline and includes a standalone CLI script.