### PR TITLE
fix: add path validation and resource bounds for archive extraction

### DIFF
--- a/src/cxas_scrapi/cli/app.py
+++ b/src/cxas_scrapi/cli/app.py
@@ -29,6 +29,7 @@ from typing import Any
 from cxas_scrapi.core.apps import Apps
 from cxas_scrapi.core.common import Common
 from cxas_scrapi.core.versions import Versions
+from cxas_scrapi.utils.archive_utils import ArchiveUtils
 
 logger = logging.getLogger(__name__)
 
@@ -118,10 +119,10 @@ def _app_pull(
         if not os.path.exists(target_dir):
             os.makedirs(target_dir)
 
-        # Extract content to target directory.
+        # Extract content to target directory safely.
         with zipfile.ZipFile(io.BytesIO(response.app_content)) as z:
             export_members = z.namelist()
-            z.extractall(target_dir)
+            ArchiveUtils.safe_extract_zip(z, target_dir)
 
         # Handle overwrite logic if requested
         if overwrite and export_members:

--- a/src/cxas_scrapi/utils/archive_utils.py
+++ b/src/cxas_scrapi/utils/archive_utils.py
@@ -1,0 +1,98 @@
+"""Archive and zip extraction security utilities."""
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import stat
+import zipfile
+
+logger = logging.getLogger(__name__)
+
+# Strict security boundaries for app archive extraction
+MAX_FILE_SIZE = 1 * 1024 * 1024 * 1024  # 1 GB per file limit
+MAX_TOTAL_SIZE = 5 * 1024 * 1024 * 1024  # 5 GB total cumulative limit
+MAX_FILE_COUNT = 100_000  # Max total entries allowed
+
+
+class ArchiveUtils:
+    """Utilities for safely inspecting and extracting archive files."""
+
+    @staticmethod
+    def safe_extract_zip(zip_obj: zipfile.ZipFile, target_dir: str) -> None:
+        """Safely extracts a ZipFile enforcing security constraints.
+
+        Args:
+            zip_obj: The opened ZipFile instance to extract.
+            target_dir: Destination directory path.
+
+        Raises:
+            ValueError: If any entry violates path traversal, symlink, or size
+                bounds.
+        """
+        target_dir_abs = os.path.abspath(target_dir)
+        total_extracted_size = 0
+
+        infolist = zip_obj.infolist()
+        if len(infolist) > MAX_FILE_COUNT:
+            raise ValueError(
+                f"Archive contains too many entries: {len(infolist)} "
+                f"(limit is {MAX_FILE_COUNT})"
+            )
+
+        for member in infolist:
+            # 1. Zip Bomb checks (single file & cumulative totals)
+            if member.file_size > MAX_FILE_SIZE:
+                raise ValueError(
+                    f"File '{member.filename}' exceeds max allowed "
+                    f"uncompressed size ({member.file_size} > "
+                    f"{MAX_FILE_SIZE} bytes)"
+                )
+            total_extracted_size += member.file_size
+            if total_extracted_size > MAX_TOTAL_SIZE:
+                raise ValueError(
+                    "Archive total uncompressed size exceeds limit "
+                    f"({total_extracted_size} > {MAX_TOTAL_SIZE} bytes)"
+                )
+
+            # 2. Zip Slip / Path Traversal protection
+            member_path = os.path.abspath(
+                os.path.join(target_dir_abs, member.filename)
+            )
+            try:
+                common = os.path.commonpath([target_dir_abs, member_path])
+            except ValueError as err:
+                msg = (
+                    "Cross-drive path traversal detected in "
+                    f"'{member.filename}'"
+                )
+                raise ValueError(msg) from err
+
+            if common != target_dir_abs:
+                raise ValueError(
+                    "Path traversal detected in archive entry: "
+                    f"'{member.filename}'"
+                )
+
+            # 3. Symlink protection
+            is_symlink = stat.S_ISLNK(member.external_attr >> 16)
+            if is_symlink:
+                raise ValueError(
+                    "Symbolic link entries are not permitted in app "
+                    f"archives: '{member.filename}'"
+                )
+
+            # 4. Extract safe member
+            zip_obj.extract(member, target_dir_abs)

--- a/tests/cxas_scrapi/utils/test_archive_utils.py
+++ b/tests/cxas_scrapi/utils/test_archive_utils.py
@@ -1,0 +1,190 @@
+"""Tests for archive security utilities."""
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import typing
+import zipfile
+
+import pytest
+
+from cxas_scrapi.utils import archive_utils
+from cxas_scrapi.utils.archive_utils import ArchiveUtils
+
+
+def test_safe_extract_zip_normal(tmp_path: typing.Any) -> None:
+    """Verifies that normal files extract without issue."""
+    target_dir = tmp_path / "extracted"
+    zip_buffer = io.BytesIO()
+    with zipfile.ZipFile(zip_buffer, "w") as z:
+        z.writestr("app.yaml", "name: My App")
+        z.writestr("tools/search.json", '{"name": "search"}')
+
+    zip_buffer.seek(0)
+    with zipfile.ZipFile(zip_buffer, "r") as z:
+        ArchiveUtils.safe_extract_zip(z, str(target_dir))
+
+    assert (target_dir / "app.yaml").read_text() == "name: My App"
+    assert (target_dir / "tools" / "search.json").read_text() == (
+        '{"name": "search"}'
+    )
+
+
+def test_safe_extract_zip_nested_directories_allowed(
+    tmp_path: typing.Any,
+) -> None:
+    """Verifies that legitimate deeply nested subfolders extract correctly."""
+    target_dir = tmp_path / "extracted_nested"
+    zip_buffer = io.BytesIO()
+    with zipfile.ZipFile(zip_buffer, "w") as z:
+        z.writestr("flows/navigation/flow.yaml", "name: Navigation")
+        z.writestr("flows/navigation/pages/home.json", '{"title": "Home"}')
+
+    zip_buffer.seek(0)
+    with zipfile.ZipFile(zip_buffer, "r") as z:
+        ArchiveUtils.safe_extract_zip(z, str(target_dir))
+
+    assert (
+        target_dir / "flows" / "navigation" / "flow.yaml"
+    ).read_text() == "name: Navigation"
+    assert (
+        target_dir / "flows" / "navigation" / "pages" / "home.json"
+    ).read_text() == '{"title": "Home"}'
+
+
+def test_safe_extract_zip_relative_traversal_rejected(
+    tmp_path: typing.Any,
+) -> None:
+    """Verifies that Zip Slip attempts with ../ are rejected."""
+    target_dir = tmp_path / "safe_dir"
+    target_dir.mkdir()
+    outside_file = tmp_path / "evil.txt"
+
+    zip_buffer = io.BytesIO()
+    with zipfile.ZipFile(zip_buffer, "w") as z:
+        z.writestr("../../evil.txt", "malicious content")
+
+    zip_buffer.seek(0)
+    with (
+        zipfile.ZipFile(zip_buffer, "r") as z,
+        pytest.raises(ValueError, match="Path traversal detected"),
+    ):
+        ArchiveUtils.safe_extract_zip(z, str(target_dir))
+
+    assert not outside_file.exists()
+
+
+def test_safe_extract_zip_absolute_path_rejected(
+    tmp_path: typing.Any,
+) -> None:
+    """Verifies that absolute paths (e.g. /etc/passwd) are rejected."""
+    target_dir = tmp_path / "target"
+    target_dir.mkdir()
+    abs_file = tmp_path / "abs_evil.txt"
+
+    zip_buffer = io.BytesIO()
+    with zipfile.ZipFile(zip_buffer, "w") as z:
+        z.writestr(str(abs_file), "malicious content")
+
+    zip_buffer.seek(0)
+    with (
+        zipfile.ZipFile(zip_buffer, "r") as z,
+        pytest.raises(ValueError, match="Path traversal detected"),
+    ):
+        ArchiveUtils.safe_extract_zip(z, str(target_dir))
+
+    assert not abs_file.exists()
+
+
+def test_safe_extract_zip_max_file_size_exceeded(
+    tmp_path: typing.Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verifies that single files exceeding MAX_FILE_SIZE raise ValueError."""
+    monkeypatch.setattr(archive_utils, "MAX_FILE_SIZE", 100)
+    target_dir = tmp_path / "extracted"
+    zip_buffer = io.BytesIO()
+    with zipfile.ZipFile(zip_buffer, "w") as z:
+        z.writestr("large.bin", b"x" * 200)
+
+    zip_buffer.seek(0)
+    with (
+        zipfile.ZipFile(zip_buffer, "r") as z,
+        pytest.raises(
+            ValueError, match="exceeds max allowed uncompressed size"
+        ),
+    ):
+        ArchiveUtils.safe_extract_zip(z, str(target_dir))
+
+
+def test_safe_extract_zip_max_total_size_exceeded(
+    tmp_path: typing.Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verifies that size exceeding MAX_TOTAL_SIZE raises ValueError."""
+    monkeypatch.setattr(archive_utils, "MAX_TOTAL_SIZE", 100)
+    target_dir = tmp_path / "extracted"
+    zip_buffer = io.BytesIO()
+    with zipfile.ZipFile(zip_buffer, "w") as z:
+        z.writestr("file1.bin", b"x" * 60)
+        z.writestr("file2.bin", b"x" * 60)
+
+    zip_buffer.seek(0)
+    with (
+        zipfile.ZipFile(zip_buffer, "r") as z,
+        pytest.raises(
+            ValueError,
+            match="Archive total uncompressed size exceeds limit",
+        ),
+    ):
+        ArchiveUtils.safe_extract_zip(z, str(target_dir))
+
+
+def test_safe_extract_zip_max_file_count_exceeded(
+    tmp_path: typing.Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verifies that entry count exceeding MAX_FILE_COUNT raises ValueError."""
+    monkeypatch.setattr(archive_utils, "MAX_FILE_COUNT", 2)
+    target_dir = tmp_path / "extracted"
+    zip_buffer = io.BytesIO()
+    with zipfile.ZipFile(zip_buffer, "w") as z:
+        z.writestr("f1.txt", "1")
+        z.writestr("f2.txt", "2")
+        z.writestr("f3.txt", "3")
+
+    zip_buffer.seek(0)
+    with (
+        zipfile.ZipFile(zip_buffer, "r") as z,
+        pytest.raises(ValueError, match="Archive contains too many entries"),
+    ):
+        ArchiveUtils.safe_extract_zip(z, str(target_dir))
+
+
+def test_safe_extract_zip_symlink_rejected(tmp_path: typing.Any) -> None:
+    """Verifies that symbolic links are rejected."""
+    target_dir = tmp_path / "extracted"
+    zip_buffer = io.BytesIO()
+    with zipfile.ZipFile(zip_buffer, "w") as z:
+        zinfo = zipfile.ZipInfo("symlink_entry")
+        # 0o120000 is S_IFLNK
+        zinfo.external_attr = 0o120777 << 16
+        z.writestr(zinfo, "/etc/passwd")
+
+    zip_buffer.seek(0)
+    with (
+        zipfile.ZipFile(zip_buffer, "r") as z,
+        pytest.raises(
+            ValueError, match="Symbolic link entries are not permitted"
+        ),
+    ):
+        ArchiveUtils.safe_extract_zip(z, str(target_dir))


### PR DESCRIPTION
### Description
Strengthens archive extraction safety during `scrapi app pull` and `scrapi app branch` operations by introducing a dedicated `ArchiveUtils.safe_extract_zip` helper.

### Changes
* **Path Traversal & Symlink Restrictions**: Enforces canonical path verification (`os.path.commonpath`) to prevent directory traversal (`../` and absolute paths) and rejects Unix symlink entries (`stat.S_ISLNK`).
* **Resource Bounds Protection**: Enforces uncompressed single-file limits (1 GB), total cumulative archive limits (5 GB), and max entry count limits (100,000) to protect against uncompressed payload expansion.
*  Comprehensive unit test suite in `tests/cxas_scrapi/utils/test_archive_utils.py` verifying normal and flat directory extractions, rejections of relative and absolute paths, rejection of symbolic links, and enforcement of single-file size, cumulative total size, and entry count limits