### PR TITLE
fix(reporting): render agent responses unmatched to a golden expectation

### DIFF
--- a/src/cxas_scrapi/utils/reporting.py
+++ b/src/cxas_scrapi/utils/reporting.py
@@ -57,6 +57,22 @@ def _fmt_duration(seconds):
     return f"{seconds:.1f}s"
 
 
+def _join_chunk_text(chunks):
+    """Join the text of every chunk in an agent response.
+
+    A single agent turn can be emitted as multiple chunks (e.g. a short
+    filler said before a tool call, then the substantive answer after the
+    tool returns). Rendering only the first chunk makes the turn look
+    truncated even though the platform stored — and the scorer evaluated —
+    the full response. Concatenate all chunk texts so the report matches.
+    """
+    if not chunks:
+        return ""
+    return " ".join(
+        text for c in chunks if (text := (c.get("text") or "").strip())
+    )
+
+
 def _resolve_tool_name(raw_name, tools_map):
     """Resolve a full resource path to a display name."""
     if not raw_name:
@@ -1172,6 +1188,82 @@ def _compile_callback_results_card(
     )
 
 
+def _build_turn_comparisons(turn):
+    """Build the expected/actual comparison rows for one replayed turn.
+
+    Each ``expectation_outcome`` entry pairs an expected element with what was
+    observed. An entry can also carry an *observed* agent response with no
+    expectation at all: this happens when the agent says more than the golden
+    modeled -- e.g. a short filler said before a tool call is matched to the
+    expected reply, and the substantive answer produced after the tool returns
+    is left unmatched. Those observed-only responses must still be rendered,
+    otherwise the report looks like the agent never said them even though the
+    platform recorded and the scorer evaluated the full turn.
+    """
+    comparisons = []
+    for o in turn.get("expectation_outcome", []):
+        exp = o.get("expectation", {})
+        comp = {"outcome": _outcome_str(o.get("outcome"))}
+
+        if "agent_response" in exp:
+            comp["type"] = "text"
+            comp["expected"] = _join_chunk_text(
+                exp["agent_response"].get("chunks", [])
+            )
+            obs = o.get("observed_agent_response", {})
+            comp["actual"] = (
+                _join_chunk_text(obs.get("chunks", [])) if obs else "(missed)"
+            )
+        elif "tool_call" in exp:
+            tc = exp["tool_call"]
+            comp["type"] = "tool_call"
+            comp["expected"] = (
+                tc.get("display_name") or tc.get("tool", "").split("/")[-1]
+            )
+            comp["expected_args"] = tc.get("args", {})
+            obs = o.get("observed_tool_call", {})
+            comp["actual"] = (
+                (obs.get("display_name") or obs.get("tool", "").split("/")[-1])
+                if obs
+                else "(missed)"
+            )
+            comp["actual_args"] = obs.get("args", {}) if obs else {}
+            tir = o.get("toolInvocationResult", {})
+            comp["tool_invocation_score"] = tir.get("parameterCorrectnessScore")
+            comp["tool_invocation_explanation"] = tir.get("explanation")
+        elif "agent_transfer" in exp:
+            at = exp["agent_transfer"]
+            comp["type"] = "transfer"
+            comp["expected"] = at.get(
+                "display_name", at.get("target_agent", "").split("/")[-1]
+            )
+            obs = o.get("observed_agent_transfer", {})
+            comp["actual"] = (
+                obs.get(
+                    "display_name",
+                    obs.get("target_agent", "").split("/")[-1],
+                )
+                if obs
+                else "(missed)"
+            )
+        elif "tool_response" in exp:
+            continue
+        elif o.get("observed_agent_response"):
+            # Observed agent utterance with no matching expected element --
+            # the agent said more than the golden turn modeled. Surface it so
+            # the turn's full agent output is visible instead of dropped.
+            comp["type"] = "text"
+            comp["expected"] = "(none)"
+            comp["actual"] = _join_chunk_text(
+                o["observed_agent_response"].get("chunks", [])
+            )
+        else:
+            continue
+
+        comparisons.append(comp)
+    return comparisons
+
+
 def load_golden_results(
     run_id: str, app_name: str, include: list[str] | None = None
 ) -> list[dict[str, Any]]:
@@ -1240,67 +1332,7 @@ def load_golden_results(
                 "semantic_explanation": sem.get("explanation"),
                 "comparisons": [],
             }
-            for o in turn.get("expectation_outcome", []):
-                exp = o.get("expectation", {})
-                outcome = _outcome_str(o.get("outcome"))
-                comp = {"outcome": outcome}
-
-                if "agent_response" in exp:
-                    chunks = exp["agent_response"].get("chunks", [])
-                    comp["type"] = "text"
-                    comp["expected"] = (
-                        chunks[0].get("text", "") if chunks else ""
-                    )
-                    obs = o.get("observed_agent_response", {})
-                    comp["actual"] = (
-                        obs.get("chunks", [{}])[0].get("text", "")
-                        if obs
-                        else "(missed)"
-                    )
-                elif "tool_call" in exp:
-                    tc = exp["tool_call"]
-                    comp["type"] = "tool_call"
-                    comp["expected"] = (
-                        tc.get("display_name")
-                        or tc.get("tool", "").split("/")[-1]
-                    )
-                    comp["expected_args"] = tc.get("args", {})
-                    obs = o.get("observed_tool_call", {})
-                    comp["actual"] = (
-                        (
-                            obs.get("display_name")
-                            or obs.get("tool", "").split("/")[-1]
-                        )
-                        if obs
-                        else "(missed)"
-                    )
-                    comp["actual_args"] = obs.get("args", {}) if obs else {}
-                    tir = o.get("toolInvocationResult", {})
-                    comp["tool_invocation_score"] = tir.get(
-                        "parameterCorrectnessScore"
-                    )
-                    comp["tool_invocation_explanation"] = tir.get("explanation")
-                elif "tool_response" in exp:
-                    continue
-                elif "agent_transfer" in exp:
-                    at = exp["agent_transfer"]
-                    comp["type"] = "transfer"
-                    comp["expected"] = at.get(
-                        "display_name",
-                        at.get("target_agent", "").split("/")[-1],
-                    )
-                    obs = o.get("observed_agent_transfer", {})
-                    if obs:
-                        comp["actual"] = obs.get(
-                            "display_name",
-                            obs.get("target_agent", "").split("/")[-1],
-                        )
-                    else:
-                        comp["actual"] = "(missed)"
-                else:
-                    continue
-
-                turn_data["comparisons"].append(comp)
+            turn_data["comparisons"] = _build_turn_comparisons(turn)
             turns.append(turn_data)
 
         expectations = []

--- a/tests/cxas_scrapi/utils/test_reporting.py
+++ b/tests/cxas_scrapi/utils/test_reporting.py
@@ -28,9 +28,11 @@ from cxas_scrapi.utils.eval_utils import (
     add_timestamp_suffix,
 )
 from cxas_scrapi.utils.reporting import (
+    _build_turn_comparisons,
     _escape,
     _fmt_duration,
     _format_trace_line,
+    _join_chunk_text,
     _load_sim_test_cases,
     _resolve_tool_name,
     _upload_to_gcs,
@@ -189,6 +191,83 @@ def test_fmt_duration():
 
 def test_escape():
     assert _escape('<script>&"') == "&lt;script&gt;&amp;&quot;"
+
+
+def test_join_chunk_text():
+    # Multi-chunk turn (filler said before a tool call, then the answer
+    # after it returns) must render every chunk, not just the first.
+    assert _join_chunk_text(
+        [
+            {"text": "Thanks, Diane. Checking that now."},
+            {"text": "You're verified. The amount due is $4,120.80."},
+        ]
+    ) == (
+        "Thanks, Diane. Checking that now. "
+        "You're verified. The amount due is $4,120.80."
+    )
+    # Single chunk is unchanged.
+    assert _join_chunk_text([{"text": "hello"}]) == "hello"
+    # Empty / missing input.
+    assert _join_chunk_text([]) == ""
+    assert _join_chunk_text(None) == ""
+    # Blank and text-less chunks are skipped, not rendered as gaps.
+    assert _join_chunk_text([{"text": "  "}, {}, {"text": "kept"}]) == "kept"
+    assert _join_chunk_text([{"text": None}]) == ""
+
+
+def test_build_turn_comparisons_renders_unmatched_observed_response():
+    # Real shape of a turn where the agent emitted a filler before a tool
+    # call and the substantive answer after it. The platform matches the
+    # filler to the expected reply (entry 0) and records the substantive
+    # answer as an observed response with NO expectation (entry 3). The
+    # renderer must surface both, not drop the unmatched one.
+    turn = {
+        "expectation_outcome": [
+            {
+                "expectation": {
+                    "agent_response": {
+                        "chunks": [
+                            {"text": "Thanks. Checking now. You're set."}
+                        ]
+                    }
+                },
+                "observed_agent_response": {
+                    "chunks": [{"text": "Thanks. Checking now."}]
+                },
+                "outcome": 2,
+            },
+            {
+                "expectation": {
+                    "tool_call": {"display_name": "verify_caller", "args": {}}
+                },
+                "observed_tool_call": {"display_name": "verify_caller"},
+                "outcome": 1,
+            },
+            {
+                "expectation": {"tool_response": {}},
+                "outcome": 1,
+            },
+            {
+                "observed_agent_response": {
+                    "chunks": [{"text": "You're verified. $4,120.80 is due."}]
+                },
+                "outcome": 0,
+            },
+        ]
+    }
+
+    comps = _build_turn_comparisons(turn)
+
+    # tool_response entry is skipped; the other three render.
+    assert len(comps) == 3
+    assert comps[0]["type"] == "text"
+    assert comps[0]["actual"] == "Thanks. Checking now."
+    assert comps[1]["type"] == "tool_call"
+    assert comps[1]["actual"] == "verify_caller"
+    # The unmatched observed answer is surfaced, not dropped.
+    assert comps[2]["type"] == "text"
+    assert comps[2]["expected"] == "(none)"
+    assert comps[2]["actual"] == "You're verified. $4,120.80 is due."
 
 
 def test_resolve_tool_name():


### PR DESCRIPTION
## Summary

A golden turn's `expectation_outcome` list can contain an entry that carries an **observed agent response with no `expectation` at all**. This happens when the agent says **more than the golden modeled** — for example it emits a short filler *before* a tool call ("Checking that now."), which the platform matches to the turn's expected reply, and then the substantive answer *after* the tool returns, which is left **unmatched**.

The turn renderer in `load_golden_results` (`utils/reporting.py`) only produced a comparison row for entries whose `expectation` had a recognized key (`agent_response` / `tool_call` / `tool_response` / `agent_transfer`). An unmatched observed response has an **empty** expectation, so it fell through `else: continue` and was **silently dropped**. The `Actual:` cell for the turn then showed only the filler, which:

- contradicted the platform Console (which shows both agent messages), and
- contradicted the turn's own semantic-similarity score, which was computed on the **full** response.

Net effect: a turn where the agent gave the right answer but omitted one detail rendered as if the agent had said nothing but the filler.

## What changed

- Extract the per-turn comparison building out of `load_golden_results` into a testable module-level helper **`_build_turn_comparisons(turn)`** (no behavior change for the existing branches).
- Add a branch that renders an **observed agent response with no matching expectation** (expected shown as `"(none)"`) instead of dropping it.
- Add **`_join_chunk_text()`** so a multi-chunk agent response renders in full rather than only its first chunk (defensive; the same helper is reused by both text branches).

Display-only: no scoring, parsing, or data-collection behavior changes.

## Before / after

For a turn where the agent said `"Thanks. Checking now."` (filler, matched) then `"You're verified. $4,120.80 is due."` (unmatched observed):

- **Before:** the turn showed only `Actual: Thanks. Checking now.`
- **After:** the turn additionally shows a row `Expected: (none) | Actual: You're verified. $4,120.80 is due.`

Verified against a real evaluation run: the previously dropped verified answer (with the balance) now renders.

## Testing

- `test_build_turn_comparisons_renders_unmatched_observed_response` — asserts the unmatched observed answer is rendered and the `tool_response` entry is still skipped.
- `test_join_chunk_text` — multi-chunk join, single chunk, empty/`None`, blank/text-less chunks skipped.
- `uv run pytest tests/cxas_scrapi/utils/test_reporting.py` → **43 passed**.
- `uv run ruff format` / `ruff check` on both changed files → clean.
