### PR TITLE
docs(agent-foundry): fix setup.sh comment to reference pyproject.toml

### DIFF
--- a/.agents/skills/cxas-agent-foundry/scripts/setup.sh
+++ b/.agents/skills/cxas-agent-foundry/scripts/setup.sh
@@ -31,7 +31,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# Find cxas-scrapi: walk up from SKILL_ROOT looking for setup.py with cxas-scrapi
+# Find cxas-scrapi: walk up from SKILL_ROOT looking for pyproject.toml with cxas-scrapi
 SCRAPI_DIR=""
 candidate="$SKILL_ROOT"
 for _ in 1 2 3 4 5; do


### PR DESCRIPTION
## What

Fixes a stale comment in `.agents/skills/cxas-agent-foundry/scripts/setup.sh`: the comment above the cxas-scrapi discovery loop said the script walks up looking for `setup.py`, but the code checks for `pyproject.toml`.

## Why

Comment-only change to keep the script's documentation accurate — no behavior change.