### PR TITLE
fix(setup): Fix skill setup issue

### DIFF
--- a/.agents/skills/cxas-agent-foundry/scripts/setup.sh
+++ b/.agents/skills/cxas-agent-foundry/scripts/setup.sh
@@ -127,7 +127,7 @@ if [ "$CONFIGURE_ONLY" = false ]; then
     source "${VENV_DIR}/bin/activate"
 
     # --- Step 2: Install cxas-scrapi from local source ---
-    if [ -z "$SCRAPI_DIR" ] || [ ! -f "$SCRAPI_DIR/setup.py" ]; then
+    if [ -z "$SCRAPI_DIR" ] || [ ! -f "$SCRAPI_DIR/pyproject.toml" ]; then
       echo "[2/3] Error: Could not find cxas-scrapi source."
       echo "      Looked relative to skill at: $SKILL_ROOT"
       exit 1


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/cxas-scrapi/issues/353


Command run: 
```
svetaksundhar-mac:cxas-scrapi svetaksundhar$ .agents/skills/cxas-agent-foundry/scripts/setup.sh --skip-config`
```

Before Change: 

```  cxas-scrapi v1.6.0 is already installed.
  Reinstall from local source? [y/N] y

[1/3] Virtualenv already exists at .venv
[2/3] Error: Could not find cxas-scrapi source.
      Looked relative to skill at: /Users/svetaksundhar/.gemini/jetski/scratch/cxas-scrapi/.agents/skills/cxas-agent-foundry
```


After this change:

```
  cxas-scrapi v1.6.0 is already installed.
  Reinstall from local source? [y/N] y

[1/3] Virtualenv already exists at .venv
[2/3] Installing cxas-scrapi from /Users/svetaksundhar/.gemini/jetski/scratch/cxas-scrapi...
      cxas-scrapi v1.6.0 installed.

[3/3] Skipping configuration wizard (--skip-config).
=========================================
 Setup complete!
=========================================
```