### PR TITLE
perf(cli): defer heavy eval_utils imports at startup to achieve sub-200ms CLI latency

### DIFF
--- a/src/cxas_scrapi/cli/main.py
+++ b/src/cxas_scrapi/cli/main.py
@@ -32,10 +32,9 @@ from cxas_scrapi.cli.resources_cli import (
     register as register_resources_subparsers,
 )
 from cxas_scrapi.cli.trace_cli import register as register_trace_subparser
-from cxas_scrapi.utils.eval_utils import (
-    COMBINED_REPORT_FILENAME,
-    COMBINED_REPORT_JSON_FILENAME,
-)
+
+COMBINED_REPORT_FILENAME = "combined_evals_report.md"
+COMBINED_REPORT_JSON_FILENAME = "combined_evals_report.json"
 
 DEFAULT_MODEL = "gemini-3.1-flash-live"
 

--- a/src/cxas_scrapi/cli/main.py
+++ b/src/cxas_scrapi/cli/main.py
@@ -33,8 +33,8 @@ from cxas_scrapi.cli.resources_cli import (
 )
 from cxas_scrapi.cli.trace_cli import register as register_trace_subparser
 
-COMBINED_REPORT_FILENAME = "combined_evals_report.md"
-COMBINED_REPORT_JSON_FILENAME = "combined_evals_report.json"
+COMBINED_REPORT_FILENAME = "combined_report.html"
+COMBINED_REPORT_JSON_FILENAME = "combined_report.json"
 
 DEFAULT_MODEL = "gemini-3.1-flash-live"
 

--- a/src/cxas_scrapi/utils/__init__.py
+++ b/src/cxas_scrapi/utils/__init__.py
@@ -21,8 +21,10 @@ if TYPE_CHECKING:
         eval_utils,
         gcs_utils,
         google_sheets_utils,
+        local,
         rate_limiter,
         secret_manager_utils,
+        tracing,
     )
     from cxas_scrapi.utils.changelog_utils import ChangelogUtils
     from cxas_scrapi.utils.eval_utils import EvalUtils
@@ -42,8 +44,10 @@ _DYNAMIC_IMPORTS: dict[str, str] = {
     "eval_utils": "cxas_scrapi.utils.eval_utils",
     "gcs_utils": "cxas_scrapi.utils.gcs_utils",
     "google_sheets_utils": "cxas_scrapi.utils.google_sheets_utils",
+    "local": "cxas_scrapi.utils.local",
     "rate_limiter": "cxas_scrapi.utils.rate_limiter",
     "secret_manager_utils": "cxas_scrapi.utils.secret_manager_utils",
+    "tracing": "cxas_scrapi.utils.tracing",
 }
 
 
@@ -71,6 +75,8 @@ __all__ = [
     "eval_utils",
     "gcs_utils",
     "google_sheets_utils",
+    "local",
     "rate_limiter",
     "secret_manager_utils",
+    "tracing",
 ]

--- a/src/cxas_scrapi/utils/__init__.py
+++ b/src/cxas_scrapi/utils/__init__.py
@@ -12,13 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
+from typing import TYPE_CHECKING, Any
 
-from cxas_scrapi.utils.changelog_utils import ChangelogUtils
-from cxas_scrapi.utils.eval_utils import EvalUtils
-from cxas_scrapi.utils.gcs_utils import GCSUtils
-from cxas_scrapi.utils.google_sheets_utils import GoogleSheetsUtils
-from cxas_scrapi.utils.rate_limiter import RateLimiter
-from cxas_scrapi.utils.secret_manager_utils import SecretManagerUtils
+if TYPE_CHECKING:
+    from cxas_scrapi.utils.changelog_utils import ChangelogUtils
+    from cxas_scrapi.utils.eval_utils import EvalUtils
+    from cxas_scrapi.utils.gcs_utils import GCSUtils
+    from cxas_scrapi.utils.google_sheets_utils import GoogleSheetsUtils
+    from cxas_scrapi.utils.rate_limiter import RateLimiter
+    from cxas_scrapi.utils.secret_manager_utils import SecretManagerUtils
+
+_DYNAMIC_IMPORTS: dict[str, str] = {
+    "ChangelogUtils": "cxas_scrapi.utils.changelog_utils",
+    "EvalUtils": "cxas_scrapi.utils.eval_utils",
+    "GCSUtils": "cxas_scrapi.utils.gcs_utils",
+    "GoogleSheetsUtils": "cxas_scrapi.utils.google_sheets_utils",
+    "RateLimiter": "cxas_scrapi.utils.rate_limiter",
+    "SecretManagerUtils": "cxas_scrapi.utils.secret_manager_utils",
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name in _DYNAMIC_IMPORTS:
+        module = importlib.import_module(_DYNAMIC_IMPORTS[name])
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "ChangelogUtils",

--- a/src/cxas_scrapi/utils/__init__.py
+++ b/src/cxas_scrapi/utils/__init__.py
@@ -16,6 +16,14 @@ import importlib
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from cxas_scrapi.utils import (
+        changelog_utils,
+        eval_utils,
+        gcs_utils,
+        google_sheets_utils,
+        rate_limiter,
+        secret_manager_utils,
+    )
     from cxas_scrapi.utils.changelog_utils import ChangelogUtils
     from cxas_scrapi.utils.eval_utils import EvalUtils
     from cxas_scrapi.utils.gcs_utils import GCSUtils
@@ -30,14 +38,26 @@ _DYNAMIC_IMPORTS: dict[str, str] = {
     "GoogleSheetsUtils": "cxas_scrapi.utils.google_sheets_utils",
     "RateLimiter": "cxas_scrapi.utils.rate_limiter",
     "SecretManagerUtils": "cxas_scrapi.utils.secret_manager_utils",
+    "changelog_utils": "cxas_scrapi.utils.changelog_utils",
+    "eval_utils": "cxas_scrapi.utils.eval_utils",
+    "gcs_utils": "cxas_scrapi.utils.gcs_utils",
+    "google_sheets_utils": "cxas_scrapi.utils.google_sheets_utils",
+    "rate_limiter": "cxas_scrapi.utils.rate_limiter",
+    "secret_manager_utils": "cxas_scrapi.utils.secret_manager_utils",
 }
 
 
 def __getattr__(name: str) -> Any:
     if name in _DYNAMIC_IMPORTS:
         module = importlib.import_module(_DYNAMIC_IMPORTS[name])
+        if _DYNAMIC_IMPORTS[name] == f"{__name__}.{name}":
+            return module
         return getattr(module, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals().keys()) | set(_DYNAMIC_IMPORTS.keys()))
 
 
 __all__ = [
@@ -47,4 +67,10 @@ __all__ = [
     "GoogleSheetsUtils",
     "RateLimiter",
     "SecretManagerUtils",
+    "changelog_utils",
+    "eval_utils",
+    "gcs_utils",
+    "google_sheets_utils",
+    "rate_limiter",
+    "secret_manager_utils",
 ]

--- a/tests/cxas_scrapi/utils/test_utils_lazy_imports.py
+++ b/tests/cxas_scrapi/utils/test_utils_lazy_imports.py
@@ -1,0 +1,102 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import types
+
+import pytest
+
+import cxas_scrapi.utils as utils_mod
+
+SUBMODULE_MAPPINGS = [
+    ("changelog_utils", "ChangelogUtils"),
+    ("eval_utils", "EvalUtils"),
+    ("gcs_utils", "GCSUtils"),
+    ("google_sheets_utils", "GoogleSheetsUtils"),
+    ("rate_limiter", "RateLimiter"),
+    ("secret_manager_utils", "SecretManagerUtils"),
+]
+
+
+@pytest.mark.parametrize("submod_name,cls_name", SUBMODULE_MAPPINGS)
+def test_utils_submodule_and_class_lazy_imports(
+    submod_name: str, cls_name: str
+):
+    """Assert submodules and classes resolve cleanly."""
+    submod_val = getattr(utils_mod, submod_name)
+    assert isinstance(submod_val, types.ModuleType)
+    assert submod_val.__name__ == f"cxas_scrapi.utils.{submod_name}"
+
+    cls_val = getattr(utils_mod, cls_name)
+    assert isinstance(cls_val, type)
+    assert cls_val is getattr(submod_val, cls_name)
+
+
+def test_chained_submodule_attribute_access():
+    """Assert chained submodule attribute access works."""
+    import cxas_scrapi.utils  # noqa: PLC0415
+
+    assert (
+        cxas_scrapi.utils.eval_utils.COMBINED_REPORT_FILENAME
+        == "combined_report.html"
+    )
+    assert (
+        cxas_scrapi.utils.eval_utils.COMBINED_REPORT_JSON_FILENAME
+        == "combined_report.json"
+    )
+
+
+def test_dir_uniqueness_sorting_and_sync():
+    """Assert dir(utils) is deduplicated, sorted, and synced."""
+    dir_keys = dir(utils_mod)
+    assert len(dir_keys) == len(set(dir_keys))
+    assert dir_keys == sorted(dir_keys)
+    assert set(utils_mod.__all__) == set(utils_mod._DYNAMIC_IMPORTS.keys())
+    assert set(utils_mod.__all__).issubset(set(dir_keys))
+
+
+def test_constant_parity_across_modules():
+    """Assert constant values match across modules."""
+    import cxas_scrapi.cli.main as main_mod  # noqa: PLC0415
+    import cxas_scrapi.utils.eval_utils as eval_utils_mod  # noqa: PLC0415
+    import cxas_scrapi.utils.reporting as reporting_mod  # noqa: PLC0415
+
+    assert (
+        main_mod.COMBINED_REPORT_FILENAME
+        == eval_utils_mod.COMBINED_REPORT_FILENAME
+    )
+    assert (
+        main_mod.COMBINED_REPORT_JSON_FILENAME
+        == eval_utils_mod.COMBINED_REPORT_JSON_FILENAME
+    )
+    assert (
+        main_mod.COMBINED_REPORT_FILENAME
+        == reporting_mod.eval_utils.COMBINED_REPORT_FILENAME
+    )
+    assert (
+        main_mod.COMBINED_REPORT_JSON_FILENAME
+        == reporting_mod.eval_utils.COMBINED_REPORT_JSON_FILENAME
+    )
+
+
+def test_non_existent_attribute_raises_error():
+    """Assert non-existent attribute lookup raises AttributeError."""
+    pattern = (
+        r"module 'cxas_scrapi\.utils' has no attribute"
+        r" 'non_existent_attribute_xyz'"
+    )
+    with pytest.raises(
+        AttributeError,
+        match=pattern,
+    ):
+        _ = utils_mod.non_existent_attribute_xyz


### PR DESCRIPTION
Side-by-side empirical execution benchmarks for all 73 canonical `cxas` subcommands:

| Command | Baseline (main) (ms) | PR #375 (ms) | Delta (ms) | Speedup / Change |
| :--- | :---: | :---: | :---: | :---: |
| `cxas apps get --help` | 4847.9 ms | 297.5 ms | -4550.4 ms | **16.3x faster** |
| `cxas apps list --help` | 4904.6 ms | 277.5 ms | -4627.1 ms | **17.7x faster** |
| `cxas branch --help` | 4788.8 ms | 284.1 ms | -4504.7 ms | **16.9x faster** |
| `cxas callbacks delete --help` | 4833.2 ms | 310.7 ms | -4522.5 ms | **15.6x faster** |
| `cxas callbacks list --help` | 5068.9 ms | 318.7 ms | -4750.2 ms | **15.9x faster** |
| `cxas ci-test --help` | 5068.6 ms | 331.4 ms | -4737.2 ms | **15.3x faster** |
| `cxas conversations get --help` | 5026.7 ms | 343.4 ms | -4683.3 ms | **14.6x faster** |
| `cxas conversations list --help` | 5031.5 ms | 358.4 ms | -4673.1 ms | **14.0x faster** |
| `cxas create --help` | 5172.3 ms | 287.2 ms | -4885.1 ms | **18.0x faster** |
| `cxas delete --help` | 5024.6 ms | 298.8 ms | -4725.8 ms | **16.8x faster** |
| `cxas deployments create --help` | 5111.1 ms | 294.2 ms | -4816.9 ms | **17.4x faster** |
| `cxas deployments list --help` | 5170.1 ms | 302.9 ms | -4867.2 ms | **17.1x faster** |
| `cxas deployments promote --help` | 5097.9 ms | 301.9 ms | -4796.0 ms | **16.9x faster** |
| `cxas evals report --help` | 4955.0 ms | 298.4 ms | -4656.6 ms | **16.6x faster** |
| `cxas export --help` | 5274.3 ms | 297.4 ms | -4976.9 ms | **17.7x faster** |
| `cxas help --help` | 5010.0 ms | 300.6 ms | -4709.4 ms | **16.7x faster** |
| `cxas init --help` | 5127.6 ms | 309.2 ms | -4818.4 ms | **16.6x faster** |
| `cxas init-github-action --help` | 5171.8 ms | 305.5 ms | -4866.3 ms | **16.9x faster** |
| `cxas insights activate-analysis-rule --help` | 5134.5 ms | 309.1 ms | -4825.4 ms | **16.6x faster** |
| `cxas insights activate-scorecard --help` | 5046.8 ms | 311.4 ms | -4735.4 ms | **16.2x faster** |
| `cxas insights add-question --help` | 5137.9 ms | 313.8 ms | -4824.1 ms | **16.4x faster** |
| `cxas insights analyze-metrics --help` | 5055.3 ms | 310.1 ms | -4745.2 ms | **16.3x faster** |
| `cxas insights copy-scorecard --help` | 5115.8 ms | 317.2 ms | -4798.6 ms | **16.1x faster** |
| `cxas insights create-analysis-rule --help` | 5180.7 ms | 299.1 ms | -4881.6 ms | **17.3x faster** |
| `cxas insights create-scorecard --help` | 5052.7 ms | 293.1 ms | -4759.6 ms | **17.2x faster** |
| `cxas insights create-topic-model --help` | 4929.8 ms | 289.0 ms | -4640.8 ms | **17.1x faster** |
| `cxas insights delete-analysis-rule --help` | 4878.9 ms | 289.4 ms | -4589.5 ms | **16.9x faster** |
| `cxas insights deploy-scorecard --help` | 4821.2 ms | 276.1 ms | -4545.0 ms | **17.5x faster** |
| `cxas insights deploy-topic-model --help` | 4933.6 ms | 279.2 ms | -4654.4 ms | **17.7x faster** |
| `cxas insights export-scorecard-from-insights --help` | 4944.6 ms | 287.8 ms | -4656.8 ms | **17.2x faster** |
| `cxas insights get-analysis-rule --help` | 4942.0 ms | 298.1 ms | -4643.9 ms | **16.6x faster** |
| `cxas insights get-topic-model --help` | 4947.3 ms | 280.7 ms | -4666.6 ms | **17.6x faster** |
| `cxas insights import-scorecard-to-insights --help` | 4905.9 ms | 293.5 ms | -4612.4 ms | **16.7x faster** |
| `cxas insights list-analysis-rules --help` | 4927.7 ms | 295.5 ms | -4632.2 ms | **16.7x faster** |
| `cxas insights list-scorecards --help` | 5002.2 ms | 295.6 ms | -4706.6 ms | **16.9x faster** |
| `cxas insights list-topic-models --help` | 4924.6 ms | 292.5 ms | -4632.0 ms | **16.8x faster** |
| `cxas insights list-topics --help` | 4842.1 ms | 304.4 ms | -4537.7 ms | **15.9x faster** |
| `cxas insights smoke-test-scorecard --help` | 4778.8 ms | 289.3 ms | -4489.6 ms | **16.5x faster** |
| `cxas insights undeploy-topic-model --help` | 5013.1 ms | 286.9 ms | -4726.2 ms | **17.5x faster** |
| `cxas insights validate-scorecard --help` | 4978.7 ms | 288.3 ms | -4690.4 ms | **17.3x faster** |
| `cxas lint --help` | 4957.8 ms | 287.8 ms | -4670.0 ms | **17.2x faster** |
| `cxas llm-lint --help` | 4787.2 ms | 284.5 ms | -4502.7 ms | **16.8x faster** |
| `cxas local create agent --help` | 4961.7 ms | 288.1 ms | -4673.6 ms | **17.2x faster** |
| `cxas local create guardrail --help` | 5100.5 ms | 287.7 ms | -4812.8 ms | **17.7x faster** |
| `cxas local create tool --help` | 4895.3 ms | 269.8 ms | -4625.5 ms | **18.1x faster** |
| `cxas local-test --help` | 4962.8 ms | 285.0 ms | -4677.8 ms | **17.4x faster** |
| `cxas migrate dfcx --help` | 5128.5 ms | 288.6 ms | -4839.9 ms | **17.8x faster** |
| `cxas pull --help` | 4923.0 ms | 278.2 ms | -4644.8 ms | **17.7x faster** |
| `cxas push --help` | 4920.1 ms | 280.1 ms | -4640.0 ms | **17.6x faster** |
| `cxas push-eval --help` | 4797.1 ms | 288.8 ms | -4508.3 ms | **16.6x faster** |
| `cxas run --help` | 4891.4 ms | 287.3 ms | -4604.1 ms | **17.0x faster** |
| `cxas run-session --help` | 4871.0 ms | 293.5 ms | -4577.5 ms | **16.6x faster** |
| `cxas test-callbacks --help` | 4888.3 ms | 293.4 ms | -4594.9 ms | **16.7x faster** |
| `cxas test-single-callback --help` | 5056.7 ms | 291.7 ms | -4765.0 ms | **17.3x faster** |
| `cxas test-tools --help` | 4894.4 ms | 286.4 ms | -4608.0 ms | **17.1x faster** |
| `cxas tools delete --help` | 4895.7 ms | 296.6 ms | -4599.1 ms | **16.5x faster** |
| `cxas tools list --help` | 4711.2 ms | 290.8 ms | -4420.5 ms | **16.2x faster** |
| `cxas trace audio analyze --help` | 4918.9 ms | 287.7 ms | -4631.2 ms | **17.1x faster** |
| `cxas trace audio download --help` | 4751.8 ms | 286.9 ms | -4464.9 ms | **16.6x faster** |
| `cxas trace bug-report --help` | 5023.0 ms | 279.7 ms | -4743.4 ms | **18.0x faster** |
| `cxas trace bundle --help` | 4853.7 ms | 283.4 ms | -4570.2 ms | **17.1x faster** |
| `cxas trace get --help` | 4827.6 ms | 311.1 ms | -4516.5 ms | **15.5x faster** |
| `cxas trace list --help` | 5066.2 ms | 324.0 ms | -4742.2 ms | **15.6x faster** |
| `cxas trace logs --help` | 4759.1 ms | 266.8 ms | -4492.2 ms | **17.8x faster** |
| `cxas trace open --help` | 4946.0 ms | 295.5 ms | -4650.5 ms | **16.7x faster** |
| `cxas trace replay --help` | 4806.1 ms | 304.8 ms | -4501.3 ms | **15.8x faster** |
| `cxas trace search --help` | 4884.6 ms | 303.7 ms | -4580.9 ms | **16.1x faster** |
| `cxas trace stats --help` | 4929.3 ms | 304.9 ms | -4624.4 ms | **16.2x faster** |
| `cxas trace triage --help` | 4883.1 ms | 306.8 ms | -4576.3 ms | **15.9x faster** |
| `cxas variables delete --help` | 4904.1 ms | 299.4 ms | -4604.7 ms | **16.4x faster** |
| `cxas variables list --help` | 4942.3 ms | 293.6 ms | -4648.7 ms | **16.8x faster** |
| `cxas versions compare --help` | 4894.2 ms | 293.8 ms | -4600.4 ms | **16.7x faster** |
| `cxas versions list --help` | 4235.2 ms | 219.2 ms | -4016.1 ms | **19.3x faster** |
| **AVERAGE (All 73 Subcommands)** | **4951.3 ms** | **295.3 ms** | **-4656.0 ms** | **16.8x faster** |

