### PR TITLE
feat(linter): add S008 rule enforcing single llmPromptSecurity guardrail per app

### DIFF
--- a/docs/guides/linting/rules.md
+++ b/docs/guides/linting/rules.md
@@ -500,8 +500,19 @@ Severities shown are the defaults. You can override any rule's severity in `cxas
     | S005 | `strict-agent-path-layout` | Error | Agent config paths must be app-relative and prefixed with `agents/{agent_name}/` |
     | S006 | `strict-tool-path-layout` | Error | Tool config paths must be app-relative and prefixed with `tools/{tool_name}/` |
     | S007 | `sub-agent-single-parent` | Error | Sub-agents must have at most one parent agent (tree constraint) |
+    | S008 | `singleton-guardrail-types` | Error | At most one guardrail of each singleton type (`llmPromptSecurity`) per app |
 
     These rules are similar to I009 and I013 but operate at a higher level, cross-referencing the agent JSON config against the local file system.
+
+    ---
+
+    **S008 — singleton-guardrail-types**
+
+    The platform allows only one guardrail of certain types per app — currently `llmPromptSecurity`. The console UI enforces the limit, but the App Import API used by `cxas push` does not, so pushing duplicates leaves the app un-editable in the console ("Too many llm prompt security guardrails, the limit is 1").
+
+    *Triggers:* More than one directory under `guardrails/` declares the same singleton guardrail type (`llmPromptSecurity` or `llm_prompt_security`).
+
+    *Fix:* Keep a single guardrail of that type and remove the others.
 
 === "V — Schema"
 

--- a/src/cxas_scrapi/utils/lint_rules/structure.py
+++ b/src/cxas_scrapi/utils/lint_rules/structure.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Structure validation rules (S001-S004).
+"""Structure validation rules (S001-S008).
 
 Validates app structure and cross-references using the existing
 ``cxas_scrapi.utils.validator.Validator`` for structural checks, plus
@@ -441,3 +441,83 @@ class SubAgentSingleParent(Rule):
                 )
             ]
         return []
+
+
+# Guardrail types the platform allows at most one of per app, mapped to
+# the config keys (camelCase and snake_case) that identify each type.
+_SINGLETON_GUARDRAIL_TYPES = {
+    "llmPromptSecurity": ("llmPromptSecurity", "llm_prompt_security"),
+}
+
+
+def _load_guardrail_config(guardrail_dir: Path) -> dict | None:
+    """Load ``<name>.yaml`` or ``<name>.json`` from a guardrail directory."""
+    for file_name, loader in (
+        (f"{guardrail_dir.name}.yaml", yaml.safe_load),
+        (f"{guardrail_dir.name}.json", json.loads),
+    ):
+        config_path = guardrail_dir / file_name
+        if config_path.exists():
+            try:
+                data = loader(config_path.read_text())
+            except Exception:
+                return None
+            return data if isinstance(data, dict) else None
+    return None
+
+
+@rule("structure")
+class SingletonGuardrailTypes(Rule):
+    """At most one guardrail of each singleton type exists per app.
+
+    The platform allows only one guardrail of certain types (currently
+    ``llmPromptSecurity``) per app. The console UI enforces the limit,
+    but the App Import API used by ``cxas push`` does not — importing
+    duplicates leaves the app un-editable in the console ("Too many llm
+    prompt security guardrails, the limit is 1").
+    """
+
+    id = "S008"
+    name = "singleton-guardrail-types"
+    description = (
+        "At most one guardrail of each singleton type (llmPromptSecurity)"
+    )
+    default_severity = Severity.ERROR
+    target = "guardrail_config"
+
+    def check(
+        self, file_path: Path, content: str, context: LintContext
+    ) -> list[LintResult]:
+        guardrail_dir = file_path if file_path.is_dir() else file_path.parent
+        config = _load_guardrail_config(guardrail_dir)
+        if config is None:
+            return []
+
+        results = []
+        for type_name, keys in _SINGLETON_GUARDRAIL_TYPES.items():
+            if not any(k in config for k in keys):
+                continue
+            duplicates = []
+            for sibling in sorted(guardrail_dir.parent.iterdir()):
+                if not sibling.is_dir() or sibling.name == guardrail_dir.name:
+                    continue
+                sibling_config = _load_guardrail_config(sibling)
+                if sibling_config and any(k in sibling_config for k in keys):
+                    duplicates.append(sibling.name)
+            if duplicates:
+                results.append(
+                    self.make_result(
+                        str(guardrail_dir),
+                        (
+                            f"Guardrail '{guardrail_dir.name}' has type "
+                            f"'{type_name}', but so do: {duplicates}. "
+                            "The platform allows at most one guardrail "
+                            "of this type per app."
+                        ),
+                        fix=(
+                            f"Keep a single '{type_name}' guardrail and "
+                            "remove the others."
+                        ),
+                    )
+                )
+        return results

--- a/tests/cxas_scrapi/utils/test_lint_rules.py
+++ b/tests/cxas_scrapi/utils/test_lint_rules.py
@@ -2159,6 +2159,119 @@ def test_s007_multi_parent_error(tmp_path, context):
     assert "parent_b" in results[0].message
 
 
+# --- Rule S008 Tests ---
+
+
+def _write_guardrail(tmp_path, name, body, fmt="json"):
+    """Create ``guardrails/<name>/<name>.<fmt>`` and return the directory."""
+    import json  # noqa: PLC0415
+
+    import yaml  # noqa: PLC0415
+
+    guardrail_dir = tmp_path / "guardrails" / name
+    guardrail_dir.mkdir(parents=True)
+    content = json.dumps(body) if fmt == "json" else yaml.safe_dump(body)
+    (guardrail_dir / f"{name}.{fmt}").write_text(content)
+    return guardrail_dir
+
+
+def test_s008_single_prompt_security_ok(tmp_path, context):
+    from cxas_scrapi.utils.lint_rules.structure import SingletonGuardrailTypes  # noqa: PLC0415,I001
+
+    rule = SingletonGuardrailTypes()
+    d = _write_guardrail(
+        tmp_path, "prompt_shield", {"llmPromptSecurity": {"enabled": True}}
+    )
+    _write_guardrail(
+        tmp_path, "safety", {"contentFilter": {"bannedPhrases": []}}
+    )
+
+    results = rule.check(d, "", context)
+    assert len(results) == 0
+
+
+def test_s008_duplicate_prompt_security_error(tmp_path, context):
+    from cxas_scrapi.utils.lint_rules.structure import SingletonGuardrailTypes  # noqa: PLC0415,I001
+
+    rule = SingletonGuardrailTypes()
+    d1 = _write_guardrail(
+        tmp_path, "prompt_shield", {"llmPromptSecurity": {"enabled": True}}
+    )
+    _write_guardrail(
+        tmp_path, "prompt_shield_2", {"llmPromptSecurity": {"enabled": True}}
+    )
+
+    results = rule.check(d1, "", context)
+    assert len(results) == 1
+    assert "llmPromptSecurity" in results[0].message
+    assert "prompt_shield_2" in results[0].message
+    assert "at most one" in results[0].message
+
+
+def test_s008_snake_case_key_detected(tmp_path, context):
+    from cxas_scrapi.utils.lint_rules.structure import SingletonGuardrailTypes  # noqa: PLC0415,I001
+
+    rule = SingletonGuardrailTypes()
+    d1 = _write_guardrail(
+        tmp_path, "prompt_shield", {"llm_prompt_security": {"enabled": True}}
+    )
+    _write_guardrail(
+        tmp_path, "prompt_shield_2", {"llmPromptSecurity": {"enabled": True}}
+    )
+
+    results = rule.check(d1, "", context)
+    assert len(results) == 1
+    assert "prompt_shield_2" in results[0].message
+
+
+def test_s008_yaml_guardrails_detected(tmp_path, context):
+    from cxas_scrapi.utils.lint_rules.structure import SingletonGuardrailTypes  # noqa: PLC0415,I001
+
+    rule = SingletonGuardrailTypes()
+    d1 = _write_guardrail(
+        tmp_path,
+        "prompt_shield",
+        {"llmPromptSecurity": {"enabled": True}},
+        fmt="yaml",
+    )
+    _write_guardrail(
+        tmp_path,
+        "prompt_shield_2",
+        {"llmPromptSecurity": {"enabled": True}},
+        fmt="yaml",
+    )
+
+    results = rule.check(d1, "", context)
+    assert len(results) == 1
+
+
+def test_s008_non_singleton_duplicates_ok(tmp_path, context):
+    from cxas_scrapi.utils.lint_rules.structure import SingletonGuardrailTypes  # noqa: PLC0415,I001
+
+    rule = SingletonGuardrailTypes()
+    d1 = _write_guardrail(
+        tmp_path, "filter_a", {"contentFilter": {"bannedPhrases": []}}
+    )
+    _write_guardrail(
+        tmp_path, "filter_b", {"contentFilter": {"bannedPhrases": []}}
+    )
+
+    results = rule.check(d1, "", context)
+    assert len(results) == 0
+
+
+def test_s008_missing_or_invalid_config_ignored(tmp_path, context):
+    from cxas_scrapi.utils.lint_rules.structure import SingletonGuardrailTypes  # noqa: PLC0415,I001
+
+    rule = SingletonGuardrailTypes()
+    guardrail_dir = tmp_path / "guardrails" / "broken"
+    guardrail_dir.mkdir(parents=True)
+    (guardrail_dir / "broken.json").write_text("{not json")
+
+    results = rule.check(guardrail_dir, "", context)
+    assert len(results) == 0
+
+
 # --- Rules A006, S005, S006 Tests ---
 
 

--- a/tests/cxas_scrapi/utils/test_linter.py
+++ b/tests/cxas_scrapi/utils/test_linter.py
@@ -230,9 +230,9 @@ def test_reset_registry():
         importlib.reload(mod)
 
     registry_restored = build_registry()
-    # 68 baseline + 11 cross-surface V100-V104 registrations
+    # 69 baseline + 11 cross-surface V100-V104 registrations
     # (V100 x3, V101 x2, V102 x2, V103 x3, V104 x1).
-    assert len(registry_restored.all_rules()) == 80  # noqa: PLR2004
+    assert len(registry_restored.all_rules()) == 81  # noqa: PLR2004
 
 
 # ── LintConfig ───────────────────────────────────────────────────────────
@@ -522,9 +522,9 @@ def test_discovery_filtering(tmp_path):
 def test_build_registry_all_rules():
     registry = build_registry()
     all_rules = registry.all_rules()
-    # 68 baseline + 11 cross-surface V100-V104 registrations
+    # 69 baseline + 11 cross-surface V100-V104 registrations
     # (V100 x3, V101 x2, V102 x2, V103 x3, V104 x1).
-    assert len(all_rules) == 80  # noqa: PLR2004
+    assert len(all_rules) == 81  # noqa: PLR2004
 
 
 def test_build_context(tmp_path):


### PR DESCRIPTION
## Summary

Adds lint rule **S008 `singleton-guardrail-types`** (structure category, error severity, target `guardrail_config`).

The platform allows only one guardrail of type `llmPromptSecurity` per app. The console UI enforces the limit, but the App Import API used by `cxas push` does not — pushing an app with duplicates succeeds and then leaves the app un-editable in the console ("Too many llm prompt security guardrails, the limit is 1"). Since SCRAPI's local-iteration workflow makes it easy to accumulate multiple guardrail files before pushing them all at once, the linter now catches this before push. (A separate bug will be filed with the product team for the API-side gap.)

## Behavior

- Flags every `guardrails/<name>/` directory declaring a singleton guardrail type when a sibling declares the same type, naming the conflicting guardrails and suggesting the fix.
- Handles both `llmPromptSecurity` and `llm_prompt_security` key forms, and both JSON and YAML configs.
- Singleton types live in one module-level constant, so future singleton guardrail types are a one-line addition.
- Malformed/missing configs are ignored (V005 already reports those).

## Testing

- 6 new unit tests in `test_lint_rules.py` (duplicate detection, snake_case, YAML, non-singleton types, invalid config); rule-count assertions in `test_linter.py` bumped 80 → 81. Full linter suites pass (217 passed).
- Verified end-to-end with `cxas lint` on a fixture app: two `llmPromptSecurity` guardrails → two S008 errors; one → clean; duplicate `contentFilter` guardrails → not flagged.
- Docs: rules reference updated with the S008 row and detail section.

Fixes #364