### PR TITLE
fix(migration): runtime NameError (DFCXFlowModel is not defined) when cxas CLI initializes

### DIFF
--- a/src/cxas_scrapi/migration/service.py
+++ b/src/cxas_scrapi/migration/service.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import asyncio
 import io
 import json

--- a/src/cxas_scrapi/migration/service.py
+++ b/src/cxas_scrapi/migration/service.py
@@ -208,7 +208,7 @@ class MigrationService:
         self,
         target_name: str | None,
         *,
-        bundle: "IRBundle | None" = None,
+        bundle: IRBundle | None = None,
         output_dir: str | None = None,
     ) -> MigrationAnalysisBuilder | None:
         """Create the analysis builder on first use; cheap no-op afterwards.
@@ -274,7 +274,7 @@ class MigrationService:
         *,
         project_id: str | None = None,
         location: str | None = None,
-    ) -> "MigrationService":
+    ) -> MigrationService:
         """Recreate a `MigrationService` from a persisted :class:`IRBundle`.
 
         Used by stage_1 / stage_2 / stage_3 to resume work against an already
@@ -350,7 +350,7 @@ class MigrationService:
     async def run_stage_1(
         self,
         *,
-        bundle: "IRBundle | None" = None,
+        bundle: IRBundle | None = None,
         gemini_client: GeminiGenerate | None = None,
         grouping_callback: Callable[..., Awaitable[dict | None]] | None = None,
         grouping_json_path: str | None = None,
@@ -521,7 +521,7 @@ class MigrationService:
     async def _run_stage_1_consolidation(
         self,
         *,
-        bundle: "IRBundle",
+        bundle: IRBundle,
         gemini: GeminiGenerate,
         grouping_callback: (
             Callable[[MigrationIR, dict], Awaitable[dict | None]] | None
@@ -701,7 +701,7 @@ class MigrationService:
         unit_tests_path: str | None = None,
         run_lint: bool = False,
         write_report_to: str | None = None,
-        bundle: "IRBundle | None" = None,
+        bundle: IRBundle | None = None,
         persist_bundle_path: str | None = None,
         console: Console | None = None,
     ) -> None:
@@ -851,7 +851,7 @@ class MigrationService:
     async def run_stage_3(
         self,
         *,
-        bundle: "IRBundle",
+        bundle: IRBundle,
         mode: str = "hub",
         version_label: str | None = "0.0.5",
         persist_bundle_path: str | None = None,
@@ -956,7 +956,7 @@ class MigrationService:
 
     def persist_bundle(
         self,
-        bundle: "IRBundle",
+        bundle: IRBundle,
         path: str,
         *,
         phase: str | None = None,


### PR DESCRIPTION
Add future annotations import to migration/service.py to prevent NameError in g3

Because the import for DFCXFlowModel is injected inside an `if TYPE_CHECKING:` block, it is evaluated strictly at runtime on module load and causes a crash in g3.

Tests run:
- `cxas --help` works in g3 when `from __future__ import annotations` is added
- `from cxas_scrapi.migration.service import MigrationService` works
- `pytest tests/cxas_scrapi/migration/test_service.py` passes all 23 tests