### PR TITLE
feat(cli): expose --single-bidi-stream flag to evals report CLI

### DIFF
--- a/src/cxas_scrapi/cli/main.py
+++ b/src/cxas_scrapi/cli/main.py
@@ -664,6 +664,7 @@ def combined_evals_report_cmd(args: argparse.Namespace) -> None:
         deployment_id=getattr(args, "deployment_id", None),
         progress_callback=progress_callback,
         capture_agent_audio=getattr(args, "capture_agent_audio", False),
+        single_bidi_stream=getattr(args, "single_bidi_stream", False),
         report_format=getattr(args, "format", "html") or "html",
     )
     print(f"Combined report generated at {actual_output_path}")
@@ -1846,6 +1847,11 @@ def get_parser() -> argparse.ArgumentParser:
         "--capture-agent-audio",
         action="store_true",
         help="Capture real-time agent output audio as WAV files",
+    )
+    parser_report.add_argument(
+        "--single-bidi-stream",
+        action="store_true",
+        help="Keep one persistent bidi WebSocket open per audio simulation instead of one connection per turn.",
     )
     parser_report.set_defaults(func=combined_evals_report_cmd)
 

--- a/tests/cxas_scrapi/cli/test_cli_reporting.py
+++ b/tests/cxas_scrapi/cli/test_cli_reporting.py
@@ -99,6 +99,7 @@ def test_combined_evals_report_cmd(tmp_path: typing.Any) -> None:
             deployment_id=None,
             progress_callback=None,
             capture_agent_audio=False,
+            single_bidi_stream=False,
             report_format="html",
         )
 
@@ -164,6 +165,7 @@ def test_combined_evals_report_cmd_with_modality_and_runs(
             deployment_id=None,
             progress_callback=None,
             capture_agent_audio=False,
+            single_bidi_stream=False,
             report_format="html",
         )
 
@@ -234,6 +236,7 @@ def test_combined_evals_report_cmd_timestamped(
             deployment_id=None,
             progress_callback=None,
             capture_agent_audio=False,
+            single_bidi_stream=False,
             report_format="html",
         )
 


### PR DESCRIPTION
As we standardize on the `cxas report evals` command, we should bring through the improvements we make to the lower level scripts.

This fix will improve test infra reliability for large scale volume tests (>10 runs).