### PR TITLE
fix(evals): support test_case max_turns and runtime overrides in simulation evals

### DIFF
--- a/src/cxas_scrapi/evals/simulation_evals.py
+++ b/src/cxas_scrapi/evals/simulation_evals.py
@@ -188,7 +188,7 @@ class LLMUserConversation(Conversation):
         genai_client: GeminiGenerate,
         genai_model: str,
         test_case: dict[str, Any],
-        max_turns: int = _MAX_TURNS,
+        max_turns: int | None = None,
         initial_utterance: str = _FIRST_UTTERANCE,
     ) -> None:
         super().__init__()
@@ -196,7 +196,10 @@ class LLMUserConversation(Conversation):
         self.genai_model = genai_model
         self.test_case = test_case
         self.initial_utterance = initial_utterance
-        self.max_turns = max_turns
+        if max_turns is not None:
+            self.max_turns = max_turns
+        else:
+            self.max_turns = test_case.get("max_turns") or _MAX_TURNS
         self.steps_progress = []
         for step in test_case["steps"]:
             self.steps_progress.append(
@@ -574,6 +577,7 @@ class SimulationEvals(Apps):
         initial_utterance: str = _FIRST_UTTERANCE,
         skip_playback_wait: bool = False,
         single_bidi_stream: bool = False,
+        max_turns: int | None = None,
         **kwargs: Any,
     ) -> LLMUserConversation:
         """Runs the simulated conversation loop.
@@ -587,6 +591,8 @@ class SimulationEvals(Apps):
             single_bidi_stream: For audio modality, keep one persistent
                 bidi WebSocket open for the whole conversation instead of
                 opening a new connection per turn (the default).
+            max_turns: Maximum number of conversation turns. Defaults to
+                the test_case's max_turns setting, or 30 if unspecified.
         """
         sim_user_model = sim_user_model or _DEFAULT_GEMINI_MODEL
         eval_model = eval_model or _DEFAULT_GEMINI_MODEL
@@ -597,6 +603,7 @@ class SimulationEvals(Apps):
             genai_client=self.genai_client,
             genai_model=sim_user_model,
             test_case=test_case,
+            max_turns=max_turns,
             initial_utterance=initial_utterance,
         )
 

--- a/tests/cxas_scrapi/evals/test_simulation_evals.py
+++ b/tests/cxas_scrapi/evals/test_simulation_evals.py
@@ -782,6 +782,129 @@ def test_llm_user_check_conversation_status_max_turns() -> None:
     assert conv._check_conversation_status() is False
 
 
+def test_llm_user_conversation_default_max_turns() -> None:
+    mock_genai_client = MagicMock()
+    test_case = {
+        "steps": [{"goal": "greet"}],
+    }
+    conv = LLMUserConversation(mock_genai_client, "model", test_case)
+    assert conv.max_turns == 30
+
+
+def test_llm_user_conversation_max_turns_from_test_case() -> None:
+    mock_genai_client = MagicMock()
+    test_case = {
+        "steps": [{"goal": "greet"}],
+        "max_turns": 15,
+    }
+    conv = LLMUserConversation(mock_genai_client, "model", test_case)
+    assert conv.max_turns == 15
+
+
+def test_llm_user_conversation_max_turns_override() -> None:
+    mock_genai_client = MagicMock()
+    test_case = {
+        "steps": [{"goal": "greet"}],
+        "max_turns": 15,
+    }
+    conv = LLMUserConversation(
+        mock_genai_client, "model", test_case, max_turns=5
+    )
+    assert conv.max_turns == 5
+
+
+def test_simulate_conversation_default_max_turns() -> None:
+    mock_sessions = MagicMock()
+    mock_response = MagicMock()
+    mock_response.session.name = (
+        "projects/test/locations/us/apps/123-abc/sessions/123"
+    )
+    mock_output = MagicMock()
+    mock_output.text = "Hello"
+    mock_response.outputs = [mock_output]
+    mock_sessions.run.return_value = mock_response
+
+    app_name = "projects/test/locations/us/apps/123-abc"
+    with patch("cxas_scrapi.evals.simulation_evals.GeminiGenerate"):  # noqa: SIM117
+        with patch("cxas_scrapi.core.apps.AgentServiceClient"):
+            simulator = SimulationEvals(app_name=app_name)
+    simulator.sessions_client = mock_sessions
+
+    test_case = {
+        "name": "test_tc_default",
+        "steps": [{"goal": "greet"}],
+    }
+    with patch.object(
+        LLMUserConversation, "next_user_utterance", return_value=("", {})
+    ):
+        conv = simulator.simulate_conversation(
+            test_case=test_case, console_logging=False
+        )
+    assert conv.max_turns == 30
+
+
+def test_simulate_conversation_uses_test_case_max_turns() -> None:
+    mock_sessions = MagicMock()
+    mock_response = MagicMock()
+    mock_response.session.name = (
+        "projects/test/locations/us/apps/123-abc/sessions/123"
+    )
+    mock_output = MagicMock()
+    mock_output.text = "Hello"
+    mock_response.outputs = [mock_output]
+    mock_sessions.run.return_value = mock_response
+
+    app_name = "projects/test/locations/us/apps/123-abc"
+    with patch("cxas_scrapi.evals.simulation_evals.GeminiGenerate"):  # noqa: SIM117
+        with patch("cxas_scrapi.core.apps.AgentServiceClient"):
+            simulator = SimulationEvals(app_name=app_name)
+    simulator.sessions_client = mock_sessions
+
+    test_case = {
+        "name": "test_tc_max_turns",
+        "max_turns": 8,
+        "steps": [{"goal": "greet"}],
+    }
+    with patch.object(
+        LLMUserConversation, "next_user_utterance", return_value=("", {})
+    ):
+        conv = simulator.simulate_conversation(
+            test_case=test_case, console_logging=False
+        )
+    assert conv.max_turns == 8
+
+
+def test_simulate_conversation_uses_explicit_max_turns() -> None:
+    mock_sessions = MagicMock()
+    mock_response = MagicMock()
+    mock_response.session.name = (
+        "projects/test/locations/us/apps/123-abc/sessions/123"
+    )
+    mock_output = MagicMock()
+    mock_output.text = "Hello"
+    mock_response.outputs = [mock_output]
+    mock_sessions.run.return_value = mock_response
+
+    app_name = "projects/test/locations/us/apps/123-abc"
+    with patch("cxas_scrapi.evals.simulation_evals.GeminiGenerate"):  # noqa: SIM117
+        with patch("cxas_scrapi.core.apps.AgentServiceClient"):
+            simulator = SimulationEvals(app_name=app_name)
+    simulator.sessions_client = mock_sessions
+
+    test_case = {
+        "name": "test_tc_max_turns",
+        "max_turns": 8,
+        "steps": [{"goal": "greet"}],
+    }
+    with patch.object(
+        LLMUserConversation, "next_user_utterance", return_value=("", {})
+    ):
+        conv = simulator.simulate_conversation(
+            test_case=test_case, max_turns=12, console_logging=False
+        )
+    assert conv.max_turns == 12
+
+
 def test_llm_user_get_active_step_index() -> None:
     mock_genai_client = MagicMock()
     test_case = {


### PR DESCRIPTION
## Summary of Changes

This PR allows simulation evals to respect the `max_turns` property defined in individual test cases, as well as optional runtime overrides via `simulate_conversation(..., max_turns=...)`, while preserving the fallback default of 30 turns.

Key changes:
- Updated `LLMUserConversation.__init__` to default `max_turns` to `None`. If omitted, it resolves from `test_case.get("max_turns")` and falls back to `_MAX_TURNS` (`30`).
- Added optional `max_turns: int | None = None` parameter to `SimulationEvals.simulate_conversation()` and forwarded it directly to `LLMUserConversation`.
- Preserved single source of truth for fallback resolution in `LLMUserConversation.__init__`.

## Motivation & Context

In CXAS SCRAPI eval YAMLs and test definitions, scenarios specify `max_turns` appropriate to flow complexity (e.g. 6 turns for simple routing, 16 turns for multi-step flows). Previously, `SimulationEvals.simulate_conversation()` did not forward turn limits to `LLMUserConversation`, causing all simulations to silently run with a hardcoded limit of 30 turns regardless of test case configuration.

## Precedence

1. **Explicit argument:** `simulate_conversation(..., max_turns=5)` ➔ `5`
2. **Test case setting:** `test_case = {"max_turns": 10, ...}` ➔ `10`
3. **Global default:** `test_case = {...}` ➔ `30`

## How Has This Been Tested?

Added comprehensive unit tests in `tests/cxas_scrapi/evals/test_simulation_evals.py`:
- `test_llm_user_conversation_default_max_turns` (verifies fallback to 30)
- `test_llm_user_conversation_max_turns_from_test_case` (verifies test case value is respected)
- `test_llm_user_conversation_max_turns_override` (verifies explicit parameter overrides test case value)
- `test_simulate_conversation_default_max_turns` (verifies `simulate_conversation` defaults to 30)
- `test_simulate_conversation_uses_test_case_max_turns` (verifies `simulate_conversation` uses test case `max_turns`)
- `test_simulate_conversation_uses_explicit_max_turns` (verifies `simulate_conversation` runtime parameter wins)

### Checks Run Locally:
```bash
ruff check src/ tests/       # PASSED
ruff format --check src/ tests/  # PASSED
pytest tests/cxas_scrapi/evals/  # 99 passed, 1 skipped