### PR TITLE
fix(gemini): retry transient errors in sync GeminiGenerate.generate()

### DIFF
--- a/src/cxas_scrapi/utils/gemini.py
+++ b/src/cxas_scrapi/utils/gemini.py
@@ -16,6 +16,7 @@ import asyncio
 import logging
 import random
 import threading
+import time
 from typing import Any
 
 from google import genai
@@ -166,17 +167,45 @@ class GeminiGenerate:
 
         contents = self._build_contents(prompt, audio_path, audio_bytes)
 
-        try:
-            response = self.client.models.generate_content(
-                model=target_model, contents=contents, config=config
-            )
+        # Retry transient failures (esp. 429 / RESOURCE_EXHAUSTED) with
+        # exponential backoff instead of returning None on the first error.
+        # Mirrors generate_async: without this, a single transient rate-limit
+        # silently drops the call, which callers cannot distinguish from a
+        # legitimate empty result.
+        max_retries = 5
+        base_delay_seconds = 10
+        for attempt in range(max_retries):
+            try:
+                response = self.client.models.generate_content(
+                    model=target_model, contents=contents, config=config
+                )
 
-            if response_mime_type == "application/json" and response_schema:
-                return response.parsed
-            return response.text
-        except Exception:
-            logger.exception("Gemini generation failed")
-            return None
+                if response_mime_type == "application/json" and response_schema:
+                    return response.parsed
+                return response.text
+
+            except Exception as e:
+                is_quota = "429" in str(e) or "RESOURCE_EXHAUSTED" in str(e)
+                err_msg = (
+                    "Quota/Rate Limit Exhausted"
+                    if is_quota
+                    else f"{type(e).__name__}: {e}"
+                )
+                logger.warning(f"  Attempt {attempt + 1} failed: {err_msg}")
+
+                if attempt == max_retries - 1:
+                    logger.exception(
+                        "  Gemini generation failed after all retries."
+                    )
+                    return None
+
+            sleep_time = (base_delay_seconds * (1.5**attempt)) + random.uniform(
+                0, 3
+            )
+            logger.info(f"    Sleeping for {sleep_time:.1f}s before retry...")
+            time.sleep(sleep_time)
+
+        return None
 
     def generate_with_parts(
         self,

--- a/tests/cxas_scrapi/utils/test_gemini.py
+++ b/tests/cxas_scrapi/utils/test_gemini.py
@@ -116,12 +116,31 @@ def test_generate_returns_parsed_for_json_schema(mock_genai):
 
 
 @patch("cxas_scrapi.utils.gemini.genai")
-def test_generate_returns_none_on_failure(mock_genai):
+@patch("cxas_scrapi.utils.gemini.time.sleep")
+def test_generate_returns_none_on_failure(mock_sleep, mock_genai):
     fake_client = MagicMock()
     mock_genai.Client.return_value = fake_client
     fake_client.models.generate_content.side_effect = RuntimeError("boom")
     gen = GeminiGenerate(project_id="p")
     assert gen.generate(prompt="p") is None
+    # generate() retries transient failures before giving up (5 attempts).
+    assert fake_client.models.generate_content.call_count == 5
+
+
+@patch("cxas_scrapi.utils.gemini.genai")
+@patch("cxas_scrapi.utils.gemini.time.sleep")
+def test_generate_retries_transient_then_succeeds(mock_sleep, mock_genai):
+    """A transient error (e.g. 429) is retried, not swallowed as None."""
+    fake_client = MagicMock()
+    mock_genai.Client.return_value = fake_client
+    fake_client.models.generate_content.side_effect = [
+        RuntimeError("429 RESOURCE_EXHAUSTED"),
+        SimpleNamespace(text="ok"),
+    ]
+    gen = GeminiGenerate(project_id="p")
+    assert gen.generate(prompt="p") == "ok"
+    assert fake_client.models.generate_content.call_count == 2
+    assert mock_sleep.call_count == 1  # one backoff between the two attempts
 
 
 @patch("cxas_scrapi.utils.gemini.genai")


### PR DESCRIPTION
## Summary

`GeminiGenerate.generate()` (the synchronous path) caught every exception and returned `None` with no retry, whereas its async counterpart `generate_async()` already retries transient failures. A single transient error — typically **429 / RESOURCE_EXHAUSTED** on a rate-limited key — therefore silently dropped the call. Callers can't distinguish that swallowed failure from a legitimate empty result, which produces confusing downstream behavior (see *Motivation*).

This update makes the sync path retry transient errors with the same exponential backoff the async path uses.

---

## What Changed

* **`src/cxas_scrapi/utils/gemini.py`** — `generate()` now wraps the model call in a retry loop (`max_retries=5`) instead of a generic `try/except: return None`:
  * **On success:** Returns the parsed object / text exactly as before (no behavior change on the happy path).
  * **On failure:** Logs the attempt (flagging quota/rate-limit vs. other errors) and backs off before retrying; returns `None` only after all attempts are exhausted.
  * **Backoff** mirrors `generate_async(): base_delay_seconds * (1.5 ** attempt) + random.uniform(0, 3), base_delay_seconds = 10.`
* **Added** `import time` (the async path uses `asyncio.sleep`; the sync path uses `time.sleep`).

---

## Behavior Changes

| Scenario | Before | After |
| --- | --- | --- |
| **Transient 429 Error** | `return None` immediately | Retry w/ backoff (5 attempts) $\rightarrow$ succeed, or `None` only if all fail |

---

## Motivation

**The primary symptom:** In the simulation loop, it treats a `None` from the sim-user model as *"the caller ended the conversation."* Because of this, a single transient 429 mid-run ended the conversation early and left goal/step progress uncredited — surfacing as a spurious sim failure rather than a retryable error.

---

## Testing

* `uv run pytest tests/cxas_scrapi/utils/test_gemini.py` $\rightarrow$ **16 passed**; `ruff check` clean.
* Updated `test_generate_returns_none_on_failure` to stub `time.sleep` and assert the retry count (5 attempts).
* Added `test_generate_retries_transient_then_succeeds`: first call raises `429 RESOURCE_EXHAUSTED`, second returns a value; asserts the retry succeeds and only one backoff occurs.