### PR TITLE
test: expand markdown link validation to all docs

### DIFF
--- a/tests/cxas_scrapi/test_markdown_links.py
+++ b/tests/cxas_scrapi/test_markdown_links.py
@@ -36,9 +36,7 @@ def get_markdown_files():
 
 
 @pytest.mark.parametrize(
-    "md_path",
-    get_markdown_files(),
-    ids=lambda p: str(p.relative_to(ROOT_DIR))
+    "md_path", get_markdown_files(), ids=lambda p: str(p.relative_to(ROOT_DIR))
 )
 def test_markdown_links(md_path):
     with open(md_path, encoding="utf-8") as f:

--- a/tests/cxas_scrapi/test_markdown_links.py
+++ b/tests/cxas_scrapi/test_markdown_links.py
@@ -1,7 +1,8 @@
 import pathlib
 import re
-import requests
+
 import pytest
+import requests
 
 ROOT_DIR = pathlib.Path(__file__).parent.parent.parent
 DOCS_DIR = ROOT_DIR / "docs"
@@ -76,5 +77,8 @@ def test_markdown_links(md_path):
                     f"Internal: {link} (Path not found: {target_path})"
                 )
 
-    msg = f"Found broken links in {md_path.relative_to(ROOT_DIR)}:\n" + "\n".join(broken_links)
+    msg = (
+        f"Found broken links in {md_path.relative_to(ROOT_DIR)}:\n"
+        + "\n".join(broken_links)
+    )
     assert not broken_links, msg

--- a/tests/cxas_scrapi/test_markdown_links.py
+++ b/tests/cxas_scrapi/test_markdown_links.py
@@ -1,9 +1,11 @@
 import pathlib
 import re
-
 import requests
+import pytest
 
-README_PATH = pathlib.Path(__file__).parent.parent.parent / "README.md"
+ROOT_DIR = pathlib.Path(__file__).parent.parent.parent
+DOCS_DIR = ROOT_DIR / "docs"
+README_PATH = ROOT_DIR / "README.md"
 
 
 def extract_links(text):
@@ -23,14 +25,25 @@ def is_ignored(url):
     return any(pattern in url for pattern in ignored_patterns)
 
 
-def test_readme_links():
-    assert README_PATH.exists(), f"README.md not found at {README_PATH}"
+def get_markdown_files():
+    files = []
+    if README_PATH.exists():
+        files.append(README_PATH)
+    if DOCS_DIR.exists():
+        files.extend(DOCS_DIR.glob("**/*.md"))
+    return files
 
-    with open(README_PATH, encoding="utf-8") as f:
+
+@pytest.mark.parametrize(
+    "md_path",
+    get_markdown_files(),
+    ids=lambda p: str(p.relative_to(ROOT_DIR))
+)
+def test_markdown_links(md_path):
+    with open(md_path, encoding="utf-8") as f:
         content = f.read()
 
     links = extract_links(content)
-
     broken_links = []
 
     for link in links:
@@ -38,8 +51,10 @@ def test_readme_links():
             continue
 
         if is_external(link):
+            if md_path != README_PATH:
+                continue
+
             try:
-                # Using a browser-like User-Agent might help avoid some blocks
                 headers = {"User-Agent": "Mozilla/5.0"}
                 response = requests.get(link, headers=headers, timeout=5)
                 if response.status_code >= 400:
@@ -53,13 +68,13 @@ def test_readme_links():
             # Remove query params or anchors if any
             clean_link = link.split("?")[0].split("#")[0]
 
-            # Path relative to README
-            target_path = README_PATH.parent / clean_link
+            # Path relative to the containing markdown file
+            target_path = (md_path.parent / clean_link).resolve()
 
             if not target_path.exists():
                 broken_links.append(
                     f"Internal: {link} (Path not found: {target_path})"
                 )
 
-    msg = "Found broken links in README.md:\n" + "\n".join(broken_links)
+    msg = f"Found broken links in {md_path.relative_to(ROOT_DIR)}:\n" + "\n".join(broken_links)
     assert not broken_links, msg


### PR DESCRIPTION
Instead of just checking links in the `Readme.MD`, we should expand this test to check the `README.md`, as well as all pages inside the `docs/` directory.



Test passing:
<img width="1120" height="138" alt="Screenshot 2026-07-14 at 4 52 21 PM" src="https://github.com/user-attachments/assets/8d3b6148-1983-4dfd-98c3-55c43ea79e6b" />

