### PR TITLE
feat: Update turn evals for tool_not_called and not_contains

### DIFF
--- a/docs/guides/evaluation/turn-evals.md
+++ b/docs/guides/evaluation/turn-evals.md
@@ -43,8 +43,10 @@ turn_evals = TurnEvals(
 | Operator | Description |
 |----------|-------------|
 | `CONTAINS` | Agent response contains the expected string |
+| `NOT_CONTAINS` | Agent response does not contain the expected string |
 | `EQUALS` | Agent response exactly equals the expected string |
 | `TOOL_CALLED` | The specified tool was called during this turn |
+| `TOOL_NOT_CALLED` | The specified tool was not called during this turn |
 | `TOOL_INPUT` | The specified tool was called with the expected input argument |
 | `TOOL_OUTPUT` | The specified tool returned the expected output |
 | `NO_TOOLS_CALLED` | No tools were called during this turn |
@@ -55,8 +57,10 @@ from cxas_scrapi.evals.turn_evals import TurnOperator
 
 # Available values
 TurnOperator.CONTAINS
+TurnOperator.NOT_CONTAINS
 TurnOperator.EQUALS
 TurnOperator.TOOL_CALLED
+TurnOperator.TOOL_NOT_CALLED
 TurnOperator.TOOL_INPUT
 TurnOperator.TOOL_OUTPUT
 TurnOperator.NO_TOOLS_CALLED

--- a/src/cxas_scrapi/evals/turn_evals.py
+++ b/src/cxas_scrapi/evals/turn_evals.py
@@ -71,8 +71,10 @@ class TurnOperator(str, enum.Enum):
     """Operators for testing single-turn expectations."""
 
     CONTAINS = "contains"
+    NOT_CONTAINS = "not_contains"
     EQUALS = "equals"
     TOOL_CALLED = "tool_called"
+    TOOL_NOT_CALLED = "tool_not_called"
     TOOL_INPUT = "tool_input"
     TOOL_OUTPUT = "tool_output"
     NO_TOOLS_CALLED = "no_tools_called"
@@ -476,6 +478,14 @@ class TurnEvals:
                     justification = (
                         f"CONTAINS failed: '{expected}' not found in '{actual}'"
                     )
+            elif op == TurnOperator.NOT_CONTAINS:
+                actual = full_text.strip()
+                if str(expected).lower() in actual.lower():
+                    status = "FAILURE"
+                    justification = (
+                        f"NOT_CONTAINS failed: '{expected}' "
+                        f"unexpectedly found in '{actual}'"
+                    )
             elif op == TurnOperator.FUZZY_MATCH:
                 import numpy as np  # noqa: PLC0415
                 from sklearn.metrics.pairwise import (  # noqa: PLC0415
@@ -522,6 +532,18 @@ class TurnEvals:
                     justification = (
                         f"TOOL_CALLED failed: Expected tool '{expected}' was "
                         f"not called. Tools called: {called_tools}"
+                    )
+            elif op == TurnOperator.TOOL_NOT_CALLED:
+                actual = str(called_tools)
+                found = any(
+                    expected == t or t.endswith(expected) for t in called_tools
+                )
+                if found:
+                    status = "FAILURE"
+                    justification = (
+                        f"TOOL_NOT_CALLED failed: Unexpected tool "
+                        f"'{expected}' was called. "
+                        f"Tools called: {called_tools}"
                     )
             elif op == TurnOperator.NO_TOOLS_CALLED:
                 actual = str(called_tools)

--- a/tests/cxas_scrapi/evals/test_turn_evals.py
+++ b/tests/cxas_scrapi/evals/test_turn_evals.py
@@ -132,11 +132,17 @@ def test_validate_turn_test_success(
             TurnExpectation(
                 type=TurnOperator.TOOL_OUTPUT, value={"status": "SUCCESS"}
             ),
+            TurnExpectation(
+                type=TurnOperator.NOT_CONTAINS, value="wrong string"
+            ),
+            TurnExpectation(
+                type=TurnOperator.TOOL_NOT_CALLED, value="wrong_tool"
+            ),
         ],
     )
 
     results = mock_turn_evals.validate_turn_test(test_case, MagicMock())
-    assert len(results) == 5
+    assert len(results) == 7
     assert all(r["status"] == "SUCCESS" for r in results)
 
 
@@ -181,17 +187,23 @@ def test_validate_turn_test_failures(
                 type=TurnOperator.TOOL_INPUT, value={"query": "shoes"}
             ),
             TurnExpectation(type=TurnOperator.NO_TOOLS_CALLED, value=None),
+            TurnExpectation(type=TurnOperator.NOT_CONTAINS, value="Nope."),
+            TurnExpectation(
+                type=TurnOperator.TOOL_NOT_CALLED, value="other_tool"
+            ),
         ],
     )
 
     results = mock_turn_evals.validate_turn_test(test_case, MagicMock())
-    assert len(results) == 5
+    assert len(results) == 7
     assert all(r["status"] == "FAILURE" for r in results)
     assert any("CONTAINS failed" in r["justification"] for r in results)
     assert any("EQUALS failed" in r["justification"] for r in results)
     assert any("TOOL_CALLED failed" in r["justification"] for r in results)
     assert any("TOOL_INPUT failed" in r["justification"] for r in results)
     assert any("NO_TOOLS_CALLED failed" in r["justification"] for r in results)
+    assert any("NOT_CONTAINS failed" in r["justification"] for r in results)
+    assert any("TOOL_NOT_CALLED failed" in r["justification"] for r in results)
 
 
 @patch("cxas_scrapi.evals.turn_evals.MessageToDict")


### PR DESCRIPTION
Adding support for turn evals to have tools_not_called and not_contains expectations to flag against calls/substrings you know you don't want to occur.