### PR TITLE
fix(test): hermetic bidi session mocks & PyType signature compatibility

### DIFF
--- a/src/cxas_scrapi/core/sessions.py
+++ b/src/cxas_scrapi/core/sessions.py
@@ -301,7 +301,7 @@ class BidiSessionHandler:
         self,
         location: str,
         token: str,
-        config: dict[str, Any],
+        config: dict[str, Any] | types.SessionConfig,
         inputs: list[dict[str, Any]] | None = None,
         input_queue: queue.Queue | None = None,
         response_queue: queue.Queue | None = None,
@@ -380,6 +380,11 @@ class BidiSessionHandler:
                 logging.warning(
                     f"Failed to load continuous background noise file: {ex}"
                 )
+
+    def _get_config_val(self, key: str, default: Any = None) -> Any:
+        if isinstance(self.config, dict):
+            return self.config.get(key, default)
+        return getattr(self.config, key, default)
 
     def _get_next_noise_chunk(self, duration_ms: int) -> bytes:
         """Extracts the next chunk of continuous background noise PCM bytes."""
@@ -517,15 +522,26 @@ class BidiSessionHandler:
     def _send_inputs(self):
         try:
             logging.debug("Config dict: %s", self.config)
-            config_message = types.BidiSessionClientMessage(
-                config=types.SessionConfig(
-                    session=self.config["session"],
-                    input_audio_config=self.config.get("input_audio_config"),
-                    output_audio_config=self.config.get("output_audio_config"),
-                    use_tool_fakes=self.config.get("use_tool_fakes", False),
-                    historical_contexts=self.config.get("historical_contexts"),
+            if isinstance(self.config, types.SessionConfig):
+                config_message = types.BidiSessionClientMessage(
+                    config=self.config
                 )
-            )
+            else:
+                config_message = types.BidiSessionClientMessage(
+                    config=types.SessionConfig(
+                        session=self.config.get("session"),
+                        input_audio_config=self.config.get(
+                            "input_audio_config"
+                        ),
+                        output_audio_config=self.config.get(
+                            "output_audio_config"
+                        ),
+                        use_tool_fakes=self.config.get("use_tool_fakes", False),
+                        historical_contexts=self.config.get(
+                            "historical_contexts"
+                        ),
+                    )
+                )
             config_json = json_format.MessageToJson(
                 config_message._pb,
                 preserving_proto_field_name=False,
@@ -624,9 +640,9 @@ class BidiSessionHandler:
             self.current_agent_turn_idx += 1
 
         if buffer_copy and self.capture_agent_audio:
-            session_name = self.config.get("session", "")
+            session_name = str(self._get_config_val("session", "") or "")
             session_id = (
-                session_name.split("/sessions/")[-1]
+                session_name.rsplit("/sessions/", maxsplit=1)[-1]
                 if "/sessions/" in session_name
                 else str(uuid.uuid4())
             )
@@ -751,9 +767,11 @@ class BidiSessionHandler:
                         self.current_agent_turn_idx, b""
                     )
                     if buffer and self.capture_agent_audio:
-                        session_name = self.config.get("session", "")
+                        session_name = str(
+                            self._get_config_val("session", "") or ""
+                        )
                         session_id = (
-                            session_name.split("/sessions/")[-1]
+                            session_name.rsplit("/sessions/", maxsplit=1)[-1]
                             if "/sessions/" in session_name
                             else str(uuid.uuid4())
                         )
@@ -1004,7 +1022,7 @@ class BidiInteractiveSession:
         self,
         sessions_client: Any,
         session_id: str,
-        config: dict[str, Any],
+        config: dict[str, Any] | types.SessionConfig,
         capture_agent_audio: bool = False,
         background_noise_file: str | None = None,
         bg_noise_snr: float = 15.0,
@@ -1462,6 +1480,7 @@ class Sessions(Common):
     def create_interactive_session(
         self,
         session_id: str,
+        deployment_id: str | None = None,
         capture_agent_audio: bool = False,
         background_noise_file: str | None = None,
         bg_noise_snr: float = 15.0,
@@ -1495,6 +1514,9 @@ class Sessions(Common):
                 sample_rate_hertz=SAMPLE_RATE,
             ),
         }
+        dep_id = deployment_id or self.deployment_id
+        if dep_id:
+            config["deployment"] = f"{self.app_name}/deployments/{dep_id}"
 
         return BidiInteractiveSession(
             sessions_client=self,

--- a/tests/cxas_scrapi/core/test_sessions.py
+++ b/tests/cxas_scrapi/core/test_sessions.py
@@ -24,6 +24,7 @@ from google.protobuf import json_format
 
 from cxas_scrapi.core.sessions import (
     AgentTurnManager,
+    BidiInteractiveSession,
     BidiSessionHandler,
     Modality,
     Sessions,
@@ -925,3 +926,183 @@ def test_bidi_session_handler_pydub_missing_raises_error():
         assert "pydub is not installed or failed to import" in str(
             exc_info.value
         )
+
+
+@patch("cxas_scrapi.core.sessions.websocket.WebSocketApp")
+@patch("cxas_scrapi.core.sessions.threading.Thread")
+@patch("cxas_scrapi.core.sessions.time.sleep")
+def test_bidi_interactive_session_start_and_close(
+    mock_sleep, mock_thread, mock_ws_app
+):
+    """Test starting and closing a BidiInteractiveSession hermetically."""
+    mock_sessions_client = MagicMock()
+    mock_sessions_client.location = "us"
+    mock_sessions_client.token = "fake_token"
+
+    config = {"session": "projects/p/locations/us/apps/a/sessions/s1"}
+    session = BidiInteractiveSession(
+        sessions_client=mock_sessions_client,
+        session_id="s1",
+        config=config,
+    )
+
+    session.start()
+    assert session.wst is not None
+    mock_thread.assert_called_once()
+
+    session.close()
+    assert session.input_queue.get() is None
+
+
+@patch("cxas_scrapi.core.sessions.AudioTransformer")
+@patch("cxas_scrapi.core.sessions.websocket.WebSocketApp")
+@patch("cxas_scrapi.core.sessions.threading.Thread")
+@patch("cxas_scrapi.core.sessions.time.sleep")
+def test_bidi_interactive_session_send_turn(
+    mock_sleep, mock_thread, mock_ws_app, mock_audio_transformer_cls
+):
+    """Test send_turn on BidiInteractiveSession."""
+    mock_transformer = mock_audio_transformer_cls.return_value
+    mock_transformer.text_to_speech_bytes.return_value = {
+        "audio_bytes": b"fake_audio",
+        "text": "Hello",
+    }
+
+    mock_sessions_client = MagicMock()
+    mock_sessions_client.location = "us"
+    mock_sessions_client.token = "fake_token"
+    mock_sessions_client.rate_limiter = None
+    mock_sessions_client.creds = MagicMock()
+    mock_sessions_client.project_id = "p"
+
+    config = {"session": "projects/p/locations/us/apps/a/sessions/s1"}
+    session = BidiInteractiveSession(
+        sessions_client=mock_sessions_client,
+        session_id="s1",
+        config=config,
+    )
+
+    mock_response = MagicMock()
+    session.response_queue.put(mock_response)
+
+    res = session.send_turn("Hello")
+    assert res == mock_response
+
+    item = session.input_queue.get()
+    assert item["audio"]["text"] == "Hello"
+
+
+@patch("cxas_scrapi.core.sessions.AudioTransformer")
+@patch("cxas_scrapi.core.sessions.websocket.WebSocketApp")
+@patch("cxas_scrapi.core.sessions.threading.Thread")
+@patch("cxas_scrapi.core.sessions.time.sleep")
+def test_bidi_interactive_session_send_turn_event(
+    mock_sleep, mock_thread, mock_ws_app, mock_audio_transformer_cls
+):
+    """Test send_turn with event on BidiInteractiveSession."""
+    mock_sessions_client = MagicMock()
+    mock_sessions_client.location = "us"
+    mock_sessions_client.token = "fake_token"
+    mock_sessions_client.rate_limiter = None
+
+    config = {"session": "projects/p/locations/us/apps/a/sessions/s1"}
+    session = BidiInteractiveSession(
+        sessions_client=mock_sessions_client,
+        session_id="s1",
+        config=config,
+    )
+
+    mock_response = MagicMock()
+    session.response_queue.put(mock_response)
+
+    res = session.send_turn("event:WELCOME", variables={"var1": "val1"})
+    assert res == mock_response
+
+    var_item = session.input_queue.get()
+    assert var_item == {"variables": {"var1": "val1"}}
+
+    event_item = session.input_queue.get()
+    assert event_item == {"event": {"event": "WELCOME"}}
+
+
+@patch("cxas_scrapi.core.sessions.AudioTransformer")
+@patch("cxas_scrapi.core.sessions.websocket.WebSocketApp")
+@patch("cxas_scrapi.core.sessions.threading.Thread")
+@patch("cxas_scrapi.core.sessions.time.sleep")
+def test_bidi_session_timeout(
+    mock_sleep, mock_thread, mock_ws_app, mock_audio_transformer_cls
+):
+    """Test TimeoutError when response_queue times out in
+    BidiInteractiveSession.
+    """
+    mock_transformer = mock_audio_transformer_cls.return_value
+    mock_transformer.text_to_speech_bytes.return_value = {
+        "audio_bytes": b"fake_audio",
+        "text": "Hello",
+    }
+
+    mock_sessions_client = MagicMock()
+    mock_sessions_client.location = "us"
+    mock_sessions_client.token = "fake_token"
+    mock_sessions_client.rate_limiter = None
+    mock_sessions_client.creds = MagicMock()
+    mock_sessions_client.project_id = "p"
+
+    config = {"session": "projects/p/locations/us/apps/a/sessions/s1"}
+    session = BidiInteractiveSession(
+        sessions_client=mock_sessions_client,
+        session_id="s1",
+        config=config,
+    )
+
+    with patch.object(session.response_queue, "get", side_effect=queue.Empty):
+        with pytest.raises(TimeoutError) as exc_info:
+            session.send_turn("Hello")
+        assert "Timeout waiting for agent response via WebSocket" in str(
+            exc_info.value
+        )
+
+
+@patch("cxas_scrapi.core.sessions.Sessions._check_audio_requirements")
+@patch("cxas_scrapi.core.sessions.SessionServiceClient")
+def test_create_interactive_session(mock_client_cls, mock_check_reqs):
+    """Test Sessions.create_interactive_session."""
+    sessions = Sessions(
+        app_name="projects/p/locations/l/apps/a", deployment_id="d1"
+    )
+    interactive_session = sessions.create_interactive_session(
+        session_id="s1",
+        capture_agent_audio=True,
+    )
+    assert isinstance(interactive_session, BidiInteractiveSession)
+    assert interactive_session.session_id == "s1"
+    assert interactive_session.capture_agent_audio is True
+    assert (
+        interactive_session.config["deployment"]
+        == "projects/p/locations/l/apps/a/deployments/d1"
+    )
+
+
+@patch("cxas_scrapi.core.sessions.time.sleep")
+@patch("cxas_scrapi.core.sessions.json_format.MessageToJson")
+def test_bidi_session_handler_with_proto_session_config(
+    mock_message_to_json, mock_sleep
+):
+    """Test BidiSessionHandler when config is a types.SessionConfig proto
+    instance.
+    """
+    mock_message_to_json.return_value = "{}"
+
+    proto_config = types.SessionConfig(
+        session="projects/p/locations/us/apps/a/sessions/s1",
+        use_tool_fakes=True,
+    )
+
+    handler = BidiSessionHandler(
+        location="us", token="fake", config=proto_config, inputs=[]
+    )
+    handler.ws_app = MagicMock()
+
+    handler._send_inputs()
+
+    assert mock_message_to_json.call_count >= 1

--- a/uv.lock
+++ b/uv.lock
@@ -610,7 +610,7 @@ wheels = [
 
 [[package]]
 name = "cxas-scrapi"
-version = "1.6.0"
+version = "1.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "absl-py" },


### PR DESCRIPTION
- Add hermetic mocks for socket, threads, and timers in BidiInteractiveSession and BidiSessionHandler tests.
- Support both dict and google.cloud.ces_v1beta.types.SessionConfig in BidiSessionHandler and BidiInteractiveSession config.
- Update CLI type annotations in cli/main.py and cli/migration_cli.py for SessionConfig compatibility.