### PR TITLE
fix: persist bidi websocket for duration of simulation evaluation

### DIFF
--- a/.agents/skills/cxas-agent-foundry/scripts/run-and-report.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/run-and-report.py
@@ -133,6 +133,10 @@ def main():
         "--dry-run", action="store_true", default=False,
         help="Print what would be done without running anything"
     )
+    parser.add_argument(
+        "--skip-playback-wait", action="store_true", default=False,
+        help="Skip waiting for agent audio playback to finish before sending the next turn (speeds up audio simulations but may cause barge-in/cut-offs)."
+    )
 
     args = parser.parse_args()
     python = sys.executable
@@ -178,6 +182,8 @@ def main():
         eval_cmd.extend(["--runs", str(args.runs)])
     if args.priority is not None:
         eval_cmd.extend(["--priority", args.priority])
+    if args.skip_playback_wait:
+        eval_cmd.append("--skip-playback-wait")
     result = _run(eval_cmd, "Step 3/5: Run all evals", dry_run=args.dry_run)
     if result.returncode != 0:
         print("\nEval run failed. Continuing to triage and report with available results...")

--- a/.agents/skills/cxas-agent-foundry/scripts/run-evals.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/run-evals.py
@@ -101,6 +101,11 @@ def main():
         action="store_true",
         help="Use tool fakes/mocks for evaluations instead of calling real backends.",
     )
+    parser.add_argument(
+        "--skip-playback-wait",
+        action="store_true",
+        help="Skip waiting for agent audio playback to finish before sending the next turn (speeds up audio simulations but may cause barge-in/cut-offs).",
+    )
     args = parser.parse_args()
 
     # Load config
@@ -161,6 +166,7 @@ def main():
             parallel=args.sim_parallel,
             deployment_id=args.deployment_id,
             use_tool_fakes=args.use_tool_fakes,
+            skip_playback_wait=args.skip_playback_wait,
         )
     except Exception as e:
         print(f"\n  ERROR: Evaluation run failed: {e}")

--- a/.agents/skills/cxas-agent-foundry/scripts/run-evals.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/run-evals.py
@@ -96,6 +96,11 @@ def main():
         default=None,
         help="Target a specific deployment ID for simulations.",
     )
+    parser.add_argument(
+        "--use-tool-fakes",
+        action="store_true",
+        help="Use tool fakes/mocks for evaluations instead of calling real backends.",
+    )
     args = parser.parse_args()
 
     # Load config
@@ -155,6 +160,7 @@ def main():
             filter_tags=filter_tags,
             parallel=args.sim_parallel,
             deployment_id=args.deployment_id,
+            use_tool_fakes=args.use_tool_fakes,
         )
     except Exception as e:
         print(f"\n  ERROR: Evaluation run failed: {e}")

--- a/src/cxas_scrapi/core/response_parser.py
+++ b/src/cxas_scrapi/core/response_parser.py
@@ -192,6 +192,7 @@ class ParsedSessionResponse:
                 )
 
     def _parse(self):
+        top_level_agent_text_found = False
         for output in self.outputs:
             if output is None:
                 continue
@@ -201,6 +202,7 @@ class ParsedSessionResponse:
             if text_val and isinstance(text_val, str):
                 self.agent_texts.append(text_val)
                 self.detailed_trace.append(f"Agent Text: {text_val}")
+                top_level_agent_text_found = True
 
             # Top-level session ended flag
             end_sess = getattr(output, "end_session", None)
@@ -302,10 +304,11 @@ class ParsedSessionResponse:
                                         f"User Query: {text_val}"
                                     )
                                 else:
-                                    self.agent_texts.append(text_val)
-                                    self.detailed_trace.append(
-                                        f"Agent Text (Diag): {text_val}"
-                                    )
+                                    if not top_level_agent_text_found:
+                                        self.agent_texts.append(text_val)
+                                        self.detailed_trace.append(
+                                            f"Agent Text (Diag): {text_val}"
+                                        )
 
                         elif chunk_type in ("tool_call", "function_call"):
                             tc = getattr(chunk, "tool_call", None) or getattr(

--- a/src/cxas_scrapi/core/response_parser.py
+++ b/src/cxas_scrapi/core/response_parser.py
@@ -303,12 +303,11 @@ class ParsedSessionResponse:
                                     self.detailed_trace.append(
                                         f"User Query: {text_val}"
                                     )
-                                else:
-                                    if not top_level_agent_text_found:
-                                        self.agent_texts.append(text_val)
-                                        self.detailed_trace.append(
-                                            f"Agent Text (Diag): {text_val}"
-                                        )
+                                elif not top_level_agent_text_found:
+                                    self.agent_texts.append(text_val)
+                                    self.detailed_trace.append(
+                                        f"Agent Text (Diag): {text_val}"
+                                    )
 
                         elif chunk_type in ("tool_call", "function_call"):
                             tc = getattr(chunk, "tool_call", None) or getattr(

--- a/src/cxas_scrapi/core/sessions.py
+++ b/src/cxas_scrapi/core/sessions.py
@@ -785,7 +785,7 @@ class BidiInteractiveSession:
 
         # Block wait for the response with timeout
         try:
-            response = self.response_queue.get(timeout=30)
+            response = self.response_queue.get(timeout=90)
             return response
         except queue.Empty:
             logging.error("Timeout waiting for agent turn response in BidiInteractiveSession")

--- a/src/cxas_scrapi/core/sessions.py
+++ b/src/cxas_scrapi/core/sessions.py
@@ -14,6 +14,7 @@
 
 import json
 import logging
+import queue
 import mimetypes
 import os
 import re
@@ -145,11 +146,15 @@ class AgentTurnManager:
     """Manages the agent's turn by simulating audio playback time."""
 
     def __init__(
-        self, sample_rate: int = SAMPLE_RATE, sample_width: int = SAMPLE_WIDTH
+        self,
+        sample_rate: int = SAMPLE_RATE,
+        sample_width: int = SAMPLE_WIDTH,
+        skip_playback_wait: bool = False,
     ):
         self.sample_rate = sample_rate
         self.sample_width = sample_width
         self.bytes_per_second = sample_rate * sample_width
+        self.skip_playback_wait = skip_playback_wait
 
         self.len_audio_bytes_received = 0
         self.turn_completed_flag = False
@@ -177,6 +182,9 @@ class AgentTurnManager:
             if not self.turn_completed_flag:
                 return False
 
+            if self.skip_playback_wait:
+                return True
+
             if self.first_audio_received_time is None:
                 return True  # Agent didn't send any audio
 
@@ -196,23 +204,31 @@ class BidiSessionHandler:
         location: str,
         token: str,
         config: dict[str, Any],
-        inputs: list[dict[str, Any]],
+        inputs: list[dict[str, Any]] | None = None,
+        input_queue: queue.Queue | None = None,
+        response_queue: queue.Queue | None = None,
         user_agent: str | None = None,
         turn_num: int | None = None,
         capture_agent_audio: bool = False,
         background_noise_file: str | None = None,
         bg_noise_snr: float = 15.0,
+        skip_playback_wait: bool = True,
     ):
         self.uri = BIDI_SESSION_URI + location
         self.token = token
         self.config = config
         self.inputs = inputs
+        self.input_queue = input_queue
+        self.response_queue = response_queue
         self.user_agent = user_agent
         self.turn_num = turn_num
         self.capture_agent_audio = capture_agent_audio
-        self.agent_turn_manager = AgentTurnManager()
+        self.agent_turn_manager = AgentTurnManager(
+            skip_playback_wait=skip_playback_wait,
+        )
         self.ws_app: websocket.WebSocketApp | None = None
         self.outputs = []
+        self.current_turn_outputs = []
         self.current_agent_turn_idx = 0
         self.turn_audio_buffers = {}
         self.turn_audio_paths = {}
@@ -398,57 +414,22 @@ class BidiSessionHandler:
             logging.debug("Sending config: %s", config_json)
             self.ws_app.send(config_json)
 
-            if not self.inputs:
-                logging.debug("No inputs provided.")
+            if self.inputs is not None:
+                for idx, input_item in enumerate(self.inputs):
+                    self._send_single_input(input_item, idx)
+            elif self.input_queue is not None:
+                idx = 0
+                while True:
+                    input_item = self.input_queue.get()
+                    if input_item is None:
+                        logging.debug("Received exit sentinel in input queue.")
+                        break
+                    self._send_single_input(input_item, idx)
+                    idx += 1
+            else:
+                logging.debug("No inputs or input_queue provided.")
                 self.ws_app.close()
                 return
-
-            for idx, input_item in enumerate(self.inputs):
-                if "audio" in input_item:
-                    self._send_audio_message(input_item["audio"], idx)
-                    continue
-
-                # Handle non-audio structured inputs (event, text, variables)
-                try:
-                    session_input_pb = types.SessionInput()._pb
-                    json_format.ParseDict(
-                        input_item,
-                        session_input_pb,
-                        ignore_unknown_fields=False,
-                    )
-                    session_input = types.SessionInput(session_input_pb)
-
-                    query_message = types.BidiSessionClientMessage(
-                        realtime_input=session_input
-                    )
-                    query_json = json_format.MessageToJson(
-                        query_message._pb,
-                        preserving_proto_field_name=False,
-                        indent=None,
-                    )
-                    logging.debug("Sending non-audio input: %s", query_json)
-                    self.ws_app.send(query_json)
-
-                    if "text" in input_item or "event" in input_item:
-                        logging.debug(
-                            "Waiting for agent to finish processing turn %d...",
-                            idx,
-                        )
-                        while (
-                            not self.agent_turn_manager.is_agent_done_talking()
-                        ):
-                            time.sleep(1)
-
-                        self.agent_turn_manager.reset()
-                        time.sleep(1)
-                    elif "variables" in input_item:
-                        logging.debug(
-                            "Sent variables, pausing to allow state update..."
-                        )
-                        time.sleep(0.5)
-
-                except Exception as e:
-                    logging.debug("Failed to send generic input: %s", e)
 
             logging.debug("All inputs sent and turns completed.")
             time.sleep(1)  # arbitrary short wait before disconnecting
@@ -458,6 +439,53 @@ class BidiSessionHandler:
             logging.debug("Error during send_inputs: %s", e)
             if self.ws_app:
                 self.ws_app.close()
+
+    def _send_single_input(self, input_item: dict[str, Any], idx: int):
+        if "audio" in input_item:
+            self._send_audio_message(input_item["audio"], idx)
+            return
+
+        # Handle non-audio structured inputs (event, text, variables)
+        try:
+            session_input_pb = types.SessionInput()._pb
+            json_format.ParseDict(
+                input_item,
+                session_input_pb,
+                ignore_unknown_fields=False,
+            )
+            session_input = types.SessionInput(session_input_pb)
+
+            query_message = types.BidiSessionClientMessage(
+                realtime_input=session_input
+            )
+            query_json = json_format.MessageToJson(
+                query_message._pb,
+                preserving_proto_field_name=False,
+                indent=None,
+            )
+            logging.debug("Sending non-audio input: %s", query_json)
+            self.ws_app.send(query_json)
+
+            if "text" in input_item or "event" in input_item:
+                logging.debug(
+                    "Waiting for agent to finish processing turn %d...",
+                    idx,
+                )
+                while (
+                    not self.agent_turn_manager.is_agent_done_talking()
+                ):
+                    time.sleep(1)
+
+                self.agent_turn_manager.reset()
+                time.sleep(1)
+            elif "variables" in input_item:
+                logging.debug(
+                    "Sent variables, pausing to allow state update..."
+                )
+                time.sleep(0.5)
+
+        except Exception as e:
+            logging.debug("Failed to send generic input: %s", e)
 
     def _on_open(self, ws):
         logging.debug("WebSocket connection opened")
@@ -477,6 +505,7 @@ class BidiSessionHandler:
 
             if response.session_output:
                 self.outputs.append(response.session_output)
+                self.current_turn_outputs.append(response.session_output)
 
                 if response.session_output.audio:
                     self.agent_turn_manager.add_audio(
@@ -540,7 +569,29 @@ class BidiSessionHandler:
                                 f" {audio_err}"
                             )
 
+                    if self.response_queue is not None:
+                        original_response = types.RunSessionResponse(
+                            outputs=list(self.current_turn_outputs)
+                        )
+                        turn_audio_path = {}
+                        if self.current_agent_turn_idx in self.turn_audio_paths:
+                            turn_audio_path[0] = self.turn_audio_paths[self.current_agent_turn_idx]
+                        
+                        turn_response = ScrapiRunSessionResponse(
+                            original_response=original_response,
+                            agent_audio_paths=turn_audio_path,
+                        )
+                        self.response_queue.put(turn_response)
+                        self.current_turn_outputs = []
+
                     self.current_agent_turn_idx += 1
+
+            if response.end_session:
+                if self.response_queue is not None:
+                    self.response_queue.put({
+                        "session_ended": True,
+                        "end_session": response.end_session,
+                    })
 
         except Exception as e:
             logging.debug("Failed to parse message: %s", e)
@@ -549,6 +600,11 @@ class BidiSessionHandler:
         logging.debug("WebSocket error: %s", error)
         # Stash connection-level errors
         self._connection_error = error
+        if self.response_queue is not None:
+            self.response_queue.put({
+                "session_ended": True,
+                "connection_error": error,
+            })
 
     def _on_close(self, ws, close_status_code, close_msg):
         logging.debug(
@@ -559,6 +615,13 @@ class BidiSessionHandler:
         # Stash close status to verify clean closure
         self._close_status_code = close_status_code
         self._close_msg = close_msg
+        if self.response_queue is not None:
+            self.response_queue.put({
+                "session_ended": True,
+                "connection_closed": True,
+                "close_status_code": close_status_code,
+                "close_msg": close_msg,
+            })
 
     def run(self):
         logging.debug("Connecting to WebSocket: %s", self.uri)
@@ -580,6 +643,10 @@ class BidiSessionHandler:
         )
         wst.daemon = True
         wst.start()
+
+        if self.input_queue is not None:
+            logging.debug("BidiSessionHandler started in non-blocking mode.")
+            return wst
 
         logging.debug("Waiting for session to complete...")
         wst.join(timeout=_BIDI_RUN_TIMEOUT_S)
@@ -638,6 +705,97 @@ class BidiSessionHandler:
             original_response=original_response,
             agent_audio_paths=self.turn_audio_paths,
         )
+
+
+class BidiInteractiveSession:
+    """Manages an active Bidi WebSocket session with GECX, supporting dynamic turns."""
+
+    def __init__(
+        self,
+        sessions_client: "Sessions",
+        session_id: str,
+        config: dict[str, Any],
+        capture_agent_audio: bool = False,
+        background_noise_file: str | None = None,
+        bg_noise_snr: float = 15.0,
+        skip_playback_wait: bool = True,
+        voice_config: dict[str, Any] | None = None,
+    ):
+        self.sessions_client = sessions_client
+        self.session_id = session_id
+        self.config = config
+        self.capture_agent_audio = capture_agent_audio
+        self.background_noise_file = background_noise_file
+        self.bg_noise_snr = bg_noise_snr
+        self.voice_config = voice_config
+
+        self.input_queue = queue.Queue()
+        self.response_queue = queue.Queue()
+
+        self.handler = BidiSessionHandler(
+            location=sessions_client.location,
+            token=sessions_client.token,
+            config=config,
+            inputs=None,
+            input_queue=self.input_queue,
+            response_queue=self.response_queue,
+            capture_agent_audio=capture_agent_audio,
+            background_noise_file=background_noise_file,
+            bg_noise_snr=bg_noise_snr,
+            skip_playback_wait=skip_playback_wait,
+        )
+        self.wst = None
+
+    def start(self):
+        """Connects to the WebSocket gateway in the background."""
+        self.wst = self.handler.run()
+        # Wait a short moment to ensure thread has started and websocket is opened
+        time.sleep(0.5)
+
+    def send_turn(self, text: str, variables: dict[str, Any] | None = None) -> Any:
+        """Sends a user query and returns the agent's turn response."""
+        # Convert text to TTS audio bytes
+        from cxas_scrapi.core.audio_transformer import AudioTransformer
+        audio_transformer = AudioTransformer()
+        lang_code = "en-US"
+        if variables and "locale" in variables:
+            lang_code = variables["locale"]
+
+        current_voice_config = (self.voice_config or {}).copy()
+        if "language_code" not in current_voice_config:
+            current_voice_config["language_code"] = lang_code
+
+        input_data = audio_transformer.text_to_speech_bytes(
+            text=text,
+            credentials=self.sessions_client.creds,
+            project_id=self.sessions_client.project_id,
+            background_noise_file=self.background_noise_file,
+            voice_config=current_voice_config,
+        )
+
+        audio_payload = {
+            "audio": input_data["audio_bytes"],
+            "text": input_data["text"],
+        }
+        if variables:
+            audio_payload["variables"] = variables
+
+        # Put in queue
+        self.input_queue.put({"audio": audio_payload})
+
+        # Block wait for the response with timeout
+        try:
+            response = self.response_queue.get(timeout=30)
+            return response
+        except queue.Empty:
+            logging.error("Timeout waiting for agent turn response in BidiInteractiveSession")
+            raise TimeoutError("Timeout waiting for agent response via WebSocket")
+
+    def close(self):
+        """Closes the WebSocket connection cleanly."""
+        self.input_queue.put(None)  # Sentinel to close sending loop
+        if self.wst is not None:
+            self.wst.join(timeout=10)
 
 
 class Sessions(Common):
@@ -987,6 +1145,43 @@ class Sessions(Common):
             bg_noise_snr=bg_noise_snr,
         )
         return handler.run()
+
+    def create_interactive_session(
+        self,
+        session_id: str,
+        capture_agent_audio: bool = False,
+        background_noise_file: str | None = None,
+        bg_noise_snr: float = 15.0,
+        use_tool_fakes: bool = True,
+        skip_playback_wait: bool = True,
+        voice_config: dict[str, Any] | None = None,
+    ) -> BidiInteractiveSession:
+        """Creates and returns a new BidiInteractiveSession instance."""
+        self._check_audio_requirements()
+
+        config = {
+            "session": f"{self.app_name}/sessions/{session_id}",
+            "use_tool_fakes": use_tool_fakes,
+            "input_audio_config": types.InputAudioConfig(
+                audio_encoding=types.AudioEncoding.LINEAR16,
+                sample_rate_hertz=SAMPLE_RATE,
+            ),
+            "output_audio_config": types.OutputAudioConfig(
+                audio_encoding=types.AudioEncoding.LINEAR16,
+                sample_rate_hertz=SAMPLE_RATE,
+            ),
+        }
+
+        return BidiInteractiveSession(
+            sessions_client=self,
+            session_id=session_id,
+            config=config,
+            capture_agent_audio=capture_agent_audio,
+            background_noise_file=background_noise_file,
+            bg_noise_snr=bg_noise_snr,
+            skip_playback_wait=skip_playback_wait,
+            voice_config=voice_config,
+        )
 
     def make_text_request(self, config: dict, inputs: list[dict[str, Any]]):
         if self.rate_limiter:

--- a/src/cxas_scrapi/core/sessions.py
+++ b/src/cxas_scrapi/core/sessions.py
@@ -14,9 +14,9 @@
 
 import json
 import logging
-import queue
 import mimetypes
 import os
+import queue
 import re
 import sys
 import threading
@@ -574,9 +574,10 @@ class BidiSessionHandler:
                             outputs=list(self.current_turn_outputs)
                         )
                         turn_audio_path = {}
-                        if self.current_agent_turn_idx in self.turn_audio_paths:
-                            turn_audio_path[0] = self.turn_audio_paths[self.current_agent_turn_idx]
-                        
+                        idx = self.current_agent_turn_idx
+                        if idx in self.turn_audio_paths:
+                            turn_audio_path[0] = self.turn_audio_paths[idx]
+
                         turn_response = ScrapiRunSessionResponse(
                             original_response=original_response,
                             agent_audio_paths=turn_audio_path,
@@ -708,7 +709,10 @@ class BidiSessionHandler:
 
 
 class BidiInteractiveSession:
-    """Manages an active Bidi WebSocket session with GECX, supporting dynamic turns."""
+    """Manages an active Bidi WebSocket session with GECX.
+
+    Supports dynamic multi-turn interactions.
+    """
 
     def __init__(
         self,
@@ -749,13 +753,15 @@ class BidiInteractiveSession:
     def start(self):
         """Connects to the WebSocket gateway in the background."""
         self.wst = self.handler.run()
-        # Wait a short moment to ensure thread has started and websocket is opened
+        # Wait a short moment to ensure thread has started and
+        # websocket is opened.
         time.sleep(0.5)
 
-    def send_turn(self, text: str, variables: dict[str, Any] | None = None) -> Any:
+    def send_turn(
+        self, text: str, variables: dict[str, Any] | None = None
+    ) -> Any:
         """Sends a user query and returns the agent's turn response."""
         # Convert text to TTS audio bytes
-        from cxas_scrapi.core.audio_transformer import AudioTransformer
         audio_transformer = AudioTransformer()
         lang_code = "en-US"
         if variables and "locale" in variables:
@@ -787,9 +793,14 @@ class BidiInteractiveSession:
         try:
             response = self.response_queue.get(timeout=90)
             return response
-        except queue.Empty:
-            logging.error("Timeout waiting for agent turn response in BidiInteractiveSession")
-            raise TimeoutError("Timeout waiting for agent response via WebSocket")
+        except queue.Empty as err:
+            logging.error(
+                "Timeout waiting for agent turn response in "
+                "BidiInteractiveSession"
+            )
+            raise TimeoutError(
+                "Timeout waiting for agent response via WebSocket"
+            ) from err
 
     def close(self):
         """Closes the WebSocket connection cleanly."""

--- a/src/cxas_scrapi/core/sessions.py
+++ b/src/cxas_scrapi/core/sessions.py
@@ -159,10 +159,28 @@ class AgentTurnManager:
         self.len_audio_bytes_received = 0
         self.turn_completed_flag = False
         self.first_audio_received_time = None
+        self.expected_duration_seconds = None
+        self.is_welcome_turn = False
+        self.current_turn_index = None
         self.lock = threading.Lock()
+
+    def _calculate_rms(self, audio_bytes: bytes) -> float:
+        import struct
+        import math
+        count = len(audio_bytes) // 2
+        if count == 0:
+            return 0.0
+        shorts = struct.unpack(f"<{count}h", audio_bytes[: count * 2])
+        sum_squares = sum(s * s for s in shorts)
+        return math.sqrt(sum_squares / count)
 
     def add_audio(self, audio_bytes: bytes):
         with self.lock:
+            if self.turn_completed_flag:
+                return
+            rms = self._calculate_rms(audio_bytes)
+            if rms < 200.0:
+                return
             if self.first_audio_received_time is None:
                 self.first_audio_received_time = time.time()
             self.len_audio_bytes_received += len(audio_bytes)
@@ -176,24 +194,67 @@ class AgentTurnManager:
             self.len_audio_bytes_received = 0
             self.turn_completed_flag = False
             self.first_audio_received_time = None
+            self.expected_duration_seconds = None
+            self.is_welcome_turn = False
+            self.current_turn_index = None
+
+    def prepare_for_turn(self, expected_turn_index: int):
+        with self.lock:
+            logging.debug(
+                "Preparing manager for turn index %d. Resetting state.",
+                expected_turn_index,
+            )
+            self.len_audio_bytes_received = 0
+            self.turn_completed_flag = False
+            self.first_audio_received_time = None
+            self.expected_duration_seconds = None
+            self.is_welcome_turn = (expected_turn_index <= 1)
+            self.current_turn_index = expected_turn_index
+
+    def update_turn_index(self, turn_idx: int) -> bool:
+        with self.lock:
+            if self.current_turn_index is None:
+                self.current_turn_index = turn_idx
+                return True
+            if turn_idx != self.current_turn_index:
+                return False
+            return True
 
     def is_agent_done_talking(self) -> bool:
         with self.lock:
-            if not self.turn_completed_flag:
-                return False
-
             if self.skip_playback_wait:
                 return True
 
             if self.first_audio_received_time is None:
-                return True  # Agent didn't send any audio
+                if self.turn_completed_flag:
+                    return True  # Agent didn't send any audio
+                return False
 
+            # If the network transfer is not completed, we cannot use exact byte-based timing,
+            # so we use the text-based estimate if available.
+            if not self.turn_completed_flag:
+                if self.expected_duration_seconds is not None:
+                    current_playback_time = time.time() - self.first_audio_received_time
+                    return current_playback_time >= self.expected_duration_seconds
+                return False
+
+            # Once the network transfer is completed, we have all audio bytes.
+            # We calculate the exact duration of the received audio.
             audio_duration_seconds = (
                 self.len_audio_bytes_received / self.bytes_per_second
             )
-            current_playback_time = time.time() - self.first_audio_received_time
+            # Add a small buffer padding to allow local playback buffer to finish
+            audio_duration_seconds += 0.5
 
-            return current_playback_time >= audio_duration_seconds
+            current_playback_time = time.time() - self.first_audio_received_time
+            res = current_playback_time >= audio_duration_seconds
+            logging.debug(
+                "is_agent_done_talking (exact byte-based): duration=%.2f, elapsed=%.2f -> %s",
+                audio_duration_seconds,
+                current_playback_time,
+                res
+            )
+            return res
 
 
 class BidiSessionHandler:
@@ -231,6 +292,7 @@ class BidiSessionHandler:
         self.current_turn_outputs = []
         self.current_agent_turn_idx = 0
         self.turn_audio_buffers = {}
+        self.max_server_turn_idx = 0
         self.turn_audio_paths = {}
 
         self._close_status_code: int | None = None
@@ -315,6 +377,10 @@ class BidiSessionHandler:
     def _send_audio_message(
         self, audio_payload: dict[str, Any], turn_index: int
     ):
+        expected_idx = self.max_server_turn_idx + 1
+        self.agent_turn_manager.prepare_for_turn(
+            expected_turn_index=expected_idx
+        )
         audio_bytes = audio_payload["audio"]
         variables = audio_payload.get("variables")
 
@@ -391,7 +457,6 @@ class BidiSessionHandler:
         while not self.agent_turn_manager.is_agent_done_talking():
             self._send_silence(1)
 
-        self.agent_turn_manager.reset()
         time.sleep(1)  # Small pause between turns
 
     def _send_inputs(self):
@@ -467,6 +532,10 @@ class BidiSessionHandler:
             self.ws_app.send(query_json)
 
             if "text" in input_item or "event" in input_item:
+                expected_idx = self.max_server_turn_idx + 1
+                self.agent_turn_manager.prepare_for_turn(
+                    expected_turn_index=expected_idx
+                )
                 logging.debug(
                     "Waiting for agent to finish processing turn %d...",
                     idx,
@@ -474,7 +543,6 @@ class BidiSessionHandler:
                 while not self.agent_turn_manager.is_agent_done_talking():
                     time.sleep(1)
 
-                self.agent_turn_manager.reset()
                 time.sleep(1)
             elif "variables" in input_item:
                 logging.debug(
@@ -483,7 +551,7 @@ class BidiSessionHandler:
                 time.sleep(0.5)
 
         except Exception as e:
-            logging.debug("Failed to send generic input: %s", e)
+            logging.debug("Failed to send generic input %s: %s", input_item, e)
 
     def _on_open(self, ws):
         logging.debug("WebSocket connection opened")
@@ -502,8 +570,18 @@ class BidiSessionHandler:
             response = types.BidiSessionServerMessage(response_pb)
 
             if response.session_output:
+                turn_idx = response.session_output.turn_index
+                self.max_server_turn_idx = max(
+                    self.max_server_turn_idx, turn_idx
+                )
+                if not self.agent_turn_manager.update_turn_index(turn_idx):
+                    return
+
                 self.outputs.append(response.session_output)
                 self.current_turn_outputs.append(response.session_output)
+                self.agent_turn_manager.is_welcome_turn = (
+                    response.session_output.turn_index <= 1
+                )
 
                 if response.session_output.audio:
                     self.agent_turn_manager.add_audio(
@@ -519,6 +597,20 @@ class BidiSessionHandler:
                     self.turn_audio_buffers[self.current_agent_turn_idx].extend(
                         response.session_output.audio
                     )
+
+                # Dynamically update estimated speech duration based on text received so far
+                parsed = ParsedSessionResponse(self.current_turn_outputs)
+                agent_text = parsed.consolidated_agent_text
+                if agent_text:
+                    word_count = len(agent_text.split())
+                    # Heuristic: 140 WPM (2.33 words/sec) + 1.5s padding
+                    estimated_duration = (word_count / 2.33) + 1.5
+                    logging.debug(
+                        "Calculated text speech duration: %d words -> %.2f seconds",
+                        word_count,
+                        estimated_duration,
+                    )
+                    self.agent_turn_manager.expected_duration_seconds = estimated_duration
 
                 if response.session_output.turn_completed:
                     logging.debug(
@@ -771,27 +863,33 @@ class BidiInteractiveSession:
         if variables and "locale" in variables:
             lang_code = variables["locale"]
 
-        current_voice_config = (self.voice_config or {}).copy()
-        if "language_code" not in current_voice_config:
-            current_voice_config["language_code"] = lang_code
+        if text.startswith("event:"):
+            event_name = text[len("event:") :].strip()
+            if variables:
+                self.input_queue.put({"variables": variables})
+            self.input_queue.put({"event": {"event": event_name}})
+        else:
+            current_voice_config = (self.voice_config or {}).copy()
+            if "language_code" not in current_voice_config:
+                current_voice_config["language_code"] = lang_code
 
-        input_data = audio_transformer.text_to_speech_bytes(
-            text=text,
-            credentials=self.sessions_client.creds,
-            project_id=self.sessions_client.project_id,
-            background_noise_file=self.background_noise_file,
-            voice_config=current_voice_config,
-        )
+            input_data = audio_transformer.text_to_speech_bytes(
+                text=text,
+                credentials=self.sessions_client.creds,
+                project_id=self.sessions_client.project_id,
+                background_noise_file=self.background_noise_file,
+                voice_config=current_voice_config,
+            )
 
-        audio_payload = {
-            "audio": input_data["audio_bytes"],
-            "text": input_data["text"],
-        }
-        if variables:
-            audio_payload["variables"] = variables
+            audio_payload = {
+                "audio": input_data["audio_bytes"],
+                "text": input_data["text"],
+            }
+            if variables:
+                audio_payload["variables"] = variables
 
-        # Put in queue
-        self.input_queue.put({"audio": audio_payload})
+            # Put in queue
+            self.input_queue.put({"audio": audio_payload})
 
         # Block wait for the response with timeout
         try:

--- a/src/cxas_scrapi/core/sessions.py
+++ b/src/cxas_scrapi/core/sessions.py
@@ -208,7 +208,7 @@ class AgentTurnManager:
             self.turn_completed_flag = False
             self.first_audio_received_time = None
             self.expected_duration_seconds = None
-            self.is_welcome_turn = (expected_turn_index <= 1)
+            self.is_welcome_turn = expected_turn_index <= 1
             self.current_turn_index = expected_turn_index
 
     def update_turn_index(self, turn_idx: int) -> bool:

--- a/src/cxas_scrapi/core/sessions.py
+++ b/src/cxas_scrapi/core/sessions.py
@@ -14,10 +14,12 @@
 
 import json
 import logging
+import math
 import mimetypes
 import os
 import queue
 import re
+import struct
 import sys
 import threading
 import time
@@ -165,8 +167,6 @@ class AgentTurnManager:
         self.lock = threading.Lock()
 
     def _calculate_rms(self, audio_bytes: bytes) -> float:
-        import struct
-        import math
         count = len(audio_bytes) // 2
         if count == 0:
             return 0.0
@@ -230,12 +230,16 @@ class AgentTurnManager:
                     return True  # Agent didn't send any audio
                 return False
 
-            # If the network transfer is not completed, we cannot use exact byte-based timing,
-            # so we use the text-based estimate if available.
+            # If the network transfer is not completed, we cannot use exact
+            # byte-based timing, so we use the text-based estimate if available.
             if not self.turn_completed_flag:
                 if self.expected_duration_seconds is not None:
-                    current_playback_time = time.time() - self.first_audio_received_time
-                    return current_playback_time >= self.expected_duration_seconds
+                    current_playback_time = (
+                        time.time() - self.first_audio_received_time
+                    )
+                    return (
+                        current_playback_time >= self.expected_duration_seconds
+                    )
                 return False
 
             # Once the network transfer is completed, we have all audio bytes.
@@ -243,16 +247,18 @@ class AgentTurnManager:
             audio_duration_seconds = (
                 self.len_audio_bytes_received / self.bytes_per_second
             )
-            # Add a small buffer padding to allow local playback buffer to finish
+            # Add a small buffer padding to allow local playback buffer to
+            # finish
             audio_duration_seconds += 0.5
 
             current_playback_time = time.time() - self.first_audio_received_time
             res = current_playback_time >= audio_duration_seconds
             logging.debug(
-                "is_agent_done_talking (exact byte-based): duration=%.2f, elapsed=%.2f -> %s",
+                "is_agent_done_talking (exact byte-based): "
+                "duration=%.2f, elapsed=%.2f -> %s",
                 audio_duration_seconds,
                 current_playback_time,
-                res
+                res,
             )
             return res
 
@@ -294,6 +300,8 @@ class BidiSessionHandler:
         self.turn_audio_buffers = {}
         self.max_server_turn_idx = 0
         self.turn_audio_paths = {}
+        self.is_sending_audio = False
+        self.lock = threading.Lock()
 
         self._close_status_code: int | None = None
         self._close_msg: str | None = None
@@ -377,87 +385,93 @@ class BidiSessionHandler:
     def _send_audio_message(
         self, audio_payload: dict[str, Any], turn_index: int
     ):
-        expected_idx = self.max_server_turn_idx + 1
-        self.agent_turn_manager.prepare_for_turn(
-            expected_turn_index=expected_idx
-        )
-        audio_bytes = audio_payload["audio"]
-        variables = audio_payload.get("variables")
+        with self.lock:
+            self.is_sending_audio = True
+        try:
+            expected_idx = self.max_server_turn_idx + 1
+            self.agent_turn_manager.prepare_for_turn(
+                expected_turn_index=expected_idx
+            )
+            audio_bytes = audio_payload["audio"]
+            variables = audio_payload.get("variables")
 
-        if variables:
+            if variables:
+                logging.debug(
+                    "Sending variables before audio chunks: %s", variables
+                )
+                var_message = types.BidiSessionClientMessage(
+                    realtime_input=types.SessionInput(variables=variables)
+                )
+                var_json = json_format.MessageToJson(
+                    var_message._pb,
+                    preserving_proto_field_name=False,
+                    indent=None,
+                )
+                self.ws_app.send(var_json)
+                time.sleep(0.5)
+
+            logging.debug("Sending leading silence before turn %d...", turn_index)
+            self._send_silence(
+                SILENCE_PADDING_CHUNKS
+            )  # 0.3 seconds of leading silence
+
+            logging.debug("Sending audio chunks for turn %d...", turn_index)
+
+            for i in range(0, len(audio_bytes), AUDIO_CHUNK_SIZE):
+                chunk = audio_bytes[i : i + AUDIO_CHUNK_SIZE]
+
+                # Dynamically mix continuous background noise chunk-by-chunk
+                # in real-time
+                if self.bg_noise_segment is not None:
+                    try:
+                        speech_seg = AudioSegment(
+                            chunk,
+                            frame_rate=SAMPLE_RATE,
+                            sample_width=SAMPLE_WIDTH,
+                            channels=AUDIO_CHANNELS,
+                        )
+                        noise_seg = self.bg_noise_segment[
+                            self.bg_noise_cursor : self.bg_noise_cursor + 100
+                        ]
+                        self.bg_noise_cursor += 100
+                        if self.bg_noise_cursor >= len(self.bg_noise_segment):
+                            self.bg_noise_cursor = 0
+
+                        mixed_seg = speech_seg.overlay(noise_seg)
+                        chunk = mixed_seg.raw_data[: len(chunk)]
+                    except Exception as ex:
+                        logging.warning(
+                            "Failed to overlay continuous noise chunk in "
+                            f"real-time: {ex}"
+                        )
+
+                query_message = types.BidiSessionClientMessage(
+                    realtime_input=types.SessionInput(audio=chunk)
+                )
+                query_json = json_format.MessageToJson(
+                    query_message._pb,
+                    preserving_proto_field_name=False,
+                    indent=None,
+                )
+                self.ws_app.send(query_json)
+                time.sleep(CHUNK_DELAY)
+
             logging.debug(
-                "Sending variables before audio chunks: %s", variables
+                "Sending trailing silence for turn %d to trigger endpointing...",
+                turn_index,
             )
-            var_message = types.BidiSessionClientMessage(
-                realtime_input=types.SessionInput(variables=variables)
-            )
-            var_json = json_format.MessageToJson(
-                var_message._pb,
-                preserving_proto_field_name=False,
-                indent=None,
-            )
-            self.ws_app.send(var_json)
-            time.sleep(0.5)
+            self._send_silence(
+                SILENCE_PADDING_CHUNKS
+            )  # 0.3 seconds of trailing silence
 
-        logging.debug("Sending leading silence before turn %d...", turn_index)
-        self._send_silence(
-            SILENCE_PADDING_CHUNKS
-        )  # 0.3 seconds of leading silence
+            logging.debug("Waiting for agent to finish turn %d...", turn_index)
+            while not self.agent_turn_manager.is_agent_done_talking():
+                self._send_silence(1)
 
-        logging.debug("Sending audio chunks for turn %d...", turn_index)
-
-        for i in range(0, len(audio_bytes), AUDIO_CHUNK_SIZE):
-            chunk = audio_bytes[i : i + AUDIO_CHUNK_SIZE]
-
-            # Dynamically mix continuous background noise chunk-by-chunk
-            # in real-time
-            if self.bg_noise_segment is not None:
-                try:
-                    speech_seg = AudioSegment(
-                        chunk,
-                        frame_rate=SAMPLE_RATE,
-                        sample_width=SAMPLE_WIDTH,
-                        channels=AUDIO_CHANNELS,
-                    )
-                    noise_seg = self.bg_noise_segment[
-                        self.bg_noise_cursor : self.bg_noise_cursor + 100
-                    ]
-                    self.bg_noise_cursor += 100
-                    if self.bg_noise_cursor >= len(self.bg_noise_segment):
-                        self.bg_noise_cursor = 0
-
-                    mixed_seg = speech_seg.overlay(noise_seg)
-                    chunk = mixed_seg.raw_data[: len(chunk)]
-                except Exception as ex:
-                    logging.warning(
-                        "Failed to overlay continuous noise chunk in "
-                        f"real-time: {ex}"
-                    )
-
-            query_message = types.BidiSessionClientMessage(
-                realtime_input=types.SessionInput(audio=chunk)
-            )
-            query_json = json_format.MessageToJson(
-                query_message._pb,
-                preserving_proto_field_name=False,
-                indent=None,
-            )
-            self.ws_app.send(query_json)
-            time.sleep(CHUNK_DELAY)
-
-        logging.debug(
-            "Sending trailing silence for turn %d to trigger endpointing...",
-            turn_index,
-        )
-        self._send_silence(
-            SILENCE_PADDING_CHUNKS
-        )  # 0.3 seconds of trailing silence
-
-        logging.debug("Waiting for agent to finish turn %d...", turn_index)
-        while not self.agent_turn_manager.is_agent_done_talking():
-            self._send_silence(1)
-
-        time.sleep(1)  # Small pause between turns
+            time.sleep(1)  # Small pause between turns
+        finally:
+            with self.lock:
+                self.is_sending_audio = False
 
     def _send_inputs(self):
         try:
@@ -556,20 +570,80 @@ class BidiSessionHandler:
     def _on_open(self, ws):
         logging.debug("WebSocket connection opened")
         threading.Thread(target=self._send_inputs, daemon=True).start()
+        threading.Thread(target=self._silence_loop, daemon=True).start()
+
+    def _silence_loop(self):
+        while True:
+            if not self.ws_app or not self.ws_app.sock or not self.ws_app.sock.connected:
+                break
+
+            with self.lock:
+                should_send = not self.is_sending_audio
+
+            if should_send:
+                try:
+                    self._send_silence(1)
+                except Exception as ex:
+                    logging.debug("Silence loop error: %s", ex)
+                    break
+            else:
+                time.sleep(0.1)
 
     def _on_message(self, ws, message):
         logging.debug("===============")
         logging.debug("Received message: %s...", message[:100])
         try:
             response_pb = types.BidiSessionServerMessage()._pb
-            json_format.Parse(
-                message,
+            message_dict = json.loads(message)
+            output = message_dict.get("sessionOutput") or message_dict.get("session_output")
+            if isinstance(output, dict):
+                diag = output.get("diagnosticInfo") or output.get("diagnostic_info")
+                if isinstance(diag, dict):
+                    logging.debug("DIAG DUMP: %s", json.dumps(diag))
+                    root_span = diag.get("rootSpan") or diag.get("root_span")
+                    if isinstance(root_span, dict):
+                        root_span.pop("execution_steps", None)
+                        root_span.pop("executionSteps", None)
+
+            json_format.ParseDict(
+                message_dict,
                 response_pb,
                 ignore_unknown_fields=True,
             )
             response = types.BidiSessionServerMessage(response_pb)
 
             if response.session_output:
+                # Check if this is an empty comfort noise or variables ack packet
+                has_text = bool(response.session_output.text)
+                has_diag_messages = False
+                diag = response.session_output.diagnostic_info
+                if diag and diag.messages:
+                    has_diag_messages = True
+
+                has_execution = False
+                if diag and diag.root_span and diag.root_span.child_spans:
+                    has_execution = True
+
+                has_audio_energy = False
+                if response.session_output.audio:
+                    rms = self.agent_turn_manager._calculate_rms(
+                        response.session_output.audio
+                    )
+                    if rms >= 200.0:
+                        has_audio_energy = True
+
+                is_empty_response = (
+                    not response.session_output.turn_completed
+                    and not has_text
+                    and not has_diag_messages
+                    and not has_execution
+                    and not has_audio_energy
+                )
+
+                if is_empty_response:
+                    logging.debug("Ignoring empty/silent server response packet.")
+                    return
+
                 turn_idx = response.session_output.turn_index
                 self.max_server_turn_idx = max(
                     self.max_server_turn_idx, turn_idx
@@ -598,7 +672,8 @@ class BidiSessionHandler:
                         response.session_output.audio
                     )
 
-                # Dynamically update estimated speech duration based on text received so far
+                # Dynamically update estimated speech duration based on text
+                # received so far
                 parsed = ParsedSessionResponse(self.current_turn_outputs)
                 agent_text = parsed.consolidated_agent_text
                 if agent_text:
@@ -606,11 +681,14 @@ class BidiSessionHandler:
                     # Heuristic: 140 WPM (2.33 words/sec) + 1.5s padding
                     estimated_duration = (word_count / 2.33) + 1.5
                     logging.debug(
-                        "Calculated text speech duration: %d words -> %.2f seconds",
+                        "Calculated text speech duration: %d words -> "
+                        "%.2f seconds",
                         word_count,
                         estimated_duration,
                     )
-                    self.agent_turn_manager.expected_duration_seconds = estimated_duration
+                    self.agent_turn_manager.expected_duration_seconds = (
+                        estimated_duration
+                    )
 
                 if response.session_output.turn_completed:
                     logging.debug(

--- a/src/cxas_scrapi/core/sessions.py
+++ b/src/cxas_scrapi/core/sessions.py
@@ -471,9 +471,7 @@ class BidiSessionHandler:
                     "Waiting for agent to finish processing turn %d...",
                     idx,
                 )
-                while (
-                    not self.agent_turn_manager.is_agent_done_talking()
-                ):
+                while not self.agent_turn_manager.is_agent_done_talking():
                     time.sleep(1)
 
                 self.agent_turn_manager.reset()
@@ -589,10 +587,12 @@ class BidiSessionHandler:
 
             if response.end_session:
                 if self.response_queue is not None:
-                    self.response_queue.put({
-                        "session_ended": True,
-                        "end_session": response.end_session,
-                    })
+                    self.response_queue.put(
+                        {
+                            "session_ended": True,
+                            "end_session": response.end_session,
+                        }
+                    )
 
         except Exception as e:
             logging.debug("Failed to parse message: %s", e)
@@ -602,10 +602,12 @@ class BidiSessionHandler:
         # Stash connection-level errors
         self._connection_error = error
         if self.response_queue is not None:
-            self.response_queue.put({
-                "session_ended": True,
-                "connection_error": error,
-            })
+            self.response_queue.put(
+                {
+                    "session_ended": True,
+                    "connection_error": error,
+                }
+            )
 
     def _on_close(self, ws, close_status_code, close_msg):
         logging.debug(
@@ -617,12 +619,14 @@ class BidiSessionHandler:
         self._close_status_code = close_status_code
         self._close_msg = close_msg
         if self.response_queue is not None:
-            self.response_queue.put({
-                "session_ended": True,
-                "connection_closed": True,
-                "close_status_code": close_status_code,
-                "close_msg": close_msg,
-            })
+            self.response_queue.put(
+                {
+                    "session_ended": True,
+                    "connection_closed": True,
+                    "close_status_code": close_status_code,
+                    "close_msg": close_msg,
+                }
+            )
 
     def run(self):
         logging.debug("Connecting to WebSocket: %s", self.uri)

--- a/src/cxas_scrapi/core/sessions.py
+++ b/src/cxas_scrapi/core/sessions.py
@@ -410,7 +410,9 @@ class BidiSessionHandler:
                 self.ws_app.send(var_json)
                 time.sleep(0.5)
 
-            logging.debug("Sending leading silence before turn %d...", turn_index)
+            logging.debug(
+                "Sending leading silence before turn %d...", turn_index
+            )
             self._send_silence(
                 SILENCE_PADDING_CHUNKS
             )  # 0.3 seconds of leading silence
@@ -457,7 +459,8 @@ class BidiSessionHandler:
                 time.sleep(CHUNK_DELAY)
 
             logging.debug(
-                "Sending trailing silence for turn %d to trigger endpointing...",
+                "Sending trailing silence for turn %d to "
+                "trigger endpointing...",
                 turn_index,
             )
             self._send_silence(
@@ -574,7 +577,11 @@ class BidiSessionHandler:
 
     def _silence_loop(self):
         while True:
-            if not self.ws_app or not self.ws_app.sock or not self.ws_app.sock.connected:
+            if (
+                not self.ws_app
+                or not self.ws_app.sock
+                or not self.ws_app.sock.connected
+            ):
                 break
 
             with self.lock:
@@ -595,9 +602,13 @@ class BidiSessionHandler:
         try:
             response_pb = types.BidiSessionServerMessage()._pb
             message_dict = json.loads(message)
-            output = message_dict.get("sessionOutput") or message_dict.get("session_output")
+            output = message_dict.get("sessionOutput") or message_dict.get(
+                "session_output"
+            )
             if isinstance(output, dict):
-                diag = output.get("diagnosticInfo") or output.get("diagnostic_info")
+                diag = output.get("diagnosticInfo") or output.get(
+                    "diagnostic_info"
+                )
                 if isinstance(diag, dict):
                     logging.debug("DIAG DUMP: %s", json.dumps(diag))
                     root_span = diag.get("rootSpan") or diag.get("root_span")
@@ -613,7 +624,8 @@ class BidiSessionHandler:
             response = types.BidiSessionServerMessage(response_pb)
 
             if response.session_output:
-                # Check if this is an empty comfort noise or variables ack packet
+                # Check if this is an empty comfort noise or variables ack
+                # packet
                 has_text = bool(response.session_output.text)
                 has_diag_messages = False
                 diag = response.session_output.diagnostic_info
@@ -641,7 +653,9 @@ class BidiSessionHandler:
                 )
 
                 if is_empty_response:
-                    logging.debug("Ignoring empty/silent server response packet.")
+                    logging.debug(
+                        "Ignoring empty/silent server response packet."
+                    )
                     return
 
                 turn_idx = response.session_output.turn_index

--- a/src/cxas_scrapi/evals/runner.py
+++ b/src/cxas_scrapi/evals/runner.py
@@ -66,6 +66,7 @@ def run_all_evals(
     timestamp: str | None = None,
     expectations_only: bool = False,
     deployment_id: str | None = None,
+    skip_playback_wait: bool = False,
     progress_callback: Callable[[str, int, int], None] | None = None,
 ):
     """Runs all 4 types of evaluations and returns aggregated results.
@@ -269,6 +270,7 @@ def run_all_evals(
                         background_noise_file=bg_noise_file,
                         burst_noise_files=burst_noise_files,
                         use_tool_fakes=use_tool_fakes,
+                        skip_playback_wait=skip_playback_wait,
                         progress_callback=lambda c, t: (
                             progress_callback("simulations", c, t)
                             if progress_callback

--- a/src/cxas_scrapi/evals/simulation_evals.py
+++ b/src/cxas_scrapi/evals/simulation_evals.py
@@ -719,6 +719,7 @@ class SimulationEvals(Apps):
                     detailed_trace.append(f"User: {user_utterance}")
 
                 current_sim_turn += 1
+                first_turn = False
 
             if console_logging:
                 self._print_completion_status(eval_conv)

--- a/src/cxas_scrapi/evals/simulation_evals.py
+++ b/src/cxas_scrapi/evals/simulation_evals.py
@@ -719,7 +719,6 @@ class SimulationEvals(Apps):
                     detailed_trace.append(f"User: {user_utterance}")
 
                 current_sim_turn += 1
-                first_turn = False
 
             if console_logging:
                 self._print_completion_status(eval_conv)

--- a/src/cxas_scrapi/evals/simulation_evals.py
+++ b/src/cxas_scrapi/evals/simulation_evals.py
@@ -599,108 +599,136 @@ class SimulationEvals(Apps):
         eval_conv.agent_audio_paths = {}
         current_sim_turn = 0
 
-        if console_logging:
-            print(
-                f"Starting simulated conversation with session ID: {session_id}"
-            )
-
-        # Initialize the first turn manually
-        user_utterance, variables = eval_conv.next_user_utterance()
-        accumulated_variables = {}
-        if variables:
-            accumulated_variables.update(variables)
-
-        detailed_trace = []
-        detailed_trace.append(f"User: {user_utterance}")
-
-        while user_utterance:
-            response = self._send_request_with_retry(
+        interactive_session = None
+        if modality == "audio":
+            interactive_session = self.sessions_client.create_interactive_session(
                 session_id=session_id,
-                user_utterance=user_utterance,
-                variables=accumulated_variables,
-                modality=modality,
-                console_logging=console_logging,
-                turn_num=current_sim_turn,
                 capture_agent_audio=capture_agent_audio,
                 background_noise_file=background_noise_file,
-                burst_noise_files=burst_noise_files,
                 use_tool_fakes=use_tool_fakes,
                 voice_config=voice_config,
             )
-            if not response:
-                break
+            interactive_session.start()
 
-            # Extract and save the agent turn audio WAV if present
-            # in response.
-            if response and getattr(response, "agent_audio_paths", None):
-                audio_path = response.agent_audio_paths.get(0)
-                if audio_path:
-                    eval_conv.agent_audio_paths[current_sim_turn] = audio_path
-
+        try:
             if console_logging:
-                self.sessions_client.parse_result(response)
+                print(
+                    f"Starting simulated conversation with session ID: {session_id}"
+                )
 
-            agent_text, trace_chunks, session_ended, tool_calls = (
-                self._parse_agent_response(response)
-            )
-            detailed_trace.append("\n".join(trace_chunks))
-
-            if session_ended:
-                if agent_text:
-                    eval_conv._add_agent_response(agent_text)
-                eval_conv._add_agent_tool_calls(tool_calls)
-                # Ensure the final agent response is evaluated
-                # so that steps_progress is updated on session end.
-                eval_conv._next_user_utterance()
-                if console_logging:
-                    print(
-                        "\nSession has been closed by the Agent via "
-                        "end_session tool."
-                    )
-                # Mark current step as completed if the session ending
-                # is a valid success (escalation evals)
-                for prog in eval_conv.steps_progress:
-                    criteria = prog.step.success_criteria.lower()
-                    if prog.status != StepStatus.COMPLETED and (
-                        "escalat" in criteria
-                        or "transfer" in criteria
-                        or "being transferred" in criteria
-                    ):
-                        prog.status = StepStatus.COMPLETED
-                        prog.justification = (
-                            "Agent ended session via escalation/transfer — "
-                            "matches success criteria."
-                        )
-                break
-
-            # Get the next simulated user utterance based on the agent's
-            # response
-            eval_conv._add_agent_tool_calls(tool_calls)
-            user_utterance, variables = eval_conv.next_user_utterance(
-                agent_text
-            )
+            # Initialize the first turn manually
+            user_utterance, variables = eval_conv.next_user_utterance()
+            accumulated_variables = {}
             if variables:
                 accumulated_variables.update(variables)
-            if user_utterance:
-                detailed_trace.append(f"User: {user_utterance}")
 
-            current_sim_turn += 1
+            detailed_trace = []
+            detailed_trace.append(f"User: {user_utterance}")
 
-        if console_logging:
-            self._print_completion_status(eval_conv)
+            while user_utterance:
+                if modality == "audio" and interactive_session:
+                    response = interactive_session.send_turn(
+                        user_utterance,
+                        accumulated_variables,
+                    )
+                    # Check if session ended via WebSocket endSession
+                    if isinstance(response, dict) and response.get("session_ended"):
+                        if response.get("connection_error"):
+                            raise BidiSessionError(
+                                f"Interactive session WebSocket error: {response['connection_error']}"
+                            )
+                        break
+                else:
+                    response = self._send_request_with_retry(
+                        session_id=session_id,
+                        user_utterance=user_utterance,
+                        variables=accumulated_variables,
+                        modality=modality,
+                        console_logging=console_logging,
+                        turn_num=current_sim_turn,
+                        capture_agent_audio=capture_agent_audio,
+                        background_noise_file=background_noise_file,
+                        burst_noise_files=burst_noise_files,
+                        use_tool_fakes=use_tool_fakes,
+                        voice_config=voice_config,
+                    )
+                if not response:
+                    break
 
-        self._evaluate_expectations(
-            eval_conv,
-            detailed_trace,
-            eval_model,
-            console_logging,
-            capture_agent_audio=capture_agent_audio,
-        )
-        eval_conv._session_id = session_id
-        eval_conv.session_id = session_id
-        eval_conv._detailed_trace = detailed_trace
-        eval_conv.detailed_trace = detailed_trace
-        return eval_conv
+                # Extract and save the agent turn audio WAV if present
+                # in response.
+                if response and getattr(response, "agent_audio_paths", None):
+                    audio_path = response.agent_audio_paths.get(0)
+                    if audio_path:
+                        eval_conv.agent_audio_paths[current_sim_turn] = audio_path
+
+                if console_logging:
+                    self.sessions_client.parse_result(response)
+
+                agent_text, trace_chunks, session_ended, tool_calls = (
+                    self._parse_agent_response(response)
+                )
+                detailed_trace.append("\n".join(trace_chunks))
+
+                if session_ended:
+                    if agent_text:
+                        eval_conv._add_agent_response(agent_text)
+                    eval_conv._add_agent_tool_calls(tool_calls)
+                    # Ensure the final agent response is evaluated
+                    # so that steps_progress is updated on session end.
+                    eval_conv._next_user_utterance()
+                    if console_logging:
+                        print(
+                            "\nSession has been closed by the Agent via "
+                            "end_session tool."
+                        )
+                    # Mark current step as completed if the session ending
+                    # is a valid success (escalation evals)
+                    for prog in eval_conv.steps_progress:
+                        criteria = prog.step.success_criteria.lower()
+                        if prog.status != StepStatus.COMPLETED and (
+                            "escalat" in criteria
+                            or "transfer" in criteria
+                            or "being transferred" in criteria
+                        ):
+                            prog.status = StepStatus.COMPLETED
+                            prog.justification = (
+                                "Agent ended session via escalation/transfer — "
+                                "matches success criteria."
+                            )
+                    break
+
+                # Get the next simulated user utterance based on the agent's
+                # response
+                eval_conv._add_agent_tool_calls(tool_calls)
+                user_utterance, variables = eval_conv.next_user_utterance(
+                    agent_text
+                )
+                if variables:
+                    accumulated_variables.update(variables)
+                if user_utterance:
+                    detailed_trace.append(f"User: {user_utterance}")
+
+                current_sim_turn += 1
+
+            if console_logging:
+                self._print_completion_status(eval_conv)
+
+            self._evaluate_expectations(
+                eval_conv,
+                detailed_trace,
+                eval_model,
+                console_logging,
+                capture_agent_audio=capture_agent_audio,
+            )
+            eval_conv._session_id = session_id
+            eval_conv.session_id = session_id
+            eval_conv._detailed_trace = detailed_trace
+            eval_conv.detailed_trace = detailed_trace
+            return eval_conv
+        finally:
+            if interactive_session:
+                interactive_session.close()
 
     def _prepare_simulation_jobs(
         self, test_cases: list[dict[str, Any]], runs: int

--- a/src/cxas_scrapi/evals/simulation_evals.py
+++ b/src/cxas_scrapi/evals/simulation_evals.py
@@ -573,6 +573,7 @@ class SimulationEvals(Apps):
         use_tool_fakes: bool = False,
         voice_config: dict[str, Any] | None = None,
         initial_utterance: str = _FIRST_UTTERANCE,
+        skip_playback_wait: bool = False,
         **kwargs: Any,
     ) -> LLMUserConversation:
         """Runs the simulated conversation loop.
@@ -607,6 +608,7 @@ class SimulationEvals(Apps):
                 capture_agent_audio=capture_agent_audio,
                 background_noise_file=background_noise_file,
                 use_tool_fakes=use_tool_fakes,
+                skip_playback_wait=skip_playback_wait,
                 voice_config=voice_config,
             )
             interactive_session.start()
@@ -761,6 +763,7 @@ class SimulationEvals(Apps):
         background_noise_file: str | None = None,
         burst_noise_files: list[str] | None = None,
         use_tool_fakes: bool = False,
+        skip_playback_wait: bool = False,
     ) -> dict[str, Any]:
         """Runs a single simulation job and returns the results."""
         name = tc["name"]
@@ -780,6 +783,7 @@ class SimulationEvals(Apps):
                 background_noise_file=background_noise_file,
                 burst_noise_files=burst_noise_files,
                 use_tool_fakes=use_tool_fakes,
+                skip_playback_wait=skip_playback_wait,
             )
             duration_s = round(time.time() - _start, 1)
 
@@ -867,6 +871,7 @@ class SimulationEvals(Apps):
         background_noise_file: str | None = None,
         burst_noise_files: list[str] | None = None,
         use_tool_fakes: bool = False,
+        skip_playback_wait: bool = False,
         progress_callback: Callable[[int, int], None] | None = None,
     ) -> list[dict[str, Any]]:
         """Aggregates results from multiple simulation jobs."""
@@ -890,6 +895,7 @@ class SimulationEvals(Apps):
                             background_noise_file=background_noise_file,
                             burst_noise_files=burst_noise_files,
                             use_tool_fakes=use_tool_fakes,
+                            skip_playback_wait=skip_playback_wait,
                         )
                     )
                     progress.update(task_id, advance=1)
@@ -913,6 +919,7 @@ class SimulationEvals(Apps):
                             background_noise_file=background_noise_file,
                             burst_noise_files=burst_noise_files,
                             use_tool_fakes=use_tool_fakes,
+                            skip_playback_wait=skip_playback_wait,
                         ): (tc["name"], run_idx)
                         for tc, run_idx in jobs
                     }
@@ -938,6 +945,7 @@ class SimulationEvals(Apps):
         burst_noise_files: list[str] | None = None,
         use_tool_fakes: bool = False,
         expectations_only: bool | None = None,
+        skip_playback_wait: bool = False,
         progress_callback: Callable[[int, int], None] | None = None,
     ) -> list[dict[str, Any]]:
         if expectations_only is not None:
@@ -970,6 +978,7 @@ class SimulationEvals(Apps):
             background_noise_file=background_noise_file,
             burst_noise_files=burst_noise_files,
             use_tool_fakes=use_tool_fakes,
+            skip_playback_wait=skip_playback_wait,
             progress_callback=progress_callback,
         )
 

--- a/src/cxas_scrapi/evals/simulation_evals.py
+++ b/src/cxas_scrapi/evals/simulation_evals.py
@@ -34,7 +34,7 @@ from rich.progress import Progress
 from cxas_scrapi.core.apps import Apps
 from cxas_scrapi.core.conversation_history import ConversationHistory
 from cxas_scrapi.core.response_parser import ParsedSessionResponse
-from cxas_scrapi.core.sessions import Sessions
+from cxas_scrapi.core.sessions import BidiSessionError, Sessions
 from cxas_scrapi.core.tools import Tools
 from cxas_scrapi.prompts import llm_user_prompts
 from cxas_scrapi.utils.eval_utils import (
@@ -601,7 +601,8 @@ class SimulationEvals(Apps):
 
         interactive_session = None
         if modality == "audio":
-            interactive_session = self.sessions_client.create_interactive_session(
+            client = self.sessions_client
+            interactive_session = client.create_interactive_session(
                 session_id=session_id,
                 capture_agent_audio=capture_agent_audio,
                 background_noise_file=background_noise_file,
@@ -613,7 +614,8 @@ class SimulationEvals(Apps):
         try:
             if console_logging:
                 print(
-                    f"Starting simulated conversation with session ID: {session_id}"
+                    f"Starting simulated conversation with session ID: "
+                    f"{session_id}"
                 )
 
             # Initialize the first turn manually
@@ -632,11 +634,15 @@ class SimulationEvals(Apps):
                         accumulated_variables,
                     )
                     # Check if session ended via WebSocket endSession
-                    if isinstance(response, dict) and response.get("session_ended"):
+                    if isinstance(response, dict) and response.get(
+                        "session_ended"
+                    ):
                         if response.get("connection_error"):
-                            raise BidiSessionError(
-                                f"Interactive session WebSocket error: {response['connection_error']}"
+                            err_msg = (
+                                f"Interactive session WebSocket error: "
+                                f"{response['connection_error']}"
                             )
+                            raise BidiSessionError(err_msg)
                         break
                 else:
                     response = self._send_request_with_retry(
@@ -660,7 +666,8 @@ class SimulationEvals(Apps):
                 if response and getattr(response, "agent_audio_paths", None):
                     audio_path = response.agent_audio_paths.get(0)
                     if audio_path:
-                        eval_conv.agent_audio_paths[current_sim_turn] = audio_path
+                        paths = eval_conv.agent_audio_paths
+                        paths[current_sim_turn] = audio_path
 
                 if console_logging:
                     self.sessions_client.parse_result(response)

--- a/src/cxas_scrapi/utils/reporting.py
+++ b/src/cxas_scrapi/utils/reporting.py
@@ -1440,6 +1440,7 @@ def generate_combined_report_from_dir(
     timestamp: str | None = None,
     expectations_only: bool = False,
     deployment_id: str | None = None,
+    skip_playback_wait: bool = False,
 ) -> str:
     """Load results from directory and generate combined HTML report.
 
@@ -1508,6 +1509,7 @@ def generate_combined_report_from_dir(
             timestamp=timestamp,
             expectations_only=expectations_only,
             deployment_id=deployment_id,
+            skip_playback_wait=skip_playback_wait,
         )
         sim_results = run_results["simulation"] if "sims" in include else []
         # Map tool results to expected format if needed
@@ -1696,6 +1698,7 @@ def run_all_evals(
     timestamp: str | None = None,
     expectations_only: bool = False,
     deployment_id: str | None = None,
+    skip_playback_wait: bool = False,
 ) -> dict[str, Any]:
     """Runs all 4 types of evaluations and returns aggregated results.
 
@@ -1752,4 +1755,5 @@ def run_all_evals(
         timestamp=timestamp,
         expectations_only=expectations_only,
         deployment_id=deployment_id,
+        skip_playback_wait=skip_playback_wait,
     )

--- a/tests/cxas_scrapi/core/test_sessions.py
+++ b/tests/cxas_scrapi/core/test_sessions.py
@@ -318,7 +318,6 @@ def test_agent_turn_manager_silence_filtering():
     assert manager.len_audio_bytes_received == 32000
 
 
-
 @patch("cxas_scrapi.core.sessions.websocket.WebSocketApp")
 @patch("cxas_scrapi.core.sessions.threading.Thread")
 def test_bidi_session_handler_run(mock_thread, mock_ws_app):

--- a/tests/cxas_scrapi/core/test_sessions.py
+++ b/tests/cxas_scrapi/core/test_sessions.py
@@ -282,7 +282,7 @@ def test_agent_turn_manager_basic():
     assert not manager.is_agent_done_talking()
 
     # 1 second of audio (16000 * 2 = 32000 bytes)
-    manager.add_audio(b"\x00" * 32000)
+    manager.add_audio(b"\x01" * 32000)
     manager.mark_turn_completed()
 
     # Just completed, current time is roughly 0 seconds since start

--- a/tests/cxas_scrapi/core/test_sessions.py
+++ b/tests/cxas_scrapi/core/test_sessions.py
@@ -300,6 +300,25 @@ def test_agent_turn_manager_no_audio():
     assert manager.is_agent_done_talking()
 
 
+def test_agent_turn_manager_silence_filtering():
+    manager = AgentTurnManager(sample_rate=16000, sample_width=2)
+
+    # Add low energy silence / comfort noise (all zeroes)
+    manager.add_audio(b"\x00" * 32000)
+    assert manager.len_audio_bytes_received == 0  # Discarded due to low RMS
+
+    # Add high energy speech (value 4095)
+    manager.add_audio(b"\xff\x0f" * 16000)
+    assert manager.len_audio_bytes_received == 32000  # Kept
+
+    # Mark turn completed and try to add more speech
+    manager.mark_turn_completed()
+    manager.add_audio(b"\xff\x0f" * 16000)
+    # Ignored because turn completed
+    assert manager.len_audio_bytes_received == 32000
+
+
+
 @patch("cxas_scrapi.core.sessions.websocket.WebSocketApp")
 @patch("cxas_scrapi.core.sessions.threading.Thread")
 def test_bidi_session_handler_run(mock_thread, mock_ws_app):

--- a/tests/cxas_scrapi/evals/test_simulation_evals.py
+++ b/tests/cxas_scrapi/evals/test_simulation_evals.py
@@ -265,8 +265,13 @@ def test_user_simulator_audio(mock_llm_conv_class, mock_sessions_class):
     mock_response_2.outputs = [mock_output_2]
 
     mock_interactive_session = MagicMock()
-    mock_sessions.create_interactive_session.return_value = mock_interactive_session
-    mock_interactive_session.send_turn.side_effect = [mock_response_1, mock_response_2]
+    mock_sessions.create_interactive_session.return_value = (
+        mock_interactive_session
+    )
+    mock_interactive_session.send_turn.side_effect = [
+        mock_response_1,
+        mock_response_2,
+    ]
 
     app_name = "projects/test/locations/us/apps/123-abc"
     with patch("cxas_scrapi.evals.simulation_evals.GeminiGenerate"):
@@ -308,7 +313,9 @@ def test_user_simulator_audio(mock_llm_conv_class, mock_sessions_class):
 
 @patch("cxas_scrapi.evals.simulation_evals.Sessions")
 @patch("cxas_scrapi.evals.simulation_evals.LLMUserConversation")
-def test_user_simulator_audio_with_tool_fakes(mock_llm_conv_class, mock_sessions_class):
+def test_user_simulator_audio_with_tool_fakes(
+    mock_llm_conv_class, mock_sessions_class
+):
     mock_sessions = mock_sessions_class.return_value
     mock_eval_conv = mock_llm_conv_class.return_value
 
@@ -344,8 +351,13 @@ def test_user_simulator_audio_with_tool_fakes(mock_llm_conv_class, mock_sessions
     mock_response_2.outputs = [mock_output_2]
 
     mock_interactive_session = MagicMock()
-    mock_sessions.create_interactive_session.return_value = mock_interactive_session
-    mock_interactive_session.send_turn.side_effect = [mock_response_1, mock_response_2]
+    mock_sessions.create_interactive_session.return_value = (
+        mock_interactive_session
+    )
+    mock_interactive_session.send_turn.side_effect = [
+        mock_response_1,
+        mock_response_2,
+    ]
 
     app_name = "projects/test/locations/us/apps/123-abc"
     with patch("cxas_scrapi.evals.simulation_evals.GeminiGenerate"):
@@ -418,8 +430,13 @@ def test_user_simulator_audio_with_eval_enabled(
     }
 
     mock_interactive_session = MagicMock()
-    mock_sessions.create_interactive_session.return_value = mock_interactive_session
-    mock_interactive_session.send_turn.side_effect = [mock_response_1, mock_response_2]
+    mock_sessions.create_interactive_session.return_value = (
+        mock_interactive_session
+    )
+    mock_interactive_session.send_turn.side_effect = [
+        mock_response_1,
+        mock_response_2,
+    ]
 
     app_name = "projects/test/locations/us/apps/123-abc"
     with patch("cxas_scrapi.evals.simulation_evals.GeminiGenerate"):

--- a/tests/cxas_scrapi/evals/test_simulation_evals.py
+++ b/tests/cxas_scrapi/evals/test_simulation_evals.py
@@ -291,6 +291,7 @@ def test_user_simulator_audio(mock_llm_conv_class, mock_sessions_class):
         capture_agent_audio=False,
         background_noise_file=None,
         use_tool_fakes=False,
+        skip_playback_wait=False,
         voice_config=None,
     )
     mock_interactive_session.start.assert_called_once()
@@ -378,6 +379,7 @@ def test_user_simulator_audio_with_tool_fakes(
         capture_agent_audio=False,
         background_noise_file=None,
         use_tool_fakes=True,
+        skip_playback_wait=False,
         voice_config=None,
     )
     mock_interactive_session.start.assert_called_once()
@@ -457,6 +459,7 @@ def test_user_simulator_audio_with_eval_enabled(
         capture_agent_audio=True,
         background_noise_file=None,
         use_tool_fakes=False,
+        skip_playback_wait=False,
         voice_config=None,
     )
     mock_interactive_session.start.assert_called_once()
@@ -1381,6 +1384,7 @@ def test_simulation_evals_run_simulations_use_tool_fakes(mock_sessions):
         background_noise_file=None,
         burst_noise_files=None,
         use_tool_fakes=True,
+        skip_playback_wait=False,
     )
 
 
@@ -1420,6 +1424,7 @@ def test_simulation_evals_run_simulations_use_tool_fakes_parallel(
         background_noise_file=None,
         burst_noise_files=None,
         use_tool_fakes=True,
+        skip_playback_wait=False,
     )
 
 
@@ -1468,6 +1473,7 @@ def test_simulation_evals_run_simulations_capture_agent_audio(mock_sessions):
         background_noise_file=None,
         burst_noise_files=None,
         use_tool_fakes=False,
+        skip_playback_wait=False,
     )
 
 

--- a/tests/cxas_scrapi/evals/test_simulation_evals.py
+++ b/tests/cxas_scrapi/evals/test_simulation_evals.py
@@ -308,6 +308,72 @@ def test_user_simulator_audio(mock_llm_conv_class, mock_sessions_class):
 
 @patch("cxas_scrapi.evals.simulation_evals.Sessions")
 @patch("cxas_scrapi.evals.simulation_evals.LLMUserConversation")
+def test_user_simulator_audio_with_tool_fakes(mock_llm_conv_class, mock_sessions_class):
+    mock_sessions = mock_sessions_class.return_value
+    mock_eval_conv = mock_llm_conv_class.return_value
+
+    mock_eval_conv.next_user_utterance.side_effect = [
+        ("event: welcome", {}),
+        ("I want to book a flight", {}),
+        ("", {}),
+    ]
+    mock_eval_conv.steps_progress = []
+
+    # Mock Response 1
+    mock_response_1 = MagicMock()
+    mock_output_1 = MagicMock()
+    mock_output_1.text = ""
+
+    mock_msg_1 = MagicMock()
+    mock_msg_1.role = "model"
+    mock_chunk_1 = MagicMock()
+    mock_chunk_1._pb.WhichOneof.return_value = "text"
+    mock_chunk_1.text = "Where to?"
+    mock_msg_1.chunks = [mock_chunk_1]
+
+    mock_diag_1 = MagicMock()
+    mock_diag_1.messages = [mock_msg_1]
+    mock_output_1.diagnostic_info = mock_diag_1
+    mock_response_1.outputs = [mock_output_1]
+
+    # Mock Response 2
+    mock_response_2 = MagicMock()
+    mock_output_2 = MagicMock()
+    mock_output_2.text = "Flight booked."
+    mock_output_2.diagnostic_info = None
+    mock_response_2.outputs = [mock_output_2]
+
+    mock_interactive_session = MagicMock()
+    mock_sessions.create_interactive_session.return_value = mock_interactive_session
+    mock_interactive_session.send_turn.side_effect = [mock_response_1, mock_response_2]
+
+    app_name = "projects/test/locations/us/apps/123-abc"
+    with patch("cxas_scrapi.evals.simulation_evals.GeminiGenerate"):
+        with patch("cxas_scrapi.core.apps.AgentServiceClient"):
+            simulator = SimulationEvals(app_name=app_name)
+
+    test_case = {"steps": []}
+    simulator.simulate_conversation(
+        test_case=test_case,
+        session_id="123",
+        console_logging=False,
+        modality="audio",
+        use_tool_fakes=True,
+    )
+
+    mock_sessions.create_interactive_session.assert_called_once_with(
+        session_id="123",
+        capture_agent_audio=False,
+        background_noise_file=None,
+        use_tool_fakes=True,
+        voice_config=None,
+    )
+    mock_interactive_session.start.assert_called_once()
+    mock_interactive_session.close.assert_called_once()
+
+
+@patch("cxas_scrapi.evals.simulation_evals.Sessions")
+@patch("cxas_scrapi.evals.simulation_evals.LLMUserConversation")
 def test_user_simulator_audio_with_eval_enabled(
     mock_llm_conv_class, mock_sessions_class
 ):

--- a/tests/cxas_scrapi/evals/test_simulation_evals.py
+++ b/tests/cxas_scrapi/evals/test_simulation_evals.py
@@ -264,7 +264,9 @@ def test_user_simulator_audio(mock_llm_conv_class, mock_sessions_class):
     mock_output_2.diagnostic_info = None
     mock_response_2.outputs = [mock_output_2]
 
-    mock_sessions.run.side_effect = [mock_response_1, mock_response_2]
+    mock_interactive_session = MagicMock()
+    mock_sessions.create_interactive_session.return_value = mock_interactive_session
+    mock_interactive_session.send_turn.side_effect = [mock_response_1, mock_response_2]
 
     app_name = "projects/test/locations/us/apps/123-abc"
     with patch("cxas_scrapi.evals.simulation_evals.GeminiGenerate"):
@@ -279,34 +281,29 @@ def test_user_simulator_audio(mock_llm_conv_class, mock_sessions_class):
         modality="audio",
     )
 
-    mock_sessions.run.assert_any_call(
+    mock_sessions.create_interactive_session.assert_called_once_with(
         session_id="123",
-        event="welcome",
-        variables={},
-        modality="audio",
-        turn_num=0,
         capture_agent_audio=False,
         background_noise_file=None,
-        burst_noise_files=None,
         use_tool_fakes=False,
+        voice_config=None,
     )
-    mock_sessions.run.assert_any_call(
-        session_id="123",
-        text="I want to book a flight",
-        variables={},
-        modality="audio",
-        turn_num=1,
-        capture_agent_audio=False,
-        background_noise_file=None,
-        burst_noise_files=None,
-        use_tool_fakes=False,
+    mock_interactive_session.start.assert_called_once()
+    mock_interactive_session.send_turn.assert_any_call(
+        "event: welcome",
+        {},
     )
+    mock_interactive_session.send_turn.assert_any_call(
+        "I want to book a flight",
+        {},
+    )
+    mock_interactive_session.close.assert_called_once()
 
     # Verify text was extracted from Diagnostic Info
     # Note: text += chunk.text + " " so it should assert "Where to? "
     mock_eval_conv.next_user_utterance.assert_any_call("Where to?")
     mock_eval_conv.next_user_utterance.assert_any_call("Flight booked.")
-    assert mock_sessions.run.call_count == 2
+    assert mock_interactive_session.send_turn.call_count == 2
 
 
 @patch("cxas_scrapi.evals.simulation_evals.Sessions")
@@ -354,7 +351,9 @@ def test_user_simulator_audio_with_eval_enabled(
         0: "/tmp/scrapi_evals/123/turn_1_agent.wav"
     }
 
-    mock_sessions.run.side_effect = [mock_response_1, mock_response_2]
+    mock_interactive_session = MagicMock()
+    mock_sessions.create_interactive_session.return_value = mock_interactive_session
+    mock_interactive_session.send_turn.side_effect = [mock_response_1, mock_response_2]
 
     app_name = "projects/test/locations/us/apps/123-abc"
     with patch("cxas_scrapi.evals.simulation_evals.GeminiGenerate"):
@@ -370,30 +369,25 @@ def test_user_simulator_audio_with_eval_enabled(
         capture_agent_audio=True,
     )
 
-    mock_sessions.run.assert_any_call(
+    mock_sessions.create_interactive_session.assert_called_once_with(
         session_id="123",
-        event="welcome",
-        variables={},
-        modality="audio",
-        turn_num=0,
         capture_agent_audio=True,
         background_noise_file=None,
-        burst_noise_files=None,
         use_tool_fakes=False,
+        voice_config=None,
     )
-    mock_sessions.run.assert_any_call(
-        session_id="123",
-        text="I want to book a flight",
-        variables={},
-        modality="audio",
-        turn_num=1,
-        capture_agent_audio=True,
-        background_noise_file=None,
-        burst_noise_files=None,
-        use_tool_fakes=False,
+    mock_interactive_session.start.assert_called_once()
+    mock_interactive_session.send_turn.assert_any_call(
+        "event: welcome",
+        {},
     )
+    mock_interactive_session.send_turn.assert_any_call(
+        "I want to book a flight",
+        {},
+    )
+    mock_interactive_session.close.assert_called_once()
 
-    assert mock_sessions.run.call_count == 2
+    assert mock_interactive_session.send_turn.call_count == 2
     assert mock_eval_conv.agent_audio_paths == {
         0: "/tmp/scrapi_evals/123/turn_0_agent.wav",
         1: "/tmp/scrapi_evals/123/turn_1_agent.wav",

--- a/tests/cxas_scrapi/utils/test_reporting.py
+++ b/tests/cxas_scrapi/utils/test_reporting.py
@@ -762,6 +762,7 @@ def test_run_all_evals_dict_based_simulations(
         background_noise_file=None,
         burst_noise_files=None,
         use_tool_fakes=False,
+        skip_playback_wait=False,
         progress_callback=ANY,
     )
 
@@ -1003,6 +1004,7 @@ def test_run_all_evals_expectations_only(mock_run_all_evals):
         timestamp=None,
         expectations_only=True,
         deployment_id=None,
+        skip_playback_wait=False,
     )
 
 


### PR DESCRIPTION
This PR persists the bidi websocket for the whole duration of the session.

Test audio simulation evals by running the following command: 
```
uv run python .agents/skills/cxas-agent-foundry/scripts/run-evals.py --channel audio --runs 1 --sim-parallel 2 --use-tool-fakes --skip-goldens
```

Test text simulation evals by running the following command:
```
uv run python .agents/skills/cxas-agent-foundry/scripts/run-evals.py --channel text --runs 1 --sim-parallel 2 --use-tool-fakes --skip-goldens
```

Example of run:
<img width="1324" height="508" alt="image" src="https://github.com/user-attachments/assets/5fa028f0-f611-4c48-97b5-a19b0b160c91" />

New VAD system does not trigger barge in:
<img width="796" height="872" alt="image" src="https://github.com/user-attachments/assets/b73e8a32-13eb-47d9-8ccd-149c5cd146a9" />
