### PR TITLE
test(ci): add retry loop and warn on transient network timeouts in markdown link checker

### DIFF
--- a/tests/cxas_scrapi/test_markdown_links.py
+++ b/tests/cxas_scrapi/test_markdown_links.py
@@ -1,6 +1,7 @@
 import pathlib
 import re
 import typing
+import warnings
 
 import pytest
 import requests
@@ -54,15 +55,25 @@ def test_markdown_links(md_path: typing.Any) -> None:
             if md_path != README_PATH:
                 continue
 
-            try:
-                headers = {"User-Agent": "Mozilla/5.0"}
-                response = requests.get(link, headers=headers, timeout=5)
-                if response.status_code >= 400:
-                    broken_links.append(
-                        f"External: {link} (Status: {response.status_code})"
-                    )
-            except requests.RequestException as e:
-                broken_links.append(f"External: {link} (Error: {e})")
+            for attempt in range(3):
+                try:
+                    headers = {"User-Agent": "Mozilla/5.0"}
+                    response = requests.get(link, headers=headers, timeout=15)
+                    if response.status_code >= 400:
+                        broken_links.append(
+                            f"External: {link} (Status: {response.status_code})"
+                        )
+                    break
+                except (requests.Timeout, requests.ConnectionError) as e:
+                    if attempt == 2:
+                        warnings.warn(
+                            f"Transient network error checking {link}: {e}",
+                            UserWarning,
+                            stacklevel=2,
+                        )
+                except requests.RequestException as e:
+                    broken_links.append(f"External: {link} (Error: {e})")
+                    break
         else:
             # Relative link
             # Remove query params or anchors if any


### PR DESCRIPTION
## Summary
Resolves transient CI failures in Python 3.10 and 3.14 where automated GitHub Actions runners timed out after 5 seconds (`read timeout=5`) when HTTP GETting external `cloud.google.com` documentation URLs in `test_markdown_links[README.md]`.

## Changes
- **Increased HTTP Request Timeout (`tests/cxas_scrapi/test_markdown_links.py`):** Raised timeout from `5` to `15` seconds.
- **3-Attempt Retry Loop:** Added retry logic (`for attempt in range(3):`) around external markdown link requests.
- **Non-Fatal Warning on Transient Network Errors:** If an external URL repeatedly raises a transient connection exception (`requests.Timeout` or `requests.ConnectionError`), emits a non-fatal `UserWarning` (`warnings.warn(..., stacklevel=2)`) instead of breaking the CI build. True broken markdown links (e.g. `404 Not Found` or `410 Gone`) still fail the test.