### PR TITLE
chore: make cxas CLI resolution robust across scripts and SDK

### DIFF
--- a/.agents/skills/cxas-agent-foundry/scripts/configure.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/configure.py
@@ -537,8 +537,13 @@ def _pull_app(config: typing.Any) -> typing.Any:
     else:
         app_resource = f"projects/{project}/locations/{location}/apps/{app_id}"
 
+    # Resolve cxas binary
+    cxas_bin = os.path.join(os.path.dirname(sys.executable), "cxas")
+    if not os.path.isfile(cxas_bin) or not os.access(cxas_bin, os.X_OK):
+        cxas_bin = "cxas"  # Fallback to PATH
+
     pull_cmd = [
-        "cxas", "pull", app_resource,
+        cxas_bin, "pull", app_resource,
         "--project-id", project,
         "--location", location,
         "--target-dir", app_dir,

--- a/.agents/skills/cxas-agent-foundry/scripts/gate-check.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/gate-check.py
@@ -123,7 +123,10 @@ def gate1_pull_lint_push(config: typing.Any, app_name: typing.Any, skip_push: ty
                 {
                     "step": label,
                     "stdout": "",
-                    "stderr": f"Error: '{cmd[0]}' command not found. Ensure it is in your PATH or virtualenv.",
+                    "stderr": (
+                        f"Error: '{cmd[0]}' command not found. "
+                        "Ensure it is in your PATH or virtualenv."
+                    ),
                 }
             )
             return False

--- a/.agents/skills/cxas-agent-foundry/scripts/gate-check.py
+++ b/.agents/skills/cxas-agent-foundry/scripts/gate-check.py
@@ -99,23 +99,38 @@ def gate1_pull_lint_push(config: typing.Any, app_name: typing.Any, skip_push: ty
 
     env = {**os.environ, "GOOGLE_CLOUD_PROJECT": project_id}
 
+    # Resolve cxas binary
+    cxas_bin = os.path.join(os.path.dirname(sys.executable), "cxas")
+    if not os.path.isfile(cxas_bin) or not os.access(cxas_bin, os.X_OK):
+        cxas_bin = "cxas"  # Fallback to PATH
+
     def _run(cmd: typing.Any, label: typing.Any) -> typing.Any:
         print(f"  $ {' '.join(cmd)}")
-        result = subprocess.run(cmd, env=env, capture_output=True, text=True)
-        if result.returncode != 0:
+        try:
+            result = subprocess.run(cmd, env=env, capture_output=True, text=True)
+            if result.returncode != 0:
+                r.findings.append(
+                    {
+                        "step": label,
+                        "stdout": result.stdout[-2000:],
+                        "stderr": result.stderr[-2000:],
+                    }
+                )
+                return False
+            return True
+        except FileNotFoundError:
             r.findings.append(
                 {
                     "step": label,
-                    "stdout": result.stdout[-2000:],
-                    "stderr": result.stderr[-2000:],
+                    "stdout": "",
+                    "stderr": f"Error: '{cmd[0]}' command not found. Ensure it is in your PATH or virtualenv.",
                 }
             )
             return False
-        return True
 
     # 1. Pull
     pull_cmd = [
-        "cxas",
+        cxas_bin,
         "pull",
         app_name,
         "--project-id",
@@ -132,7 +147,7 @@ def gate1_pull_lint_push(config: typing.Any, app_name: typing.Any, skip_push: ty
         return r
 
     # 2. Lint
-    lint_cmd = ["cxas", "lint", "--app-dir", app_dir]
+    lint_cmd = [cxas_bin, "lint", "--app-dir", app_dir]
     lint_clean = _run(lint_cmd, "lint")
 
     if not lint_clean:
@@ -143,7 +158,7 @@ def gate1_pull_lint_push(config: typing.Any, app_name: typing.Any, skip_push: ty
     # 3. Push (only if lint clean and not skipped)
     if lint_clean and not skip_push:
         push_cmd = [
-            "cxas",
+            cxas_bin,
             "push",
             "--app-dir",
             app_dir,

--- a/src/cxas_scrapi/cli/main.py
+++ b/src/cxas_scrapi/cli/main.py
@@ -783,6 +783,11 @@ def ci_test(args: argparse.Namespace) -> None:
     from cxas_scrapi.core.apps import Apps
     from cxas_scrapi.core.evaluations import Evaluations
 
+    # Resolve cxas binary path relative to the current python interpreter
+    cxas_bin = os.path.join(os.path.dirname(sys.executable), "cxas")
+    if not os.path.isfile(cxas_bin) or not os.access(cxas_bin, os.X_OK):
+        cxas_bin = "cxas"  # Fallback to PATH
+
     print("Starting CI Test Lifecycle...")
 
     if hasattr(args, "display_name") and args.display_name:
@@ -813,7 +818,7 @@ def ci_test(args: argparse.Namespace) -> None:
         if os.path.exists(test_file):
             print(f"\\n--- Running Tool Tests on {temp_app_name} ---")
             cmd = [
-                "cxas",
+                cxas_bin,
                 "test-tools",
                 "--app-name",
                 temp_app_name,
@@ -842,7 +847,7 @@ def ci_test(args: argparse.Namespace) -> None:
             )
             for eval_id in all_eval_ids:
                 cmd = [
-                    "cxas",
+                    cxas_bin,
                     "run",
                     "--app-name",
                     temp_app_name,

--- a/src/cxas_scrapi/migration/post_deploy_lint.py
+++ b/src/cxas_scrapi/migration/post_deploy_lint.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import sys
 import tempfile
 from typing import TYPE_CHECKING
 
@@ -51,23 +52,33 @@ async def run_post_deploy_lint(
         console.print(f"[yellow]{msg}[/]")
         return False, msg
 
+    # Resolve cxas binary path relative to the current python interpreter
+    cxas_bin = os.path.join(os.path.dirname(sys.executable), "cxas")
+    if not os.path.isfile(cxas_bin) or not os.access(cxas_bin, os.X_OK):
+        cxas_bin = "cxas"  # Fallback to PATH
+
     with tempfile.TemporaryDirectory(prefix="cxas_lint_") as temp_dir:
         console.print(f"  Pulling {app_resource} → {temp_dir}")
-        pull = await asyncio.create_subprocess_exec(
-            "cxas",
-            "pull",
-            app_resource,
-            "--target-dir",
-            temp_dir,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        _, pull_err = await pull.communicate()
-        if pull.returncode != 0:
-            err = pull_err.decode(errors="replace")
-            logger.error("cxas pull failed: %s", err)
-            console.print(f"[red]cxas pull failed:[/]\n{err}")
-            return False, err
+        try:
+            pull = await asyncio.create_subprocess_exec(
+                cxas_bin,
+                "pull",
+                app_resource,
+                "--target-dir",
+                temp_dir,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, pull_err = await pull.communicate()
+            if pull.returncode != 0:
+                err = pull_err.decode(errors="replace")
+                logger.error("cxas pull failed: %s", err)
+                console.print(f"[red]cxas pull failed:[/]\n{err}")
+                return False, err
+        except FileNotFoundError:
+            msg = f"Error: '{cxas_bin}' command not found. Ensure it is in your PATH or virtualenv."
+            console.print(f"[red]{msg}[/]")
+            return False, msg
 
         app_dir = _find_app_dir(temp_dir)
         if not app_dir:
@@ -76,17 +87,22 @@ async def run_post_deploy_lint(
             return False, msg
 
         console.print(f"  Linting {app_dir}")
-        lint = await asyncio.create_subprocess_exec(
-            "cxas",
-            "lint",
-            "--app-dir",
-            app_dir,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-        )
-        lint_out, _ = await lint.communicate()
-        output = lint_out.decode(errors="replace")
-        console.print(output)
+        try:
+            lint = await asyncio.create_subprocess_exec(
+                cxas_bin,
+                "lint",
+                "--app-dir",
+                app_dir,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+            lint_out, _ = await lint.communicate()
+            output = lint_out.decode(errors="replace")
+            console.print(output)
+        except FileNotFoundError:
+            msg = f"Error: '{cxas_bin}' command not found. Ensure it is in your PATH or virtualenv."
+            console.print(f"[red]{msg}[/]")
+            return False, msg
 
         if lint.returncode == 0:
             console.print("[bold green]Lint passed with 0 errors.[/]")

--- a/src/cxas_scrapi/migration/post_deploy_lint.py
+++ b/src/cxas_scrapi/migration/post_deploy_lint.py
@@ -76,7 +76,10 @@ async def run_post_deploy_lint(
                 console.print(f"[red]cxas pull failed:[/]\n{err}")
                 return False, err
         except FileNotFoundError:
-            msg = f"Error: '{cxas_bin}' command not found. Ensure it is in your PATH or virtualenv."
+            msg = (
+                f"Error: '{cxas_bin}' command not found. "
+                "Ensure it is in your PATH or virtualenv."
+            )
             console.print(f"[red]{msg}[/]")
             return False, msg
 
@@ -100,7 +103,10 @@ async def run_post_deploy_lint(
             output = lint_out.decode(errors="replace")
             console.print(output)
         except FileNotFoundError:
-            msg = f"Error: '{cxas_bin}' command not found. Ensure it is in your PATH or virtualenv."
+            msg = (
+                f"Error: '{cxas_bin}' command not found. "
+                "Ensure it is in your PATH or virtualenv."
+            )
             console.print(f"[red]{msg}[/]")
             return False, msg
 


### PR DESCRIPTION
This PR improves the useability of both the Agent Foundry scripts and the core SDK CLI/migration modules by ensuring the `cxas` CLI tool is executed from the correct environment (the active virtualenv), even if the virtualenv's bin directory is not explicitly in the user's `PATH`. This very likely will happen if a customer seeks to use these in their CI/CD workflow.

This is also standardizing these files to standardize the pattern found in other parts of the repo: eg: https://github.com/GoogleCloudPlatform/cxas-scrapi/blob/main/.agents/skills/cxas-agent-foundry/scripts/setup-project.py#L106