### PR TITLE
refactor: AST validation and restricted builtins for callback execution

### DIFF
--- a/src/cxas_scrapi/core/callbacks.py
+++ b/src/cxas_scrapi/core/callbacks.py
@@ -27,6 +27,7 @@ from google.cloud.ces_v1beta import types
 from google.protobuf import field_mask_pb2
 
 from cxas_scrapi.core.agents import Agents
+from cxas_scrapi.utils.code_security_utils import CodeSecurityUtils
 
 
 class Callbacks(Agents):
@@ -242,11 +243,17 @@ class Callbacks(Agents):
                     "code string."
                 )
 
-        # Prepare a restricted execution environment
-        exec_globals = {}
+        # 1. Validate callback AST safety before execution
+        try:
+            CodeSecurityUtils.validate_callback_ast(code_str)
+        except (ValueError, SyntaxError) as e:
+            return {"error": f"Security validation failed: {e!s}"}
+
+        # 2. Prepare a restricted execution environment with safe builtins
+        exec_globals = {"__builtins__": CodeSecurityUtils.get_safe_builtins()}
 
         try:
-            # Execute the string into our globals namespace
+            # Execute the string into our restricted globals namespace
             exec(code_str, exec_globals)
         except Exception as e:
             return {"error": f"Compilation failed: {e!s}"}
@@ -257,11 +264,15 @@ class Callbacks(Agents):
                 f"the code block."
             }
 
+        target_fn = exec_globals[func_name]
+        if not callable(target_fn):
+            return {"error": f"Function {func_name} is not callable."}
+
         # Call the function hermetically
         try:
             # The execution signature usually accepts a `session` argument
             # containing the state dict
-            result = exec_globals[func_name](mock_session_input)
+            result = target_fn(mock_session_input)
             return {"success": True, "result": result}
         except Exception as e:
             return {

--- a/src/cxas_scrapi/utils/code_security_utils.py
+++ b/src/cxas_scrapi/utils/code_security_utils.py
@@ -1,0 +1,123 @@
+"""Security utilities for safe AST validation and execution of callback code."""
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ast
+from typing import Any
+
+FORBIDDEN_CALL_NAMES = frozenset(
+    {
+        "__import__",
+        "compile",
+        "eval",
+        "exec",
+        "globals",
+        "input",
+        "locals",
+        "open",
+    }
+)
+
+SAFE_BUILTINS: dict[str, Any] = {
+    "abs": abs,
+    "all": all,
+    "any": any,
+    "bool": bool,
+    "dict": dict,
+    "enumerate": enumerate,
+    "filter": filter,
+    "float": float,
+    "format": format,
+    "int": int,
+    "isinstance": isinstance,
+    "issubclass": issubclass,
+    "len": len,
+    "list": list,
+    "map": map,
+    "max": max,
+    "min": min,
+    "range": range,
+    "reversed": reversed,
+    "round": round,
+    "set": set,
+    "slice": slice,
+    "sorted": sorted,
+    "str": str,
+    "sum": sum,
+    "tuple": tuple,
+    "zip": zip,
+    "None": None,
+    "True": True,
+    "False": False,
+}
+
+
+class _CallbackSecurityVisitor(ast.NodeVisitor):
+    """AST visitor that enforces safety constraints on callback code."""
+
+    def visit_Import(self, node: ast.Import) -> None:
+        raise ValueError(
+            f"Import statements are forbidden in localized callbacks "
+            f"(line {node.lineno})."
+        )
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        raise ValueError(
+            f"'from ... import' statements are forbidden in localized "
+            f"callbacks (line {node.lineno})."
+        )
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        # Block dunder introspection attacks (__class__, __subclasses__, etc.)
+        if node.attr.startswith("__") and node.attr.endswith("__"):
+            raise ValueError(
+                f"Access to private/dunder attribute '{node.attr}' is "
+                f"forbidden (line {node.lineno})."
+            )
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        # Block direct calls to dangerous builtins (eval, exec, open, etc.)
+        if (
+            isinstance(node.func, ast.Name)
+            and node.func.id in FORBIDDEN_CALL_NAMES
+        ):
+            raise ValueError(
+                f"Call to forbidden builtin function '{node.func.id}' "
+                f"(line {node.lineno})."
+            )
+        self.generic_visit(node)
+
+
+class CodeSecurityUtils:
+    """Utilities for safely validating and executing untrusted callback code."""
+
+    @staticmethod
+    def validate_callback_ast(code_str: str) -> None:
+        """Parses and validates callback code against an AST safety policy.
+
+        Raises:
+            ValueError: If the AST contains forbidden syntax (imports, dunder
+                attributes, or dangerous builtins).
+            SyntaxError: If the code is not valid Python syntax.
+        """
+        tree = ast.parse(code_str)
+        visitor = _CallbackSecurityVisitor()
+        visitor.visit(tree)
+
+    @staticmethod
+    def get_safe_builtins() -> dict[str, Any]:
+        """Returns a restricted dictionary of safe Python builtins."""
+        return dict(SAFE_BUILTINS)

--- a/tests/cxas_scrapi/core/test_callbacks.py
+++ b/tests/cxas_scrapi/core/test_callbacks.py
@@ -155,3 +155,39 @@ def test_execute_callback_callable() -> None:
     res = Callbacks.execute_callback(my_callable, {})
     assert res["success"] is True
     assert res["result"]["added_by_callable"] is True
+
+
+def test_execute_callback_import_blocked() -> None:
+    """Verifies that execute_callback fails safely on import statements."""
+    code = """
+def beforeModelCallback(session):
+    import os
+    return session
+"""
+    res = Callbacks.execute_callback(code, {})
+    assert "error" in res
+    assert "Security validation failed" in res["error"]
+
+
+def test_execute_callback_dunder_reflection_blocked() -> None:
+    """Verifies that execute_callback fails safely on dunder attacks."""
+    code = """
+def beforeModelCallback(session):
+    subclasses = session.__class__.__base__.__subclasses__()
+    return session
+"""
+    res = Callbacks.execute_callback(code, {})
+    assert "error" in res
+    assert "Security validation failed" in res["error"]
+
+
+def test_execute_callback_forbidden_builtin_blocked() -> None:
+    """Verifies that execute_callback fails safely on open() and eval()."""
+    code = """
+def beforeModelCallback(session):
+    open('/tmp/test', 'w')
+    return session
+"""
+    res = Callbacks.execute_callback(code, {})
+    assert "error" in res
+    assert "Security validation failed" in res["error"]

--- a/tests/cxas_scrapi/utils/test_code_security_utils.py
+++ b/tests/cxas_scrapi/utils/test_code_security_utils.py
@@ -1,0 +1,127 @@
+"""Tests for code security and AST evaluation utilities."""
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+
+import pytest
+
+from cxas_scrapi.utils.code_security_utils import CodeSecurityUtils
+
+
+def test_validate_callback_ast_valid_session_transformations() -> None:
+    """Verifies that legitimate callback logic passes AST validation."""
+    code = """
+def beforeModelCallback(session):
+    user_query = session.get("user_query", "").strip()
+    session["normalized_query"] = user_query.lower()
+    session["token_count"] = len(user_query.split())
+    session["is_valid"] = bool(user_query)
+
+    tags = []
+    for word in user_query.split():
+        if len(word) > 3:
+            tags.append(word.upper())
+    session["tags"] = tags
+    return session
+"""
+    # Should not raise
+    CodeSecurityUtils.validate_callback_ast(code)
+
+
+def test_validate_callback_ast_import_rejected() -> None:
+    """Verifies that import statements are strictly rejected."""
+    code = """
+def callback(session):
+    import os
+    os.system("echo compromised")
+    return session
+"""
+    with pytest.raises(
+        ValueError,
+        match="Import statements are forbidden in localized callbacks",
+    ):
+        CodeSecurityUtils.validate_callback_ast(code)
+
+
+def test_validate_callback_ast_import_from_rejected() -> None:
+    """Verifies that 'from ... import' statements are strictly rejected."""
+    code = """
+def callback(session):
+    from subprocess import Popen
+    return session
+"""
+    pattern = re.escape(
+        "'from ... import' statements are forbidden in localized callbacks"
+    )
+    with pytest.raises(ValueError, match=pattern):
+        CodeSecurityUtils.validate_callback_ast(code)
+
+
+def test_validate_callback_ast_dunder_attribute_rejected() -> None:
+    """Verifies that dunder attribute access is strictly rejected."""
+    code = """
+def callback(session):
+    subclasses = ().__class__.__base__.__subclasses__()
+    return session
+"""
+    with pytest.raises(
+        ValueError,
+        match="Access to private/dunder attribute",
+    ):
+        CodeSecurityUtils.validate_callback_ast(code)
+
+
+def test_validate_callback_ast_forbidden_builtins_rejected() -> None:
+    """Verifies that direct calls to forbidden builtins are rejected."""
+    forbidden_snippets = [
+        "def cb(s):\n    open('/tmp/test', 'w')\n    return s",
+        "def cb(s):\n    eval('1 + 1')\n    return s",
+        "def cb(s):\n    exec('x = 1')\n    return s",
+        "def cb(s):\n    compile('x = 1', '', 'exec')\n    return s",
+        "def cb(s):\n    globals()['foo'] = 1\n    return s",
+        "def cb(s):\n    locals()['foo'] = 1\n    return s",
+        "def cb(s):\n    __import__('os')\n    return s",
+    ]
+    for snippet in forbidden_snippets:
+        with pytest.raises(
+            ValueError, match="Call to forbidden builtin function"
+        ):
+            CodeSecurityUtils.validate_callback_ast(snippet)
+
+
+def test_validate_callback_ast_syntax_error() -> None:
+    """Verifies that invalid Python code raises a SyntaxError."""
+    code = "def broken_syntax(:"
+    with pytest.raises(SyntaxError):
+        CodeSecurityUtils.validate_callback_ast(code)
+
+
+def test_get_safe_builtins_isolation() -> None:
+    """Verifies that safe builtins contain standard helpers without danger."""
+    safe = CodeSecurityUtils.get_safe_builtins()
+
+    assert "len" in safe
+    assert "int" in safe
+    assert "str" in safe
+    assert "dict" in safe
+    assert "list" in safe
+    assert "isinstance" in safe
+
+    assert "open" not in safe
+    assert "eval" not in safe
+    assert "exec" not in safe
+    assert "compile" not in safe
+    assert "__import__" not in safe


### PR DESCRIPTION
### Description
Hardens localized callback execution in `Callbacks.execute_callback()` by introducing `CodeSecurityUtils` to perform static AST validation and restrict runtime builtins.

### Changes
* **AST Safety Policy**: Rejects `import` / `from ... import` statements, dangerous builtins (`open`, `eval`, `exec`, `compile`, `globals`, `locals`, `__import__`, `input`), and dunder reflection attributes (`__class__`, `__subclasses__`, `__globals__`).
* **Restricted Builtins**: Executes verified callbacks inside a copy-safe namespace containing only safe data primitives (`len`, `str`, `int`, `dict`, `list`, `isinstance`, `range`, `sum`, `max`, `min`, etc.).
* **Type Narrowing**: Verifies `target_fn` is callable before invocation.
*  Unit tests and integration testing