### PR TITLE
feat(evals): add --capture-agent-audio flag to cxas evals report CLI

### DIFF
--- a/src/cxas_scrapi/cli/main.py
+++ b/src/cxas_scrapi/cli/main.py
@@ -659,6 +659,7 @@ def combined_evals_report_cmd(args: argparse.Namespace) -> None:
         expectations_only=getattr(args, "expectations_only", False),
         deployment_id=getattr(args, "deployment_id", None),
         progress_callback=progress_callback,
+        capture_agent_audio=getattr(args, "capture_agent_audio", False),
     )
     print(f"Combined report generated at {actual_output_path}")
 
@@ -1825,6 +1826,11 @@ def get_parser() -> argparse.ArgumentParser:
         "--deployment-id",
         default=None,
         help="Optional: Target a specific deployment ID for simulations.",
+    )
+    parser_report.add_argument(
+        "--capture-agent-audio",
+        action="store_true",
+        help="Capture real-time agent output audio as WAV files",
     )
     parser_report.set_defaults(func=combined_evals_report_cmd)
 

--- a/src/cxas_scrapi/evals/runner.py
+++ b/src/cxas_scrapi/evals/runner.py
@@ -67,6 +67,7 @@ def run_all_evals(
     expectations_only: bool = False,
     deployment_id: str | None = None,
     progress_callback: Callable[[str, int, int], None] | None = None,
+    capture_agent_audio: bool = False,
 ):
     """Runs all 4 types of evaluations and returns aggregated results.
 
@@ -274,6 +275,7 @@ def run_all_evals(
                             if progress_callback
                             else None
                         ),
+                        capture_agent_audio=capture_agent_audio,
                     )
                     results["simulation"] = sim_results
                     if output_dir:

--- a/src/cxas_scrapi/utils/reporting.py
+++ b/src/cxas_scrapi/utils/reporting.py
@@ -1441,6 +1441,7 @@ def generate_combined_report_from_dir(
     expectations_only: bool = False,
     deployment_id: str | None = None,
     progress_callback: Callable[[str, int, int], None] | None = None,
+    capture_agent_audio: bool = False,
 ) -> str:
     """Load results from directory and generate combined HTML report.
 
@@ -1510,6 +1511,7 @@ def generate_combined_report_from_dir(
             expectations_only=expectations_only,
             deployment_id=deployment_id,
             progress_callback=progress_callback,
+            capture_agent_audio=capture_agent_audio,
         )
         sim_results = run_results["simulation"] if "sims" in include else []
         # Map tool results to expected format if needed
@@ -1699,6 +1701,7 @@ def run_all_evals(
     expectations_only: bool = False,
     deployment_id: str | None = None,
     progress_callback: Callable[[str, int, int], None] | None = None,
+    capture_agent_audio: bool = False,
 ) -> dict[str, Any]:
     """Runs all 4 types of evaluations and returns aggregated results.
 
@@ -1756,4 +1759,5 @@ def run_all_evals(
         expectations_only=expectations_only,
         deployment_id=deployment_id,
         progress_callback=progress_callback,
+        capture_agent_audio=capture_agent_audio,
     )

--- a/tests/cxas_scrapi/cli/test_cli_reporting.py
+++ b/tests/cxas_scrapi/cli/test_cli_reporting.py
@@ -96,6 +96,7 @@ def test_combined_evals_report_cmd(tmp_path):
             expectations_only=False,
             deployment_id=None,
             progress_callback=None,
+            capture_agent_audio=False,
         )
 
 
@@ -157,6 +158,7 @@ def test_combined_evals_report_cmd_with_modality_and_runs(tmp_path):
             expectations_only=False,
             deployment_id=None,
             progress_callback=None,
+            capture_agent_audio=False,
         )
 
 
@@ -223,6 +225,7 @@ def test_combined_evals_report_cmd_timestamped(mock_datetime, tmp_path):
             expectations_only=False,
             deployment_id=None,
             progress_callback=None,
+            capture_agent_audio=False,
         )
 
 

--- a/tests/cxas_scrapi/utils/test_reporting.py
+++ b/tests/cxas_scrapi/utils/test_reporting.py
@@ -763,6 +763,7 @@ def test_run_all_evals_dict_based_simulations(
         burst_noise_files=None,
         use_tool_fakes=False,
         progress_callback=ANY,
+        capture_agent_audio=False,
     )
 
 
@@ -1004,6 +1005,7 @@ def test_run_all_evals_expectations_only(mock_run_all_evals):
         expectations_only=True,
         deployment_id=None,
         progress_callback=None,
+        capture_agent_audio=False,
     )
 
 


### PR DESCRIPTION
Now that scrapi-sim-runner has been brought into `cxas evals`, we can make the `--capture-agent-audio` flag available here as well.