### PR TITLE
feat: add trace estimate-quota CLI for quota estimation

### DIFF
--- a/.agents/skills/cxas-agent-foundry/SKILL.md
+++ b/.agents/skills/cxas-agent-foundry/SKILL.md
@@ -35,7 +35,14 @@ python .agents/skills/cxas-agent-foundry/scripts/run-and-report.py --message "wh
 # Generate dynamic interactive HTML dashboard with Gemini LLM failure clustering and parameter filters
 python .agents/skills/cxas-agent-foundry/scripts/generate_interactive_report.py --input <path_to_sim_results.json> --output <path_to_report.html>
 
+# Estimate token and tool call production quotas based on sampled trace telemetry
+cxas trace estimate-quota --app-name projects/<project_id>/locations/<location>/apps/<app_id> --peak-text-cpm 100 --peak-audio-cpm 50 --time-filter 7d
+
+# You can also bound the history precisely using UTC ISO strings to override --time-filter
+cxas trace estimate-quota --app-name projects/<project_id>/locations/<location>/apps/<app_id> --time-start "2026-07-29T12:00:00" --time-end "2026-07-30T10:00:00"
+
 # Inspect app architecture
+
 python .agents/skills/cxas-agent-foundry/scripts/inspect-app.py
 
 # Triage failures

--- a/.agents/skills/cxas-agent-foundry/references/generating-reports.md
+++ b/.agents/skills/cxas-agent-foundry/references/generating-reports.md
@@ -287,3 +287,14 @@ For each agent, produce:
 - Tool invocation correctness below 1.0 means missed or wrong tool calls
 - Compare trends across the last 10 results to spot regressions
 - When a golden eval is marked `invalid: true`, it references a deleted/changed tool -- flag prominently
+
+## Estimating Production Quotas (Trace Extrapolation)
+
+When preparing an agent for production, you can calculate the expected Gemini Enterprise conversational quotas based on past trace history and an assumed traffic volume:
+
+```bash
+# Estimate token and tool call production quotas
+cxas trace estimate-quota --app-name projects/<project_id>/locations/<location>/apps/<app_id> --peak-text-cpm 100 --peak-audio-cpm 50 --time-filter 7d
+```
+
+This will output estimated QPM (Quota per Minute) targets for `Chat/GenerateContent` (Tokens) and `Session/StreamingAnalyzeContent` (Turns).

--- a/docs/cli/trace.md
+++ b/docs/cli/trace.md
@@ -28,6 +28,7 @@ All `cxas trace` subcommands share a few flags:
 | `cxas trace audio transcribe <id>` / `cxas trace transcribe-audio <id>` | Transcribe GCS user turn audio with Gemini Flash/Flash-Lite, calculate WER against CES transcripts, and optionally reprocess into a cloned BigQuery export table. |
 | `cxas trace triage <id>` | Run text-only Gemini triage prompts over the transcript. |
 | `cxas trace replay <id>` | Replay user inputs against the current agent and diff. |
+| `cxas trace estimate-quota` | Estimates production token and tool quotas based on an average of recent conversational traces. |
 | `cxas trace stats` | Aggregate stats over recent conversations. |
 | `cxas trace bundle <id>` | Zip transcript + logs + audio + report into a single archive. |
 | `cxas trace bug-report <id>` | Flag a conversation as a platform bug; uploads bundle to a configured GCS bucket. |
@@ -57,6 +58,16 @@ Compare a deployed conversation against the current agent:
 
 ```
 cxas trace replay conv-id-1 --app-name projects/p/locations/l/apps/a --diff
+```
+
+
+Generate a quota estimation based on conversational traces from the last 7 days, assuming a peak traffic of 100 conversations per minute:
+
+```
+cxas trace estimate-quota \
+  --app-name projects/p/locations/l/apps/a \
+  --peak-text-cpm 100 --peak-audio-cpm 50 \
+  --time-filter 7d
 ```
 
 Generate a 7-day stats report grouped by source, written as Markdown:

--- a/fix_quotas.py
+++ b/fix_quotas.py
@@ -1,0 +1,32 @@
+with open("src/cxas_scrapi/core/traces.py", "r") as f:
+    text = f.read()
+
+# We need to define _compute_quotas right before it is used.
+import re
+
+pattern = re.compile(r"        ret_avgs = \{\}\n        ret_quotas = \{\}", re.DOTALL)
+new_defs = """        def _compute_quotas(avgs, peak_cpm):
+            q = {
+                "chat_token_quota": avgs.get("tokens_total", 0) * peak_cpm,
+                "execute_tool_quota": avgs.get("tool_calls", 0) * peak_cpm,
+                "streaming_analyze_content_quota": avgs.get("turns", 0) * peak_cpm,
+            }
+            if "duration_seconds" in avgs:
+                q["audio_seconds_per_minute"] = avgs["duration_seconds"] * peak_cpm
+                q["concurrent_bidi_sessions"] = (peak_cpm / 60.0) * avgs["duration_seconds"]
+            return q
+
+        ret_avgs = {}
+        ret_quotas = {}"""
+
+text = pattern.sub(new_defs, text)
+
+# We also still have the old hardcoded return block floating below our new return block!!!
+# Let's purge everything after our return { traffic_assumptions... } up to the end of the method.
+
+pattern2 = re.compile(r"                    \"estimated_quotas_per_minute\": ret_quotas\n        \}\n        \n        if peak_audio_cpm > 0 and audio_avgs:.*?        return \{\n.*?        \}", re.DOTALL)
+text = pattern2.sub("                    \"estimated_quotas_per_minute\": ret_quotas\n        }", text)
+
+with open("src/cxas_scrapi/core/traces.py", "w") as f:
+    f.write(text)
+

--- a/patch_skill.py
+++ b/patch_skill.py
@@ -1,0 +1,20 @@
+import re
+
+with open(".agents/skills/cxas-agent-foundry/SKILL.md", "r") as f:
+    text = f.read()
+
+conflict = re.compile(r"<<<<<<< HEAD.*?=======\n(.*?)\n>>>>>>>.*?\n", re.DOTALL)
+
+def replacer(match):
+    # Keep both the HEAD part (interactive report) and the feature part (estimate quota)
+    # But for estimate-quota, we must use our updated flags that I had patched earlier locally
+    return """# Generate dynamic interactive HTML dashboard with Gemini LLM failure clustering and parameter filters
+python .agents/skills/cxas-agent-foundry/scripts/generate_interactive_report.py --input <path_to_sim_results.json> --output <path_to_report.html>
+
+# Estimate token and tool call production quotas based on sampled trace telemetry
+cxas trace estimate-quota --app-name projects/<project_id>/locations/<location>/apps/<app_id> --peak-text-cpm 100 --peak-audio-cpm 50 --time-filter 7d\n"""
+
+text = conflict.sub(replacer, text)
+
+with open(".agents/skills/cxas-agent-foundry/SKILL.md", "w") as f:
+    f.write(text)

--- a/patch_trace_cli.py
+++ b/patch_trace_cli.py
@@ -1,0 +1,90 @@
+import re
+
+with open("src/cxas_scrapi/cli/trace_cli.py", "r") as f:
+    text = f.read()
+
+# Replace trace_estimate_quota function
+pattern_func = re.compile(r"def trace_estimate_quota\(args: argparse\.Namespace\) -> None:.*?# ----------------------------- argparse wiring ------------------------------", re.DOTALL)
+
+new_func = """def trace_estimate_quota(args: argparse.Namespace) -> None:
+    try:
+        traces = _build_traces(args)
+        stats = traces.estimate_quota(
+            peak_text_cpm=args.peak_text_cpm,
+            peak_audio_cpm=args.peak_audio_cpm,
+            time_filter=args.time_filter,
+            source_filter=args.source,
+            limit=args.limit,
+        )
+    except Exception as e:
+        print(f"Estimation failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.format == "json":
+        import json
+        print(json.dumps(stats, indent=2, default=str))
+        return
+
+    # default: formatted text
+    print(f"# Quota Estimation Based on Last {args.time_filter}")
+    print("\\n## Traffic Assumptions")
+    print(f"- Peak Text Conversations / Minute: {stats.get('traffic_assumptions', {}).get('peak_text_cpm')}")
+    print(f"- Peak Audio Conversations / Minute: {stats.get('traffic_assumptions', {}).get('peak_audio_cpm')}")
+    print(f"- Total Traces Sampled: {stats.get('traffic_assumptions', {}).get('sample_size')} (Audio: {stats.get('traffic_assumptions', {}).get('audio_samples')}, Text: {stats.get('traffic_assumptions', {}).get('text_samples')})")
+
+    if "error" in stats:
+        print(f"\\nError: {stats['error']}")
+        return
+
+    avgs = stats.get('averages_per_conversation', {})
+    qs = stats.get('estimated_quotas_per_minute', {})
+
+    if args.peak_text_cpm > 0 and "text" in avgs:
+        print("\\n### TEXT Traffic")
+        print("#### Averages per Conversation")
+        print(f"- Tokens Input:  {avgs['text'].get('tokens_input', 0):.2f}")
+        print(f"- Tokens Output: {avgs['text'].get('tokens_output', 0):.2f}")
+        print(f"- Tokens Total:  {avgs['text'].get('tokens_total', 0):.2f}")
+        print(f"- Tool Calls:    {avgs['text'].get('tool_calls', 0):.2f}")
+        print(f"- Turns:         {avgs['text'].get('turns', 0):.2f}")
+        
+        print("\\n#### Estimated Quotas per Minute")
+        tq = qs.get("text", {})
+        print(f"- Chat Token Quota: {tq.get('chat_token_quota', 0):.2f}")
+        print(f"- ExecuteTool Quota: {tq.get('execute_tool_quota', 0):.2f}")
+        print(f"- StreamingAnalyzeContent Quota: {tq.get('streaming_analyze_content_quota', 0):.2f} (≈ turns per minute)")
+
+    if args.peak_audio_cpm > 0 and "audio" in avgs:
+        print("\\n### AUDIO Traffic")
+        print("#### Averages per Conversation")
+        print(f"- Tokens Input:  {avgs['audio'].get('tokens_input', 0):.2f}")
+        print(f"- Tokens Output: {avgs['audio'].get('tokens_output', 0):.2f}")
+        print(f"- Tokens Total:  {avgs['audio'].get('tokens_total', 0):.2f}")
+        print(f"- Tool Calls:    {avgs['audio'].get('tool_calls', 0):.2f}")
+        print(f"- Turns:         {avgs['audio'].get('turns', 0):.2f}")
+        print(f"- Duration (s):  {avgs['audio'].get('duration_seconds', 0):.2f}")
+        
+        print("\\n#### Estimated Quotas per Minute")
+        aq = qs.get("audio", {})
+        print(f"- Chat Token Quota: {aq.get('chat_token_quota', 0):.2f}")
+        print(f"- ExecuteTool Quota: {aq.get('execute_tool_quota', 0):.2f}")
+        print(f"- StreamingAnalyzeContent Quota: {aq.get('streaming_analyze_content_quota', 0):.2f} (≈ turns per minute)")
+        print(f"- Audio Seconds per Minute: {aq.get('audio_seconds_per_minute', 0):.2f}")
+        print(f"- Concurrent BidiRunSession: {aq.get('concurrent_bidi_sessions', 0):.2f} (≈ active connections)")
+
+
+# ----------------------------- argparse wiring ------------------------------"""
+
+text = pattern_func.sub(new_func, text)
+
+# Replace argparse setup
+pattern_args = re.compile(r"    p_eq.add_argument\(\"--peak-conversations-per-minute\".*?\)", re.DOTALL)
+new_args = """    p_eq.add_argument("--peak-text-cpm", type=int, default=0, help="Estimated peak text conversations per minute.")
+    p_eq.add_argument("--peak-audio-cpm", type=int, default=0, help="Estimated peak audio conversations per minute.")"""
+
+text = pattern_args.sub(new_args, text)
+
+with open("src/cxas_scrapi/cli/trace_cli.py", "w") as f:
+    f.write(text)
+
+print("PATCH CLI SUCCESS")

--- a/patch_trace_cli2.py
+++ b/patch_trace_cli2.py
@@ -1,0 +1,42 @@
+import re
+
+with open("src/cxas_scrapi/cli/trace_cli.py", "r") as f:
+    text = f.read()
+
+# Replace the specific print calls with a dynamic loop over channels
+pattern = re.compile(r"    if args\.peak_text_cpm > 0 and \"text\" in avgs:.*?\(≈ active connections\)\"\)", re.DOTALL)
+
+new_logic = """    for ch, a in avgs.items():
+        # Fallback to 0 if a custom channel doesn't have a specific peak cpm flag
+        cpm = args.peak_text_cpm
+        if ch.upper() == "AUDIO":
+            cpm = args.peak_audio_cpm
+        
+        # Don't print stats for a channel if its target CPM is 0 and it isn't text
+        if cpm == 0 and ch.upper() != "TEXT":
+            continue
+
+        print(f"\\n### {ch.upper()} Traffic")
+        print("#### Averages per Conversation")
+        print(f"- Tokens Input:  {a.get('tokens_input', 0):.2f}")
+        print(f"- Tokens Output: {a.get('tokens_output', 0):.2f}")
+        print(f"- Tokens Total:  {a.get('tokens_total', 0):.2f}")
+        print(f"- Tool Calls:    {a.get('tool_calls', 0):.2f}")
+        print(f"- Turns:         {a.get('turns', 0):.2f}")
+        if 'duration_seconds' in a:
+            print(f"- Duration (s):  {a.get('duration_seconds', 0):.2f}")
+        
+        print("\\n#### Estimated Quotas per Minute")
+        q = qs.get(ch, {})
+        print(f"- Chat Token Quota: {q.get('chat_token_quota', 0):.2f}")
+        print(f"- ExecuteTool Quota: {q.get('execute_tool_quota', 0):.2f}")
+        print(f"- StreamingAnalyzeContent Quota: {q.get('streaming_analyze_content_quota', 0):.2f} (≈ turns per minute)")
+        if 'audio_seconds_per_minute' in q:
+            print(f"- Audio Seconds per Minute: {q.get('audio_seconds_per_minute', 0):.2f}")
+            print(f"- Concurrent BidiRunSession: {q.get('concurrent_bidi_sessions', 0):.2f} (≈ active connections)")"""
+
+text = pattern.sub(new_logic, text)
+
+with open("src/cxas_scrapi/cli/trace_cli.py", "w") as f:
+    f.write(text)
+

--- a/patch_traces.py
+++ b/patch_traces.py
@@ -1,0 +1,29 @@
+with open("src/cxas_scrapi/core/traces.py", "r") as f:
+    text = f.read()
+
+# Replace the hardcoded TEXT/AUDIO initialization and forced defaulting logic
+old_logic = """        stats_by_channel = {
+            "TEXT": _init_stats(),
+            "AUDIO": _init_stats()
+        }
+
+        for item in fetched_items:
+            n = item["normalized"]
+            ch = item["channel"] or "TEXT"
+            if ch not in stats_by_channel:
+                ch = "TEXT" # Default unknown to text"""
+
+new_logic = """        stats_by_channel = {}
+
+        for item in fetched_items:
+            n = item["normalized"]
+            ch = item["channel"] or "UNKNOWN"
+            if ch not in stats_by_channel:
+                stats_by_channel[ch] = _init_stats()"""
+
+text = text.replace(old_logic, new_logic)
+
+# Re-read and output
+with open("src/cxas_scrapi/core/traces.py", "w") as f:
+    f.write(text)
+

--- a/patch_traces2.py
+++ b/patch_traces2.py
@@ -1,0 +1,102 @@
+with open("src/cxas_scrapi/core/traces.py", "r") as f:
+    text = f.read()
+
+import re
+
+# We will modify how stats_by_channel is constructed.
+# Let's dynamically add the channel to stats_by_channel!
+
+old_code = """        stats_by_channel = {
+            "TEXT": {"traffic_assumptions": {}, "averages_per_conversation": {}, "sum": {}, "sample_size": 0},
+            "AUDIO": {"traffic_assumptions": {}, "averages_per_conversation": {}, "sum": {}, "sample_size": 0},
+        }
+
+        for fut in futures:
+            item = futures[fut]
+            if "error" in item:
+                continue
+
+            ch = item["channel"] or "TEXT"
+            if ch not in stats_by_channel:
+                ch = "TEXT"
+
+            b = stats_by_channel[ch]"""
+
+new_code = """        stats_by_channel = {}
+        for fut in futures:
+            item = futures[fut]
+            if "error" in item:
+                continue
+                
+            ch = item["channel"] or "UNKNOWN"
+            if ch not in stats_by_channel:
+                stats_by_channel[ch] = {"traffic_assumptions": {}, "averages_per_conversation": {}, "sum": {}, "sample_size": 0}
+
+            b = stats_by_channel[ch]"""
+
+if old_code in text:
+    text = text.replace(old_code, new_code)
+else:
+    print("Could not find old_code")
+
+# Fix what gets returned
+old_return = """        text_avgs = _compute_averages(stats_by_channel["TEXT"])
+        audio_avgs = _compute_averages(stats_by_channel["AUDIO"])
+
+        text_q = _compute_quotas(text_avgs, peak_text_cpm)
+        audio_q = _compute_quotas(audio_avgs, peak_audio_cpm)
+
+        return {
+            "traffic_assumptions": {
+                "peak_text_cpm": peak_text_cpm,
+                "peak_audio_cpm": peak_audio_cpm,
+                "sample_size": len([f for f in futures if "error" not in futures[f]]),
+                "audio_samples": stats_by_channel["AUDIO"]["sample_size"],
+                "text_samples": stats_by_channel["TEXT"]["sample_size"]
+            },
+            "averages_per_conversation": {
+                "text": text_avgs,
+                "audio": audio_avgs,
+            },
+            "estimated_quotas_per_minute": {
+                "text": text_q,
+                "audio": audio_q,
+            }
+        }"""
+
+new_return = """        ret_avgs = {}
+        ret_quotas = {}
+        
+        # Determine the peak cpm dynamically per channel based on inputs (fallback to text cpm for unknown)
+        for ch, stats in stats_by_channel.items():
+            avgs = _compute_averages(stats)
+            ret_avgs[ch.lower()] = avgs
+            
+            cpm = peak_text_cpm
+            if ch == "AUDIO":
+                cpm = peak_audio_cpm
+            
+            ret_quotas[ch.lower()] = _compute_quotas(avgs, cpm)
+            
+        return {
+            "traffic_assumptions": {
+                "peak_text_cpm": peak_text_cpm,
+                "peak_audio_cpm": peak_audio_cpm,
+                "sample_size": len([f for f in futures if "error" not in futures[f]]),
+                "samples_per_channel": {ch: stats["sample_size"] for ch, stats in stats_by_channel.items()}
+            },
+            "averages_per_conversation": ret_avgs,
+            "estimated_quotas_per_minute": ret_quotas
+        }"""
+
+if old_return in text:
+    text = text.replace(old_return, new_return)
+else:
+    # Try regex fallback for return if we missed something due to indentation
+    pattern = re.compile(r"        text_avgs = _compute_averages\(stats_by_channel\[\"TEXT\"\]\).*?        }", re.DOTALL)
+    text = pattern.sub(new_return, text)
+
+
+with open("src/cxas_scrapi/core/traces.py", "w") as f:
+    f.write(text)
+

--- a/src/cxas_scrapi/cli/trace_cli.py
+++ b/src/cxas_scrapi/cli/trace_cli.py
@@ -696,6 +696,72 @@ def trace_open(args: argparse.Namespace) -> None:
             subprocess.run(["open", url], check=False)
 
 
+
+def trace_estimate_quota(args: argparse.Namespace) -> None:
+    try:
+        traces = _build_traces(args)
+        stats = traces.estimate_quota(
+            peak_text_cpm=args.peak_text_cpm,
+            peak_audio_cpm=args.peak_audio_cpm,
+            start_time=args.time_start,
+            end_time=args.time_end,
+            time_filter=args.time_filter,
+            source_filter=args.source,
+            limit=args.limit,
+        )
+    except Exception as e:
+        print(f"Estimation failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.format == "json":
+        import json
+        print(json.dumps(stats, indent=2, default=str))
+        return
+
+    # default: formatted text
+    print(f"# Quota Estimation Based on Last {args.time_filter}")
+    print("\n## Traffic Assumptions")
+    print(f"- Peak Text Conversations / Minute: {stats.get('traffic_assumptions', {}).get('peak_text_cpm')}")
+    print(f"- Peak Audio Conversations / Minute: {stats.get('traffic_assumptions', {}).get('peak_audio_cpm')}")
+    print(f"- Total Traces Sampled: {stats.get('traffic_assumptions', {}).get('sample_size')} (Audio: {stats.get('traffic_assumptions', {}).get('audio_samples')}, Text: {stats.get('traffic_assumptions', {}).get('text_samples')})")
+
+    if "error" in stats:
+        print(f"\nError: {stats['error']}")
+        return
+
+    avgs = stats.get('averages_per_conversation', {})
+    qs = stats.get('estimated_quotas_per_minute', {})
+
+    for ch, a in avgs.items():
+        # Fallback to 0 if a custom channel doesn't have a specific peak cpm flag
+        cpm = args.peak_text_cpm
+        if ch.upper() == "VOICE":
+            cpm = args.peak_audio_cpm
+        
+        # Don't print stats for a channel if its target CPM is 0 and it isn't chat
+        if cpm == 0 and ch.upper() != "CHAT":
+            continue
+
+        print(f"\n### {ch.upper()} Traffic")
+        print("#### Averages per Conversation")
+        print(f"- Tokens Input:  {a.get('tokens_input', 0):.2f}")
+        print(f"- Tokens Output: {a.get('tokens_output', 0):.2f}")
+        print(f"- Tokens Total:  {a.get('tokens_total', 0):.2f}")
+        print(f"- Tool Calls:    {a.get('tool_calls', 0):.2f}")
+        print(f"- Turns:         {a.get('turns', 0):.2f}")
+        if 'duration_seconds' in a:
+            print(f"- Duration (s):  {a.get('duration_seconds', 0):.2f}")
+        
+        print("\n#### Estimated Quotas per Minute")
+        q = qs.get(ch, {})
+        print(f"- Chat Token Quota: {q.get('chat_token_quota', 0):.2f}")
+        print(f"- ExecuteTool Quota: {q.get('execute_tool_quota', 0):.2f}")
+        print(f"- StreamingAnalyzeContent Quota: {q.get('streaming_analyze_content_quota', 0):.2f} (≈ turns per minute)")
+        if 'audio_seconds_per_minute' in q:
+            print(f"- Audio Seconds per Minute: {q.get('audio_seconds_per_minute', 0):.2f}")
+            print(f"- Concurrent BidiRunSession: {q.get('concurrent_bidi_sessions', 0):.2f} (≈ active connections)")
+
+
 # ----------------------------- argparse wiring ------------------------------
 
 
@@ -733,6 +799,34 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         "--format", choices=["table", "json", "csv"], default="table"
     )
     p_list.set_defaults(func=trace_list)
+
+
+    # estimate-quota
+    p_eq = trace_subparsers.add_parser(
+        "estimate-quota", help="Estimate quotas based on average token and tool call usage."
+    )
+    add_trace_args(p_eq)
+    p_eq.add_argument("--peak-text-cpm", type=int, default=0, help="Estimated peak text conversations per minute.")
+    p_eq.add_argument("--peak-audio-cpm", type=int, default=0, help="Estimated peak audio conversations per minute.")
+    p_eq.add_argument("--time-filter", default="7d", help="Time filter to average over, e.g. \"7d\" or \"24h\".")
+    p_eq.add_argument("--time-start", help="Optional start time ISO string")
+    p_eq.add_argument("--time-end", help="Optional end time ISO string")
+    p_eq.add_argument(
+        "--source",
+        choices=["LIVE", "SIMULATOR", "EVAL"],
+        help="Filter by conversation source.",
+    )
+    p_eq.add_argument(
+        "--channel",
+        choices=["TEXT", "AUDIO", "MULTIMODAL", "OTHER"],
+        help="Filter by input channel.",
+    )
+    p_eq.add_argument("--limit", type=int, default=200, help="Max traces to sample.")
+    p_eq.add_argument(
+        "--format", choices=["text", "json"], default="text"
+    )
+    p_eq.set_defaults(func=trace_estimate_quota)
+
 
     # search
     p_search = trace_subparsers.add_parser(

--- a/src/cxas_scrapi/core/traces.py
+++ b/src/cxas_scrapi/core/traces.py
@@ -1280,7 +1280,191 @@ class Traces(Common):
             "top_transfer_targets": _top_n(per_transfer, 10),
         }
 
-    # ----------------------------- bundle/bug -------------------------------
+    def estimate_quota(
+        self,
+        peak_text_cpm: int = 0,
+        peak_audio_cpm: int = 0,
+        start_time: str | None = None,
+        end_time: str | None = None,
+        time_filter: str = "7d",
+        source_filter: str | None = None,
+        limit: int = 200,
+        max_workers: int = 8,
+    ) -> dict[str, Any]:
+        """Estimates production quotas based on sampled traces separately for text and audio.
+
+        Args:
+            peak_text_cpm: Estimated peak text conversations per minute.
+            peak_audio_cpm: Estimated peak audio conversations per minute.
+            start_time: ISO string for the start of the trace inclusion window.
+            end_time: ISO string for the end of the trace inclusion window.
+            time_filter: Time window for sampling traces.
+            source_filter: Optional source filter.
+            limit: Max number of traces to sample for the average.
+            max_workers: Concurrency for fetching traces.
+
+        Returns:
+            A dictionary containing quota estimations split by channel.
+        """
+        rows = self.list(
+            time_filter=time_filter,
+            source_filter=source_filter,
+            limit=limit,
+        )
+        if not rows:
+            return {
+                "error": "No conversations found to estimate quotas.",
+                "traffic_assumptions": {
+                    "peak_text_cpm": peak_text_cpm,
+                    "peak_audio_cpm": peak_audio_cpm
+                }
+            }
+
+        fetched_items = []
+        with ThreadPoolExecutor(max_workers=max_workers) as ex:
+            futures = {ex.submit(self.get_normalized, r["id"]): r for r in rows}
+            for fut in as_completed(futures):
+                try:
+                    fetched_items.append({
+                        "normalized": fut.result(),
+                        "channel": futures[fut].get("channel", "TEXT")
+                    })
+                except Exception as e:
+                    logger.warning(f"Failed to fetch {futures[fut]['id']}: {e}")
+
+        def _init_stats():
+            return {
+                "total_tokens_input": 0, "total_tokens_output": 0, 
+                "total_tool_calls": 0, "total_turns": 0, 
+                "total_duration_ms": 0, "sample_size": 0
+            }
+
+        stats_by_channel = {}
+
+        for item in fetched_items:
+            n = item["normalized"]
+            conv_dict = n.get("raw", {})
+            start_iso = n.get("start_time")
+            
+            if start_time and start_iso and start_iso < start_time:
+                continue
+            if end_time and start_iso and start_iso > end_time:
+                continue
+            
+            turn_modalities = {"VOICE": 0, "CHAT": 0, "UNSPECIFIED": 0}
+            
+            for turn in conv_dict.get("turns", []):
+                rs = turn.get("root_span") or {}
+                attrs = rs.get("attributes") or {}
+                
+                input_types = attrs.get("input types", attrs.get("input_types", []))
+                input_str = str(input_types).lower()
+                
+                if "audio" in input_str:
+                    turn_modalities["VOICE"] += 1
+                elif "text" in input_str:
+                    turn_modalities["CHAT"] += 1
+                else:
+                    turn_modalities["UNSPECIFIED"] += 1
+
+            ch = "UNSPECIFIED"
+            if conv_dict.get("turns", []):
+                # Select the highest count. In case of ties, max() favors the keys that appear first in the dict.
+                # So if TEXT and AUDIO tie, VOICE wins (which is usually safe for capacity).
+                ch = max(turn_modalities, key=turn_modalities.get)
+
+            if ch not in stats_by_channel:
+                stats_by_channel[ch] = _init_stats()
+            
+            b = stats_by_channel[ch]
+            b["total_turns"] += n.get("num_turns", 0)
+            
+            totals = n.get("totals") or {}
+            
+            t = totals.get("tokens") or {}
+            b["total_tokens_input"] += t.get("input", 0)
+            b["total_tokens_output"] += t.get("output", 0)
+
+            sc = totals.get("span_counts") or {}
+            b["total_tool_calls"] += (sc.get("Tool", 0) + sc.get("ToolUse", 0))
+            b["total_duration_ms"] += totals.get("duration_ms", 0)
+            b["sample_size"] += 1
+
+        def _compute_averages(b):
+            s = b["sample_size"]
+            if s == 0:
+                return {}
+            avg_duration_sec = (b["total_duration_ms"] / 1000.0) / s
+            return {
+                "tokens_input": b["total_tokens_input"] / s,
+                "tokens_output": b["total_tokens_output"] / s,
+                "tokens_total": (b["total_tokens_input"] + b["total_tokens_output"]) / s,
+                "tool_calls": b["total_tool_calls"] / s,
+                "turns": b["total_turns"] / s,
+                "duration_seconds": avg_duration_sec
+            }
+
+        def _compute_quotas(avgs, peak_cpm):
+            q = {
+                "chat_token_quota": avgs.get("tokens_total", 0) * peak_cpm,
+                "execute_tool_quota": avgs.get("tool_calls", 0) * peak_cpm,
+                "streaming_analyze_content_quota": avgs.get("turns", 0) * peak_cpm,
+            }
+            if "duration_seconds" in avgs:
+                q["audio_seconds_per_minute"] = avgs["duration_seconds"] * peak_cpm
+                q["concurrent_bidi_sessions"] = (peak_cpm / 60.0) * avgs["duration_seconds"]
+            return q
+
+        ret_avgs = {}
+        ret_quotas = {}
+        
+        # Determine the peak cpm dynamically per channel based on inputs (fallback to text cpm for unknown)
+        for ch, stats in stats_by_channel.items():
+            avgs = _compute_averages(stats)
+            ret_avgs[ch.lower()] = avgs
+            
+            cpm = peak_text_cpm
+            if ch == "VOICE":
+                cpm = peak_audio_cpm
+            
+            ret_quotas[ch.lower()] = _compute_quotas(avgs, cpm)
+            
+        return {
+            "traffic_assumptions": {
+                "peak_text_cpm": peak_text_cpm,
+                "peak_audio_cpm": peak_audio_cpm,
+                "sample_size": len([f for f in futures if "error" not in futures[f]]),
+                "samples_per_channel": {ch: stats["sample_size"] for ch, stats in stats_by_channel.items()}
+            },
+            "averages_per_conversation": ret_avgs,
+            "estimated_quotas_per_minute": ret_quotas
+        }
+        
+        if peak_audio_cpm > 0 and audio_avgs:
+            audio_sec_per_min = audio_avgs["duration_seconds"] * peak_audio_cpm
+            concurrent_bidi = (peak_audio_cpm / 60.0) * audio_avgs["duration_seconds"]
+            estimates["audio"] = {
+                "chat_token_quota": audio_avgs["tokens_total"] * peak_audio_cpm,
+                "execute_tool_quota": audio_avgs["tool_calls"] * peak_audio_cpm,
+                "streaming_analyze_content_quota": audio_avgs["turns"] * peak_audio_cpm,
+                "audio_seconds_per_minute": audio_sec_per_min,
+                "concurrent_bidi_sessions": concurrent_bidi
+            }
+
+        return {
+            "traffic_assumptions": {
+                "peak_text_cpm": peak_text_cpm,
+                "peak_audio_cpm": peak_audio_cpm,
+                "sample_size": len(fetched_items),
+                "audio_samples": stats_by_channel["AUDIO"]["sample_size"],
+                "text_samples": stats_by_channel["TEXT"]["sample_size"]
+            },
+            "averages_per_conversation": {
+                "text": text_avgs,
+                "audio": audio_avgs
+            },
+            "estimated_quotas_per_minute": estimates
+        }
 
     def bundle(
         self,

--- a/tests/cxas_scrapi/cli/test_trace_cli.py
+++ b/tests/cxas_scrapi/cli/test_trace_cli.py
@@ -844,3 +844,39 @@ def test_trace_transcribe_audio_failure(fake_traces: typing.Any) -> None:
     args = _ns(conversation_id="c1")
     with pytest.raises(SystemExit):
         trace_cli.trace_transcribe_audio(args)
+
+def test_trace_estimate_quota_json(fake_traces: typing.Any, capsys: typing.Any) -> None:
+    fake_traces.estimate_quota.return_value = {
+        "traffic_assumptions": {"peak_text_cpm": 10},
+        "averages_per_conversation": {"tool_calls": 2.0},
+        "estimated_quotas_per_minute": {"ExecuteTool_Quota": 20.0}
+    }
+    trace_cli.trace_estimate_quota(
+        _ns(
+            peak_text_cpm=10, peak_audio_cpm=0,
+            time_filter="7d",
+            source=None,
+            channel=None,
+            limit=200,
+            format="json",
+        )
+    )
+    out = capsys.readouterr().out
+    assert "ExecuteTool_Quota" in out
+    parsed = json.loads(out)
+    assert parsed["estimated_quotas_per_minute"]["ExecuteTool_Quota"] == 20.0
+
+
+def test_trace_estimate_quota_failure(fake_traces: typing.Any) -> None:
+    fake_traces.estimate_quota.side_effect = RuntimeError("boom")
+    with pytest.raises(SystemExit):
+        trace_cli.trace_estimate_quota(
+            _ns(
+                peak_text_cpm=10, peak_audio_cpm=0,
+                time_filter="7d",
+                source=None,
+                channel=None,
+                limit=200,
+                format="text",
+            )
+        )


### PR DESCRIPTION
This commit introduces a new subcommand `cxas trace estimate-quota` that connects trace history to project limits in order to output estimates for traffic capacity planning (tokens and tool invocations per minute) ahead of scaling.

- Adds estimator function mapping peak load against history sample sizes.
- Exposes CLI mappings.
- Appends quota estimator commands to the agent-foundry skills.
- Adds regression unit tests validating CLI handler and mocks.
- Documents tool in `docs/cli/trace.md`.