### PR TITLE
feat(sims): deterministic tool-call assertions for simulations

### DIFF
--- a/src/cxas_scrapi/evals/simulation_evals.py
+++ b/src/cxas_scrapi/evals/simulation_evals.py
@@ -130,6 +130,35 @@ class SimulationReport:
         return html
 
 
+def evaluate_tool_calls(actual_tool_calls, expected, forbidden):
+    """Deterministically check the tools an agent ACTUALLY invoked against a
+    test case's ``expected_tool_calls`` / ``forbidden_tool_calls``.
+
+    Unlike goal/expectation judging (LLM-based, over the transcript text), this
+    inspects the real tool calls -- so an agent that merely *says* "I've done X"
+    without calling the tool is caught. Matching is on the tool basename,
+    case-insensitively. Returns a dict:
+    ``{ran, passed, actual, missing, forbidden_hit}``. ``ran`` is False when
+    the test case declares neither list (no scoring effect; back-compatible).
+    """
+
+    def _base(name):
+        return str(name).split("/")[-1].lower()
+
+    actual_bases = [_base(n) for n in (actual_tool_calls or [])]
+    expected = expected or []
+    forbidden = forbidden or []
+    missing = [t for t in expected if _base(t) not in actual_bases]
+    forbidden_hit = [t for t in forbidden if _base(t) in actual_bases]
+    return {
+        "ran": bool(expected or forbidden),
+        "passed": (not missing and not forbidden_hit),
+        "actual": list(actual_tool_calls or []),
+        "missing": missing,
+        "forbidden_hit": forbidden_hit,
+    }
+
+
 class Conversation:
     """Base class for users."""
 
@@ -137,6 +166,7 @@ class Conversation:
         self.current_turn = 0
         self.utterance_turn = 0
         self.transcript = []
+        self.actual_tool_calls: list[str] = []
 
     def get_num_turns(self) -> int:
         """Gets the number of turns in the conversation."""
@@ -151,11 +181,13 @@ class Conversation:
         self.transcript.append(f"Agent: {agent_response}")
 
     def _add_agent_tool_calls(self, tool_calls: list[Any]) -> None:
-        """Adds agent tool calls to the transcript."""
+        """Adds agent tool calls to the transcript and records them for
+        deterministic tool-call assertions."""
         for tc in tool_calls:
             self.transcript.append(
                 f"Agent Action: Call Tool {tc.name} with args {tc.args}"
             )
+            self.actual_tool_calls.append(tc.name)
 
     def _add_user_utterance(self, user_utterance: str) -> None:
         """Adds a user utterance to the transcript."""
@@ -813,12 +845,27 @@ class SimulationEvals(Apps):
             elif total_exp > 0:
                 passed = passed and (expectations_met == total_exp)
 
+            # Deterministic tool-call assertion (checks ACTUAL calls, not text).
+            tcheck = evaluate_tool_calls(
+                getattr(conv, "actual_tool_calls", []),
+                tc.get("expected_tool_calls", []),
+                tc.get("forbidden_tool_calls", []),
+            )
+            if tcheck["ran"]:
+                passed = passed and tcheck["passed"]
+
             status = "PASS" if passed else "FAIL"
             if parallel > 1 or not verbose:
+                tool_seg = (
+                    f"tools: {'ok' if tcheck['passed'] else 'FAIL'} | "
+                    if tcheck["ran"]
+                    else ""
+                )
                 print(
                     f"  {status}  {label} | goals: "
                     f"{goals_completed}/{total_goals} | "
                     f"expectations: {expectations_met}/{total_exp} | "
+                    f"{tool_seg}"
                     f"turns: {conv.current_turn} | {duration_s}s"
                 )
 
@@ -828,6 +875,15 @@ class SimulationEvals(Apps):
                 "passed": passed,
                 "goals": f"{goals_completed}/{total_goals}",
                 "expectations": f"{expectations_met}/{total_exp}",
+                "tool_check": (
+                    ("PASS" if tcheck["passed"] else "FAIL")
+                    if tcheck["ran"]
+                    else "n/a"
+                ),
+                "actual_tool_calls": tcheck["actual"],
+                "expected_tool_calls": tc.get("expected_tool_calls", []) or [],
+                "missing_tool_calls": tcheck["missing"],
+                "forbidden_tool_calls_hit": tcheck["forbidden_hit"],
                 "turns": conv.current_turn,
                 "duration_s": duration_s,
                 "session_id": session_id,

--- a/src/cxas_scrapi/utils/combined_report_template.html
+++ b/src/cxas_scrapi/utils/combined_report_template.html
@@ -271,7 +271,7 @@
           {% set failed_str = "false" if r.get("passed") else "true" %}
 
           <details class="run-detail" data-failed="{{ failed_str }}">
-            <summary>Run {{ r.get('run','?') }} — <span class="{{ run_cls }}">{% if r.get('passed') %}PASS{% else %}FAIL{% endif %}</span> | goals: {{ r.get('goals','?') }} | expectations: {{ r.get('expectations','?') }} | turns: {{ r.get('turns','?') }}{% if r.get('duration_s') %} | {{ _fmt_duration(r['duration_s']) }}{% endif %}</summary>
+            <summary>Run {{ r.get('run','?') }} — <span class="{{ run_cls }}">{% if r.get('passed') %}PASS{% else %}FAIL{% endif %}</span> | goals: {{ r.get('goals','?') }} | expectations: {{ r.get('expectations','?') }}{% if r.get('tool_check') and r.get('tool_check') != 'n/a' %} | tools: {{ r['tool_check'] }}{% endif %} | turns: {{ r.get('turns','?') }}{% if r.get('duration_s') %} | {{ _fmt_duration(r['duration_s']) }}{% endif %}</summary>
 
             {% if r.get('session_id') %}
               {% if ces_base %}
@@ -318,6 +318,16 @@
                   {% endif %}
                 </div>
               {% endfor %}
+
+              {% if r.get('tool_check') and r.get('tool_check') != 'n/a' %}
+                {% set t_cls = "met" if r['tool_check'] == "PASS" else "not-met" %}
+                <div class="expectation">
+                  <span class="badge {{ t_cls }}">tools: {{ r['tool_check'] | escape }}</span>
+                  <span class="meta">expected: {{ (r.get('expected_tool_calls') or []) | join(', ') or '(none)' }} &nbsp;|&nbsp; actual: {{ (r.get('actual_tool_calls') or []) | join(', ') or '(none)' }}</span>
+                  {% if r.get('missing_tool_calls') %}<br><span class="meta" style="color:#b00020;font-weight:600;">MISSING (declared but never called): {{ r['missing_tool_calls'] | join(', ') }}</span>{% endif %}
+                  {% if r.get('forbidden_tool_calls_hit') %}<br><span class="meta" style="color:#b00020;font-weight:600;">FORBIDDEN (called but must not): {{ r['forbidden_tool_calls_hit'] | join(', ') }}</span>{% endif %}
+                </div>
+              {% endif %}
 
               {% if r.get('_processed_trace') %}
                 <details open><summary>Conversation Trace ({{ r.get('turns','?') }} turns)</summary>

--- a/src/cxas_scrapi/utils/reporting.py
+++ b/src/cxas_scrapi/utils/reporting.py
@@ -364,6 +364,44 @@ def _render_trace(trace, tools_map, turns):
     return html
 
 
+def _render_tool_check(r):
+    """Render the deterministic tool-call check for a sim run.
+
+    Sourced from the result's expected_tool_calls / actual_tool_calls /
+    missing_tool_calls / forbidden_tool_calls_hit -- the tools the agent
+    ACTUALLY invoked, not its text. Empty when no tool assertion was declared.
+    """
+    tc = r.get("tool_check", "n/a")
+    expected = r.get("expected_tool_calls", []) or []
+    actual = r.get("actual_tool_calls", []) or []
+    missing = r.get("missing_tool_calls", []) or []
+    forbidden_hit = r.get("forbidden_tool_calls_hit", []) or []
+    if tc == "n/a" and not expected and not actual:
+        return ""
+    cls = "met" if tc == "PASS" else ("not-met" if tc == "FAIL" else "")
+    html = '<div class="expectation">'
+    html += f'<span class="badge {cls}">tools: {_escape(tc)}</span> '
+    html += (
+        f'<span class="meta">expected: '
+        f"{_escape(', '.join(expected) or '(none)')} &nbsp;|&nbsp; actual: "
+        f"{_escape(', '.join(actual) or '(none)')}</span>"
+    )
+    if missing:
+        html += (
+            f'<br><span class="meta" style="color:#b00020;font-weight:600;">'
+            f"MISSING (declared but never called): "
+            f"{_escape(', '.join(missing))}</span>"
+        )
+    if forbidden_hit:
+        html += (
+            f'<br><span class="meta" style="color:#b00020;font-weight:600;">'
+            f"FORBIDDEN (called but must not): "
+            f"{_escape(', '.join(forbidden_hit))}</span>"
+        )
+    html += "</div>\n"
+    return html
+
+
 def _get_run_detail(r, ces_base, tools_map):
     """Return the HTML for a single run detail."""
     html = ""
@@ -375,9 +413,12 @@ def _get_run_detail(r, ces_base, tools_map):
         f'<span class="{run_cls}">'
         f"{'PASS' if r.get('passed') else 'FAIL'}</span>"
     )
+    _tc = r.get("tool_check", "n/a")
+    _tc_seg = f"tools: {_tc} | " if _tc and _tc != "n/a" else ""
     html += (
         f" | goals: {r.get('goals', '?')} | "
         f"expectations: {r.get('expectations', '?')} | "
+        f"{_tc_seg}"
         f"turns: {r.get('turns', '?')}</summary>\n"
     )
 
@@ -395,6 +436,8 @@ def _get_run_detail(r, ces_base, tools_map):
         html += _render_step_details(r.get("step_details", []))
 
         html += _render_expectation_details(r.get("expectation_details", []))
+
+        html += _render_tool_check(r)
 
         html += _render_trace(
             r.get("detailed_trace", []), tools_map, r.get("turns", "?")
@@ -747,6 +790,16 @@ def generate_combined_html_report(
                     failure_groups.setdefault(reason, set()).add(
                         ("sim", r["name"])
                     )
+            missing_tools = r.get("missing_tool_calls", []) or []
+            if missing_tools:
+                reason = f"Tool(s) NOT called: {', '.join(missing_tools)[:60]}"
+                failure_groups.setdefault(reason, set()).add(("sim", r["name"]))
+            forbidden_hit = r.get("forbidden_tool_calls_hit", []) or []
+            if forbidden_hit:
+                reason = (
+                    f"Forbidden tool(s) called: {', '.join(forbidden_hit)[:50]}"
+                )
+                failure_groups.setdefault(reason, set()).add(("sim", r["name"]))
 
     # Collect tool test failures
     if tool_results:

--- a/tests/cxas_scrapi/evals/test_simulation_evals.py
+++ b/tests/cxas_scrapi/evals/test_simulation_evals.py
@@ -29,6 +29,7 @@ from cxas_scrapi.evals.simulation_evals import (
     StepStatus,
     ToolCall,
     Turn,
+    evaluate_tool_calls,
 )
 from cxas_scrapi.utils.eval_utils import (
     ExpectationResult,
@@ -1773,3 +1774,50 @@ def test_simulation_evals_escalation_transfer_handling(
     assert (
         "Agent ended session via escalation/transfer" in step_prog.justification
     )
+
+
+def test_evaluate_tool_calls():
+    # All expected tools were actually called -> pass.
+    r = evaluate_tool_calls(
+        ["verify_caller", "get_billing_summary"],
+        ["verify_caller", "get_billing_summary"],
+        [],
+    )
+    assert r["ran"] is True
+    assert r["passed"] is True
+    assert r["missing"] == []
+
+    # An expected tool was never called -> fail (the fabrication-catch case:
+    # the agent may have *said* it did X without calling the tool).
+    r = evaluate_tool_calls(
+        ["verify_caller"],
+        ["verify_caller", "submit_late_fee_waiver_request"],
+        [],
+    )
+    assert r["passed"] is False
+    assert r["missing"] == ["submit_late_fee_waiver_request"]
+
+    # No tools called at all -> every expected tool is missing.
+    r = evaluate_tool_calls([], ["verify_caller"], [])
+    assert r["passed"] is False
+    assert r["missing"] == ["verify_caller"]
+
+    # A forbidden tool was called -> fail.
+    r = evaluate_tool_calls(
+        ["verify_caller", "record_transfer_reason"],
+        [],
+        ["record_transfer_reason"],
+    )
+    assert r["passed"] is False
+    assert r["forbidden_hit"] == ["record_transfer_reason"]
+
+    # Matching is on the basename, case-insensitively (full resource path).
+    r = evaluate_tool_calls(
+        ["projects/p/apps/a/tools/Verify_Caller"], ["verify_caller"], []
+    )
+    assert r["passed"] is True
+    assert r["missing"] == []
+
+    # No assertion declared -> ran is False (no effect on scoring).
+    r = evaluate_tool_calls(["verify_caller"], [], [])
+    assert r["ran"] is False

--- a/tests/cxas_scrapi/utils/test_reporting.py
+++ b/tests/cxas_scrapi/utils/test_reporting.py
@@ -30,6 +30,7 @@ from cxas_scrapi.utils.reporting import (
     _fmt_duration,
     _format_trace_line,
     _load_sim_test_cases,
+    _render_tool_check,
     _resolve_tool_name,
     _upload_to_gcs,
     generate_combined_html_report,
@@ -1105,3 +1106,38 @@ def test_sim_runner_load_sim_templates_backward_compatibility_with_list(
             assert templates["sim2"]["expectations"] == [
                 "Specific expectation 2"
             ]
+
+
+def test_render_tool_check_pass():
+    html = _render_tool_check(
+        {
+            "tool_check": "PASS",
+            "expected_tool_calls": ["verify_caller", "get_billing_summary"],
+            "actual_tool_calls": ["verify_caller", "get_billing_summary"],
+            "missing_tool_calls": [],
+            "forbidden_tool_calls_hit": [],
+        }
+    )
+    assert "tools: PASS" in html
+    assert "expected:" in html and "verify_caller" in html
+    assert "MISSING" not in html
+
+
+def test_render_tool_check_missing_and_forbidden():
+    html = _render_tool_check(
+        {
+            "tool_check": "FAIL",
+            "expected_tool_calls": ["verify_caller"],
+            "actual_tool_calls": ["record_transfer_reason"],
+            "missing_tool_calls": ["verify_caller"],
+            "forbidden_tool_calls_hit": ["record_transfer_reason"],
+        }
+    )
+    assert "tools: FAIL" in html
+    assert "MISSING (declared but never called): verify_caller" in html
+    assert "FORBIDDEN (called but must not): record_transfer_reason" in html
+
+
+def test_render_tool_check_empty_when_no_assertion():
+    # No tool assertion declared -> renders nothing.
+    assert _render_tool_check({"tool_check": "n/a"}) == ""


### PR DESCRIPTION
## Summary

Simulations were scored on goal completion plus LLM-judged expectations evaluated over the conversation *transcript*. Because that judgment reads the agent's text, an agent that merely *says* it did something ("I've submitted your request") without actually calling the tool could still pass. This adds optional, deterministic assertions on the tools the agent **actually invoked**, independent of its text. It's fully backward compatible — no effect unless a test case opts in.

## What changed

- **Sim test-case schema** — two optional fields:
  - `expected_tool_calls`: tools that must be invoked.
  - `forbidden_tool_calls`: tools that must **not** be invoked (e.g. "must not
    route/transfer").
- `src/cxas_scrapi/evals/simulation_evals.py`:
  - New `evaluate_tool_calls(actual, expected, forbidden)` — matches on tool
    **basename, case-insensitively**; returns
    `{ran, passed, actual, missing, forbidden_hit}`. `ran` is `False` when
    neither list is declared (so scoring is unaffected).
  - `Conversation` now accumulates `actual_tool_calls`, populated in the existing
    `_add_agent_tool_calls` hook — no new capture path; it reuses the tool calls
    already parsed from each turn.
  - `_run_single_simulation_job` folds a hard pass/fail into the run result
    **only when** a test case declares the lists, and records `tool_check`,
    `actual_tool_calls`, `expected_tool_calls`, `missing_tool_calls`,
    `forbidden_tool_calls_hit`.
- `src/cxas_scrapi/utils/reporting.py` + `combined_report_template.html` surface
  the check:
  - a `tools: PASS/FAIL` segment in each run's summary line,
  - an expected / actual / **MISSING** / **FORBIDDEN** detail block per run,
  - grouped entries in the **Failure Patterns** section ("Tool(s) NOT called: …",
    "Forbidden tool(s) called: …").

## Test-case shape

```yaml
- name: sim_resend_invoice
  steps: [ ... ]
  expectations: [ ... ]
  expected_tool_calls: [verify_caller, resend_invoice]
  forbidden_tool_calls: [record_transfer_reason]   # optional
```

## Report / console shape

```
FAIL  sim_resend_invoice | goals: 1/1 | expectations: 3/3 | tools: FAIL | turns: 4
  tools: FAIL — expected: verify_caller, resend_invoice | actual: record_transfer_reason
  MISSING (declared but never called): verify_caller, resend_invoice
```

## Testing

- `uv run pytest tests/cxas_scrapi/evals/test_simulation_evals.py tests/cxas_scrapi/utils/test_reporting.py`
  → **84 passed**; `ruff check` clean.
- New tests: `test_evaluate_tool_calls` (all-present pass; missing → fail; nothing-called → fail; forbidden-hit → fail; full-resource-path + case-insensitive matching; no-assertion → `ran` False); `test_render_tool_check_*` (PASS render, MISSING/FORBIDDEN render, empty when no assertion).
- End-to-end: rendered a combined report from a sim result carrying a failing tool-check and confirmed the summary segment, the detail block, and the Failure Patterns entry all appear.