### PR TITLE
fix(migration): prevent browser launch in headless context during tests

### DIFF
--- a/src/cxas_scrapi/migration/service.py
+++ b/src/cxas_scrapi/migration/service.py
@@ -427,6 +427,7 @@ class MigrationService:
         if (
             getattr(bundle.config, "web_confirm_grouping", False)
             and not getattr(bundle.config, "auto_confirm_grouping", False)
+            and not _is_headless_context()
             and self._review_context is None
         ):
             from cxas_scrapi.migration import (  # noqa: PLC0415
@@ -1070,6 +1071,7 @@ class MigrationService:
         if (
             getattr(config, "web_confirm_grouping", False)
             and not getattr(config, "auto_confirm_grouping", False)
+            and not _is_headless_context()
             and self._review_context is None
         ):
             from cxas_scrapi.migration import (  # noqa: PLC0415

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@
 
 import os
 import sys
+import webbrowser
 from unittest.mock import MagicMock, create_autospec
 
 import google.cloud.ces_v1beta as real_ces
@@ -160,3 +161,12 @@ def mock_gemini_generate(request, monkeypatch):
     monkeypatch.setattr(GeminiGenerate, "generate_async", mock_generate_async)
     monkeypatch.setattr(GeminiGenerate, "generate", mock_generate)
     yield
+
+
+@pytest.fixture(autouse=True)
+def mock_webbrowser(monkeypatch):
+    """Globally mock webbrowser to prevent opening browsers during tests."""
+    monkeypatch.setattr(webbrowser, "open", lambda *args, **kwargs: True)
+    monkeypatch.setattr(
+        webbrowser, "open_new_tab", lambda *args, **kwargs: True
+    )


### PR DESCRIPTION
This PR fixes an issue where running the test suite (`uvtest` / `pytest`) automatically launches multiple browser windows/tabs on the developer's machine. The issue was introduced when structural consolidation was made the default, which enabled the interactive grouping review gate and its associated web review server by default. Although the confirmation gate itself was correctly skipped in headless contexts (like tests and CI), the early boot logic for the review server was executed unconditionally, triggering `webbrowser.open`. 

To resolve this, we:
1. Updated the early boot logic in `service.py` (`run_stage_1` and `run_migration`) to check `_is_headless_context()` and avoid starting the server/opening the browser in headless environments.
2. Added an autouse mock for the `webbrowser` module in `tests/conftest.py` as a global safety net to guarantee that no test run can ever trigger a browser launch, even if executed in a pseudo-TTY environment (e.g., when running with `pytest -s`).