### PR TITLE
fix(evals): prevent agent audio output file chopping in audio files

### DIFF
--- a/src/cxas_scrapi/core/sessions.py
+++ b/src/cxas_scrapi/core/sessions.py
@@ -479,8 +479,7 @@ class BidiSessionHandler:
             current_turn = (self.turn_num or 0) + turn_index
             os.makedirs(f"/tmp/scrapi_evals/{session_id}", exist_ok=True)
             wav_filename = (
-                f"/tmp/scrapi_evals/{session_id}/"
-                f"turn_{current_turn}_agent.wav"
+                f"/tmp/scrapi_evals/{session_id}/turn_{current_turn}_agent.wav"
             )
             try:
                 with wave.open(wav_filename, "wb") as wav_file:
@@ -519,14 +518,10 @@ class BidiSessionHandler:
                         response.session_output.audio
                     )
                     with self.audio_lock:
-                        if (
-                            self.current_agent_turn_idx
-                            not in self.turn_audio_buffers
-                        ):
-                            self.turn_audio_buffers[self.current_agent_turn_idx] = (
-                                bytearray()
-                            )
-                        self.turn_audio_buffers[self.current_agent_turn_idx].extend(
+                        idx = self.current_agent_turn_idx
+                        if idx not in self.turn_audio_buffers:
+                            self.turn_audio_buffers[idx] = bytearray()
+                        self.turn_audio_buffers[idx].extend(
                             response.session_output.audio
                         )
 

--- a/src/cxas_scrapi/core/sessions.py
+++ b/src/cxas_scrapi/core/sessions.py
@@ -213,6 +213,7 @@ class BidiSessionHandler:
         self.agent_turn_manager = AgentTurnManager()
         self.ws_app: websocket.WebSocketApp | None = None
         self.outputs = []
+        self.audio_lock = threading.Lock()
         self.current_agent_turn_idx = 0
         self.turn_audio_buffers = {}
         self.turn_audio_paths = {}
@@ -375,6 +376,7 @@ class BidiSessionHandler:
         while not self.agent_turn_manager.is_agent_done_talking():
             self._send_silence(1)
 
+        self._save_and_increment_agent_audio()
         self.agent_turn_manager.reset()
         time.sleep(1)  # Small pause between turns
 
@@ -439,6 +441,7 @@ class BidiSessionHandler:
                         ):
                             time.sleep(1)
 
+                        self._save_and_increment_agent_audio()
                         self.agent_turn_manager.reset()
                         time.sleep(1)
                     elif "variables" in input_item:
@@ -458,6 +461,39 @@ class BidiSessionHandler:
             logging.debug("Error during send_inputs: %s", e)
             if self.ws_app:
                 self.ws_app.close()
+
+    def _save_and_increment_agent_audio(self):
+        with self.audio_lock:
+            turn_index = self.current_agent_turn_idx
+            buffer = self.turn_audio_buffers.get(turn_index, b"")
+            buffer_copy = bytes(buffer)
+            self.current_agent_turn_idx += 1
+
+        if buffer_copy and self.capture_agent_audio:
+            session_name = self.config.get("session", "")
+            session_id = (
+                session_name.split("/sessions/")[-1]
+                if "/sessions/" in session_name
+                else str(uuid.uuid4())
+            )
+            current_turn = (self.turn_num or 0) + turn_index
+            os.makedirs(f"/tmp/scrapi_evals/{session_id}", exist_ok=True)
+            wav_filename = (
+                f"/tmp/scrapi_evals/{session_id}/"
+                f"turn_{current_turn}_agent.wav"
+            )
+            try:
+                with wave.open(wav_filename, "wb") as wav_file:
+                    wav_file.setnchannels(1)
+                    wav_file.setsampwidth(2)
+                    wav_file.setframerate(16000)
+                    wav_file.writeframes(buffer_copy)
+                self.turn_audio_paths[turn_index] = wav_filename
+                logging.info(f"Wrote agent turn audio to {wav_filename}")
+            except Exception as audio_err:
+                logging.error(
+                    f"Failed to write WAV file {wav_filename}: {audio_err}"
+                )
 
     def _on_open(self, ws):
         logging.debug("WebSocket connection opened")
@@ -482,16 +518,17 @@ class BidiSessionHandler:
                     self.agent_turn_manager.add_audio(
                         response.session_output.audio
                     )
-                    if (
-                        self.current_agent_turn_idx
-                        not in self.turn_audio_buffers
-                    ):
-                        self.turn_audio_buffers[self.current_agent_turn_idx] = (
-                            bytearray()
+                    with self.audio_lock:
+                        if (
+                            self.current_agent_turn_idx
+                            not in self.turn_audio_buffers
+                        ):
+                            self.turn_audio_buffers[self.current_agent_turn_idx] = (
+                                bytearray()
+                            )
+                        self.turn_audio_buffers[self.current_agent_turn_idx].extend(
+                            response.session_output.audio
                         )
-                    self.turn_audio_buffers[self.current_agent_turn_idx].extend(
-                        response.session_output.audio
-                    )
 
                 if response.session_output.turn_completed:
                     logging.debug(
@@ -499,48 +536,6 @@ class BidiSessionHandler:
                         "Waiting for audio playback."
                     )
                     self.agent_turn_manager.mark_turn_completed()
-
-                    # Get the active buffer
-                    buffer = self.turn_audio_buffers.get(
-                        self.current_agent_turn_idx, b""
-                    )
-                    if buffer and self.capture_agent_audio:
-                        session_name = self.config.get("session", "")
-                        session_id = (
-                            session_name.split("/sessions/")[-1]
-                            if "/sessions/" in session_name
-                            else str(uuid.uuid4())
-                        )
-                        current_turn = (
-                            self.turn_num or 0
-                        ) + self.current_agent_turn_idx
-                        os.makedirs(
-                            f"/tmp/scrapi_evals/{session_id}", exist_ok=True
-                        )
-                        wav_filename = (
-                            f"/tmp/scrapi_evals/{session_id}/"
-                            f"turn_{current_turn}_agent.wav"
-                        )
-
-                        try:
-                            with wave.open(wav_filename, "wb") as wav_file:
-                                wav_file.setnchannels(1)
-                                wav_file.setsampwidth(2)
-                                wav_file.setframerate(16000)
-                                wav_file.writeframes(buffer)
-                            self.turn_audio_paths[
-                                self.current_agent_turn_idx
-                            ] = wav_filename
-                            logging.info(
-                                f"Wrote agent turn audio to {wav_filename}"
-                            )
-                        except Exception as audio_err:
-                            logging.error(
-                                f"Failed to write WAV file {wav_filename}:"
-                                f" {audio_err}"
-                            )
-
-                    self.current_agent_turn_idx += 1
 
         except Exception as e:
             logging.debug("Failed to parse message: %s", e)

--- a/tests/cxas_scrapi/core/test_sessions.py
+++ b/tests/cxas_scrapi/core/test_sessions.py
@@ -735,6 +735,58 @@ def test_bidi_session_handler_audio_writing_enabled(
 
 @patch("cxas_scrapi.core.sessions.wave.open")
 @patch("cxas_scrapi.core.sessions.os.makedirs")
+def test_bidi_session_handler_multipart_turn_writes_single_wav(
+    mock_makedirs, mock_wave_open
+):
+    """Test that a multi-part agent turn produces a single WAV file.
+
+    Intermediate turn_completed signals (e.g. around a mid-turn tool
+    call) must not split the turn's audio across multiple files.
+    """
+    config = {"session": "projects/p/locations/us/apps/a/sessions/s1"}
+    handler = BidiSessionHandler(
+        location="us",
+        token="fake",
+        config=config,
+        inputs=[],
+        capture_agent_audio=True,
+    )
+
+    def receive(session_output):
+        msg = types.BidiSessionServerMessage(session_output=session_output)
+        handler._on_message(
+            MagicMock(),
+            json_format.MessageToJson(
+                msg._pb, preserving_proto_field_name=False
+            ),
+        )
+
+    # Part 1 audio, then a premature turn_completed (mid-turn tool call)
+    receive(types.SessionOutput(audio=b"part_one"))
+    receive(types.SessionOutput(turn_completed=True))
+    # Part 2 audio, then the final turn_completed
+    receive(types.SessionOutput(audio=b"part_two"))
+    receive(types.SessionOutput(turn_completed=True))
+
+    # No file is written until the sender thread saves the finished turn
+    mock_wave_open.assert_not_called()
+
+    handler._save_and_increment_agent_audio()
+
+    # Exactly one WAV containing the full turn audio
+    mock_wave_open.assert_called_once_with(
+        "/tmp/scrapi_evals/s1/turn_0_agent.wav", "wb"
+    )
+    wav_file = mock_wave_open.return_value.__enter__.return_value
+    wav_file.writeframes.assert_called_once_with(b"part_onepart_two")
+    assert handler.turn_audio_paths == {
+        0: "/tmp/scrapi_evals/s1/turn_0_agent.wav"
+    }
+    assert handler.current_agent_turn_idx == 1
+
+
+@patch("cxas_scrapi.core.sessions.wave.open")
+@patch("cxas_scrapi.core.sessions.os.makedirs")
 def test_bidi_session_handler_audio_writing_disabled(
     mock_makedirs, mock_wave_open
 ):

--- a/tests/cxas_scrapi/core/test_sessions.py
+++ b/tests/cxas_scrapi/core/test_sessions.py
@@ -719,6 +719,7 @@ def test_bidi_session_handler_audio_writing_enabled(
     )
 
     handler._on_message(MagicMock(), json_complete)
+    handler._save_and_increment_agent_audio()
 
     # Verify audio file was written
     mock_makedirs.assert_called_once_with("/tmp/scrapi_evals/s1", exist_ok=True)


### PR DESCRIPTION

Resolve an issue where multi-part responses or intermediate tool calls trigger turn_completed multiple times, causing BidiSessionHandler to write premature WAV chunks and increment the turn index too early. Instead, save the WAV file and increment the index only after the agent has completely finished speaking.

https://github.com/GoogleCloudPlatform/cxas-scrapi/issues/351