### PR TITLE
feat(evals): add JSON output format for combined eval reports

### DIFF
--- a/src/cxas_scrapi/cli/main.py
+++ b/src/cxas_scrapi/cli/main.py
@@ -32,7 +32,10 @@ from cxas_scrapi.cli.resources_cli import (
     register as register_resources_subparsers,
 )
 from cxas_scrapi.cli.trace_cli import register as register_trace_subparser
-from cxas_scrapi.utils.eval_utils import COMBINED_REPORT_FILENAME
+from cxas_scrapi.utils.eval_utils import (
+    COMBINED_REPORT_FILENAME,
+    COMBINED_REPORT_JSON_FILENAME,
+)
 
 DEFAULT_MODEL = "gemini-3.1-flash-live"
 
@@ -660,6 +663,7 @@ def combined_evals_report_cmd(args: argparse.Namespace) -> None:
         deployment_id=getattr(args, "deployment_id", None),
         progress_callback=progress_callback,
         capture_agent_audio=getattr(args, "capture_agent_audio", False),
+        report_format=getattr(args, "format", "html") or "html",
     )
     print(f"Combined report generated at {actual_output_path}")
 
@@ -1682,7 +1686,19 @@ def get_parser() -> argparse.ArgumentParser:
     )
     parser_report.add_argument(
         "--output",
-        help=f"Output path. Defaults to <evals-dir>/{COMBINED_REPORT_FILENAME}",
+        help=(
+            f"Output path. Defaults to <evals-dir>/{COMBINED_REPORT_FILENAME} "
+            f"(or {COMBINED_REPORT_JSON_FILENAME} with --format json)."
+        ),
+    )
+    parser_report.add_argument(
+        "--format",
+        choices=["html", "json"],
+        default="html",
+        help=(
+            "Output format for the combined report: 'html' (default) or "
+            "'json' for a machine-readable report with the same data."
+        ),
     )
     parser_report.add_argument(
         "--golden-run",

--- a/src/cxas_scrapi/utils/eval_utils.py
+++ b/src/cxas_scrapi/utils/eval_utils.py
@@ -41,6 +41,7 @@ SIM_RESULTS_FILENAME = "sim_results.json"
 TOOL_RESULTS_FILENAME = "tool_results.csv"
 CALLBACK_RESULTS_FILENAME = "callback_results.csv"
 COMBINED_REPORT_FILENAME = "combined_report.html"
+COMBINED_REPORT_JSON_FILENAME = "combined_report.json"
 TIMESTAMP_PATTERN = r"\d{8}_\d{6}"
 
 logger = logging.getLogger(__name__)

--- a/src/cxas_scrapi/utils/reporting.py
+++ b/src/cxas_scrapi/utils/reporting.py
@@ -404,11 +404,17 @@ def _get_run_detail(r, ces_base, tools_map):
     return html
 
 
-def _upload_to_gcs(output_path: str, html_content: str) -> str | None:
+def _upload_to_gcs(
+    output_path: str,
+    content: str,
+    content_type: str = "text/html; charset=utf-8",
+) -> str | None:
     """Uploads the report to GCS and returns the mTLS URL or None on failure."""
     try:
         gcs = gcs_utils.GCSUtils()
-        mtls_url = gcs.upload_string(output_path, html_content)
+        mtls_url = gcs.upload_string(
+            output_path, content, content_type=content_type
+        )
         print(f"Report uploaded to GCS: {output_path}")
         print(f"Authenticated URL: {mtls_url}")
         return mtls_url
@@ -974,6 +980,112 @@ def generate_combined_html_report(
     return output_path
 
 
+def _sanitize_for_json(results: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Strip internal keys (prefixed with '_') from result dicts."""
+    return [
+        {k: v for k, v in r.items() if not str(k).startswith("_")}
+        for r in results
+    ]
+
+
+def generate_combined_json_report(
+    golden_results: list[dict[str, Any]] | None = None,
+    sim_results: list[dict[str, Any]] | None = None,
+    tool_results: list[dict[str, Any]] | None = None,
+    callback_results: list[dict[str, Any]] | None = None,
+    output_path: str = "",
+    app_name: str = "",
+    golden_modality: str = "text",
+    sim_modality: str = "text",
+    sim_wall_clock_s: float | None = None,
+) -> str:
+    """Generate a combined JSON report based on results from multiple sources.
+
+    Emits the same underlying evaluation data as the combined HTML report,
+    but as a single machine-readable JSON document so downstream consumers
+    do not need to scrape the HTML.
+
+    Args:
+      golden_results: The list of golden evaluation results.
+      sim_results: The list of simulation evaluation results.
+      tool_results: The list of tool evaluation results.
+      callback_results: The list of callback evaluation results.
+      output_path: The path to save the JSON report (local or GCS).
+      app_name: CX Agent Studio (CXAS) agent resource name.
+      golden_modality: The modality used for the golden evaluations.
+      sim_modality: The modality used for the simulation evaluations.
+      sim_wall_clock_s: Total elapsed execution time for simulations in
+        seconds.
+
+    Returns:
+      The resolved output path or URL where the report was saved.
+    """
+    golden_results = golden_results or []
+    sim_results = sim_results or []
+    tool_results = tool_results or []
+    callback_results = callback_results or []
+
+    def _counts(results):
+        return {
+            "total": len(results),
+            "passed": sum(1 for r in results if r.get("passed")),
+        }
+
+    per_type = {
+        "golden": _counts(golden_results),
+        "simulation": _counts(sim_results),
+        "tool": _counts(tool_results),
+        "callback": _counts(callback_results),
+    }
+    total = sum(c["total"] for c in per_type.values())
+    passed = sum(c["passed"] for c in per_type.values())
+
+    report = {
+        "schema_version": 1,
+        "generated_at": datetime.datetime.now().isoformat(),
+        "app_name": app_name,
+        "modality": {
+            "golden": golden_modality,
+            "simulation": sim_modality,
+        },
+        "sim_wall_clock_s": sim_wall_clock_s,
+        "summary": {
+            "total": total,
+            "passed": passed,
+            "pass_rate_pct": round(100 * passed / total, 2) if total else 0,
+            **per_type,
+        },
+        "results": {
+            "golden": _sanitize_for_json(golden_results),
+            "simulation": _sanitize_for_json(sim_results),
+            "tool": _sanitize_for_json(tool_results),
+            "callback": _sanitize_for_json(callback_results),
+        },
+    }
+    json_out = json.dumps(report, indent=2, default=str)
+
+    if output_path:
+        if output_path.startswith("gs://"):
+            mtls_url = _upload_to_gcs(
+                output_path, json_out, content_type="application/json"
+            )
+            if not mtls_url:
+                # Fallback to local file if upload failed
+                filename = output_path.rsplit("/", maxsplit=1)[-1]
+                if not filename.endswith(".json"):
+                    filename = "report_fallback.json"
+                output_path = filename
+                with open(output_path, "w") as f:
+                    f.write(json_out)
+            else:
+                output_path = mtls_url
+        else:
+            with open(output_path, "w") as f:
+                f.write(json_out)
+
+    return output_path
+
+
 def _outcome_str(val):
     if isinstance(val, int):
         return {0: "UNSPECIFIED", 1: "PASS", 2: "FAIL"}.get(val, f"?{val}")
@@ -1442,14 +1554,15 @@ def generate_combined_report_from_dir(
     deployment_id: str | None = None,
     progress_callback: Callable[[str, int, int], None] | None = None,
     capture_agent_audio: bool = False,
+    report_format: str = "html",
 ) -> str:
-    """Load results from directory and generate combined HTML report.
+    """Load results from directory and generate a combined report.
 
     Args:
       output_dir: Directory containing the evaluation results.
       golden_run: The golden evaluation run ID.
       app_name: CX Agent Studio (CXAS) agent resource name.
-      output_path: Optional GCS or local path to write the HTML report to.
+      output_path: Optional GCS or local path to write the report to.
       run: If True, triggers execution of evals before compiling report.
       app_dir: Directory containing CX Agent Studio (CXAS) agent code.
       tool_test_file: Path to tool tests definition file.
@@ -1468,12 +1581,20 @@ def generate_combined_report_from_dir(
         during replay.
       use_tool_fakes: Use fake tools for the session if available.
       deployment_id: Optional deployment ID to target for simulations.
+      report_format: Output format for the combined report, 'html'
+        (default) or 'json'.
 
     Returns:
       The resolved output path or URL where the report was saved.
     """
     if not os.path.isdir(output_dir):
         raise ValueError(f"{output_dir} is not a directory.")
+
+    if report_format not in ("html", "json"):
+        raise ValueError(
+            f"Unsupported report format: {report_format!r}. "
+            "Expected 'html' or 'json'."
+        )
 
     if include is None or "all" in include:
         include = ["sims", "goldens", "tools", "callbacks"]
@@ -1656,10 +1777,27 @@ def generate_combined_report_from_dir(
             )
 
     if not output_path:
+        default_filename = (
+            eval_utils.COMBINED_REPORT_JSON_FILENAME
+            if report_format == "json"
+            else eval_utils.COMBINED_REPORT_FILENAME
+        )
         report_name = eval_utils.add_timestamp_suffix(
-            eval_utils.COMBINED_REPORT_FILENAME, resolved_timestamp
+            default_filename, resolved_timestamp
         )
         output_path = os.path.join(output_dir, report_name)
+
+    if report_format == "json":
+        return generate_combined_json_report(
+            golden_results=golden_results,
+            sim_results=sim_results,
+            tool_results=tool_results,
+            callback_results=callback_results,
+            output_path=output_path,
+            app_name=app_name or "",
+            golden_modality=modality,
+            sim_modality=modality,
+        )
 
     actual_path = generate_combined_html_report(
         golden_results=golden_results,

--- a/tests/cxas_scrapi/cli/test_cli_reporting.py
+++ b/tests/cxas_scrapi/cli/test_cli_reporting.py
@@ -97,6 +97,7 @@ def test_combined_evals_report_cmd(tmp_path):
             deployment_id=None,
             progress_callback=None,
             capture_agent_audio=False,
+            report_format="html",
         )
 
 
@@ -159,6 +160,7 @@ def test_combined_evals_report_cmd_with_modality_and_runs(tmp_path):
             deployment_id=None,
             progress_callback=None,
             capture_agent_audio=False,
+            report_format="html",
         )
 
 
@@ -226,6 +228,7 @@ def test_combined_evals_report_cmd_timestamped(mock_datetime, tmp_path):
             deployment_id=None,
             progress_callback=None,
             capture_agent_audio=False,
+            report_format="html",
         )
 
 
@@ -271,6 +274,43 @@ def test_combined_evals_report_cmd_with_filters_and_progress(tmp_path):
         assert call_kwargs["filter_tags"] == ["P0", "P1"]
         assert call_kwargs["filter_names"] == ["test_name_1", "test_name_2"]
         assert call_kwargs["progress_callback"] is not None
+
+
+def test_combined_evals_report_cmd_format_json(tmp_path):
+    evals_dir = tmp_path / "evals"
+    evals_dir.mkdir()
+
+    class Args:
+        def __init__(self):
+            self.output_dir = str(evals_dir)
+            self.output = None
+            self.gcs_path = None
+            self.golden_run = None
+            self.app_name = None
+            self.run = False
+            self.app_dir = None
+            self.tool_test_file = None
+            self.goldens_dir = None
+            self.simulation_dir = None
+            self.include = "sims"
+            self.input_dir = None
+            self.modality = "text"
+            self.runs = 1
+            self.use_tool_fakes = False
+            self.sim_user_model = None
+            self.eval_model = None
+            self.format = "json"
+
+    args = Args()
+
+    with patch(
+        "cxas_scrapi.utils.reporting.generate_combined_report_from_dir"
+    ) as mock_report:
+        combined_evals_report_cmd(args)
+
+        mock_report.assert_called_once()
+        call_kwargs = mock_report.call_args[1]
+        assert call_kwargs["report_format"] == "json"
 
 
 def test_combined_evals_report_cmd_with_deployment_id(tmp_path):

--- a/tests/cxas_scrapi/utils/test_reporting.py
+++ b/tests/cxas_scrapi/utils/test_reporting.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 import importlib.util
 import json
 import os
@@ -23,6 +24,7 @@ import pytest
 
 from cxas_scrapi.utils.eval_utils import (
     COMBINED_REPORT_FILENAME,
+    COMBINED_REPORT_JSON_FILENAME,
     add_timestamp_suffix,
 )
 from cxas_scrapi.utils.reporting import (
@@ -33,6 +35,7 @@ from cxas_scrapi.utils.reporting import (
     _resolve_tool_name,
     _upload_to_gcs,
     generate_combined_html_report,
+    generate_combined_json_report,
     generate_combined_report_from_dir,
     generate_html_report,
     run_all_evals,
@@ -414,6 +417,251 @@ def test_generate_combined_report_from_dir_include_all(tmp_path):
         content = f.read()
         assert "test_sim" in content
         assert "test_tool" in content
+
+
+def test_generate_combined_json_report_local(tmp_path):
+    output_path = tmp_path / COMBINED_REPORT_JSON_FILENAME
+
+    sim_results = [
+        {
+            "name": "test_sim",
+            "passed": True,
+            "detailed_trace": ["User: hi\nAgent Text: hello"],
+            "_processed_trace": [("user", "hi")],
+        },
+        {"name": "test_sim", "passed": False},
+    ]
+    golden_results = [
+        {
+            "name": "test_golden",
+            "passed": True,
+            "turns": [{"semantic_score": 3.5}],
+        }
+    ]
+    tool_results = [
+        {
+            "name": "test_tool",
+            "tool": "my_tool",
+            "passed": True,
+            "status": "PASSED",
+            "latency_ms": 50,
+            "errors": "",
+        }
+    ]
+    callback_results = [
+        {
+            "name": "test_callback",
+            "agent": "my_agent",
+            "callback_type": "my_callback",
+            "passed": False,
+            "status": "FAILED",
+            "error": "boom",
+        }
+    ]
+
+    resolved_path = generate_combined_json_report(
+        golden_results=golden_results,
+        sim_results=sim_results,
+        tool_results=tool_results,
+        callback_results=callback_results,
+        output_path=str(output_path),
+        app_name="projects/p/locations/l/apps/a",
+        sim_wall_clock_s=12.5,
+    )
+
+    assert resolved_path == str(output_path)
+    with open(output_path) as f:
+        report = json.load(f)
+
+    assert report["schema_version"] == 1
+    assert report["app_name"] == "projects/p/locations/l/apps/a"
+    assert report["sim_wall_clock_s"] == 12.5
+
+    summary = report["summary"]
+    assert summary["total"] == 5
+    assert summary["passed"] == 3
+    assert summary["pass_rate_pct"] == 60.0
+    assert summary["simulation"] == {"total": 2, "passed": 1}
+    assert summary["golden"] == {"total": 1, "passed": 1}
+    assert summary["tool"] == {"total": 1, "passed": 1}
+    assert summary["callback"] == {"total": 1, "passed": 0}
+
+    results = report["results"]
+    assert results["simulation"][0]["name"] == "test_sim"
+    assert results["simulation"][0]["detailed_trace"] == [
+        "User: hi\nAgent Text: hello"
+    ]
+    # Internal keys are stripped from the JSON output.
+    assert "_processed_trace" not in results["simulation"][0]
+    assert results["golden"][0]["turns"] == [{"semantic_score": 3.5}]
+    assert results["tool"][0]["latency_ms"] == 50
+    assert results["callback"][0]["error"] == "boom"
+
+
+def test_generate_combined_json_report_serializes_non_json_values(tmp_path):
+    output_path = tmp_path / "report.json"
+
+    generate_combined_json_report(
+        sim_results=[
+            {
+                "name": "test_sim",
+                "passed": True,
+                "started_at": datetime.datetime(2026, 7, 16, 12, 0, 0),
+            }
+        ],
+        output_path=str(output_path),
+    )
+
+    with open(output_path) as f:
+        report = json.load(f)
+    assert "2026-07-16" in report["results"]["simulation"][0]["started_at"]
+
+
+@patch("cxas_scrapi.utils.reporting._upload_to_gcs")
+@patch("builtins.open", new_callable=mock_open)
+def test_generate_combined_json_report_gcs_success(mock_file, mock_upload):
+    mock_upload.return_value = "https://url"
+
+    resolved_path = generate_combined_json_report(
+        sim_results=[{"name": "test_sim", "passed": True}],
+        output_path="gs://bucket/report.json",
+    )
+
+    assert resolved_path == "https://url"
+    mock_upload.assert_called_once_with(
+        "gs://bucket/report.json", ANY, content_type="application/json"
+    )
+    mock_file.assert_not_called()
+
+
+@patch("cxas_scrapi.utils.reporting._upload_to_gcs")
+@patch("builtins.open", new_callable=mock_open)
+def test_generate_combined_json_report_gcs_fallback(mock_file, mock_upload):
+    mock_upload.return_value = None
+
+    resolved_path = generate_combined_json_report(
+        sim_results=[{"name": "test_sim", "passed": True}],
+        output_path="gs://bucket/report.json",
+    )
+
+    assert resolved_path == "report.json"
+    mock_file.assert_any_call("report.json", "w")
+
+
+@patch("cxas_scrapi.utils.reporting._upload_to_gcs")
+@patch("builtins.open", new_callable=mock_open)
+def test_generate_combined_json_report_gcs_fallback_no_extension(
+    mock_file, mock_upload
+):
+    mock_upload.return_value = None
+
+    resolved_path = generate_combined_json_report(
+        sim_results=[{"name": "test_sim", "passed": True}],
+        output_path="gs://bucket/no_ext",
+    )
+
+    assert resolved_path == "report_fallback.json"
+    mock_file.assert_any_call("report_fallback.json", "w")
+
+
+def test_generate_combined_report_from_dir_json(tmp_path):
+    evals_dir = tmp_path / "evals"
+    evals_dir.mkdir()
+
+    sim_file = evals_dir / "sim_results.json"
+    sim_file.write_text(json.dumps([{"name": "test_sim", "passed": True}]))
+
+    tool_file = evals_dir / "tool_results.csv"
+    df_tool = pd.DataFrame(
+        [
+            {
+                "test_name": "test_tool",
+                "tool": "my_tool",
+                "status": "PASSED",
+                "latency (ms)": 50,
+                "errors": "",
+            }
+        ]
+    )
+    df_tool.to_csv(tool_file, index=False)
+
+    callback_file = evals_dir / "callback_results.csv"
+    df_callback = pd.DataFrame(
+        [
+            {
+                "test_name": "test_callback",
+                "agent_name": "my_agent",
+                "callback_type": "my_callback",
+                "status": "FAILED",
+                "error_message": "boom",
+            }
+        ]
+    )
+    df_callback.to_csv(callback_file, index=False)
+
+    resolved_path = generate_combined_report_from_dir(
+        output_dir=str(evals_dir), report_format="json"
+    )
+
+    # Defaults to combined_report.json in the output directory.
+    assert resolved_path == str(evals_dir / COMBINED_REPORT_JSON_FILENAME)
+    assert os.path.exists(resolved_path)
+
+    with open(resolved_path) as f:
+        report = json.load(f)
+
+    assert report["summary"]["total"] == 3
+    assert report["summary"]["passed"] == 2
+    assert report["results"]["simulation"][0]["name"] == "test_sim"
+    assert report["results"]["tool"][0]["name"] == "test_tool"
+    assert report["results"]["tool"][0]["passed"] is True
+    assert report["results"]["callback"][0]["name"] == "test_callback"
+    assert report["results"]["callback"][0]["passed"] is False
+
+
+def test_generate_combined_report_from_dir_json_explicit_output(tmp_path):
+    evals_dir = tmp_path / "evals"
+    evals_dir.mkdir()
+
+    sim_file = evals_dir / "sim_results.json"
+    sim_file.write_text(json.dumps([{"name": "test_sim", "passed": True}]))
+
+    output_path = tmp_path / "custom_report.json"
+
+    resolved_path = generate_combined_report_from_dir(
+        output_dir=str(evals_dir),
+        output_path=str(output_path),
+        report_format="json",
+    )
+
+    assert resolved_path == str(output_path)
+    with open(output_path) as f:
+        report = json.load(f)
+    assert report["summary"]["total"] == 1
+
+
+def test_generate_combined_report_from_dir_invalid_format(tmp_path):
+    evals_dir = tmp_path / "evals"
+    evals_dir.mkdir()
+
+    with pytest.raises(ValueError, match="Unsupported report format"):
+        generate_combined_report_from_dir(
+            output_dir=str(evals_dir), report_format="xml"
+        )
+
+
+def test_generate_combined_report_from_dir_html_default_unchanged(tmp_path):
+    evals_dir = tmp_path / "evals"
+    evals_dir.mkdir()
+
+    sim_file = evals_dir / "sim_results.json"
+    sim_file.write_text(json.dumps([{"name": "test_sim", "passed": True}]))
+
+    resolved_path = generate_combined_report_from_dir(output_dir=str(evals_dir))
+
+    assert resolved_path == str(evals_dir / COMBINED_REPORT_FILENAME)
+    with open(resolved_path) as f:
+        assert "Combined Eval Report" in f.read()
 
 
 @patch("cxas_scrapi.evals.runner.Evaluations")


### PR DESCRIPTION
## Summary

Adds a `--format {html,json}` option to `cxas evals report` so consumers can get a single machine-readable `combined_report.json` instead of scraping the HTML report.

Fixes #366

## What changed

- **`cxas evals report --format json`** emits `combined_report.json` (default filename, or use `--output` / `--gcs-path` as before). Default behavior is unchanged: `--format html` remains the default.
- **`generate_combined_json_report()`** in `utils/reporting.py` serializes the same underlying result data the HTML report renders — golden, simulation, tool, and callback results — plus a `summary` block with pass/total counts per category. Internal keys (prefixed `_`) are stripped, and non-JSON-native values fall back to string serialization.
- **`generate_combined_report_from_dir()`** gains a `report_format` parameter and dispatches to the JSON or HTML renderer after the shared result-gathering step. Unsupported formats raise `ValueError`.
- GCS output (`gs://...`) works the same as HTML, including local-file fallback on upload failure, and uploads with `application/json` content type.

## Report shape

```json
{
  "schema_version": 1,
  "generated_at": "...",
  "app_name": "projects/.../apps/...",
  "modality": {"golden": "text", "simulation": "text"},
  "summary": {
    "total": 3, "passed": 2, "pass_rate_pct": 66.67,
    "golden": {"total": 0, "passed": 0},
    "simulation": {"total": 2, "passed": 1},
    "tool": {"total": 1, "passed": 1},
    "callback": {"total": 0, "passed": 0}
  },
  "results": {"golden": [...], "simulation": [...], "tool": [...], "callback": [...]}
}
```

## Testing

- New unit tests covering the JSON renderer (summary math, key sanitization, non-serializable values, GCS success/fallback paths) and the `from_dir` dispatch (default filename, explicit output path, invalid format, HTML default unchanged).
- New CLI test asserting `--format json` is passed through; existing CLI tests updated for the new kwarg.
- Verified end-to-end: `cxas evals report --output-dir <dir> --format json` against sample sim/tool results produces a valid combined_report.json.
- `pytest tests/cxas_scrapi/utils/test_reporting.py tests/cxas_scrapi/cli/test_cli_reporting.py`: 47 passed. Ruff lint/format clean.