### PR TITLE
feat(foundry): support FunctionCall delegation in Slot Filling DAG pattern

### DIFF
--- a/.agents/skills/cxas-agent-foundry/agents/scaffolder.md
+++ b/.agents/skills/cxas-agent-foundry/agents/scaffolder.md
@@ -88,6 +88,7 @@ For each callback in the TDD's Callbacks section:
 - `<app_dir>/agents/<agent>/<callback_type>/<name>/python_code.py`
 - Common callbacks: `before_agent_callback` (auth derivation), `before_model_callback` (trigger pattern), `after_model_callback` (text injection)
 - Use the template's callbacks as reference for the function signature; adapt the body to the TDD's described logic.
+- **Slot-filling & DAG task execution:** When scaffolding `before_model_callback` for slot-filling agents, implement task execution by returning `LlmResponse.from_parts([Part.from_function_call(name=..., args=...)])` when DAG inputs are ready (along with `Part.from_text(..., partial=True)` for audio agents). Do NOT default to static text preemption so the LLM can generate natural confirmation turns from the tool return.
 - Update the agent's JSON to reference the callback (e.g., `beforeAgentCallbacks: [{pythonCode: "..."}]`). **Crucial**: The callback's `"pythonCode"` path in the agent's JSON must be relative to the app root and prefixed with `"agents/<agent>/"` (e.g., `"agents/support_bot/callbacks/greet_cb.py"`).
 - Follow `references/api-reference.md` → "Callbacks" verbatim for the runtime API. The rules there cover state access, return-value contracts, type imports, and the per-turn semantics that fail only at platform-push (not at lint) — re-read it if you're not sure.
 

--- a/.agents/skills/cxas-agent-foundry/agents/tdd-writer.md
+++ b/.agents/skills/cxas-agent-foundry/agents/tdd-writer.md
@@ -116,6 +116,8 @@ In either mode, if you find yourself about to write a name or behavior you didn'
 
 **Draft mode:** Propose callbacks ONLY when a source requires data derivation, side effects, or trigger-based behavior. For each: agent, callback type (`before_agent`, `before_model`, `after_model`, `after_agent`), proposed purpose, and which source justifies it. If no source motivates any callbacks, write *"No callbacks proposed; revisit if coverage analysis surfaces a need."* Don't add callbacks for symmetry — every callback is complexity the scaffolder will need to write and maintain.
 
+**Slot-Filling & Task Execution Rule:** When designing slot-filling or multi-input collection flows in a TDD, specify that `before_model_callback` uses **`FunctionCall` delegation** (`Part.from_function_call`) when all DAG dependencies are ready, rather than hardcoding static text preemption. This ensures the LLM synthesizes natural confirmation turns from the `toolResponse`. If the app uses audio modality, note the inclusion of `Part.from_text(..., partial=True)` for streaming voice filler during API latency.
+
 ### Step 6 — Coverage Map
 
 For each distinct behavior the sources describe:

--- a/.agents/skills/cxas-agent-foundry/references/callback-api.md
+++ b/.agents/skills/cxas-agent-foundry/references/callback-api.md
@@ -57,11 +57,25 @@ LlmResponse.from_parts(parts=[
     Part.from_text(text="Let me look that up for you.", partial=True),
     Part.from_function_call(name="lookup_account", args={"id": "123"}),
 ])
+
+# 3. Slot-Filling / DAG Task Delegation (Executes task when inputs ready, LLM synthesizes natural confirmation):
+LlmResponse.from_parts(parts=[
+    Part.from_text(text="Locking in your reservation now...", partial=True),
+    Part.from_function_call(
+        name="create_booking",
+        args={
+            "date": sm["filled"]["date"],
+            "time": sm["filled"]["time"],
+            "party_size": sm["filled"]["party_size"],
+        },
+    ),
+])
 ```
 
 **LLM Lifecycle Decision Matrix:**
-- **Text-Only Parts (`Part.from_text`)**: CXAS sends speech to user and closes bot turn. **LLM is bypassed.**
-- **FunctionCall Parts (`Part.from_function_call`)**: CXAS executes tool and feeds `toolResponse` back to LLM. **LLM is invoked.**
+- **Text-Only Parts (`Part.from_text`)**: CXAS sends speech/text to user and closes bot turn. **LLM is bypassed.**
+- **FunctionCall Parts (`Part.from_function_call`)**: CXAS executes tool and feeds `toolResponse` back to LLM. **LLM is invoked** to generate the final response turn based on persona and instructions.
+  - See [before_model_callback for DAG and slot-filling](https://googlecloudplatform.github.io/cxas-scrapi/stable/design-guide/callbacks/#before_model_callback-for-dag-and-slot-filling).
 - **Gotcha (`EMPTY_RESPONSE`)**: If you need to speak a prompt deterministically and wait for user speech, do NOT return a `FunctionCall` part in the same response. Execute the tool synchronously via `tools.<tool_name>()` in Python and return only `Part.from_text(...)`.
 
 **Reading responses** (in after_model callbacks):

--- a/.agents/skills/cxas-agent-foundry/references/gecx-design-guide.md
+++ b/.agents/skills/cxas-agent-foundry/references/gecx-design-guide.md
@@ -582,9 +582,12 @@ Three layers, all in one callback file:
 
 **Lean on the orchestrator.** If a constraint is enforced by code (validation, tool visibility, retry logic), don't duplicate it in prompts or tool docstrings. Redundant constraints cause the LLM to pre-filter input, skip tool calls, or improvise error messages — bypassing the framework's error handling.
 
-**Setters are thin.** Setter tools validate input, write to `pending`, signal errors via `_slot_errors`, and return. They contain zero DAG logic, zero control flow, zero knowledge of other slots.
-
-**Preempt when the answer is known.** When a task fires and the framework knows exactly what to say, it skips the LLM via `LlmResponse.from_parts()`. Faster, deterministic, and consistent.
+**Task Execution: FunctionCall Delegation vs. Static Preemption.**
+When all required slot dependencies are satisfied and a task is ready to fire, choose the appropriate completion pattern:
+- **`FunctionCall` Delegation (Recommended for Natural & Empathetic Responses):** Instead of executing the tool in Python and sending hardcoded text, the `before_model_callback` returns `Part.from_function_call(name=..., args=...)`. The platform executes the tool, returns `toolResponse` to the LLM, and allows the model to synthesize a warm, persona-aligned confirmation turn naturally.
+  - *Audio Filler Optimization:* When modality is audio, combine with `Part.from_text(text="...", partial=True)` to stream conversational filler while the backend API executes, eliminating dead air.
+  - Reference: See [before_model_callback for DAG and slot-filling](https://googlecloudplatform.github.io/cxas-scrapi/stable/design-guide/callbacks/#before_model_callback-for-dag-and-slot-filling).
+- **Static Preemption (`Part.from_text`):** Use only when strict, zero-variance compliance or zero-token turns are required. Bypasses the LLM completely with fixed text.
 
 ### Reference Implementation
 

--- a/docs/patterns/slot-filling.md
+++ b/docs/patterns/slot-filling.md
@@ -420,14 +420,39 @@ The `requires` field on `selected_time` enforces the dependency at two levels:
 1. The question is skipped in `_next_question` until `available_times` is filled.
 2. The setter tool is **hidden** from the LLM's tool list until the dependency is met — so the LLM structurally cannot call `set_selected_time` before availability is known.
 
----
+## The callback preemption mechanism & FunctionCall delegation
 
-## The callback preemption mechanism
+When all required task inputs are ready, the callback has two execution paths:
 
-!!! warning "Callback Preemption — the most critical architectural detail"
-    When the callback fires a task and preempts the LLM, **the LLM does not get a turn**. Any setter tools the LLM had queued in the current response but not yet called are **permanently lost**. This is why the agent instruction must require all setter tools to be called in the **same response** — deferring any setter to a later turn creates a race condition with the callback.
+### 1. FunctionCall Delegation (Recommended for Natural Responses)
 
-Preemption uses `LlmResponse.from_parts()` to bypass LLM generation entirely:
+Rather than executing the task inside the callback and returning static text, the callback returns a `Part.from_function_call()`. The platform executes the tool and feeds the `toolResponse` back to the LLM in the same turn, allowing the model to generate a warm, persona-aligned confirmation:
+
+```python
+if dag_all_inputs_ready:
+    return LlmResponse.from_parts(parts=[
+        # Optional: Conversational audio filler
+        Part.from_text(text="Locking in your reservation now...", partial=True),
+        Part.from_function_call(
+            name="book_reservation",
+            args={
+                "party_size": sm["filled"]["party_size"],
+                "preferred_date": sm["filled"]["preferred_date"],
+                "selected_time": sm["filled"]["selected_time"],
+                "guest_name": sm["filled"]["guest_name"],
+            }
+        )
+    ])
+```
+
+See [before_model_callback for DAG and slot-filling](https://googlecloudplatform.github.io/cxas-scrapi/stable/design-guide/callbacks/#before_model_callback-for-dag-and-slot-filling) for full details on this lifecycle.
+
+### 2. Callback Preemption (Static Text)
+
+!!! warning "Callback Preemption — architectural detail"
+    When the callback fires a task and preempts the LLM with text, **the LLM does not get a turn**. Any setter tools the LLM had queued in the current response but not yet called are **permanently lost**. This is why the agent instruction must require all setter tools to be called in the **same response** — deferring any setter to a later turn creates a race condition with the callback.
+
+Preemption uses `LlmResponse.from_parts()` with text to bypass LLM generation entirely:
 
 ```python
 if task_fired and llm_request.contents and len(llm_request.contents) > 1:
@@ -445,10 +470,9 @@ User message
     → LLM calls setter tool(s) in one response
     → before_model_callback fires
         → Check DAG: are all task inputs now satisfied?
-            YES → fire task, store result in sm
-                → If multi-content (not first turn): PREEMPT
-                    → LlmResponse returned directly — LLM skipped
-                    → Task result delivered verbatim
+            YES →
+                Option A (Delegation): Return FunctionCall part → Tool runs → LLM generates natural confirmation
+                Option B (Preemption): Execute in Python → Return LlmResponse with text → LLM skipped
             NO → compute next question
                 → Set sm['_system_message']
                 → Return OK → LLM generates response using _system_message


### PR DESCRIPTION
### Summary
This PR updates the `cxas-agent-foundry` skill and SDK documentation to support and prescribe the **`FunctionCall` Delegation Pattern** for Slot-Filling DAG task completion, adopting the principles described in the CXAS Callback Design Guide:
👉 [before_model_callback for DAG and slot-filling](https://googlecloudplatform.github.io/cxas-scrapi/stable/design-guide/callbacks/#before_model_callback-for-dag-and-slot-filling)

### Problem
Previously, the Slot-Filling DAG framework guided agents to synchronously execute tools in Python and preempt the model with static text (`Part.from_text(...)`). While deterministic, this resulted in robotic, hardcoded transactional confirmations that could not leverage agent personas or generate natural conversational phrasing.

### Solution
Allow `before_model_callback` to return `Part.from_function_call(name=..., args=...)` when DAG prerequisites are ready. The platform executes the tool, feeds the `toolResponse` back to the model, and allows the LLM to generate a natural, empathetic response.

### Changes Included
- **`references/gecx-design-guide.md`**: Replaced static text preemption with FunctionCall delegation and added the voice streaming filler pattern (`partial=True`).
- **`references/callback-api.md`**: Updated `LlmResponse` decision matrix and added code pattern for DAG FunctionCall delegation.
- **`agents/tdd-writer.md`**: Added Step 5 callback rule to specify FunctionCall delegation in generated TDDs.
- **`agents/scaffolder.md`**: Updated Step 5 to scaffold `before_model_callback` returning `Part.from_function_call`.
- **`docs/patterns/slot-filling.md`**: Documented the delegation workflow alongside preemption and linked to the callback design guide.

### Related Issue
Closes https://github.com/GoogleCloudPlatform/cxas-scrapi/issues/424
