### PR TITLE
feat(evals): make vertex_location configurable in SimulationEvals and TurnEvals

### DIFF
--- a/docs/cli/trace.md
+++ b/docs/cli/trace.md
@@ -98,6 +98,7 @@ cloud_logging:
 
 gemini:
   model: gemini-2.5-flash
+  location: null                    # Optional: Vertex AI location (e.g. "europe-west4", "global"). Defaults to VERTEX_LOCATION env var or "global"
   # Audio analyses come from `cxas_scrapi.utils.audio_analysis.ANALYSIS_REGISTRY`
   # (5 built-ins: agent_voice_consistency, no_long_pauses,
   # agent_having_trouble, agent_looping, agent_cutoff). Each declares which

--- a/docs/guides/evaluation/local-simulations.md
+++ b/docs/guides/evaluation/local-simulations.md
@@ -95,8 +95,15 @@ from cxas_scrapi.evals.simulation_evals import SimulationEvals
 
 sim_evals = SimulationEvals(
     app_name="projects/my-project/locations/us/apps/my-app",
+    vertex_location="europe-west4",  # Optional: custom region for data residency
 )
 ```
+
+!!! note "Data Residency & Regional Vertex AI"
+    By default, Vertex AI calls for simulation generation use `"global"`. If your organization requires a specific region due to data residency policies (e.g. `europe-west4` or `us-central1`), pass `vertex_location="europe-west4"` to `SimulationEvals` or set the `VERTEX_LOCATION` environment variable:
+    ```bash
+    export VERTEX_LOCATION="europe-west4"
+    ```
 
 ### Running a single evaluation programmatically
 

--- a/docs/guides/evaluation/turn-evals.md
+++ b/docs/guides/evaluation/turn-evals.md
@@ -31,8 +31,15 @@ from cxas_scrapi.evals.turn_evals import TurnEvals
 
 turn_evals = TurnEvals(
     app_name="projects/my-project/locations/us/apps/my-app",
+    vertex_location="europe-west4",  # Optional: custom region for data residency
 )
 ```
+
+!!! note "Data Residency & Regional Vertex AI"
+    By default, Vertex AI calls use `"global"`. If your organization requires a specific region (e.g. `europe-west4` or `us-central1`), pass `vertex_location="europe-west4"` to `TurnEvals` or set the `VERTEX_LOCATION` environment variable:
+    ```bash
+    export VERTEX_LOCATION="europe-west4"
+    ```
 
 ---
 

--- a/src/cxas_scrapi/cli/migration_cli.py
+++ b/src/cxas_scrapi/cli/migration_cli.py
@@ -626,7 +626,9 @@ class MigrationCLI:
 
             migration_service = MigrationService(
                 project_id=config.project_id,
-                location="us",
+                location=config.location,
+                gemini_location=config.vertex_location
+                or os.getenv("VERTEX_LOCATION", "global"),
                 default_model=config.model,
             )
 

--- a/src/cxas_scrapi/cli/migration_cli.py
+++ b/src/cxas_scrapi/cli/migration_cli.py
@@ -627,8 +627,7 @@ class MigrationCLI:
             migration_service = MigrationService(
                 project_id=config.project_id,
                 location=config.location,
-                gemini_location=config.vertex_location
-                or os.getenv("VERTEX_LOCATION", "global"),
+                gemini_location=config.vertex_location,
                 default_model=config.model,
             )
 

--- a/src/cxas_scrapi/core/traces.py
+++ b/src/cxas_scrapi/core/traces.py
@@ -494,9 +494,14 @@ class Traces(Common):
         else:
             selected = list(ANALYSIS_REGISTRY.values())
 
+        vertex_location = (
+            self.trace_config.gemini.location
+            or os.getenv("VERTEX_LOCATION", "global")
+        )
         gem = GeminiGenerate(
             project_id=self.project_id,
             credentials=self.creds,
+            location=vertex_location,
             model_name=self.trace_config.gemini.model,
         )
         overrides = self.trace_config.gemini.audio_metrics
@@ -543,9 +548,14 @@ class Traces(Common):
         normalized = normalized or self.get_normalized(conversation_id)
         transcript = trace_report.to_text(normalized)
 
+        vertex_location = (
+            self.trace_config.gemini.location
+            or os.getenv("VERTEX_LOCATION", "global")
+        )
         gem = GeminiGenerate(
             project_id=self.project_id,
             credentials=self.creds,
+            location=vertex_location,
             model_name=self.trace_config.gemini.model,
         )
         all_metrics = self.trace_config.gemini.triage_metrics

--- a/src/cxas_scrapi/core/traces.py
+++ b/src/cxas_scrapi/core/traces.py
@@ -494,14 +494,10 @@ class Traces(Common):
         else:
             selected = list(ANALYSIS_REGISTRY.values())
 
-        vertex_location = (
-            self.trace_config.gemini.location
-            or os.getenv("VERTEX_LOCATION", "global")
-        )
         gem = GeminiGenerate(
             project_id=self.project_id,
             credentials=self.creds,
-            location=vertex_location,
+            location=self.trace_config.gemini.location,
             model_name=self.trace_config.gemini.model,
         )
         overrides = self.trace_config.gemini.audio_metrics
@@ -548,14 +544,10 @@ class Traces(Common):
         normalized = normalized or self.get_normalized(conversation_id)
         transcript = trace_report.to_text(normalized)
 
-        vertex_location = (
-            self.trace_config.gemini.location
-            or os.getenv("VERTEX_LOCATION", "global")
-        )
         gem = GeminiGenerate(
             project_id=self.project_id,
             credentials=self.creds,
-            location=vertex_location,
+            location=self.trace_config.gemini.location,
             model_name=self.trace_config.gemini.model,
         )
         all_metrics = self.trace_config.gemini.triage_metrics

--- a/src/cxas_scrapi/evals/simulation_evals.py
+++ b/src/cxas_scrapi/evals/simulation_evals.py
@@ -19,7 +19,6 @@ import enum
 import functools
 import inspect
 import json
-import os
 import re
 import shutil
 import time
@@ -433,15 +432,12 @@ class SimulationEvals(Apps):
 
         # Vertex AI requires a specific region (e.g. global), whereas CXAS
         # Apps use 'us' or 'eu'
-        self.vertex_location = vertex_location or os.getenv(
-            "VERTEX_LOCATION", "global"
-        )
-
         self.genai_client = GeminiGenerate(
             project_id=self.project_id,
-            location=self.vertex_location,
+            location=vertex_location,
             credentials=self.creds,
         )
+        self.vertex_location = self.genai_client.location
 
     def _parse_agent_response(
         self, response: Any

--- a/src/cxas_scrapi/evals/simulation_evals.py
+++ b/src/cxas_scrapi/evals/simulation_evals.py
@@ -415,7 +415,7 @@ class SimulationEvals(Apps):
             expectations_only: Whether to run expectations only
             deployment_id: Optional deployment ID
             vertex_location: Optional Vertex AI location (defaults to
-              VERTEX_LOCATION env var or 'global')
+                VERTEX_LOCATION env var or 'global')
         """
         self.app_name = app_name
         self.expectations_only = expectations_only

--- a/src/cxas_scrapi/evals/simulation_evals.py
+++ b/src/cxas_scrapi/evals/simulation_evals.py
@@ -404,7 +404,7 @@ class SimulationEvals(Apps):
         rate_limiter: RateLimiter | None = None,
         expectations_only: bool = False,
         deployment_id: str | None = None,
-        vertex_location: str | None = None,
+        vertex_location: str = "global",
         **kwargs: typing.Any,
     ) -> None:
         """Initializes the SimulationEvals client.
@@ -414,8 +414,7 @@ class SimulationEvals(Apps):
             rate_limiter: Optional RateLimiter for API calls
             expectations_only: Whether to run expectations only
             deployment_id: Optional deployment ID
-            vertex_location: Optional Vertex AI location (defaults to
-                VERTEX_LOCATION env var or 'global')
+            vertex_location: Optional Vertex AI location. Defaults to 'global'.
         """
         self.app_name = app_name
         self.expectations_only = expectations_only
@@ -437,7 +436,6 @@ class SimulationEvals(Apps):
             location=vertex_location,
             credentials=self.creds,
         )
-        self.vertex_location = self.genai_client.location
 
     def _parse_agent_response(
         self, response: Any

--- a/src/cxas_scrapi/evals/simulation_evals.py
+++ b/src/cxas_scrapi/evals/simulation_evals.py
@@ -408,6 +408,16 @@ class SimulationEvals(Apps):
         vertex_location: str | None = None,
         **kwargs: typing.Any,
     ) -> None:
+        """Initializes the SimulationEvals client.
+
+        Args:
+            app_name: CXAS App Name
+            rate_limiter: Optional RateLimiter for API calls
+            expectations_only: Whether to run expectations only
+            deployment_id: Optional deployment ID
+            vertex_location: Optional Vertex AI location (defaults to
+              VERTEX_LOCATION env var or 'global')
+        """
         self.app_name = app_name
         self.expectations_only = expectations_only
         project_id = app_name.split("/")[1]

--- a/src/cxas_scrapi/evals/simulation_evals.py
+++ b/src/cxas_scrapi/evals/simulation_evals.py
@@ -19,6 +19,7 @@ import enum
 import functools
 import inspect
 import json
+import os
 import re
 import shutil
 import time
@@ -404,6 +405,7 @@ class SimulationEvals(Apps):
         rate_limiter: RateLimiter | None = None,
         expectations_only: bool = False,
         deployment_id: str | None = None,
+        vertex_location: str | None = None,
         **kwargs: typing.Any,
     ) -> None:
         self.app_name = app_name
@@ -421,11 +423,13 @@ class SimulationEvals(Apps):
 
         # Vertex AI requires a specific region (e.g. global), whereas CXAS
         # Apps use 'us' or 'eu'
-        vertex_location = "global"
+        self.vertex_location = vertex_location or os.getenv(
+            "VERTEX_LOCATION", "global"
+        )
 
         self.genai_client = GeminiGenerate(
             project_id=self.project_id,
-            location=vertex_location,
+            location=self.vertex_location,
             credentials=self.creds,
         )
 

--- a/src/cxas_scrapi/evals/turn_evals.py
+++ b/src/cxas_scrapi/evals/turn_evals.py
@@ -152,15 +152,12 @@ class TurnEvals:
 
         # Initialize GenAI Client
         project_id = app_name.split("/")[1]
-        self.vertex_location = vertex_location or os.getenv(
-            "VERTEX_LOCATION", "global"
-        )
-
         self.genai_client = GeminiGenerate(
             project_id=project_id,
-            location=self.vertex_location,
+            location=vertex_location,
             credentials=self.creds,
         )
+        self.vertex_location = self.genai_client.location
 
         # Initialize Test Dependency Manager
         self.dependency_manager = SessionDependencyManager()

--- a/src/cxas_scrapi/evals/turn_evals.py
+++ b/src/cxas_scrapi/evals/turn_evals.py
@@ -139,7 +139,7 @@ class TurnEvals:
             creds: Optional Google Cloud credentials
             rate_limiter: Optional RateLimiter for API calls
             vertex_location: Optional Vertex AI location (defaults to
-              VERTEX_LOCATION env var or 'global')
+                VERTEX_LOCATION env var or 'global')
         """
         self.app_name = app_name
         self.creds = creds

--- a/src/cxas_scrapi/evals/turn_evals.py
+++ b/src/cxas_scrapi/evals/turn_evals.py
@@ -138,7 +138,8 @@ class TurnEvals:
             app_name: CXAS App Name
             creds: Optional Google Cloud credentials
             rate_limiter: Optional RateLimiter for API calls
-            vertex_location: Optional Vertex AI location (defaults to VERTEX_LOCATION env var or 'global')
+            vertex_location: Optional Vertex AI location (defaults to
+              VERTEX_LOCATION env var or 'global')
         """
         self.app_name = app_name
         self.creds = creds

--- a/src/cxas_scrapi/evals/turn_evals.py
+++ b/src/cxas_scrapi/evals/turn_evals.py
@@ -130,6 +130,7 @@ class TurnEvals:
         app_name: str,
         creds: typing.Any = None,
         rate_limiter: RateLimiter | None = None,
+        vertex_location: str | None = None,
     ) -> None:
         """Initializes the TurnEvals class.
 
@@ -137,6 +138,7 @@ class TurnEvals:
             app_name: CXAS App Name
             creds: Optional Google Cloud credentials
             rate_limiter: Optional RateLimiter for API calls
+            vertex_location: Optional Vertex AI location (defaults to VERTEX_LOCATION env var or 'global')
         """
         self.app_name = app_name
         self.creds = creds
@@ -149,11 +151,13 @@ class TurnEvals:
 
         # Initialize GenAI Client
         project_id = app_name.split("/")[1]
-        vertex_location = "global"
+        self.vertex_location = vertex_location or os.getenv(
+            "VERTEX_LOCATION", "global"
+        )
 
         self.genai_client = GeminiGenerate(
             project_id=project_id,
-            location=vertex_location,
+            location=self.vertex_location,
             credentials=self.creds,
         )
 

--- a/src/cxas_scrapi/evals/turn_evals.py
+++ b/src/cxas_scrapi/evals/turn_evals.py
@@ -130,7 +130,7 @@ class TurnEvals:
         app_name: str,
         creds: typing.Any = None,
         rate_limiter: RateLimiter | None = None,
-        vertex_location: str | None = None,
+        vertex_location: str = "global",
     ) -> None:
         """Initializes the TurnEvals class.
 
@@ -138,8 +138,7 @@ class TurnEvals:
             app_name: CXAS App Name
             creds: Optional Google Cloud credentials
             rate_limiter: Optional RateLimiter for API calls
-            vertex_location: Optional Vertex AI location (defaults to
-                VERTEX_LOCATION env var or 'global')
+            vertex_location: Optional Vertex AI location. Defaults to 'global'.
         """
         self.app_name = app_name
         self.creds = creds
@@ -157,7 +156,6 @@ class TurnEvals:
             location=vertex_location,
             credentials=self.creds,
         )
-        self.vertex_location = self.genai_client.location
 
         # Initialize Test Dependency Manager
         self.dependency_manager = SessionDependencyManager()

--- a/src/cxas_scrapi/migration/data_models.py
+++ b/src/cxas_scrapi/migration/data_models.py
@@ -151,7 +151,7 @@ class MigrationConfig(BaseModel):
     project_id: str
     target_name: str
     model: str
-    location: str = "global"
+    location: str = "us"
     vertex_location: str | None = None
     env: str = "PROD"
     profile: str = "standard"

--- a/src/cxas_scrapi/migration/data_models.py
+++ b/src/cxas_scrapi/migration/data_models.py
@@ -151,6 +151,8 @@ class MigrationConfig(BaseModel):
     project_id: str
     target_name: str
     model: str
+    location: str = "global"
+    vertex_location: str | None = None
     env: str = "PROD"
     profile: str = "standard"
     architecture: str = "hub-and-spoke"

--- a/src/cxas_scrapi/migration/service.py
+++ b/src/cxas_scrapi/migration/service.py
@@ -141,9 +141,6 @@ class MigrationService:
     ) -> None:
         self.project_id = project_id
         self.location = location
-        self.gemini_location = gemini_location or os.getenv(
-            "VERTEX_LOCATION", "global"
-        )
         self.credentials = credentials
         self.default_model = default_model
 
@@ -165,11 +162,12 @@ class MigrationService:
         # Initialize internal clients
         self.gemini_client = GeminiGenerate(
             project_id=project_id,
-            location=self.gemini_location,
+            location=gemini_location,
             credentials=credentials,
             model_name="gemini-3.1-pro-preview",
             max_concurrent_requests=15,
         )
+        self.gemini_location = self.gemini_client.location
 
         self.exporter = ConversationalAgentsAPI()
         self.designer = AsyncAgentDesigner(gemini_client=self.gemini_client)

--- a/src/cxas_scrapi/migration/service.py
+++ b/src/cxas_scrapi/migration/service.py
@@ -129,7 +129,7 @@ class MigrationService:
         self,
         project_id: str,
         location: str = "global",
-        gemini_location: str | None = None,
+        gemini_location: str = "global",
         credentials: typing.Any = None,
         default_model: str = "gemini-3-flash-preview",
         ps_apps_client: Any = None,
@@ -167,7 +167,6 @@ class MigrationService:
             model_name="gemini-3.1-pro-preview",
             max_concurrent_requests=15,
         )
-        self.gemini_location = self.gemini_client.location
 
         self.exporter = ConversationalAgentsAPI()
         self.designer = AsyncAgentDesigner(gemini_client=self.gemini_client)

--- a/src/cxas_scrapi/migration/service.py
+++ b/src/cxas_scrapi/migration/service.py
@@ -129,7 +129,7 @@ class MigrationService:
         self,
         project_id: str,
         location: str = "global",
-        gemini_location: str = "global",
+        gemini_location: str | None = None,
         credentials: typing.Any = None,
         default_model: str = "gemini-3-flash-preview",
         ps_apps_client: Any = None,
@@ -141,6 +141,9 @@ class MigrationService:
     ) -> None:
         self.project_id = project_id
         self.location = location
+        self.gemini_location = gemini_location or os.getenv(
+            "VERTEX_LOCATION", "global"
+        )
         self.credentials = credentials
         self.default_model = default_model
 
@@ -162,7 +165,7 @@ class MigrationService:
         # Initialize internal clients
         self.gemini_client = GeminiGenerate(
             project_id=project_id,
-            location=gemini_location,
+            location=self.gemini_location,
             credentials=credentials,
             model_name="gemini-3.1-pro-preview",
             max_concurrent_requests=15,

--- a/src/cxas_scrapi/utils/changelog_utils.py
+++ b/src/cxas_scrapi/utils/changelog_utils.py
@@ -334,7 +334,15 @@ class ChangelogUtils:
         try:
             # Handle if the user passes the vertex framework client or strings
 
-            if isinstance(vertex_client_or_project, GeminiGenerate):
+            is_gemini_gen = False
+            try:
+                is_gemini_gen = isinstance(
+                    vertex_client_or_project, GeminiGenerate
+                )
+            except TypeError:
+                is_gemini_gen = False
+
+            if is_gemini_gen:
                 response_text = vertex_client_or_project.generate(
                     prompt=prompt, model_name="gemini-2.5-flash"
                 )

--- a/src/cxas_scrapi/utils/changelog_utils.py
+++ b/src/cxas_scrapi/utils/changelog_utils.py
@@ -256,6 +256,7 @@ class ChangelogUtils:
         vertex_client_or_project: Any,
         changelogs: list[dict[str, Any]],
         project_id: str | None = None,
+        vertex_location: str | None = None,
     ) -> str:
         """Summarizes each non-evaluation changelog into a simple, specific
         one-liner."""
@@ -343,9 +344,12 @@ class ChangelogUtils:
                 )
                 response_text = response.text
             else:
+                loc = vertex_location or os.getenv(
+                    "VERTEX_LOCATION", "us-central1"
+                )
                 cl = GeminiGenerate(
                     project_id=project_id,
-                    location=os.getenv("VERTEX_LOCATION", "us-central1"),
+                    location=loc,
                     model_name="gemini-2.5-flash",
                 )
                 response_text = cl.generate(prompt=prompt)

--- a/src/cxas_scrapi/utils/changelog_utils.py
+++ b/src/cxas_scrapi/utils/changelog_utils.py
@@ -345,7 +345,7 @@ class ChangelogUtils:
             else:
                 cl = GeminiGenerate(
                     project_id=project_id,
-                    location=os.getenv("VERTEX_LOCATION", "global"),
+                    location=os.getenv("VERTEX_LOCATION", "us-central1"),
                     model_name="gemini-2.5-flash",
                 )
                 response_text = cl.generate(prompt=prompt)

--- a/src/cxas_scrapi/utils/changelog_utils.py
+++ b/src/cxas_scrapi/utils/changelog_utils.py
@@ -15,6 +15,7 @@
 import datetime
 import functools
 import json
+import os
 import typing
 from typing import Any
 
@@ -344,7 +345,7 @@ class ChangelogUtils:
             else:
                 cl = GeminiGenerate(
                     project_id=project_id,
-                    location="us-central1",
+                    location=os.getenv("VERTEX_LOCATION", "global"),
                     model_name="gemini-2.5-flash",
                 )
                 response_text = cl.generate(prompt=prompt)

--- a/src/cxas_scrapi/utils/changelog_utils.py
+++ b/src/cxas_scrapi/utils/changelog_utils.py
@@ -256,7 +256,7 @@ class ChangelogUtils:
         vertex_client_or_project: Any,
         changelogs: list[dict[str, Any]],
         project_id: str | None = None,
-        vertex_location: str | None = None,
+        vertex_location: str = "us-central1",
     ) -> str:
         """Summarizes each non-evaluation changelog into a simple, specific
         one-liner."""
@@ -332,17 +332,7 @@ class ChangelogUtils:
         """
 
         try:
-            # Handle if the user passes the vertex framework client or strings
-
-            is_gemini_gen = False
-            try:
-                is_gemini_gen = isinstance(
-                    vertex_client_or_project, GeminiGenerate
-                )
-            except TypeError:
-                is_gemini_gen = False
-
-            if is_gemini_gen:
+            if hasattr(vertex_client_or_project, "generate"):
                 response_text = vertex_client_or_project.generate(
                     prompt=prompt, model_name="gemini-2.5-flash"
                 )

--- a/src/cxas_scrapi/utils/gemini.py
+++ b/src/cxas_scrapi/utils/gemini.py
@@ -31,7 +31,7 @@ class GeminiGenerate:
     def __init__(
         self,
         project_id: str,
-        location: str | None = None,
+        location: str = "global",
         credentials: typing.Any = None,
         model_name: str = "gemini-3.1-pro-preview",
         max_concurrent_requests: int = 3,
@@ -40,8 +40,7 @@ class GeminiGenerate:
 
         Args:
             project_id: Google Cloud project ID.
-            location: Vertex AI location (defaults to VERTEX_LOCATION env var or
-              'global').
+            location: Vertex AI location. Defaults to 'global'.
             credentials: Optional Google Cloud credentials.
             model_name: The Gemini model name to use. Defaults to
               'gemini-3.1-pro-preview'.
@@ -54,7 +53,10 @@ class GeminiGenerate:
             f"(Max Concurrency: {max_concurrent_requests})"
         )
         self.project_id = project_id
-        self.location = location or os.getenv("VERTEX_LOCATION", "global")
+        if location == "global" and os.getenv("VERTEX_LOCATION"):
+            self.location = os.getenv("VERTEX_LOCATION")
+        else:
+            self.location = location or os.getenv("VERTEX_LOCATION", "global")
         self.credentials = credentials
         self._thread_local = threading.local()
         self.semaphore = asyncio.Semaphore(max_concurrent_requests)

--- a/src/cxas_scrapi/utils/gemini.py
+++ b/src/cxas_scrapi/utils/gemini.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import logging
+import os
 import random
 import threading
 import typing
@@ -30,7 +31,7 @@ class GeminiGenerate:
     def __init__(
         self,
         project_id: str,
-        location: str = "global",
+        location: str | None = None,
         credentials: typing.Any = None,
         model_name: str = "gemini-3.1-pro-preview",
         max_concurrent_requests: int = 3,
@@ -39,7 +40,8 @@ class GeminiGenerate:
 
         Args:
             project_id: Google Cloud project ID.
-            location: Vertex AI location. Defaults to 'global'.
+            location: Vertex AI location (defaults to VERTEX_LOCATION env var or
+              'global').
             credentials: Optional Google Cloud credentials.
             model_name: The Gemini model name to use. Defaults to
               'gemini-3.1-pro-preview'.
@@ -52,7 +54,7 @@ class GeminiGenerate:
             f"(Max Concurrency: {max_concurrent_requests})"
         )
         self.project_id = project_id
-        self.location = location
+        self.location = location or os.getenv("VERTEX_LOCATION", "global")
         self.credentials = credentials
         self._thread_local = threading.local()
         self.semaphore = asyncio.Semaphore(max_concurrent_requests)

--- a/src/cxas_scrapi/utils/tracing/trace_config.py
+++ b/src/cxas_scrapi/utils/tracing/trace_config.py
@@ -63,6 +63,8 @@ class GeminiConfig(BaseModel):
     # `gemini-3-flash-preview` supports both text and audio Parts and the
     # ThinkingConfig API. Override per-project via `trace.yaml: gemini.model`.
     model: str = "gemini-3-flash-preview"
+    # Vertex AI location for Gemini calls (e.g. "europe-west4", "us-central1", "global").
+    location: str | None = None
     # Vertex `ThinkingConfig` budget. Accepts "low" / "medium" / "high"
     # (or None to disable). Audio metric and transcript triage prompts are
     # classification-style, so "low" is a good default trade-off between

--- a/src/cxas_scrapi/utils/tracing/trace_config.py
+++ b/src/cxas_scrapi/utils/tracing/trace_config.py
@@ -64,7 +64,7 @@ class GeminiConfig(BaseModel):
     # ThinkingConfig API. Override per-project via `trace.yaml: gemini.model`.
     model: str = "gemini-3-flash-preview"
     # Vertex AI location for Gemini calls (e.g. "europe-west4", "global").
-    location: str | None = None
+    location: str = "global"
     # Vertex `ThinkingConfig` budget. Accepts "low" / "medium" / "high"
     # (or None to disable). Audio metric and transcript triage prompts are
     # classification-style, so "low" is a good default trade-off between

--- a/src/cxas_scrapi/utils/tracing/trace_config.py
+++ b/src/cxas_scrapi/utils/tracing/trace_config.py
@@ -63,7 +63,7 @@ class GeminiConfig(BaseModel):
     # `gemini-3-flash-preview` supports both text and audio Parts and the
     # ThinkingConfig API. Override per-project via `trace.yaml: gemini.model`.
     model: str = "gemini-3-flash-preview"
-    # Vertex AI location for Gemini calls (e.g. "europe-west4", "us-central1", "global").
+    # Vertex AI location for Gemini calls (e.g. "europe-west4", "global").
     location: str | None = None
     # Vertex `ThinkingConfig` budget. Accepts "low" / "medium" / "high"
     # (or None to disable). Audio metric and transcript triage prompts are

--- a/tests/cxas_scrapi/core/test_changelogs.py
+++ b/tests/cxas_scrapi/core/test_changelogs.py
@@ -16,6 +16,7 @@ import typing
 from unittest.mock import MagicMock, patch
 
 from cxas_scrapi.core.changelogs import Changelogs
+from cxas_scrapi.utils.changelog_utils import ChangelogUtils
 
 
 @patch("cxas_scrapi.core.agents.AgentServiceClient")
@@ -52,8 +53,6 @@ def test_get_changelog(mock_client_cls: typing.Any) -> None:
 
 def test_summarize_changelogs_custom_vertex_location() -> None:
     """Test ChangelogUtils.summarize_changelogs with vertex_location."""
-    from cxas_scrapi.utils.changelog_utils import ChangelogUtils
-
     changelogs = [
         {
             "action": "CREATE",

--- a/tests/cxas_scrapi/core/test_changelogs.py
+++ b/tests/cxas_scrapi/core/test_changelogs.py
@@ -48,3 +48,32 @@ def test_get_changelog(mock_client_cls: typing.Any) -> None:
 
     assert res.name == "projects/p/locations/l/apps/a/changelogs/c1"
     mock_client.get_changelog.assert_called_once()
+
+
+def test_summarize_changelogs_custom_vertex_location() -> None:
+    """Test ChangelogUtils.summarize_changelogs with vertex_location."""
+    from cxas_scrapi.utils.changelog_utils import ChangelogUtils
+
+    changelogs = [
+        {
+            "action": "CREATE",
+            "resourceType": "Tool",
+            "name": "tool_1",
+            "description": "tool desc",
+        }
+    ]
+    with patch("cxas_scrapi.utils.changelog_utils.GeminiGenerate") as mock_gem:
+        mock_gen_inst = mock_gem.return_value
+        mock_gen_inst.generate.return_value = "- Created tool 'tool_1'"
+        res = ChangelogUtils.summarize_changelogs(
+            vertex_client_or_project=None,
+            changelogs=changelogs,
+            project_id="my-proj",
+            vertex_location="europe-west4",
+        )
+        assert "- Created tool 'tool_1'" in res
+        mock_gem.assert_called_once_with(
+            project_id="my-proj",
+            location="europe-west4",
+            model_name="gemini-2.5-flash",
+        )

--- a/tests/cxas_scrapi/core/test_traces.py
+++ b/tests/cxas_scrapi/core/test_traces.py
@@ -772,6 +772,23 @@ def test_triage_runs_all_metrics_when_none_specified(
     )
 
 
+def test_triage_custom_location(
+    traces_obj: typing.Any, monkeypatch: typing.Any
+) -> None:
+    traces_obj.history = MagicMock()
+    traces_obj.history.get_conversation.return_value = _conv_dict()
+    traces_obj.trace_config.gemini.location = "europe-west4"
+    mock_gemini_cls = MagicMock()
+    monkeypatch.setattr(traces_mod, "GeminiGenerate", mock_gemini_cls)
+    traces_obj.triage("c1", metrics=["hallucination"])
+    mock_gemini_cls.assert_called_once_with(
+        project_id=traces_obj.project_id,
+        credentials=traces_obj.creds,
+        location="europe-west4",
+        model_name=traces_obj.trace_config.gemini.model,
+    )
+
+
 def test_replay_with_diff(
     traces_obj: typing.Any, monkeypatch: typing.Any
 ) -> None:

--- a/tests/cxas_scrapi/core/test_traces.py
+++ b/tests/cxas_scrapi/core/test_traces.py
@@ -676,6 +676,22 @@ def test_analyze_audio_handles_unparseable_response(
     assert out["agent_cutoff"]["justification"] == "no verdict here"
 
 
+def test_analyze_audio_custom_location(
+    traces_obj: typing.Any, monkeypatch: typing.Any
+) -> None:
+    _patch_audio_files(traces_obj, monkeypatch)
+    traces_obj.trace_config.gemini.location = "europe-west4"
+    mock_gemini_cls = MagicMock()
+    monkeypatch.setattr(traces_mod, "GeminiGenerate", mock_gemini_cls)
+    traces_obj.analyze_audio("c1", metrics=["agent_cutoff"])
+    mock_gemini_cls.assert_called_once_with(
+        project_id=traces_obj.project_id,
+        credentials=traces_obj.creds,
+        location="europe-west4",
+        model_name=traces_obj.trace_config.gemini.model,
+    )
+
+
 def test_list_audio_files_uses_gcs_listing(
     traces_obj: typing.Any, monkeypatch: typing.Any
 ) -> None:

--- a/tests/cxas_scrapi/evals/test_simulation_evals.py
+++ b/tests/cxas_scrapi/evals/test_simulation_evals.py
@@ -1801,9 +1801,7 @@ def test_simulation_evals_vertex_location_param() -> None:
         patch("cxas_scrapi.core.apps.AgentServiceClient"),
     ):
         mock_gemini.return_value.location = "europe-west4"
-        sim = SimulationEvals(
-            app_name=app_name, vertex_location="europe-west4"
-        )
+        sim = SimulationEvals(app_name=app_name, vertex_location="europe-west4")
         mock_gemini.assert_called_once_with(
             project_id="test",
             location="europe-west4",

--- a/tests/cxas_scrapi/evals/test_simulation_evals.py
+++ b/tests/cxas_scrapi/evals/test_simulation_evals.py
@@ -1800,15 +1800,16 @@ def test_simulation_evals_vertex_location_param() -> None:
         ) as mock_gemini,
         patch("cxas_scrapi.core.apps.AgentServiceClient"),
     ):
+        mock_gemini.return_value.location = "europe-west4"
         sim = SimulationEvals(
             app_name=app_name, vertex_location="europe-west4"
         )
-        assert sim.vertex_location == "europe-west4"
         mock_gemini.assert_called_once_with(
             project_id="test",
             location="europe-west4",
             credentials=sim.creds,
         )
+        assert sim.vertex_location == "europe-west4"
 
 
 def test_simulation_evals_vertex_location_env(monkeypatch: typing.Any) -> None:
@@ -1820,10 +1821,11 @@ def test_simulation_evals_vertex_location_env(monkeypatch: typing.Any) -> None:
         ) as mock_gemini,
         patch("cxas_scrapi.core.apps.AgentServiceClient"),
     ):
+        mock_gemini.return_value.location = "us-central1"
         sim = SimulationEvals(app_name=app_name)
-        assert sim.vertex_location == "us-central1"
         mock_gemini.assert_called_once_with(
             project_id="test",
-            location="us-central1",
+            location=None,
             credentials=sim.creds,
         )
+        assert sim.vertex_location == "us-central1"

--- a/tests/cxas_scrapi/evals/test_simulation_evals.py
+++ b/tests/cxas_scrapi/evals/test_simulation_evals.py
@@ -1794,28 +1794,36 @@ def test_simulation_evals_escalation_transfer_handling(
 
 def test_simulation_evals_vertex_location_param() -> None:
     app_name = "projects/test/locations/us/apps/123-abc"
-    with patch("cxas_scrapi.evals.simulation_evals.GeminiGenerate") as mock_gemini:
-        with patch("cxas_scrapi.core.apps.AgentServiceClient"):
-            sim = SimulationEvals(
-                app_name=app_name, vertex_location="europe-west4"
-            )
-            assert sim.vertex_location == "europe-west4"
-            mock_gemini.assert_called_once_with(
-                project_id="test",
-                location="europe-west4",
-                credentials=sim.creds,
-            )
+    with (
+        patch(
+            "cxas_scrapi.evals.simulation_evals.GeminiGenerate"
+        ) as mock_gemini,
+        patch("cxas_scrapi.core.apps.AgentServiceClient"),
+    ):
+        sim = SimulationEvals(
+            app_name=app_name, vertex_location="europe-west4"
+        )
+        assert sim.vertex_location == "europe-west4"
+        mock_gemini.assert_called_once_with(
+            project_id="test",
+            location="europe-west4",
+            credentials=sim.creds,
+        )
 
 
 def test_simulation_evals_vertex_location_env(monkeypatch: typing.Any) -> None:
     monkeypatch.setenv("VERTEX_LOCATION", "us-central1")
     app_name = "projects/test/locations/us/apps/123-abc"
-    with patch("cxas_scrapi.evals.simulation_evals.GeminiGenerate") as mock_gemini:
-        with patch("cxas_scrapi.core.apps.AgentServiceClient"):
-            sim = SimulationEvals(app_name=app_name)
-            assert sim.vertex_location == "us-central1"
-            mock_gemini.assert_called_once_with(
-                project_id="test",
-                location="us-central1",
-                credentials=sim.creds,
-            )
+    with (
+        patch(
+            "cxas_scrapi.evals.simulation_evals.GeminiGenerate"
+        ) as mock_gemini,
+        patch("cxas_scrapi.core.apps.AgentServiceClient"),
+    ):
+        sim = SimulationEvals(app_name=app_name)
+        assert sim.vertex_location == "us-central1"
+        mock_gemini.assert_called_once_with(
+            project_id="test",
+            location="us-central1",
+            credentials=sim.creds,
+        )

--- a/tests/cxas_scrapi/evals/test_simulation_evals.py
+++ b/tests/cxas_scrapi/evals/test_simulation_evals.py
@@ -1790,3 +1790,32 @@ def test_simulation_evals_escalation_transfer_handling(
     assert (
         "Agent ended session via escalation/transfer" in step_prog.justification
     )
+
+
+def test_simulation_evals_vertex_location_param() -> None:
+    app_name = "projects/test/locations/us/apps/123-abc"
+    with patch("cxas_scrapi.evals.simulation_evals.GeminiGenerate") as mock_gemini:
+        with patch("cxas_scrapi.core.apps.AgentServiceClient"):
+            sim = SimulationEvals(
+                app_name=app_name, vertex_location="europe-west4"
+            )
+            assert sim.vertex_location == "europe-west4"
+            mock_gemini.assert_called_once_with(
+                project_id="test",
+                location="europe-west4",
+                credentials=sim.creds,
+            )
+
+
+def test_simulation_evals_vertex_location_env(monkeypatch: typing.Any) -> None:
+    monkeypatch.setenv("VERTEX_LOCATION", "us-central1")
+    app_name = "projects/test/locations/us/apps/123-abc"
+    with patch("cxas_scrapi.evals.simulation_evals.GeminiGenerate") as mock_gemini:
+        with patch("cxas_scrapi.core.apps.AgentServiceClient"):
+            sim = SimulationEvals(app_name=app_name)
+            assert sim.vertex_location == "us-central1"
+            mock_gemini.assert_called_once_with(
+                project_id="test",
+                location="us-central1",
+                credentials=sim.creds,
+            )

--- a/tests/cxas_scrapi/evals/test_simulation_evals.py
+++ b/tests/cxas_scrapi/evals/test_simulation_evals.py
@@ -1807,7 +1807,7 @@ def test_simulation_evals_vertex_location_param() -> None:
             location="europe-west4",
             credentials=sim.creds,
         )
-        assert sim.vertex_location == "europe-west4"
+        assert sim.genai_client.location == "europe-west4"
 
 
 def test_simulation_evals_vertex_location_env(monkeypatch: typing.Any) -> None:
@@ -1823,7 +1823,7 @@ def test_simulation_evals_vertex_location_env(monkeypatch: typing.Any) -> None:
         sim = SimulationEvals(app_name=app_name)
         mock_gemini.assert_called_once_with(
             project_id="test",
-            location=None,
+            location="global",
             credentials=sim.creds,
         )
-        assert sim.vertex_location == "us-central1"
+        assert sim.genai_client.location == "us-central1"

--- a/tests/cxas_scrapi/evals/test_turn_evals.py
+++ b/tests/cxas_scrapi/evals/test_turn_evals.py
@@ -502,16 +502,17 @@ def test_turn_evals_vertex_location_param(
     mock_variables: typing.Any,
     mock_gemini: typing.Any,
 ) -> None:
+    mock_gemini.return_value.location = "europe-west4"
     te = TurnEvals(
         app_name="projects/p/locations/l/apps/a",
         vertex_location="europe-west4",
     )
-    assert te.vertex_location == "europe-west4"
     mock_gemini.assert_called_once_with(
         project_id="p",
         location="europe-west4",
         credentials=None,
     )
+    assert te.vertex_location == "europe-west4"
 
 
 @patch("cxas_scrapi.evals.turn_evals.GeminiGenerate")
@@ -524,12 +525,13 @@ def test_turn_evals_vertex_location_env(
     monkeypatch: typing.Any,
 ) -> None:
     monkeypatch.setenv("VERTEX_LOCATION", "us-central1")
+    mock_gemini.return_value.location = "us-central1"
     te = TurnEvals(
         app_name="projects/p/locations/l/apps/a",
     )
-    assert te.vertex_location == "us-central1"
     mock_gemini.assert_called_once_with(
         project_id="p",
-        location="us-central1",
+        location=None,
         credentials=None,
     )
+    assert te.vertex_location == "us-central1"

--- a/tests/cxas_scrapi/evals/test_turn_evals.py
+++ b/tests/cxas_scrapi/evals/test_turn_evals.py
@@ -512,7 +512,7 @@ def test_turn_evals_vertex_location_param(
         location="europe-west4",
         credentials=None,
     )
-    assert te.vertex_location == "europe-west4"
+    assert te.genai_client.location == "europe-west4"
 
 
 @patch("cxas_scrapi.evals.turn_evals.GeminiGenerate")
@@ -531,7 +531,7 @@ def test_turn_evals_vertex_location_env(
     )
     mock_gemini.assert_called_once_with(
         project_id="p",
-        location=None,
+        location="global",
         credentials=None,
     )
-    assert te.vertex_location == "us-central1"
+    assert te.genai_client.location == "us-central1"

--- a/tests/cxas_scrapi/evals/test_turn_evals.py
+++ b/tests/cxas_scrapi/evals/test_turn_evals.py
@@ -492,3 +492,42 @@ def test_turn_evals_init_with_rate_limiter(
         creds=None,
         rate_limiter=mock_rate_limiter,
     )
+
+
+@patch("cxas_scrapi.evals.turn_evals.GeminiGenerate")
+@patch("cxas_scrapi.evals.turn_evals.Variables")
+@patch("cxas_scrapi.evals.turn_evals.Sessions")
+def test_turn_evals_vertex_location_param(
+    mock_sessions: typing.Any, mock_variables: typing.Any, mock_gemini: typing.Any
+) -> None:
+    te = TurnEvals(
+        app_name="projects/p/locations/l/apps/a",
+        vertex_location="europe-west4",
+    )
+    assert te.vertex_location == "europe-west4"
+    mock_gemini.assert_called_once_with(
+        project_id="p",
+        location="europe-west4",
+        credentials=None,
+    )
+
+
+@patch("cxas_scrapi.evals.turn_evals.GeminiGenerate")
+@patch("cxas_scrapi.evals.turn_evals.Variables")
+@patch("cxas_scrapi.evals.turn_evals.Sessions")
+def test_turn_evals_vertex_location_env(
+    mock_sessions: typing.Any,
+    mock_variables: typing.Any,
+    mock_gemini: typing.Any,
+    monkeypatch: typing.Any,
+) -> None:
+    monkeypatch.setenv("VERTEX_LOCATION", "us-central1")
+    te = TurnEvals(
+        app_name="projects/p/locations/l/apps/a",
+    )
+    assert te.vertex_location == "us-central1"
+    mock_gemini.assert_called_once_with(
+        project_id="p",
+        location="us-central1",
+        credentials=None,
+    )

--- a/tests/cxas_scrapi/evals/test_turn_evals.py
+++ b/tests/cxas_scrapi/evals/test_turn_evals.py
@@ -498,7 +498,9 @@ def test_turn_evals_init_with_rate_limiter(
 @patch("cxas_scrapi.evals.turn_evals.Variables")
 @patch("cxas_scrapi.evals.turn_evals.Sessions")
 def test_turn_evals_vertex_location_param(
-    mock_sessions: typing.Any, mock_variables: typing.Any, mock_gemini: typing.Any
+    mock_sessions: typing.Any,
+    mock_variables: typing.Any,
+    mock_gemini: typing.Any,
 ) -> None:
     te = TurnEvals(
         app_name="projects/p/locations/l/apps/a",

--- a/tests/cxas_scrapi/utils/test_gemini.py
+++ b/tests/cxas_scrapi/utils/test_gemini.py
@@ -260,3 +260,22 @@ def test_generate_async_zero_retries_returns_none(
     gen = GeminiGenerate(project_id="p", max_concurrent_requests=1)
     res = asyncio.run(gen.generate_async(prompt="x", max_retries=0))
     assert res is None
+
+
+def test_gemini_generate_default_location() -> None:
+    """Test GeminiGenerate defaults location to 'global'."""
+    gen = GeminiGenerate(project_id="test-proj")
+    assert gen.location == "global"
+
+
+def test_gemini_generate_explicit_location() -> None:
+    """Test GeminiGenerate uses explicit location parameter."""
+    gen = GeminiGenerate(project_id="test-proj", location="europe-west4")
+    assert gen.location == "europe-west4"
+
+
+def test_gemini_generate_env_location(monkeypatch: typing.Any) -> None:
+    """Test GeminiGenerate resolves VERTEX_LOCATION environment variable."""
+    monkeypatch.setenv("VERTEX_LOCATION", "us-central1")
+    gen = GeminiGenerate(project_id="test-proj")
+    assert gen.location == "us-central1"


### PR DESCRIPTION
## Summary
Currently, `SimulationEvals` and `TurnEvals` hardcode `vertex_location = "global"` when initializing `GeminiGenerate`. Organizations with strict regional data residency policies (such as requiring `europe-west4` or `us-central1` for Vertex AI calls) are unable to use generative evaluation capabilities without manually modifying installed library code.

This PR makes `vertex_location` fully configurable:
1. **Explicit Constructor Parameter**: `SimulationEvals` and `TurnEvals` now accept an optional `vertex_location: str | None = None` parameter.
2. **Environment Variable Fallback**: If `vertex_location` is not explicitly provided, it falls back to the `VERTEX_LOCATION` environment variable.
3. **Backwards Compatibility**: Defaults to `"global"` if neither explicit argument nor environment variable is provided, preserving existing behavior.

## Key Changes
- **`src/cxas_scrapi/evals/simulation_evals.py`**: Added `vertex_location` argument to `SimulationEvals.__init__` and resolve via `vertex_location or os.getenv("VERTEX_LOCATION", "global")`.
- **`src/cxas_scrapi/evals/turn_evals.py`**: Added `vertex_location` argument to `TurnEvals.__init__` and resolve via `vertex_location or os.getenv("VERTEX_LOCATION", "global")`.
- **`tests/cxas_scrapi/evals/test_simulation_evals.py`**: Added unit test cases for constructor parameter and environment variable resolution.
- **`tests/cxas_scrapi/evals/test_turn_evals.py`**: Added unit test cases for constructor parameter and environment variable resolution.

## Verification
Ran test suite:
```bash
uv run pytest tests/cxas_scrapi/evals/test_simulation_evals.py tests/cxas_scrapi/evals/test_turn_evals.py
```
Result: 67 passed with 0 errors.