### PR TITLE
fix: extract voice_config from test case in simulate_conversation

### DIFF
--- a/src/cxas_scrapi/evals/simulation_evals.py
+++ b/src/cxas_scrapi/evals/simulation_evals.py
@@ -588,6 +588,7 @@ class SimulationEvals(Apps):
         eval_model = eval_model or _DEFAULT_GEMINI_MODEL
         if session_id is None:
             session_id = str(uuid.uuid4())
+        voice_config = voice_config or test_case.get("voice_config")
         eval_conv = LLMUserConversation(
             genai_client=self.genai_client,
             genai_model=sim_user_model,


### PR DESCRIPTION
Propagate voice_config from YAML test cases down to the core session runner.

This should complete https://github.com/GoogleCloudPlatform/cxas-scrapi/issues/180's work after the merge of EnhancedSimRunner into core SimRunner. 


TAG=agy
CONV=244d10e3-31e9-4646-8795-94e352817cd0