### PR TITLE
chore: ignore .active-project orchestrator pointer file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ z_adhoc/
 *scratch.py
 .agent/
 *.tar
+.active-project
 
 # `cxas trace` workspace — local audio downloads, smoke-test outputs,
 # and per-developer trace.yaml. Users create their own.


### PR DESCRIPTION
Adds the local orchestrator pointer file `.active-project` to `.gitignore`. This file is generated dynamically by GECX workspace skills to track the active project directory and should never be committed to the repository.

TAG=agy
CONV=1873e287-e9fd-48b0-8f28-0a6280051fff