### PR TITLE
feat: add declarative autolabeling rules engine, CLI, and cxas-autolabel-rules skillFeat/insights autolabel rules

### DIFF
--- a/.agents/skills/cxas-autolabel-rules/SKILL.md
+++ b/.agents/skills/cxas-autolabel-rules/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: cxas-autolabel-rules
+description: >-
+  Author, validate, and manage Contact Center AI (CCAI) Insights Autolabeling Rules.
+  Use when users want to translate business labeling logic into CEL condition expressions,
+  maintain declarative autolabel_rules.yaml configurations, or synchronize rules to GCP projects.
+---
+
+# CCAI Insights Autolabeling Rules Skill
+
+This skill guides you in authoring, refining, validating, and synchronizing **Contact Center AI (CCAI) Insights Autolabeling Rules**.
+
+Autolabeling rules enrich ingested conversations with custom key-value metadata evaluated via Common Expression Language (CEL).
+
+______________________________________________________________________
+
+## 1. Overview & Declarative YAML Schema
+
+Rules are defined declaratively in `autolabel_rules.yaml`:
+
+```yaml
+version: "1.0"
+project_id: "your-gcp-project-id"
+location: "us-central1"
+
+autolabeling_rules:
+  - rule_id: "agent_domain"
+    display_name: "Agent Domain Classifier"
+    label_key: "agent_domain"
+    label_key_type: "LABEL_KEY_TYPE_CUSTOM"
+    active: true
+    conditions:
+      - condition: "containsSubAgent(conversation, 'billing_specialist')"
+        value: "'billing'"
+      - condition: "containsSubAgent(conversation, 'tech_support')"
+        value: "'tech_support'"
+      - condition: ""
+        value: "'general'"
+```
+
+### Core Schema Requirements
+
+1. **`rule_id`**: Unique alphanumeric identifier (snake_case or kebab-case).
+1. **`label_key`**: The metadata key name to attach to `conversation.labels`.
+1. **`conditions`**: Ordered array of conditions evaluated top-to-bottom.
+   - `condition`: CEL boolean expression (e.g. `conversation.duration > 300`).
+   - `value`: CEL expression or quoted string literal (e.g. `'vip'`, `'escalated'`).
+   - **Mandatory Fallback**: The final condition in every rule MUST be `condition: ""` to act as the default fallback value.
+
+______________________________________________________________________
+
+## 2. Common Expression Language (CEL) Authoring Rules
+
+Refer to the [CEL Cookbook](references/cel_cookbook.md) for full syntax and function references.
+
+### Built-in Helper Functions
+
+- **Sub-Agent / Flow Detection**:
+  ```cel
+  containsSubAgent(conversation, "billing_subagent")
+  ```
+- **Session Parameter Matching**:
+  ```cel
+  hasSessionParam(conversation, "authenticated", "true")
+  ```
+- **Sentiment Analysis**:
+  ```cel
+  hasCallerSentiment(conversation, "NEGATIVE")
+  ```
+- **Turn & Duration Checks**:
+  ```cel
+  conversation.duration > 300 && conversation.turn_count >= 10
+  ```
+
+______________________________________________________________________
+
+## 3. Step-by-Step Workflow
+
+Follow these steps when helping a user build or update autolabeling rules:
+
+### Step 1: Ingest Requirements
+
+- Ask the user what conversation properties or behaviors they want to classify (e.g., specific sub-agents, customer sentiment, authentication status, duration thresholds).
+- Determine target GCP project ID and location.
+
+### Step 2: Draft or Edit Declarative YAML
+
+- Create or update `autolabel_rules.yaml` in the user's workspace.
+- Translate business logic into clear, prioritized CEL expressions.
+- Ensure every rule ends with a fallback (`condition: ""`).
+
+### Step 3: Compare with Active Remote Rules (`diff`)
+
+Run `diff` to preview additions, modifications, and deletions:
+
+```bash
+uv run cxas insights diff-autolabel-rules --file autolabel_rules.yaml
+```
+
+### Step 4: Dry-Run Deploy
+
+Run `push` with `--dry-run` to verify API compatibility:
+
+```bash
+uv run cxas insights push-autolabel-rules --file autolabel_rules.yaml --dry-run
+```
+
+### Step 5: Deploy to GCP Project (`push`)
+
+Deploy the changes:
+
+```bash
+uv run cxas insights push-autolabel-rules --file autolabel_rules.yaml
+```
+
+*(To delete remote rules that are no longer in the local YAML, append `--force`.)*
+
+### Step 6: Export Existing Rules (`pull`)
+
+To export existing active rules from an environment into YAML:
+
+```bash
+uv run cxas insights pull-autolabel-rules --parent projects/<PROJECT>/locations/<LOCATION> --out autolabel_rules.yaml
+```
+
+______________________________________________________________________
+
+## 4. References & Tooling
+
+- **[CEL Cookbook](references/cel_cookbook.md)**: Curated expressions and helper function recipes.
+- **[JSON Schema](references/schema.json)**: Schema definition for YAML linting.
+- **[Design Document](references/design.md)**: Architectural specification.

--- a/.agents/skills/cxas-autolabel-rules/SKILL.md
+++ b/.agents/skills/cxas-autolabel-rules/SKILL.md
@@ -69,7 +69,7 @@ Refer to the [CEL Cookbook](references/cel_cookbook.md) for full syntax and func
   ```
 - **Turn & Duration Checks**:
   ```cel
-  conversation.duration > 300 && conversation.turn_count >= 10
+  conversation.duration > 300 && conversation.turnCount >= 10
   ```
 
 ______________________________________________________________________

--- a/.agents/skills/cxas-autolabel-rules/references/cel_cookbook.md
+++ b/.agents/skills/cxas-autolabel-rules/references/cel_cookbook.md
@@ -1,0 +1,181 @@
+# Contact Center AI Insights CEL Cookbook & Reference Guide
+
+This document is a comprehensive reference for authoring Common Expression Language (CEL) rules for Google Cloud Contact Center AI (CCAI) Insights Autolabeling Rules.
+
+______________________________________________________________________
+
+## 1. Overview & Evaluation Semantics
+
+Autolabeling rules evaluate incoming conversations in real-time or during batch ingestion.
+
+- **Evaluation Order**: Conditions are evaluated from top to bottom (first-match-wins).
+- **Fallback Rules**: The last condition should always have an empty condition `condition: ""` to act as the default fallback tag.
+- **String Literals**: Values in CEL expressions or return values should be properly quoted (e.g. `'vip_tier'`, `"support"`).
+- **Return Value**: The matched `value` expression is assigned to the conversation's `labels[label_key]`.
+
+______________________________________________________________________
+
+## 2. Conversation Attributes & Available Variables
+
+When writing CEL condition expressions, the root `conversation` object is accessible with the following properties:
+
+| Field                                      | Type                  | Description                           | Example                                                   |
+| ------------------------------------------ | --------------------- | ------------------------------------- | --------------------------------------------------------- |
+| `conversation.agent_id`                    | `string`              | ID or name of the virtual agent / app | `conversation.agent_id == 'billing_bot'`                  |
+| `conversation.language_code`               | `string`              | BCP-47 language tag                   | `conversation.language_code == 'es-US'`                   |
+| `conversation.duration`                    | `duration` / `int`    | Length of call/chat (seconds)         | `conversation.duration > 300`                             |
+| `conversation.turn_count`                  | `int`                 | Total number of dialog turns          | `conversation.turn_count >= 10`                           |
+| `conversation.labels`                      | `map[string, string]` | Pre-existing key-value labels         | `'vip' in conversation.labels`                            |
+| `conversation.dialogflow_runtime_metadata` | `map`                 | Dialogflow / CXAS session metadata    | `conversation.dialogflow_runtime_metadata.session_params` |
+
+______________________________________________________________________
+
+## 3. Built-in CCAI Helper Functions
+
+CCAI Insights provides specialized helper functions to inspect transcripts and runtime annotators:
+
+### 3.1 Sub-Agent / Flow Traversal
+
+Checks whether a specific GECX/CXAS sub-agent or Dialogflow flow participated in the conversation:
+
+```cel
+containsSubAgent(conversation, "billing_subagent")
+```
+
+```cel
+containsSubAgent(conversation, "payment_flow")
+```
+
+### 3.2 Session Parameters & Context
+
+Inspects session variables captured during the interaction (e.g., from tools or webhook responses):
+
+```cel
+hasSessionParam(conversation, "authenticated", "true")
+```
+
+```cel
+hasSessionParam(conversation, "membership_tier", "platinum")
+```
+
+### 3.3 Sentiment Analysis
+
+Checks sentiment score across conversation participants:
+
+```cel
+// Customer sentiment is negative (-1.0 to 1.0)
+hasCallerSentiment(conversation, "NEGATIVE")
+```
+
+```cel
+// Agent sentiment is positive
+hasAgentSentiment(conversation, "POSITIVE")
+```
+
+### 3.4 Entity & Keyword Matching
+
+Checks if specific entity types or phrase matchers fired:
+
+```cel
+hasEntity(conversation, "CREDIT_CARD_DISPUTE")
+```
+
+```cel
+hasIntent(conversation, "cancel_subscription")
+```
+
+______________________________________________________________________
+
+## 4. Common Recipes & Examples
+
+### Recipe 1: Sub-Agent Routing & Containment
+
+Classifies conversation category based on the sub-agents traversed during the session.
+
+```yaml
+- rule_id: "agent_domain"
+  display_name: "Agent Domain Classifier"
+  label_key: "agent_domain"
+  label_key_type: "LABEL_KEY_TYPE_CUSTOM"
+  active: true
+  conditions:
+    - condition: "containsSubAgent(conversation, 'billing_specialist') || containsSubAgent(conversation, 'invoice_lookup')"
+      value: "'billing'"
+    - condition: "containsSubAgent(conversation, 'tech_support') || containsSubAgent(conversation, 'troubleshooting')"
+      value: "'tech_support'"
+    - condition: "containsSubAgent(conversation, 'sales_inquiry')"
+      value: "'sales'"
+    - condition: ""
+      value: "'general_inquiry'"
+```
+
+______________________________________________________________________
+
+### Recipe 2: Customer Frustration & Escalation Risk
+
+Flags conversations that exhibited negative caller sentiment, high turn count, or repeated clarification questions.
+
+```yaml
+- rule_id: "escalation_risk"
+  display_name: "Escalation Risk Detector"
+  label_key: "escalation_risk"
+  active: true
+  conditions:
+    - condition: "hasCallerSentiment(conversation, 'NEGATIVE') && conversation.turn_count > 12"
+      value: "'high_risk'"
+    - condition: "hasCallerSentiment(conversation, 'NEGATIVE') || conversation.turn_count > 15"
+      value: "'medium_risk'"
+    - condition: ""
+      value: "'low_risk'"
+```
+
+______________________________________________________________________
+
+### Recipe 3: User Authentication Status
+
+Tags whether the caller completed two-factor or step-up authentication during their journey.
+
+```yaml
+- rule_id: "auth_status"
+  display_name: "User Authentication Status"
+  label_key: "auth_status"
+  active: true
+  conditions:
+    - condition: "hasSessionParam(conversation, 'auth_level', '2fa_verified')"
+      value: "'authenticated_2fa'"
+    - condition: "hasSessionParam(conversation, 'auth_level', 'pin_verified')"
+      value: "'authenticated_pin'"
+    - condition: "hasSessionParam(conversation, 'auth_attempted', 'true')"
+      value: "'auth_failed'"
+    - condition: ""
+      value: "'unauthenticated'"
+```
+
+______________________________________________________________________
+
+### Recipe 4: Interaction Complexity (Duration & Turns)
+
+Buckets sessions by length and turn count to isolate quick self-service resolutions vs lengthy troubleshooting.
+
+```yaml
+- rule_id: "interaction_complexity"
+  display_name: "Interaction Complexity Tier"
+  label_key: "complexity"
+  active: true
+  conditions:
+    - condition: "conversation.duration > 600 || conversation.turn_count > 20"
+      value: "'very_complex'"
+    - condition: "conversation.duration > 240 || conversation.turn_count > 8"
+      value: "'moderate'"
+    - condition: ""
+      value: "'simple_quick'"
+```
+
+______________________________________________________________________
+
+## 5. Authoring Best Practices
+
+1. **Explicit Fallback**: Always ensure the final condition in every rule is `condition: ""` to guarantee deterministic labeling.
+1. **Quoted Values**: Ensure all string literal values in the `value` field are single or double quoted (e.g. `'billing'` instead of `billing`).
+1. **Keep Expressions Focused**: Use logical operators (`&&`, `||`, `!`) to combine checks cleanly rather than writing monolithic nested logic.
+1. **Test via Dry-Run**: Always review diffs before deploying (`cxas insights diff-autolabel-rules` or `push-autolabel-rules --dry-run`).

--- a/.agents/skills/cxas-autolabel-rules/references/cel_cookbook.md
+++ b/.agents/skills/cxas-autolabel-rules/references/cel_cookbook.md
@@ -10,9 +10,10 @@ Autolabeling rules evaluate incoming conversations in real-time or during batch 
 
 - **Evaluation Order**: Conditions are evaluated sequentially from top to bottom (first-match-wins).
 - **Fallback Rules**: The last condition should always have an empty condition `condition: ""` to act as the default fallback tag.
-- **String Literals**: Values in CEL expressions or return values should be properly quoted (e.g. `'vip_tier'`, `"support"`).
-- **Return Value**: The matched `value` expression is assigned to the conversation's `labels[label_key]`.
+- **String Literals**: Values in CEL expressions or return values should be properly quoted (e.g. `'Yes'`, `'No'`, `'vip_tier'`).
+- **Return Value**: The matched `value` expression is assigned to the conversation's `labels[labelKey]`.
 - **Field Naming Convention**: In CEL expressions, all protobuf fields are accessed using **camelCase** identifiers.
+- **Defensive Property Access**: When traversing nested objects or maps that may be unset on some conversations, use `'fieldName' in object` guards (e.g., `'transcript' in conversation && 'transcriptSegments' in conversation.transcript`).
 
 ______________________________________________________________________
 
@@ -27,6 +28,7 @@ graph TD
     Conv --> CallMeta["callMetadata<br/>customerChannel, agentChannel"]
     Conv --> QualMeta["qualityMetadata<br/>agentInfo, customerSatisfactionRating, waitDuration"]
     Conv --> Runtime["runtimeInputs / dialogflowRuntimeMetadata<br/>sessionParams, entrySubagentId, subagents, flows"]
+    Conv --> Annotations["runtimeAnnotations[]<br/>cesTurnAnnotation.messages[].chunks[]<br/>(toolResponse, toolCall, text)"]
     Conv --> Transcript["transcript<br/>transcriptSegments[]<br/>(text, role, sentiment, words, channelTag)"]
     Conv --> Analysis["latestAnalysis<br/>analysisResult.callAnalysisMetadata<br/>(sentiments, silence, issueModelResult, qaScorecardResults)"]
 ```
@@ -85,36 +87,47 @@ ______________________________________________________________________
 
 Defined by `message Transcript` and `message TranscriptSegment`:
 
-| Field Path                                   | Type                      | Description                                              | CEL Example                                              |
-| -------------------------------------------- | ------------------------- | -------------------------------------------------------- | -------------------------------------------------------- |
-| `conversation.transcript.transcriptSegments` | `list[TranscriptSegment]` | Ordered sequence of conversation turns                   | `conversation.transcript.transcriptSegments.size() > 15` |
-| `segment.text`                               | `string`                  | Transcribed text spoken/typed in turn                    | `segment.text.contains('cancel my account')`             |
-| `segment.confidence`                         | `float`                   | ASR speech-to-text confidence score (0.0 to 1.0)         | `segment.confidence < 0.7`                               |
-| `segment.channelTag`                         | `int`                     | Channel index (1 or 2)                                   | `segment.channelTag == 1`                                |
-| `segment.participant.role`                   | `enum` / `int`            | `1` (HUMAN_AGENT), `2` (AUTOMATED_AGENT), `3` (END_USER) | `segment.participant.role == 3`                          |
-| `segment.participant.userId`                 | `string`                  | Unique identifier for the participant                    | `segment.participant.userId != ''`                       |
-| `segment.sentiment.score`                    | `float`                   | Sentiment score (-1.0 to +1.0)                           | `segment.sentiment.score < -0.5`                         |
-| `segment.sentiment.magnitude`                | `float`                   | Sentiment strength / magnitude (0.0 to +inf)             | `segment.sentiment.magnitude > 2.0`                      |
+| Field Path                                                     | Type                      | Description                                                               | CEL Example                                                                                  |
+| -------------------------------------------------------------- | ------------------------- | ------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `conversation.transcript.transcriptSegments`                   | `list[TranscriptSegment]` | Ordered sequence of conversation turns                                    | `conversation.transcript.transcriptSegments.size() > 15`                                     |
+| `segment.text`                                                 | `string`                  | Transcribed text spoken/typed in turn                                     | `segment.text.contains('cancel my account')`                                                 |
+| `segment.confidence`                                           | `float`                   | ASR speech-to-text confidence score (0.0 to 1.0)                          | `segment.confidence < 0.7`                                                                   |
+| `segment.channelTag`                                           | `int`                     | Channel index (1 or 2)                                                    | `segment.channelTag == 1`                                                                    |
+| `segment.segmentParticipant.role` / `segment.participant.role` | `enum` / `string` / `int` | `HUMAN_AGENT` (1), `AUTOMATED_AGENT` (2), `END_USER` (3), `ANY_AGENT` (4) | `segment.segmentParticipant.role == 'HUMAN_AGENT' \|\| segment.segmentParticipant.role == 1` |
+| `segment.participant.userId`                                   | `string`                  | Unique identifier for the participant                                     | `segment.participant.userId != ''`                                                           |
+| `segment.sentiment.score`                                      | `float`                   | Sentiment score (-1.0 to +1.0)                                            | `segment.sentiment.score < -0.5`                                                             |
+| `segment.sentiment.magnitude`                                  | `float`                   | Sentiment strength / magnitude (0.0 to +inf)                              | `segment.sentiment.magnitude > 2.0`                                                          |
 
-#### Transcript Segment Traversal Examples:
+______________________________________________________________________
+
+### 2.5 Runtime Annotations & CES Execution Traces (`runtimeAnnotations`)
+
+CCAI Insights captures deep diagnostic traces of agent execution within `conversation.runtimeAnnotations`. Each entry contains `cesTurnAnnotation` detailing the exact message payloads, agent chunk emissions, tool executions, and state transfers:
+
+- **`runtimeAnnotations`**: List of turn annotations.
+- **`cesTurnAnnotation.messages`**: List of messages exchanged during the turn.
+- **`message.chunks`**: List of action chunks emitted by the agent or runtime:
+  - **`toolResponse`**: Results returned from a tool/webhook execution (`displayName`, `response.result`, `name`, `status`).
+  - **`toolCall`**: Invocation request sent to a tool (`displayName`, `parameters`).
+  - **`agentTransfer`**: Routing action transferring between agents (`targetAgent`).
+
+#### CEL Transformation Pipeline for Tool Inspection:
 
 ```cel
-// Check if user uttered specific cancellation keywords
-conversation.transcript.transcriptSegments.exists(
-  s, s.participant.role == 3 && (s.text.contains('cancel') || s.text.contains('close account'))
-)
-```
-
-```cel
-// Check if customer had deeply negative sentiment on any turn
-conversation.transcript.transcriptSegments.exists(
-  s, s.participant.role == 3 && s.sentiment.score < -0.6
-)
+'runtimeAnnotations' in conversation &&
+conversation.runtimeAnnotations
+  .filter(a, 'cesTurnAnnotation' in a && 'messages' in a.cesTurnAnnotation)
+  .map(a, a.cesTurnAnnotation.messages)
+  .flatten()
+  .filter(m, 'chunks' in m)
+  .map(m, m.chunks)
+  .flatten()
+  .exists(c, 'toolResponse' in c && c.toolResponse.displayName == 'my_tool')
 ```
 
 ______________________________________________________________________
 
-### 2.5 Analysis Results & QA Scorecards (`latestAnalysis.analysisResult`)
+### 2.6 Analysis Results & QA Scorecards (`latestAnalysis.analysisResult`)
 
 Defined by `message Analysis`, `message AnalysisResult`, and `message CallAnalysisMetadata`:
 
@@ -185,16 +198,140 @@ hasIntent(conversation, "cancel_subscription")
 
 ______________________________________________________________________
 
-## 4. Common Recipes & Complete YAML Examples
+## 4. Production Rule Examples & Recipes
 
-### Recipe 1: Sub-Agent Routing & Containment
+### Example 1: Agent Inappropriate Language Detection (Regex & Role Matching)
+
+Labels conversation as `'Yes'` if the agent uttered inappropriate words (`idiot` or `dumb`), otherwise `'No'`.
+
+#### JSON Configuration:
+
+```json
+{
+  "displayName": "Agent Inappropriate Language Detection",
+  "description": "Labels conversation as Yes if agent used words 'idiot' or 'dumb', otherwise No",
+  "active": true,
+  "labelKeyType": "LABEL_KEY_TYPE_CUSTOM",
+  "labelKey": "AgentInappropriateLanguage",
+  "conditions": [
+    {
+      "condition": "'transcript' in conversation && 'transcriptSegments' in conversation.transcript && conversation.transcript.transcriptSegments.exists(s, 'text' in s && 'segmentParticipant' in s && 'role' in s.segmentParticipant && (s.segmentParticipant.role == 'HUMAN_AGENT' || s.segmentParticipant.role == 'AUTOMATED_AGENT' || s.segmentParticipant.role == 'ANY_AGENT' || s.segmentParticipant.role == 1 || s.segmentParticipant.role == 2 || s.segmentParticipant.role == 4) && s.text.matches('(?i).*\\\\b(idiot|dumb)\\\\b.*'))",
+      "value": "'Yes'"
+    },
+    {
+      "condition": "",
+      "value": "'No'"
+    }
+  ]
+}
+```
+
+#### YAML Declarative Format:
+
+```yaml
+- rule_id: "agent_inappropriate_language"
+  display_name: "Agent Inappropriate Language Detection"
+  label_key: "AgentInappropriateLanguage"
+  label_key_type: "LABEL_KEY_TYPE_CUSTOM"
+  active: true
+  conditions:
+    - condition: "'transcript' in conversation && 'transcriptSegments' in conversation.transcript && conversation.transcript.transcriptSegments.exists(s, 'text' in s && 'segmentParticipant' in s && 'role' in s.segmentParticipant && (s.segmentParticipant.role == 'HUMAN_AGENT' || s.segmentParticipant.role == 'AUTOMATED_AGENT' || s.segmentParticipant.role == 'ANY_AGENT' || s.segmentParticipant.role == 1 || s.segmentParticipant.role == 2 || s.segmentParticipant.role == 4) && s.text.matches('(?i).*\\\\b(idiot|dumb)\\\\b.*'))"
+      value: "'Yes'"
+    - condition: ""
+      value: "'No'"
+```
+
+______________________________________________________________________
+
+### Example 2: Active Flow & Tool Response Inspection
+
+Labels conversation as `'Yes'` if `set_active_flow` tool executed successfully with `RxRefill_Agent` and `refill` value.
+
+#### JSON Configuration:
+
+```json
+{
+  "displayName": "Rx Refill Active Flow Rule",
+  "description": "Labels conversation as Yes if set_active_flow was executed with RxRefill_Agent and refill value",
+  "active": true,
+  "labelKeyType": "LABEL_KEY_TYPE_CUSTOM",
+  "labelKey": "RxRefillActiveFlow",
+  "conditions": [
+    {
+      "condition": "'runtimeAnnotations' in conversation && conversation.runtimeAnnotations.filter(a, 'cesTurnAnnotation' in a && 'messages' in a.cesTurnAnnotation).map(a, a.cesTurnAnnotation.messages).flatten().filter(m, 'chunks' in m).map(m, m.chunks).flatten().exists(c, 'toolResponse' in c && 'displayName' in c.toolResponse && c.toolResponse.displayName == 'set_active_flow' && 'response' in c.toolResponse && 'result' in c.toolResponse.response && 'stored' in c.toolResponse.response.result && (c.toolResponse.response.result.stored == true || c.toolResponse.response.result.stored == 'true') && 'value' in c.toolResponse.response.result && c.toolResponse.response.result.value == 'refill' && (('target_agent' in c.toolResponse.response.result && c.toolResponse.response.result.target_agent == 'RxRefill_Agent') || ('targetAgent' in c.toolResponse.response.result && c.toolResponse.response.result.targetAgent == 'RxRefill_Agent')))",
+      "value": "'Yes'"
+    },
+    {
+      "condition": "",
+      "value": "'No'"
+    }
+  ]
+}
+```
+
+#### YAML Declarative Format:
+
+```yaml
+- rule_id: "rx_refill_active_flow"
+  display_name: "Rx Refill Active Flow Rule"
+  label_key: "RxRefillActiveFlow"
+  label_key_type: "LABEL_KEY_TYPE_CUSTOM"
+  active: true
+  conditions:
+    - condition: "'runtimeAnnotations' in conversation && conversation.runtimeAnnotations.filter(a, 'cesTurnAnnotation' in a && 'messages' in a.cesTurnAnnotation).map(a, a.cesTurnAnnotation.messages).flatten().filter(m, 'chunks' in m).map(m, m.chunks).flatten().exists(c, 'toolResponse' in c && 'displayName' in c.toolResponse && c.toolResponse.displayName == 'set_active_flow' && 'response' in c.toolResponse && 'result' in c.toolResponse.response && 'stored' in c.toolResponse.response.result && (c.toolResponse.response.result.stored == true || c.toolResponse.response.result.stored == 'true') && 'value' in c.toolResponse.response.result && c.toolResponse.response.result.value == 'refill' && (('target_agent' in c.toolResponse.response.result && c.toolResponse.response.result.target_agent == 'RxRefill_Agent') || ('targetAgent' in c.toolResponse.response.result && c.toolResponse.response.result.targetAgent == 'RxRefill_Agent')))"
+      value: "'Yes'"
+    - condition: ""
+      value: "'No'"
+```
+
+______________________________________________________________________
+
+### Example 3: Customer Escalation & Representative Demand Regex
+
+Labels conversation as `'Yes'` if the end-user explicitly demanded to speak with a human agent or supervisor.
+
+```yaml
+- rule_id: "human_escalation_requested"
+  display_name: "Human Escalation Requested"
+  label_key: "HumanEscalationRequested"
+  label_key_type: "LABEL_KEY_TYPE_CUSTOM"
+  active: true
+  conditions:
+    - condition: "'transcript' in conversation && 'transcriptSegments' in conversation.transcript && conversation.transcript.transcriptSegments.exists(s, 'text' in s && 'segmentParticipant' in s && 'role' in s.segmentParticipant && (s.segmentParticipant.role == 'END_USER' || s.segmentParticipant.role == 3) && s.text.matches('(?i).*\\\\b(speak to (a )?human|representative|supervisor|agent|manager|real person)\\\\b.*'))"
+      value: "'Yes'"
+    - condition: ""
+      value: "'No'"
+```
+
+______________________________________________________________________
+
+### Example 4: Tool Execution Failure / Error Detection
+
+Identifies interactions where any tool execution returned an error status or exception code.
+
+```yaml
+- rule_id: "tool_execution_failed"
+  display_name: "Tool Execution Failure Detection"
+  label_key: "ToolFailureDetected"
+  label_key_type: "LABEL_KEY_TYPE_CUSTOM"
+  active: true
+  conditions:
+    - condition: "'runtimeAnnotations' in conversation && conversation.runtimeAnnotations.filter(a, 'cesTurnAnnotation' in a && 'messages' in a.cesTurnAnnotation).map(a, a.cesTurnAnnotation.messages).flatten().filter(m, 'chunks' in m).map(m, m.chunks).flatten().exists(c, 'toolResponse' in c && 'response' in c.toolResponse && (('error' in c.toolResponse.response && c.toolResponse.response.error != '') || ('status' in c.toolResponse.response && c.toolResponse.response.status == 'ERROR')))"
+      value: "'Yes'"
+    - condition: ""
+      value: "'No'"
+```
+
+______________________________________________________________________
+
+### Example 5: Sub-Agent Routing & Containment Classifier
 
 Classifies conversation category based on the sub-agents traversed during the session.
 
 ```yaml
 - rule_id: "agent_domain"
   display_name: "Agent Domain Classifier"
-  label_key: "agent_domain"
+  label_key: "AgentDomain"
   label_key_type: "LABEL_KEY_TYPE_CUSTOM"
   active: true
   conditions:
@@ -210,72 +347,11 @@ Classifies conversation category based on the sub-agents traversed during the se
 
 ______________________________________________________________________
 
-### Recipe 2: Customer Frustration & Escalation Risk
-
-Flags conversations that exhibited negative caller sentiment, high turn count, or poor scorecard score.
-
-```yaml
-- rule_id: "escalation_risk"
-  display_name: "Escalation Risk Detector"
-  label_key: "escalation_risk"
-  active: true
-  conditions:
-    - condition: "hasCallerSentiment(conversation, 'NEGATIVE') && (conversation.turnCount > 12 || conversation.duration > 400)"
-      value: "'high_risk'"
-    - condition: "hasCallerSentiment(conversation, 'NEGATIVE') || conversation.turnCount > 15"
-      value: "'medium_risk'"
-    - condition: ""
-      value: "'low_risk'"
-```
-
-______________________________________________________________________
-
-### Recipe 3: User Authentication Status
-
-Tags whether the caller completed two-factor or PIN authentication during their journey.
-
-```yaml
-- rule_id: "auth_status"
-  display_name: "User Authentication Status"
-  label_key: "auth_status"
-  active: true
-  conditions:
-    - condition: "hasSessionParam(conversation, 'auth_level', '2fa_verified')"
-      value: "'authenticated_2fa'"
-    - condition: "hasSessionParam(conversation, 'auth_level', 'pin_verified')"
-      value: "'authenticated_pin'"
-    - condition: "hasSessionParam(conversation, 'auth_attempted', 'true')"
-      value: "'auth_failed'"
-    - condition: ""
-      value: "'unauthenticated'"
-```
-
-______________________________________________________________________
-
-### Recipe 4: Interaction Complexity (Duration & Silence)
-
-Buckets sessions by duration and excessive dead air/silence.
-
-```yaml
-- rule_id: "interaction_complexity"
-  display_name: "Interaction Complexity Tier"
-  label_key: "complexity"
-  active: true
-  conditions:
-    - condition: "conversation.duration > 600 || conversation.turnCount > 20 || conversation.latestAnalysis.analysisResult.callAnalysisMetadata.silence.silencePercentage > 30.0"
-      value: "'very_complex'"
-    - condition: "conversation.duration > 240 || conversation.turnCount > 8"
-      value: "'moderate'"
-    - condition: ""
-      value: "'simple_quick'"
-```
-
-______________________________________________________________________
-
 ## 5. Authoring Best Practices
 
 1. **camelCase Identifiers**: Always use camelCase for protobuf message fields (e.g. `conversation.agentId`, `conversation.turnCount`, `conversation.startTime`, `conversation.qualityMetadata.waitDuration`).
-1. **Explicit Fallback**: Always ensure the final condition in every rule is `condition: ""` to guarantee deterministic labeling.
-1. **Quoted Values**: Ensure all string literal values in the `value` field are quoted (e.g. `'billing'` instead of `billing`).
-1. **List Quantifiers**: Use `.exists(...)` or `.all(...)` when checking elements within repeated fields such as `transcript.transcriptSegments` or `qaScorecardResults`.
-1. **Test via Dry-Run**: Always review diffs before deploying (`cxas insights diff-autolabel-rules` or `push-autolabel-rules --dry-run`).
+1. **Defensive Guards**: Guard nested lookups with `'key' in object` (e.g., `'transcript' in conversation && 'transcriptSegments' in conversation.transcript`).
+1. **Regex Word Boundaries**: When using `.matches('(?i)...')`, escape backslashes appropriately (use `\\\\b` in string literals or YAML double-quoted strings).
+1. **List Transformation Pipelines**: Chain `.filter().map().flatten().exists()` to cleanly inspect deeply nested arrays like `runtimeAnnotations.cesTurnAnnotation.messages.chunks`.
+1. **Deterministic Fallback**: Always ensure the final condition in every rule is `condition: ""` to guarantee deterministic labeling.
+1. **Test via Dry-Run**: Always preview diffs before deploying (`cxas insights diff-autolabel-rules` or `push-autolabel-rules --dry-run`).

--- a/.agents/skills/cxas-autolabel-rules/references/cel_cookbook.md
+++ b/.agents/skills/cxas-autolabel-rules/references/cel_cookbook.md
@@ -12,56 +12,57 @@ Autolabeling rules evaluate incoming conversations in real-time or during batch 
 - **Fallback Rules**: The last condition should always have an empty condition `condition: ""` to act as the default fallback tag.
 - **String Literals**: Values in CEL expressions or return values should be properly quoted (e.g. `'vip_tier'`, `"support"`).
 - **Return Value**: The matched `value` expression is assigned to the conversation's `labels[label_key]`.
+- **Field Naming Convention**: In CEL expressions, all protobuf fields are accessed using **camelCase** identifiers.
 
 ______________________________________________________________________
 
 ## 2. Conversation Resource Schema (`resources.proto`)
 
-In CEL expressions, the root `conversation` variable provides direct access to the full `google.cloud.contactcenterinsights.v1.Conversation` protobuf message.
+In CEL expressions, the root `conversation` variable provides direct access to the `google.cloud.contactcenterinsights.v1.Conversation` object. All field identifiers are in **camelCase**.
 
 ```mermaid
 graph TD
     Conv["conversation (Conversation)"]
-    Conv --> Meta["Top-level Metadata<br/>agent_id, language_code, medium,<br/>duration, turn_count, start_time, labels"]
-    Conv --> CallMeta["call_metadata<br/>customer_channel, agent_channel"]
-    Conv --> QualMeta["quality_metadata<br/>agent_info, csat, wait_duration"]
-    Conv --> Runtime["runtime_inputs / dialogflow_runtime_metadata<br/>session_params, entry_subagent_id"]
-    Conv --> Transcript["transcript<br/>transcript_segments[]<br/>(text, role, sentiment, words)"]
-    Conv --> Analysis["latest_analysis<br/>call_analysis_metadata<br/>(sentiments, silence, issues, qa_scorecard_results)"]
+    Conv --> Meta["Top-level Metadata<br/>agentId, languageCode, medium,<br/>duration, turnCount, startTime, labels"]
+    Conv --> CallMeta["callMetadata<br/>customerChannel, agentChannel"]
+    Conv --> QualMeta["qualityMetadata<br/>agentInfo, customerSatisfactionRating, waitDuration"]
+    Conv --> Runtime["runtimeInputs / dialogflowRuntimeMetadata<br/>sessionParams, entrySubagentId, subagents, flows"]
+    Conv --> Transcript["transcript<br/>transcriptSegments[]<br/>(text, role, sentiment, words, channelTag)"]
+    Conv --> Analysis["latestAnalysis<br/>analysisResult.callAnalysisMetadata<br/>(sentiments, silence, issueModelResult, qaScorecardResults)"]
 ```
 
 ### 2.1 Top-Level Attributes
 
-| Field Path                   | Type                  | Description                                                   | CEL Example                                                              |
-| ---------------------------- | --------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `conversation.name`          | `string`              | Full resource name (`projects/*/locations/*/conversations/*`) | `conversation.name.endsWith('/conv123')`                                 |
-| `conversation.agent_id`      | `string`              | Identifier of virtual agent / CXAS app / bot                  | `conversation.agent_id == 'billing_bot'`                                 |
-| `conversation.language_code` | `string`              | BCP-47 language tag                                           | `conversation.language_code == 'es-US'`                                  |
-| `conversation.medium`        | `enum` / `int`        | `1` (PHONE_CALL), `2` (CHAT), `0` (UNSPECIFIED)               | `conversation.medium == 1`                                               |
-| `conversation.duration`      | `duration` / `int`    | Total interaction duration                                    | `conversation.duration > 300`                                            |
-| `conversation.turn_count`    | `int`                 | Total number of conversational turns                          | `conversation.turn_count >= 10`                                          |
-| `conversation.start_time`    | `timestamp`           | Start timestamp of interaction                                | `conversation.start_time > timestamp('2026-01-01T00:00:00Z')`            |
-| `conversation.labels`        | `map[string, string]` | Key-value labels already attached to conversation             | `'tier' in conversation.labels && conversation.labels['tier'] == 'gold'` |
+| Field Path                  | Type                  | Description                                                   | CEL Example                                                              |
+| --------------------------- | --------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `conversation.name`         | `string`              | Full resource name (`projects/*/locations/*/conversations/*`) | `conversation.name.endsWith('/conv123')`                                 |
+| `conversation.agentId`      | `string`              | Identifier of virtual agent / CXAS app / bot                  | `conversation.agentId == 'billing_bot'`                                  |
+| `conversation.languageCode` | `string`              | BCP-47 language tag                                           | `conversation.languageCode == 'es-US'`                                   |
+| `conversation.medium`       | `enum` / `int`        | `1` (PHONE_CALL), `2` (CHAT), `0` (UNSPECIFIED)               | `conversation.medium == 1`                                               |
+| `conversation.duration`     | `duration` / `int`    | Total interaction duration (seconds)                          | `conversation.duration > 300`                                            |
+| `conversation.turnCount`    | `int`                 | Total number of conversational turns                          | `conversation.turnCount >= 10`                                           |
+| `conversation.startTime`    | `timestamp`           | Start timestamp of interaction                                | `conversation.startTime > timestamp('2026-01-01T00:00:00Z')`             |
+| `conversation.labels`       | `map[string, string]` | Key-value labels attached to conversation                     | `'tier' in conversation.labels && conversation.labels['tier'] == 'gold'` |
 
 ______________________________________________________________________
 
-### 2.2 Call & Quality Metadata (`call_metadata`, `quality_metadata`)
+### 2.2 Call & Quality Metadata (`callMetadata`, `qualityMetadata`)
 
 Defined by `message CallMetadata` and `message QualityMetadata`:
 
-| Field Path                                                   | Type              | Description                                         | CEL Example                                                                   |
-| ------------------------------------------------------------ | ----------------- | --------------------------------------------------- | ----------------------------------------------------------------------------- |
-| `conversation.call_metadata.customer_channel`                | `int`             | Audio channel tag for customer (typically 1 or 2)   | `conversation.call_metadata.customer_channel == 1`                            |
-| `conversation.call_metadata.agent_channel`                   | `int`             | Audio channel tag for agent                         | `conversation.call_metadata.agent_channel == 2`                               |
-| `conversation.quality_metadata.customer_satisfaction_rating` | `int`             | Customer satisfaction rating (CSAT score, e.g. 1-5) | `conversation.quality_metadata.customer_satisfaction_rating <= 2`             |
-| `conversation.quality_metadata.wait_duration`                | `duration`        | Time spent waiting in queue before agent answered   | `conversation.quality_metadata.wait_duration > 120`                           |
-| `conversation.quality_metadata.menu_path`                    | `string`          | IVR menu path traversed by caller                   | `conversation.quality_metadata.menu_path.contains('Billing')`                 |
-| `conversation.quality_metadata.agent_info`                   | `list[AgentInfo]` | List of human or virtual agents handling the call   | `conversation.quality_metadata.agent_info.exists(a, a.team == 'escalations')` |
+| Field Path                                                | Type              | Description                                         | CEL Example                                                                 |
+| --------------------------------------------------------- | ----------------- | --------------------------------------------------- | --------------------------------------------------------------------------- |
+| `conversation.callMetadata.customerChannel`               | `int`             | Audio channel tag for customer (typically 1 or 2)   | `conversation.callMetadata.customerChannel == 1`                            |
+| `conversation.callMetadata.agentChannel`                  | `int`             | Audio channel tag for agent                         | `conversation.callMetadata.agentChannel == 2`                               |
+| `conversation.qualityMetadata.customerSatisfactionRating` | `int`             | Customer satisfaction rating (CSAT score, e.g. 1-5) | `conversation.qualityMetadata.customerSatisfactionRating <= 2`              |
+| `conversation.qualityMetadata.waitDuration`               | `duration`        | Time spent waiting in queue before agent answered   | `conversation.qualityMetadata.waitDuration > 120`                           |
+| `conversation.qualityMetadata.menuPath`                   | `string`          | IVR menu path traversed by caller                   | `conversation.qualityMetadata.menuPath.contains('Billing')`                 |
+| `conversation.qualityMetadata.agentInfo`                  | `list[AgentInfo]` | List of human or virtual agents handling the call   | `conversation.qualityMetadata.agentInfo.exists(a, a.team == 'escalations')` |
 
 Each `AgentInfo` contains:
 
-- `agent_id`: `string`
-- `display_name`: `string`
+- `agentId`: `string`
+- `displayName`: `string`
 - `team`: `string`
 - `teams`: `list[string]`
 
@@ -69,62 +70,62 @@ ______________________________________________________________________
 
 ### 2.3 Runtime Session Parameters & Dialogflow Metadata
 
-Defined by `runtime_inputs` and `dialogflow_runtime_metadata`:
+Defined by `runtimeInputs` and `dialogflowRuntimeMetadata`:
 
-| Field Path                                                   | Type                  | Description                                             | CEL Example                                                                  |
-| ------------------------------------------------------------ | --------------------- | ------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| `conversation.runtime_inputs.session_params`                 | `map[string, string]` | Dynamic session parameters from CXAS/Dialogflow session | `conversation.runtime_inputs.session_params['auth_status'] == 'verified'`    |
-| `conversation.dialogflow_runtime_metadata.entry_subagent_id` | `string`              | First sub-agent entered during interaction              | `conversation.dialogflow_runtime_metadata.entry_subagent_id == 'onboarding'` |
-| `conversation.dialogflow_runtime_metadata.subagents`         | `list[string]`        | All sub-agents visited during the conversation          | `conversation.dialogflow_runtime_metadata.subagents.contains('payment_v2')`  |
-| `conversation.dialogflow_runtime_metadata.flows`             | `list[string]`        | All flows executed                                      | `conversation.dialogflow_runtime_metadata.flows.contains('refund_flow')`     |
+| Field Path                                               | Type                  | Description                                             | CEL Example                                                               |
+| -------------------------------------------------------- | --------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `conversation.runtimeInputs.sessionParams`               | `map[string, string]` | Dynamic session parameters from CXAS/Dialogflow session | `conversation.runtimeInputs.sessionParams['auth_status'] == 'verified'`   |
+| `conversation.dialogflowRuntimeMetadata.entrySubagentId` | `string`              | First sub-agent entered during interaction              | `conversation.dialogflowRuntimeMetadata.entrySubagentId == 'onboarding'`  |
+| `conversation.dialogflowRuntimeMetadata.subagents`       | `list[string]`        | All sub-agents visited during the conversation          | `conversation.dialogflowRuntimeMetadata.subagents.contains('payment_v2')` |
+| `conversation.dialogflowRuntimeMetadata.flows`           | `list[string]`        | All flows executed                                      | `conversation.dialogflowRuntimeMetadata.flows.contains('refund_flow')`    |
 
 ______________________________________________________________________
 
-### 2.4 Transcripts & Turn Segments (`transcript.transcript_segments`)
+### 2.4 Transcripts & Turn Segments (`transcript.transcriptSegments`)
 
 Defined by `message Transcript` and `message TranscriptSegment`:
 
-| Field Path                                    | Type                      | Description                                              | CEL Example                                               |
-| --------------------------------------------- | ------------------------- | -------------------------------------------------------- | --------------------------------------------------------- |
-| `conversation.transcript.transcript_segments` | `list[TranscriptSegment]` | Ordered sequence of conversation turns                   | `conversation.transcript.transcript_segments.size() > 15` |
-| `segment.text`                                | `string`                  | Transcribed text spoken/typed in turn                    | `segment.text.contains('cancel my account')`              |
-| `segment.confidence`                          | `float`                   | ASR speech-to-text confidence score (0.0 to 1.0)         | `segment.confidence < 0.7`                                |
-| `segment.channel_tag`                         | `int`                     | Channel index (1 or 2)                                   | `segment.channel_tag == 1`                                |
-| `segment.participant.role`                    | `enum` / `int`            | `1` (HUMAN_AGENT), `2` (AUTOMATED_AGENT), `3` (END_USER) | `segment.participant.role == 3`                           |
-| `segment.participant.user_id`                 | `string`                  | Unique identifier for the participant                    | `segment.participant.user_id != ''`                       |
-| `segment.sentiment.score`                     | `float`                   | Sentiment score (-1.0 to +1.0)                           | `segment.sentiment.score < -0.5`                          |
-| `segment.sentiment.magnitude`                 | `float`                   | Sentiment strength / magnitude (0.0 to +inf)             | `segment.sentiment.magnitude > 2.0`                       |
+| Field Path                                   | Type                      | Description                                              | CEL Example                                              |
+| -------------------------------------------- | ------------------------- | -------------------------------------------------------- | -------------------------------------------------------- |
+| `conversation.transcript.transcriptSegments` | `list[TranscriptSegment]` | Ordered sequence of conversation turns                   | `conversation.transcript.transcriptSegments.size() > 15` |
+| `segment.text`                               | `string`                  | Transcribed text spoken/typed in turn                    | `segment.text.contains('cancel my account')`             |
+| `segment.confidence`                         | `float`                   | ASR speech-to-text confidence score (0.0 to 1.0)         | `segment.confidence < 0.7`                               |
+| `segment.channelTag`                         | `int`                     | Channel index (1 or 2)                                   | `segment.channelTag == 1`                                |
+| `segment.participant.role`                   | `enum` / `int`            | `1` (HUMAN_AGENT), `2` (AUTOMATED_AGENT), `3` (END_USER) | `segment.participant.role == 3`                          |
+| `segment.participant.userId`                 | `string`                  | Unique identifier for the participant                    | `segment.participant.userId != ''`                       |
+| `segment.sentiment.score`                    | `float`                   | Sentiment score (-1.0 to +1.0)                           | `segment.sentiment.score < -0.5`                         |
+| `segment.sentiment.magnitude`                | `float`                   | Sentiment strength / magnitude (0.0 to +inf)             | `segment.sentiment.magnitude > 2.0`                      |
 
 #### Transcript Segment Traversal Examples:
 
 ```cel
 // Check if user uttered specific cancellation keywords
-conversation.transcript.transcript_segments.exists(
+conversation.transcript.transcriptSegments.exists(
   s, s.participant.role == 3 && (s.text.contains('cancel') || s.text.contains('close account'))
 )
 ```
 
 ```cel
 // Check if customer had deeply negative sentiment on any turn
-conversation.transcript.transcript_segments.exists(
+conversation.transcript.transcriptSegments.exists(
   s, s.participant.role == 3 && s.sentiment.score < -0.6
 )
 ```
 
 ______________________________________________________________________
 
-### 2.5 Analysis Results & QA Scorecards (`latest_analysis.analysis_result`)
+### 2.5 Analysis Results & QA Scorecards (`latestAnalysis.analysisResult`)
 
 Defined by `message Analysis`, `message AnalysisResult`, and `message CallAnalysisMetadata`:
 
-| Field Path                                                                                       | Type                               | Description                                                          | CEL Example                                                                                                                                     |
-| ------------------------------------------------------------------------------------------------ | ---------------------------------- | -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `conversation.latest_analysis.analysis_result.call_analysis_metadata.sentiments`                 | `list[ConversationLevelSentiment]` | Channel-level aggregated sentiment scores                            | `conversation.latest_analysis.analysis_result.call_analysis_metadata.sentiments.exists(s, s.channel_tag == 1 && s.sentiment_data.score < -0.3)` |
-| `conversation.latest_analysis.analysis_result.call_analysis_metadata.silence.silence_percentage` | `float`                            | Percentage of interaction spent in dead air / silence (0.0 to 100.0) | `conversation.latest_analysis.analysis_result.call_analysis_metadata.silence.silence_percentage > 25.0`                                         |
-| `conversation.latest_analysis.analysis_result.call_analysis_metadata.silence.silence_duration`   | `duration`                         | Total silence duration                                               | `conversation.latest_analysis.analysis_result.call_analysis_metadata.silence.silence_duration > 60`                                             |
-| `conversation.latest_analysis.analysis_result.call_analysis_metadata.issue_model_result.issues`  | `list[IssueAssignment]`            | Topics assigned by Topic Models                                      | `conversation.latest_analysis.analysis_result.call_analysis_metadata.issue_model_result.issues.exists(i, i.display_name == 'Billing Dispute')`  |
-| `conversation.latest_analysis.analysis_result.call_analysis_metadata.phrase_matchers`            | `map[string, PhraseMatchData]`     | Phrase matchers triggered                                            | `'competitor_mention' in conversation.latest_analysis.analysis_result.call_analysis_metadata.phrase_matchers`                                   |
-| `conversation.latest_analysis.analysis_result.call_analysis_metadata.qa_scorecard_results`       | `list[QaScorecardResult]`          | Evaluation scorecard scores and question answers                     | `conversation.latest_analysis.analysis_result.call_analysis_metadata.qa_scorecard_results.exists(q, q.normalized_score < 70.0)`                 |
+| Field Path                                                                                  | Type                               | Description                                               | CEL Example                                                                                                                               |
+| ------------------------------------------------------------------------------------------- | ---------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `conversation.latestAnalysis.analysisResult.callAnalysisMetadata.sentiments`                | `list[ConversationLevelSentiment]` | Channel-level aggregated sentiment scores                 | `conversation.latestAnalysis.analysisResult.callAnalysisMetadata.sentiments.exists(s, s.channelTag == 1 && s.sentimentData.score < -0.3)` |
+| `conversation.latestAnalysis.analysisResult.callAnalysisMetadata.silence.silencePercentage` | `float`                            | Percentage of interaction spent in silence (0.0 to 100.0) | `conversation.latestAnalysis.analysisResult.callAnalysisMetadata.silence.silencePercentage > 25.0`                                        |
+| `conversation.latestAnalysis.analysisResult.callAnalysisMetadata.silence.silenceDuration`   | `duration`                         | Total silence duration                                    | `conversation.latestAnalysis.analysisResult.callAnalysisMetadata.silence.silenceDuration > 60`                                            |
+| `conversation.latestAnalysis.analysisResult.callAnalysisMetadata.issueModelResult.issues`   | `list[IssueAssignment]`            | Topics assigned by Topic Models                           | `conversation.latestAnalysis.analysisResult.callAnalysisMetadata.issueModelResult.issues.exists(i, i.displayName == 'Billing Dispute')`   |
+| `conversation.latestAnalysis.analysisResult.callAnalysisMetadata.phraseMatchers`            | `map[string, PhraseMatchData]`     | Phrase matchers triggered                                 | `'competitor_mention' in conversation.latestAnalysis.analysisResult.callAnalysisMetadata.phraseMatchers`                                  |
+| `conversation.latestAnalysis.analysisResult.callAnalysisMetadata.qaScorecardResults`        | `list[QaScorecardResult]`          | Evaluation scorecard scores and question answers          | `conversation.latestAnalysis.analysisResult.callAnalysisMetadata.qaScorecardResults.exists(q, q.normalizedScore < 70.0)`                  |
 
 ______________________________________________________________________
 
@@ -219,9 +220,9 @@ Flags conversations that exhibited negative caller sentiment, high turn count, o
   label_key: "escalation_risk"
   active: true
   conditions:
-    - condition: "hasCallerSentiment(conversation, 'NEGATIVE') && (conversation.turn_count > 12 || conversation.duration > 400)"
+    - condition: "hasCallerSentiment(conversation, 'NEGATIVE') && (conversation.turnCount > 12 || conversation.duration > 400)"
       value: "'high_risk'"
-    - condition: "hasCallerSentiment(conversation, 'NEGATIVE') || conversation.turn_count > 15"
+    - condition: "hasCallerSentiment(conversation, 'NEGATIVE') || conversation.turnCount > 15"
       value: "'medium_risk'"
     - condition: ""
       value: "'low_risk'"
@@ -261,9 +262,9 @@ Buckets sessions by duration and excessive dead air/silence.
   label_key: "complexity"
   active: true
   conditions:
-    - condition: "conversation.duration > 600 || conversation.turn_count > 20 || conversation.latest_analysis.analysis_result.call_analysis_metadata.silence.silence_percentage > 30.0"
+    - condition: "conversation.duration > 600 || conversation.turnCount > 20 || conversation.latestAnalysis.analysisResult.callAnalysisMetadata.silence.silencePercentage > 30.0"
       value: "'very_complex'"
-    - condition: "conversation.duration > 240 || conversation.turn_count > 8"
+    - condition: "conversation.duration > 240 || conversation.turnCount > 8"
       value: "'moderate'"
     - condition: ""
       value: "'simple_quick'"
@@ -273,7 +274,8 @@ ______________________________________________________________________
 
 ## 5. Authoring Best Practices
 
+1. **camelCase Identifiers**: Always use camelCase for protobuf message fields (e.g. `conversation.agentId`, `conversation.turnCount`, `conversation.startTime`, `conversation.qualityMetadata.waitDuration`).
 1. **Explicit Fallback**: Always ensure the final condition in every rule is `condition: ""` to guarantee deterministic labeling.
 1. **Quoted Values**: Ensure all string literal values in the `value` field are quoted (e.g. `'billing'` instead of `billing`).
-1. **List Quantifiers**: Use `.exists(...)` or `.all(...)` when checking elements within repeated fields such as `transcript.transcript_segments` or `qa_scorecard_results`.
+1. **List Quantifiers**: Use `.exists(...)` or `.all(...)` when checking elements within repeated fields such as `transcript.transcriptSegments` or `qaScorecardResults`.
 1. **Test via Dry-Run**: Always review diffs before deploying (`cxas insights diff-autolabel-rules` or `push-autolabel-rules --dry-run`).

--- a/.agents/skills/cxas-autolabel-rules/references/cel_cookbook.md
+++ b/.agents/skills/cxas-autolabel-rules/references/cel_cookbook.md
@@ -24,9 +24,8 @@ In CEL expressions, the root `conversation` variable provides direct access to t
 ```mermaid
 graph TD
     Conv["conversation (Conversation)"]
-    Conv --> Meta["Top-level Metadata<br/>agentId, languageCode, medium,<br/>duration, turnCount, startTime, labels"]
+    Conv --> Meta["Top-level Metadata<br/>agentId, languageCode, medium,<br/>duration, turnCount, startTime"]
     Conv --> CallMeta["callMetadata<br/>customerChannel, agentChannel"]
-    Conv --> QualMeta["qualityMetadata<br/>agentInfo, customerSatisfactionRating, waitDuration"]
     Conv --> Runtime["runtimeInputs / dialogflowRuntimeMetadata<br/>sessionParams, entrySubagentId, subagents, flows"]
     Conv --> Annotations["runtimeAnnotations[]<br/>cesTurnAnnotation.messages[].chunks[]<br/>(toolResponse, toolCall, text)"]
     Conv --> Transcript["transcript<br/>transcriptSegments[]<br/>(text, role, sentiment, words, channelTag)"]
@@ -35,38 +34,26 @@ graph TD
 
 ### 2.1 Top-Level Attributes
 
-| Field Path                  | Type                  | Description                                                   | CEL Example                                                              |
-| --------------------------- | --------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `conversation.name`         | `string`              | Full resource name (`projects/*/locations/*/conversations/*`) | `conversation.name.endsWith('/conv123')`                                 |
-| `conversation.agentId`      | `string`              | Identifier of virtual agent / CXAS app / bot                  | `conversation.agentId == 'billing_bot'`                                  |
-| `conversation.languageCode` | `string`              | BCP-47 language tag                                           | `conversation.languageCode == 'es-US'`                                   |
-| `conversation.medium`       | `enum` / `int`        | `1` (PHONE_CALL), `2` (CHAT), `0` (UNSPECIFIED)               | `conversation.medium == 1`                                               |
-| `conversation.duration`     | `duration` / `int`    | Total interaction duration (seconds)                          | `conversation.duration > 300`                                            |
-| `conversation.turnCount`    | `int`                 | Total number of conversational turns                          | `conversation.turnCount >= 10`                                           |
-| `conversation.startTime`    | `timestamp`           | Start timestamp of interaction                                | `conversation.startTime > timestamp('2026-01-01T00:00:00Z')`             |
-| `conversation.labels`       | `map[string, string]` | Key-value labels attached to conversation                     | `'tier' in conversation.labels && conversation.labels['tier'] == 'gold'` |
+| Field Path                  | Type               | Description                                                   | CEL Example                                                  |
+| --------------------------- | ------------------ | ------------------------------------------------------------- | ------------------------------------------------------------ |
+| `conversation.name`         | `string`           | Full resource name (`projects/*/locations/*/conversations/*`) | `conversation.name.endsWith('/conv123')`                     |
+| `conversation.agentId`      | `string`           | Identifier of virtual agent / CXAS app / bot                  | `conversation.agentId == 'billing_bot'`                      |
+| `conversation.languageCode` | `string`           | BCP-47 language tag                                           | `conversation.languageCode == 'es-US'`                       |
+| `conversation.medium`       | `enum` / `int`     | `1` (PHONE_CALL), `2` (CHAT), `0` (UNSPECIFIED)               | `conversation.medium == 1`                                   |
+| `conversation.duration`     | `duration` / `int` | Total interaction duration (seconds)                          | `conversation.duration > 300`                                |
+| `conversation.turnCount`    | `int`              | Total number of conversational turns                          | `conversation.turnCount >= 10`                               |
+| `conversation.startTime`    | `timestamp`        | Start timestamp of interaction                                | `conversation.startTime > timestamp('2026-01-01T00:00:00Z')` |
 
 ______________________________________________________________________
 
-### 2.2 Call & Quality Metadata (`callMetadata`, `qualityMetadata`)
+### 2.2 Call Metadata (`callMetadata`)
 
-Defined by `message CallMetadata` and `message QualityMetadata`:
+Defined by `message CallMetadata`:
 
-| Field Path                                                | Type              | Description                                         | CEL Example                                                                 |
-| --------------------------------------------------------- | ----------------- | --------------------------------------------------- | --------------------------------------------------------------------------- |
-| `conversation.callMetadata.customerChannel`               | `int`             | Audio channel tag for customer (typically 1 or 2)   | `conversation.callMetadata.customerChannel == 1`                            |
-| `conversation.callMetadata.agentChannel`                  | `int`             | Audio channel tag for agent                         | `conversation.callMetadata.agentChannel == 2`                               |
-| `conversation.qualityMetadata.customerSatisfactionRating` | `int`             | Customer satisfaction rating (CSAT score, e.g. 1-5) | `conversation.qualityMetadata.customerSatisfactionRating <= 2`              |
-| `conversation.qualityMetadata.waitDuration`               | `duration`        | Time spent waiting in queue before agent answered   | `conversation.qualityMetadata.waitDuration > 120`                           |
-| `conversation.qualityMetadata.menuPath`                   | `string`          | IVR menu path traversed by caller                   | `conversation.qualityMetadata.menuPath.contains('Billing')`                 |
-| `conversation.qualityMetadata.agentInfo`                  | `list[AgentInfo]` | List of human or virtual agents handling the call   | `conversation.qualityMetadata.agentInfo.exists(a, a.team == 'escalations')` |
-
-Each `AgentInfo` contains:
-
-- `agentId`: `string`
-- `displayName`: `string`
-- `team`: `string`
-- `teams`: `list[string]`
+| Field Path                                  | Type  | Description                                       | CEL Example                                      |
+| ------------------------------------------- | ----- | ------------------------------------------------- | ------------------------------------------------ |
+| `conversation.callMetadata.customerChannel` | `int` | Audio channel tag for customer (typically 1 or 2) | `conversation.callMetadata.customerChannel == 1` |
+| `conversation.callMetadata.agentChannel`    | `int` | Audio channel tag for agent                       | `conversation.callMetadata.agentChannel == 2`    |
 
 ______________________________________________________________________
 
@@ -349,7 +336,7 @@ ______________________________________________________________________
 
 ## 5. Authoring Best Practices
 
-1. **camelCase Identifiers**: Always use camelCase for protobuf message fields (e.g. `conversation.agentId`, `conversation.turnCount`, `conversation.startTime`, `conversation.qualityMetadata.waitDuration`).
+1. **camelCase Identifiers**: Always use camelCase for protobuf message fields (e.g. `conversation.agentId`, `conversation.turnCount`, `conversation.startTime`, `conversation.callMetadata.customerChannel`).
 1. **Defensive Guards**: Guard nested lookups with `'key' in object` (e.g., `'transcript' in conversation && 'transcriptSegments' in conversation.transcript`).
 1. **Regex Word Boundaries**: When using `.matches('(?i)...')`, escape backslashes appropriately (use `\\\\b` in string literals or YAML double-quoted strings).
 1. **List Transformation Pipelines**: Chain `.filter().map().flatten().exists()` to cleanly inspect deeply nested arrays like `runtimeAnnotations.cesTurnAnnotation.messages.chunks`.

--- a/.agents/skills/cxas-autolabel-rules/references/cel_cookbook.md
+++ b/.agents/skills/cxas-autolabel-rules/references/cel_cookbook.md
@@ -8,47 +8,145 @@ ______________________________________________________________________
 
 Autolabeling rules evaluate incoming conversations in real-time or during batch ingestion.
 
-- **Evaluation Order**: Conditions are evaluated from top to bottom (first-match-wins).
+- **Evaluation Order**: Conditions are evaluated sequentially from top to bottom (first-match-wins).
 - **Fallback Rules**: The last condition should always have an empty condition `condition: ""` to act as the default fallback tag.
 - **String Literals**: Values in CEL expressions or return values should be properly quoted (e.g. `'vip_tier'`, `"support"`).
 - **Return Value**: The matched `value` expression is assigned to the conversation's `labels[label_key]`.
 
 ______________________________________________________________________
 
-## 2. Conversation Attributes & Available Variables
+## 2. Conversation Resource Schema (`resources.proto`)
 
-When writing CEL condition expressions, the root `conversation` object is accessible with the following properties:
+In CEL expressions, the root `conversation` variable provides direct access to the full `google.cloud.contactcenterinsights.v1.Conversation` protobuf message.
 
-| Field                                      | Type                  | Description                           | Example                                                   |
-| ------------------------------------------ | --------------------- | ------------------------------------- | --------------------------------------------------------- |
-| `conversation.agent_id`                    | `string`              | ID or name of the virtual agent / app | `conversation.agent_id == 'billing_bot'`                  |
-| `conversation.language_code`               | `string`              | BCP-47 language tag                   | `conversation.language_code == 'es-US'`                   |
-| `conversation.duration`                    | `duration` / `int`    | Length of call/chat (seconds)         | `conversation.duration > 300`                             |
-| `conversation.turn_count`                  | `int`                 | Total number of dialog turns          | `conversation.turn_count >= 10`                           |
-| `conversation.labels`                      | `map[string, string]` | Pre-existing key-value labels         | `'vip' in conversation.labels`                            |
-| `conversation.dialogflow_runtime_metadata` | `map`                 | Dialogflow / CXAS session metadata    | `conversation.dialogflow_runtime_metadata.session_params` |
+```mermaid
+graph TD
+    Conv["conversation (Conversation)"]
+    Conv --> Meta["Top-level Metadata<br/>agent_id, language_code, medium,<br/>duration, turn_count, start_time, labels"]
+    Conv --> CallMeta["call_metadata<br/>customer_channel, agent_channel"]
+    Conv --> QualMeta["quality_metadata<br/>agent_info, csat, wait_duration"]
+    Conv --> Runtime["runtime_inputs / dialogflow_runtime_metadata<br/>session_params, entry_subagent_id"]
+    Conv --> Transcript["transcript<br/>transcript_segments[]<br/>(text, role, sentiment, words)"]
+    Conv --> Analysis["latest_analysis<br/>call_analysis_metadata<br/>(sentiments, silence, issues, qa_scorecard_results)"]
+```
+
+### 2.1 Top-Level Attributes
+
+| Field Path                   | Type                  | Description                                                   | CEL Example                                                              |
+| ---------------------------- | --------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `conversation.name`          | `string`              | Full resource name (`projects/*/locations/*/conversations/*`) | `conversation.name.endsWith('/conv123')`                                 |
+| `conversation.agent_id`      | `string`              | Identifier of virtual agent / CXAS app / bot                  | `conversation.agent_id == 'billing_bot'`                                 |
+| `conversation.language_code` | `string`              | BCP-47 language tag                                           | `conversation.language_code == 'es-US'`                                  |
+| `conversation.medium`        | `enum` / `int`        | `1` (PHONE_CALL), `2` (CHAT), `0` (UNSPECIFIED)               | `conversation.medium == 1`                                               |
+| `conversation.duration`      | `duration` / `int`    | Total interaction duration                                    | `conversation.duration > 300`                                            |
+| `conversation.turn_count`    | `int`                 | Total number of conversational turns                          | `conversation.turn_count >= 10`                                          |
+| `conversation.start_time`    | `timestamp`           | Start timestamp of interaction                                | `conversation.start_time > timestamp('2026-01-01T00:00:00Z')`            |
+| `conversation.labels`        | `map[string, string]` | Key-value labels already attached to conversation             | `'tier' in conversation.labels && conversation.labels['tier'] == 'gold'` |
+
+______________________________________________________________________
+
+### 2.2 Call & Quality Metadata (`call_metadata`, `quality_metadata`)
+
+Defined by `message CallMetadata` and `message QualityMetadata`:
+
+| Field Path                                                   | Type              | Description                                         | CEL Example                                                                   |
+| ------------------------------------------------------------ | ----------------- | --------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `conversation.call_metadata.customer_channel`                | `int`             | Audio channel tag for customer (typically 1 or 2)   | `conversation.call_metadata.customer_channel == 1`                            |
+| `conversation.call_metadata.agent_channel`                   | `int`             | Audio channel tag for agent                         | `conversation.call_metadata.agent_channel == 2`                               |
+| `conversation.quality_metadata.customer_satisfaction_rating` | `int`             | Customer satisfaction rating (CSAT score, e.g. 1-5) | `conversation.quality_metadata.customer_satisfaction_rating <= 2`             |
+| `conversation.quality_metadata.wait_duration`                | `duration`        | Time spent waiting in queue before agent answered   | `conversation.quality_metadata.wait_duration > 120`                           |
+| `conversation.quality_metadata.menu_path`                    | `string`          | IVR menu path traversed by caller                   | `conversation.quality_metadata.menu_path.contains('Billing')`                 |
+| `conversation.quality_metadata.agent_info`                   | `list[AgentInfo]` | List of human or virtual agents handling the call   | `conversation.quality_metadata.agent_info.exists(a, a.team == 'escalations')` |
+
+Each `AgentInfo` contains:
+
+- `agent_id`: `string`
+- `display_name`: `string`
+- `team`: `string`
+- `teams`: `list[string]`
+
+______________________________________________________________________
+
+### 2.3 Runtime Session Parameters & Dialogflow Metadata
+
+Defined by `runtime_inputs` and `dialogflow_runtime_metadata`:
+
+| Field Path                                                   | Type                  | Description                                             | CEL Example                                                                  |
+| ------------------------------------------------------------ | --------------------- | ------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `conversation.runtime_inputs.session_params`                 | `map[string, string]` | Dynamic session parameters from CXAS/Dialogflow session | `conversation.runtime_inputs.session_params['auth_status'] == 'verified'`    |
+| `conversation.dialogflow_runtime_metadata.entry_subagent_id` | `string`              | First sub-agent entered during interaction              | `conversation.dialogflow_runtime_metadata.entry_subagent_id == 'onboarding'` |
+| `conversation.dialogflow_runtime_metadata.subagents`         | `list[string]`        | All sub-agents visited during the conversation          | `conversation.dialogflow_runtime_metadata.subagents.contains('payment_v2')`  |
+| `conversation.dialogflow_runtime_metadata.flows`             | `list[string]`        | All flows executed                                      | `conversation.dialogflow_runtime_metadata.flows.contains('refund_flow')`     |
+
+______________________________________________________________________
+
+### 2.4 Transcripts & Turn Segments (`transcript.transcript_segments`)
+
+Defined by `message Transcript` and `message TranscriptSegment`:
+
+| Field Path                                    | Type                      | Description                                              | CEL Example                                               |
+| --------------------------------------------- | ------------------------- | -------------------------------------------------------- | --------------------------------------------------------- |
+| `conversation.transcript.transcript_segments` | `list[TranscriptSegment]` | Ordered sequence of conversation turns                   | `conversation.transcript.transcript_segments.size() > 15` |
+| `segment.text`                                | `string`                  | Transcribed text spoken/typed in turn                    | `segment.text.contains('cancel my account')`              |
+| `segment.confidence`                          | `float`                   | ASR speech-to-text confidence score (0.0 to 1.0)         | `segment.confidence < 0.7`                                |
+| `segment.channel_tag`                         | `int`                     | Channel index (1 or 2)                                   | `segment.channel_tag == 1`                                |
+| `segment.participant.role`                    | `enum` / `int`            | `1` (HUMAN_AGENT), `2` (AUTOMATED_AGENT), `3` (END_USER) | `segment.participant.role == 3`                           |
+| `segment.participant.user_id`                 | `string`                  | Unique identifier for the participant                    | `segment.participant.user_id != ''`                       |
+| `segment.sentiment.score`                     | `float`                   | Sentiment score (-1.0 to +1.0)                           | `segment.sentiment.score < -0.5`                          |
+| `segment.sentiment.magnitude`                 | `float`                   | Sentiment strength / magnitude (0.0 to +inf)             | `segment.sentiment.magnitude > 2.0`                       |
+
+#### Transcript Segment Traversal Examples:
+
+```cel
+// Check if user uttered specific cancellation keywords
+conversation.transcript.transcript_segments.exists(
+  s, s.participant.role == 3 && (s.text.contains('cancel') || s.text.contains('close account'))
+)
+```
+
+```cel
+// Check if customer had deeply negative sentiment on any turn
+conversation.transcript.transcript_segments.exists(
+  s, s.participant.role == 3 && s.sentiment.score < -0.6
+)
+```
+
+______________________________________________________________________
+
+### 2.5 Analysis Results & QA Scorecards (`latest_analysis.analysis_result`)
+
+Defined by `message Analysis`, `message AnalysisResult`, and `message CallAnalysisMetadata`:
+
+| Field Path                                                                                       | Type                               | Description                                                          | CEL Example                                                                                                                                     |
+| ------------------------------------------------------------------------------------------------ | ---------------------------------- | -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `conversation.latest_analysis.analysis_result.call_analysis_metadata.sentiments`                 | `list[ConversationLevelSentiment]` | Channel-level aggregated sentiment scores                            | `conversation.latest_analysis.analysis_result.call_analysis_metadata.sentiments.exists(s, s.channel_tag == 1 && s.sentiment_data.score < -0.3)` |
+| `conversation.latest_analysis.analysis_result.call_analysis_metadata.silence.silence_percentage` | `float`                            | Percentage of interaction spent in dead air / silence (0.0 to 100.0) | `conversation.latest_analysis.analysis_result.call_analysis_metadata.silence.silence_percentage > 25.0`                                         |
+| `conversation.latest_analysis.analysis_result.call_analysis_metadata.silence.silence_duration`   | `duration`                         | Total silence duration                                               | `conversation.latest_analysis.analysis_result.call_analysis_metadata.silence.silence_duration > 60`                                             |
+| `conversation.latest_analysis.analysis_result.call_analysis_metadata.issue_model_result.issues`  | `list[IssueAssignment]`            | Topics assigned by Topic Models                                      | `conversation.latest_analysis.analysis_result.call_analysis_metadata.issue_model_result.issues.exists(i, i.display_name == 'Billing Dispute')`  |
+| `conversation.latest_analysis.analysis_result.call_analysis_metadata.phrase_matchers`            | `map[string, PhraseMatchData]`     | Phrase matchers triggered                                            | `'competitor_mention' in conversation.latest_analysis.analysis_result.call_analysis_metadata.phrase_matchers`                                   |
+| `conversation.latest_analysis.analysis_result.call_analysis_metadata.qa_scorecard_results`       | `list[QaScorecardResult]`          | Evaluation scorecard scores and question answers                     | `conversation.latest_analysis.analysis_result.call_analysis_metadata.qa_scorecard_results.exists(q, q.normalized_score < 70.0)`                 |
 
 ______________________________________________________________________
 
 ## 3. Built-in CCAI Helper Functions
 
-CCAI Insights provides specialized helper functions to inspect transcripts and runtime annotators:
+CCAI Insights provides specialized helper functions that simplify inspecting transcripts, session parameters, and annotators:
 
 ### 3.1 Sub-Agent / Flow Traversal
 
 Checks whether a specific GECX/CXAS sub-agent or Dialogflow flow participated in the conversation:
 
 ```cel
-containsSubAgent(conversation, "billing_subagent")
+containsSubAgent(conversation, "billing_specialist")
 ```
 
 ```cel
-containsSubAgent(conversation, "payment_flow")
+containsSubAgent(conversation, "order_lookup_flow")
 ```
 
 ### 3.2 Session Parameters & Context
 
-Inspects session variables captured during the interaction (e.g., from tools or webhook responses):
+Inspects session parameters captured during the interaction (from webhook responses or tool executions):
 
 ```cel
 hasSessionParam(conversation, "authenticated", "true")
@@ -60,10 +158,10 @@ hasSessionParam(conversation, "membership_tier", "platinum")
 
 ### 3.3 Sentiment Analysis
 
-Checks sentiment score across conversation participants:
+Checks participant sentiment level:
 
 ```cel
-// Customer sentiment is negative (-1.0 to 1.0)
+// Customer sentiment is negative
 hasCallerSentiment(conversation, "NEGATIVE")
 ```
 
@@ -72,9 +170,9 @@ hasCallerSentiment(conversation, "NEGATIVE")
 hasAgentSentiment(conversation, "POSITIVE")
 ```
 
-### 3.4 Entity & Keyword Matching
+### 3.4 Entity & Intent Matching
 
-Checks if specific entity types or phrase matchers fired:
+Checks if specific entity types or intents were detected:
 
 ```cel
 hasEntity(conversation, "CREDIT_CARD_DISPUTE")
@@ -86,7 +184,7 @@ hasIntent(conversation, "cancel_subscription")
 
 ______________________________________________________________________
 
-## 4. Common Recipes & Examples
+## 4. Common Recipes & Complete YAML Examples
 
 ### Recipe 1: Sub-Agent Routing & Containment
 
@@ -113,7 +211,7 @@ ______________________________________________________________________
 
 ### Recipe 2: Customer Frustration & Escalation Risk
 
-Flags conversations that exhibited negative caller sentiment, high turn count, or repeated clarification questions.
+Flags conversations that exhibited negative caller sentiment, high turn count, or poor scorecard score.
 
 ```yaml
 - rule_id: "escalation_risk"
@@ -121,7 +219,7 @@ Flags conversations that exhibited negative caller sentiment, high turn count, o
   label_key: "escalation_risk"
   active: true
   conditions:
-    - condition: "hasCallerSentiment(conversation, 'NEGATIVE') && conversation.turn_count > 12"
+    - condition: "hasCallerSentiment(conversation, 'NEGATIVE') && (conversation.turn_count > 12 || conversation.duration > 400)"
       value: "'high_risk'"
     - condition: "hasCallerSentiment(conversation, 'NEGATIVE') || conversation.turn_count > 15"
       value: "'medium_risk'"
@@ -133,7 +231,7 @@ ______________________________________________________________________
 
 ### Recipe 3: User Authentication Status
 
-Tags whether the caller completed two-factor or step-up authentication during their journey.
+Tags whether the caller completed two-factor or PIN authentication during their journey.
 
 ```yaml
 - rule_id: "auth_status"
@@ -153,9 +251,9 @@ Tags whether the caller completed two-factor or step-up authentication during th
 
 ______________________________________________________________________
 
-### Recipe 4: Interaction Complexity (Duration & Turns)
+### Recipe 4: Interaction Complexity (Duration & Silence)
 
-Buckets sessions by length and turn count to isolate quick self-service resolutions vs lengthy troubleshooting.
+Buckets sessions by duration and excessive dead air/silence.
 
 ```yaml
 - rule_id: "interaction_complexity"
@@ -163,7 +261,7 @@ Buckets sessions by length and turn count to isolate quick self-service resoluti
   label_key: "complexity"
   active: true
   conditions:
-    - condition: "conversation.duration > 600 || conversation.turn_count > 20"
+    - condition: "conversation.duration > 600 || conversation.turn_count > 20 || conversation.latest_analysis.analysis_result.call_analysis_metadata.silence.silence_percentage > 30.0"
       value: "'very_complex'"
     - condition: "conversation.duration > 240 || conversation.turn_count > 8"
       value: "'moderate'"
@@ -176,6 +274,6 @@ ______________________________________________________________________
 ## 5. Authoring Best Practices
 
 1. **Explicit Fallback**: Always ensure the final condition in every rule is `condition: ""` to guarantee deterministic labeling.
-1. **Quoted Values**: Ensure all string literal values in the `value` field are single or double quoted (e.g. `'billing'` instead of `billing`).
-1. **Keep Expressions Focused**: Use logical operators (`&&`, `||`, `!`) to combine checks cleanly rather than writing monolithic nested logic.
+1. **Quoted Values**: Ensure all string literal values in the `value` field are quoted (e.g. `'billing'` instead of `billing`).
+1. **List Quantifiers**: Use `.exists(...)` or `.all(...)` when checking elements within repeated fields such as `transcript.transcript_segments` or `qa_scorecard_results`.
 1. **Test via Dry-Run**: Always review diffs before deploying (`cxas insights diff-autolabel-rules` or `push-autolabel-rules --dry-run`).

--- a/.agents/skills/cxas-autolabel-rules/references/design.md
+++ b/.agents/skills/cxas-autolabel-rules/references/design.md
@@ -1,0 +1,194 @@
+# Design Document: `cxas-autolabel-rules` Skill & Insights Autolabeling Architecture
+
+* **Author:** Gokulnath Babu & Jetski
+* **Status:** Draft / Proposed
+* **Repository Path:** `.agents/skills/cxas-autolabel-rules/references/design.md`
+* **Target Components:** 
+  * Skill: `.agents/skills/cxas-autolabel-rules/`
+  * Core SDK: `src/cxas_scrapi/core/insights.py`
+  * CLI: `src/cxas_scrapi/cli/insights_cli.py`
+* **Reference Documentation:** [Customer Experience Insights Autolabeling Rules](https://docs.cloud.google.com/gemini-enterprise-cx/insights/autolabel-correlation-rules)
+
+---
+
+## 1. Executive Summary
+
+This document specifies a new agent skill (`cxas-autolabel-rules`) and corresponding Core SDK / CLI enhancements in `cxas-scrapi` dedicated exclusively to **Contact Center AI (CCAI) Insights Autolabeling Rules**.
+
+Autolabeling rules enrich ingested conversations with custom key-value metadata evaluated via Common Expression Language (CEL). This design provides a streamlined declarative (GitOps / IaC) workflow allowing developers and AI agents to:
+1. **Define & Author** CEL labeling rules from natural language specifications with automatic syntax and helper function validation.
+2. **Maintain & Version** rules in a human-readable declarative YAML schema (`autolabel_rules.yaml`).
+3. **Synchronize & Deploy** rules to GCP projects (`pull`, `push`, `diff`).
+
+---
+
+## 2. Background & Problem Statement
+
+### 2.1 What are Autolabeling Rules?
+CCAI Insights evaluates `AutoLabelingRule` resources at conversation ingestion/import time. Each rule specifies:
+* `labelKey`: The key name of the label (e.g., `escalation_risk`, `agent_category`, `customer_tier`).
+* `labelKeyType`: Custom (`LABEL_KEY_TYPE_CUSTOM`) or standard.
+* `conditions`: An ordered list of `LabelingCondition` objects containing:
+  * `condition`: A boolean CEL expression (e.g., `conversation.turn_count > 10`). Empty string `""` evaluates to `true` (acting as a fallback default).
+  * `value`: A string CEL expression evaluated if `condition` is true (e.g., `'long_call'`).
+* **Evaluation Semantics**: The first condition in the list that evaluates to `true` sets the label's value.
+
+### 2.2 Challenges
+* **CEL Complexity**: Writing CEL expressions against nested conversation runtime annotations, subagent transitions, and sentiment structures is error-prone.
+* **Lack of Local Infrastructure-as-Code (IaC)**: Managing rules solely through cloud consoles or ad-hoc curl scripts leads to configuration drift across environments (dev -> staging -> prod).
+
+---
+
+## 3. Architecture & Component Breakdown
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 1. AI Agent Skill (.agents/skills/cxas-autolabel-rules)     │
+│    - SKILL.md: Natural Language <-> CEL Prompt Engineering   │
+│    - scripts/sync_rules.py: Push / Pull / Diff runner       │
+└──────────────────────────────┬──────────────────────────────┘
+                               │ uses
+┌──────────────────────────────▼──────────────────────────────┐
+│ 2. CLI Tooling (src/cxas_scrapi/cli/insights_cli.py)        │
+│    - cxas insights autolabel pull / push / diff             │
+│    - Static schema & CEL structure validation               │
+└──────────────────────────────┬──────────────────────────────┘
+                               │ calls
+┌──────────────────────────────▼──────────────────────────────┐
+│ 3. Core SDK (src/cxas_scrapi/core/insights.py)              │
+│    - REST CRUD methods for AutoLabelingRule API             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 4. Declarative YAML Schema Specification
+
+Rules are stored in a version-controlled YAML file (e.g., `autolabel_rules.yaml`):
+
+```yaml
+version: "1.0"
+project_id: "my-gcp-project"
+location: "us-central1"
+
+autolabeling_rules:
+  - rule_id: "agent_category"
+    display_name: "Agent Category Classifier"
+    label_key: "agent_category"
+    label_key_type: "LABEL_KEY_TYPE_CUSTOM"
+    active: true
+    conditions:
+      - condition: "conversation.agent_id == 'vip_agent'"
+        value: "'vip_support'"
+      - condition: "get_last_subagent() == 'billing_agent'"
+        value: "'billing'"
+      - condition: ""  # Fallback default
+        value: "'general'"
+
+  - rule_id: "escalation_risk"
+    display_name: "High Escalation Risk Indicator"
+    label_key: "escalation_risk"
+    label_key_type: "LABEL_KEY_TYPE_CUSTOM"
+    active: true
+    conditions:
+      - condition: "has_same_caller_conversation_in_n_hours(-24) && conversation.turn_count > 10"
+        value: "'repeat_caller_long_session'"
+      - condition: "has(conversation.latest_analysis.analysis_result.call_analysis_metadata.sentiments) && conversation.latest_analysis.analysis_result.call_analysis_metadata.sentiments.exists(s, s.sentiment_data.score < -0.5)"
+        value: "'negative_sentiment'"
+      - condition: ""
+        value: "'normal'"
+
+  - rule_id: "extracted_order_id"
+    display_name: "Extract Order ID from Session Parameters"
+    label_key: "order_id"
+    active: true
+    conditions:
+      - condition: "get_session_params('order_id') != ''"
+        value: "get_session_params('order_id')"
+      - condition: ""
+        value: "'none'"
+```
+
+---
+
+## 5. Core SDK Enhancements (`src/cxas_scrapi/core/insights.py`)
+
+Extend `Insights` with native `AutoLabelingRule` operations verified against the Google Cloud CCAI Insights REST / RPC specifications:
+
+| Method | HTTP Endpoint | Description |
+| :--- | :--- | :--- |
+| `list_autolabeling_rules()` | `GET /v1/{parent}/autoLabelingRules` | Lists all rules in the project/location. |
+| `get_autolabeling_rule(name)` | `GET /v1/{name}` | Retrieves a rule by resource name or rule ID. |
+| `create_autolabeling_rule(rule_dict, rule_id)` | `POST /v1/{parent}/autoLabelingRules?autoLabelingRuleId={rule_id}` | Creates a new autolabeling rule. |
+| `update_autolabeling_rule(name, rule_dict, update_mask)` | `PATCH /v1/{name}?updateMask={fields}` | Updates an existing rule. |
+| `delete_autolabeling_rule(name)` | `DELETE /v1/{name}` | Deletes a rule. |
+
+*(Note: API endpoint paths and query parameter names like `autoLabelingRuleId` and `updateMask` have been verified against the official Contact Center Insights v1 Discovery and protobuf specifications).*
+
+---
+
+## 6. CLI Commands Specification (`cxas insights autolabel`)
+
+The `cxas insights autolabel` subcommands provide terminal operations for GitOps:
+
+1. **`cxas insights autolabel pull`**:
+   * Fetches all cloud `autoLabelingRules` from the project and exports them into `autolabel_rules.yaml`.
+   * Flag: `--out <path>` (defaults to `./autolabel_rules.yaml`).
+2. **`cxas insights autolabel diff`**:
+   * Compares the local YAML configuration against the active rules in GCP.
+   * Outputs additions, modifications, and deletions with colorized diffs.
+3. **`cxas insights autolabel push`**:
+   * Deploys local rules to the project, updating existing rules and creating new ones.
+   * Flags: `--dry-run`, `--force` (optionally delete remote rules missing from local YAML).
+
+---
+
+## 7. AI Skill Specification (`.agents/skills/cxas-autolabel-rules/`)
+
+### 7.1 Directory Layout
+```
+.agents/skills/cxas-autolabel-rules/
+├── SKILL.md
+├── scripts/
+│   └── sync_rules.py       # Standalone sync runner for pulling/pushing YAML
+└── references/
+    ├── cel_cookbook.md     # Ready-to-use CEL snippets for GECX/CES scenarios
+    └── schema.json         # JSON schema for validating autolabel_rules.yaml
+```
+
+### 7.2 Key Capabilities in `SKILL.md`
+
+#### A. Natural Language to CEL Formulation
+The skill converts business objectives into valid CEL syntax using verified CCAI Insights helper functions:
+* **Session Parameter Extraction**: `get_session_params('param_key')`
+* **Sub-Agent Tracking**: `get_last_subagent(['escalation_handler'])`
+* **Caller History**: `has_same_caller_conversation_in_n_hours(-24)`
+* **Existing Label Lookup**: `get_label('existing_key')`
+* **Turn & Duration Filters**: `conversation.turn_count > 12`, `conversation.duration > duration('120s')`
+
+#### B. Validation & Safety Checks
+* Enforces that every rule ends with an empty condition fallback (`condition: ""`).
+* Checks CEL expression syntax against character limits (max 256 chars/value, 100 labels max).
+* Validates condition ordering (most specific condition first, default fallback last).
+
+---
+
+## 8. Future Work & Extensions
+
+1. **Rule Evaluation & Backtesting against Test Conversations**:
+   * Calling `POST /v1/{parent}/autoLabelingRules:test` to evaluate rules against synthetic or sample conversation JSON objects. Deferred to future iterations to keep the initial developer experience lightweight and friction-free.
+2. **CI/CD Automation**:
+   * Running `cxas insights autolabel diff` in GitHub Actions / pre-commit to prevent configuration drift.
+
+---
+
+## 9. Verification & Testing Plan
+
+1. **Unit Tests**:
+   * Core SDK tests under `tests/cxas_scrapi/core/test_insights_autolabel.py`.
+   * CLI tests under `tests/cxas_scrapi/cli/test_insights_cli.py`.
+   * YAML serialization/deserialization validation.
+2. **Skill Linter & Format**:
+   * `uv run mdformat .agents/skills/cxas-autolabel-rules/SKILL.md`
+   * `uv run ruff check --fix`
+   * Brand compliance check via `scripts/check_brands.py`.

--- a/.agents/skills/cxas-autolabel-rules/references/implementation_plan.md
+++ b/.agents/skills/cxas-autolabel-rules/references/implementation_plan.md
@@ -1,0 +1,61 @@
+# Implementation Plan: `cxas-autolabel-rules` Skill & Tooling
+
+* **Status:** Ready for Execution
+* **Repository Path:** `.agents/skills/cxas-autolabel-rules/references/implementation_plan.md`
+* **Design Doc:** `.agents/skills/cxas-autolabel-rules/references/design.md`
+
+---
+
+## 1. Execution Roadmap
+
+```mermaid
+graph LR
+    P1["Phase 1: Core SDK Methods"] --> P2["Phase 2: YAML Engine & CLI"]
+    P2 --> P3["Phase 3: Skill Authoring"]
+    P3 --> P4["Phase 4: Verification & Docs"]
+```
+
+---
+
+## 2. Phase-by-Phase Breakdown
+
+### Phase 1: Core SDK Extensions
+**Files:** `src/cxas_scrapi/core/insights.py`, `tests/cxas_scrapi/core/test_insights.py`
+* Add `list_autolabeling_rules(parent, page_size)`.
+* Add `get_autolabeling_rule(name)`.
+* Add `create_autolabeling_rule(auto_labeling_rule, auto_labeling_rule_id, parent)`.
+* Add `update_autolabeling_rule(name, auto_labeling_rule, update_mask)`.
+* Add `delete_autolabeling_rule(name)`.
+* Unit tests for all REST operations with mocked API responses.
+
+### Phase 2: Declarative YAML Engine & CLI
+**Files:** `src/cxas_scrapi/core/autolabel_sync.py`, `src/cxas_scrapi/cli/insights_cli.py`
+* Implement YAML parser and serializer for `autolabel_rules.yaml`.
+* Implement `diff_rules(local, remote)` to detect added, updated, and deleted rules.
+* Implement `sync_rules(client, local, force, dry_run)`.
+* Wire CLI commands:
+  * `cxas insights autolabel pull --out <file>`
+  * `cxas insights autolabel diff --file <file>`
+  * `cxas insights autolabel push --file <file> [--dry-run] [--force]`
+* Unit tests for CLI subcommands and diff logic.
+
+### Phase 3: AI Skill Scaffolding
+**Directory:** `.agents/skills/cxas-autolabel-rules/`
+* Create `SKILL.md` (Natural Language $\to$ CEL rules, YAML editing, GitOps deploy flow).
+* Create `references/cel_cookbook.md` (curated recipes for sub-agent routing, session params, caller history, sentiment).
+* Create `references/schema.json` (JSON schema for YAML linting).
+* Create `scripts/sync_rules.py` helper script.
+
+### Phase 4: Verification & Documentation
+**Files:** `AGENTS.md`
+* Register `cxas-autolabel-rules` in `AGENTS.md`.
+* Run `uv run mdformat .agents/skills/cxas-autolabel-rules/SKILL.md`.
+* Run `uv run ruff check --fix` and `uv run ruff format`.
+* Run `uv run pytest` across all test suites.
+* Run `uv run python3 scripts/check_brands.py --code-files`.
+
+---
+
+## 3. Review & Proceed
+
+Click **Proceed** below or let me know when you'd like to start with **Phase 1 (Core SDK Extensions)**.

--- a/.agents/skills/cxas-autolabel-rules/references/schema.json
+++ b/.agents/skills/cxas-autolabel-rules/references/schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "CCAI Insights AutoLabeling Rules Configuration",
+  "description": "Declarative YAML/JSON schema for configuring CCAI Insights AutoLabeling Rules.",
+  "type": "object",
+  "required": [
+    "version",
+    "project_id",
+    "location",
+    "autolabeling_rules"
+  ],
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "Configuration schema version, e.g. '1.0'."
+    },
+    "project_id": {
+      "type": "string",
+      "description": "Google Cloud Project ID hosting CCAI Insights."
+    },
+    "location": {
+      "type": "string",
+      "description": "Google Cloud Region / Location (e.g. 'us-central1', 'global')."
+    },
+    "autolabeling_rules": {
+      "type": "array",
+      "description": "List of autolabeling rule configurations.",
+      "items": {
+        "type": "object",
+        "required": [
+          "rule_id",
+          "label_key",
+          "conditions"
+        ],
+        "properties": {
+          "rule_id": {
+            "type": "string",
+            "description": "Unique identifier for the autolabeling rule."
+          },
+          "display_name": {
+            "type": "string",
+            "description": "Human-readable display name for the rule."
+          },
+          "label_key": {
+            "type": "string",
+            "description": "The metadata label key to write to conversation labels."
+          },
+          "label_key_type": {
+            "type": "string",
+            "enum": [
+              "LABEL_KEY_TYPE_UNSPECIFIED",
+              "LABEL_KEY_TYPE_CUSTOM",
+              "LABEL_KEY_TYPE_SYSTEM"
+            ],
+            "default": "LABEL_KEY_TYPE_CUSTOM",
+            "description": "The category type of the label key."
+          },
+          "active": {
+            "type": "boolean",
+            "default": true,
+            "description": "Whether the autolabeling rule is actively evaluated on incoming conversations."
+          },
+          "conditions": {
+            "type": "array",
+            "description": "Ordered list of CEL conditions evaluated top-to-bottom. The last condition should be '' for default fallback.",
+            "items": {
+              "type": "object",
+              "required": [
+                "condition",
+                "value"
+              ],
+              "properties": {
+                "condition": {
+                  "type": "string",
+                  "description": "CEL boolean expression (empty string '' matches anything as default fallback)."
+                },
+                "value": {
+                  "type": "string",
+                  "description": "CEL literal or expression representing the label value to set."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/.agents/skills/cxas-autolabel-rules/scripts/sync_rules.py
+++ b/.agents/skills/cxas-autolabel-rules/scripts/sync_rules.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Helper script to sync declarative autolabel rules with CCAI Insights."""
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import sys
+
+from cxas_scrapi.core.autolabel_sync import (
+    diff_autolabel_rules,
+    dump_autolabel_rules_yaml,
+    export_remote_rules_to_yaml_dict,
+    load_autolabel_rules_yaml,
+    sync_autolabel_rules,
+)
+from cxas_scrapi.core.insights import Insights
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Sync declarative autolabeling rules with CCAI Insights."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # pull
+    pull_p = subparsers.add_parser(
+        "pull", help="Pull rules from project to YAML."
+    )
+    pull_p.add_argument(
+        "--project-id", required=True, help="Google Cloud project ID."
+    )
+    pull_p.add_argument(
+        "--location", default="us-central1", help="GCP location."
+    )
+    pull_p.add_argument(
+        "--out", default="autolabel_rules.yaml", help="Output YAML file path."
+    )
+
+    # diff
+    diff_p = subparsers.add_parser(
+        "diff", help="Diff local YAML against project."
+    )
+    diff_p.add_argument(
+        "--file", default="autolabel_rules.yaml", help="Path to YAML file."
+    )
+    diff_p.add_argument(
+        "--project-id", help="Optional GCP project ID override."
+    )
+    diff_p.add_argument("--location", help="Optional GCP location override.")
+
+    # push
+    push_p = subparsers.add_parser("push", help="Deploy local YAML to project.")
+    push_p.add_argument(
+        "--file", default="autolabel_rules.yaml", help="Path to YAML file."
+    )
+    push_p.add_argument(
+        "--project-id", help="Optional GCP project ID override."
+    )
+    push_p.add_argument("--location", help="Optional GCP location override.")
+    push_p.add_argument(
+        "--dry-run", action="store_true", help="Preview changes only."
+    )
+    push_p.add_argument(
+        "--force",
+        action="store_true",
+        help="Delete remote rules missing from local YAML.",
+    )
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    if args.command == "pull":
+        client = Insights(project_id=args.project_id, location=args.location)
+        parent = f"projects/{args.project_id}/locations/{args.location}"
+        print(f"Fetching rules from {parent}...")
+        rules = client.list_autolabeling_rules(parent=parent)
+        data = export_remote_rules_to_yaml_dict(
+            rules, args.project_id, args.location
+        )
+        dump_autolabel_rules_yaml(data, args.out)
+        print(f"Successfully exported {len(rules)} rules to {args.out}")
+
+    elif args.command == "diff":
+        data = load_autolabel_rules_yaml(args.file)
+        proj = args.project_id or data.get("project_id")
+        loc = args.location or data.get("location")
+        if not proj or not loc:
+            print("Error: project_id and location must be specified.")
+            sys.exit(1)
+        client = Insights(project_id=proj, location=loc)
+        parent = f"projects/{proj}/locations/{loc}"
+        print(f"Comparing '{args.file}' against {parent}...")
+        remote_rules = client.list_autolabeling_rules(parent=parent)
+        diff_res = diff_autolabel_rules(data, remote_rules)
+        print(diff_res["report"])
+
+    elif args.command == "push":
+        data = load_autolabel_rules_yaml(args.file)
+        proj = args.project_id or data.get("project_id")
+        loc = args.location or data.get("location")
+        if not proj or not loc:
+            print("Error: project_id and location must be specified.")
+            sys.exit(1)
+        client = Insights(project_id=proj, location=loc)
+        parent = f"projects/{proj}/locations/{loc}"
+        action = "Dry-run pushing" if args.dry_run else "Pushing"
+        print(f"{action} '{args.file}' to {parent}...")
+        summary = sync_autolabel_rules(
+            client=client,
+            file_path=args.file,
+            parent=parent,
+            force=args.force,
+            dry_run=args.dry_run,
+        )
+        if not args.dry_run:
+            print(
+                f"Sync Complete. Created: {len(summary['created'])}, "
+                f"Updated: {len(summary['updated'])}, "
+                f"Deleted: {len(summary['deleted'])}"
+            )
+        else:
+            print(summary["diff_report"])
+
+
+if __name__ == "__main__":
+    main()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,13 +26,15 @@ Run the setup script to create a virtual environment and install the `cxas-scrap
 ```
 
 Requires Python 3.10+ and [astral-uv](https://docs.astral.sh/uv/getting-started/installation/).
-  - Always execute `cxas` commands using `uv run cxas` instead of using .venv/.
+
+- Always execute `cxas` commands using `uv run cxas` instead of using .venv/.
 
 ## Available Skills
 
-This workspace provides several specialized AI skills to assist with development. 
+This workspace provides several specialized AI skills to assist with development.
 
 - **`cxas-agent-foundry`**: The primary skill for the end-to-end GECX agent lifecycle. Use this for building agents from PRDs, generating and running evals, debugging failures, and syncing code.
+- **`cxas-autolabel-rules`**: Author, validate, and manage Contact Center AI (CCAI) Insights Autolabeling Rules declaratively via YAML and CEL.
 - **`cxas-sim-eval`**: A utility skill for converting CXAS golden evaluations to SCRAPI SimulationEvals test cases.
 
 ## CLI Features
@@ -43,5 +45,3 @@ This workspace provides several specialized AI skills to assist with development
 - **`cxas trace search`**: Find conversations whose transcript contains a query, mirroring the console search box. Uses the server-side `ces_transcript.search(...)` full-text function (case-insensitive, substring/prefix; searches the user + agent transcript only). Use `--match {phrase,all,any}` for multi-word handling and `--snippets` to show highlighted excerpts. Example: `cxas trace search "app crashing" --app-name <app> --match all --snippets`. Run `cxas trace search --help` for details.
 
 *Note: For detailed development workflows, linter policies, and GECX-specific conventions, refer to the documentation within the respective skills (e.g., `.agents/skills/cxas-agent-foundry/SKILL.md`).*
-
-

--- a/src/cxas_scrapi/cli/insights_cli.py
+++ b/src/cxas_scrapi/cli/insights_cli.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import argparse
+import json
 import logging
 import sys
 import tempfile
@@ -689,6 +690,193 @@ def handle_analyze_metrics(args: argparse.Namespace) -> None:
         sys.exit(1)
 
 
+def handle_pull_autolabel_rules(args: argparse.Namespace) -> None:
+    """Handles the 'insights pull-autolabel-rules' command."""
+    from cxas_scrapi.core.autolabel_sync import (
+        dump_autolabel_rules_yaml,
+        export_remote_rules_to_yaml_dict,
+    )
+    from cxas_scrapi.core.insights import Insights
+
+    project_id, location = _get_project_and_location_from_parent(args.parent)
+    client = Insights(project_id=project_id, location=location)
+
+    out_path = (
+        getattr(args, "out", None)
+        or getattr(args, "file", None)
+        or "autolabel_rules.yaml"
+    )
+    print(f"Fetching autolabeling rules from {args.parent}...")
+    try:
+        rules = client.list_autolabeling_rules(parent=args.parent)
+        data = export_remote_rules_to_yaml_dict(rules, project_id, location)
+        dump_autolabel_rules_yaml(data, out_path)
+        print(
+            f"Successfully exported {len(rules)} autolabeling rule(s) to {out_path}"
+        )
+    except Exception as e:
+        print(f"Failed to pull autolabeling rules: {e}")
+        sys.exit(1)
+
+
+def handle_diff_autolabel_rules(args: argparse.Namespace) -> None:
+    """Handles the 'insights diff-autolabel-rules' command."""
+    from cxas_scrapi.core.autolabel_sync import (
+        diff_autolabel_rules,
+        load_autolabel_rules_yaml,
+    )
+    from cxas_scrapi.core.insights import Insights
+
+    file_path = getattr(args, "file", None) or "autolabel_rules.yaml"
+    try:
+        data = load_autolabel_rules_yaml(file_path)
+    except Exception as e:
+        print(f"Error loading {file_path}: {e}")
+        sys.exit(1)
+
+    parent = getattr(args, "parent", None)
+    if parent:
+        project_id, location = _get_project_and_location_from_parent(parent)
+    else:
+        project_id = data.get("project_id")
+        location = data.get("location")
+        if not project_id or not location:
+            print(
+                "Error: Specify --parent or include project_id and location in YAML."
+            )
+            sys.exit(1)
+        parent = f"projects/{project_id}/locations/{location}"
+
+    client = Insights(project_id=project_id, location=location)
+    print(f"Comparing local rules in '{file_path}' against {parent}...")
+    try:
+        remote_rules = client.list_autolabeling_rules(parent=parent)
+        diff_res = diff_autolabel_rules(data, remote_rules)
+        print(diff_res["report"])
+    except Exception as e:
+        print(f"Failed to diff autolabeling rules: {e}")
+        sys.exit(1)
+
+
+def handle_push_autolabel_rules(args: argparse.Namespace) -> None:
+    """Handles the 'insights push-autolabel-rules' command."""
+    from cxas_scrapi.core.autolabel_sync import (
+        load_autolabel_rules_yaml,
+        sync_autolabel_rules,
+    )
+    from cxas_scrapi.core.insights import Insights
+
+    file_path = getattr(args, "file", None) or "autolabel_rules.yaml"
+    try:
+        data = load_autolabel_rules_yaml(file_path)
+    except Exception as e:
+        print(f"Error loading {file_path}: {e}")
+        sys.exit(1)
+
+    parent = getattr(args, "parent", None)
+    if parent:
+        project_id, location = _get_project_and_location_from_parent(parent)
+    else:
+        project_id = data.get("project_id")
+        location = data.get("location")
+        if not project_id or not location:
+            print(
+                "Error: Specify --parent or include project_id and location in YAML."
+            )
+            sys.exit(1)
+        parent = f"projects/{project_id}/locations/{location}"
+
+    client = Insights(project_id=project_id, location=location)
+    dry_run = getattr(args, "dry_run", False)
+    force = getattr(args, "force", False)
+
+    action_label = "Dry-run syncing" if dry_run else "Syncing"
+    print(f"{action_label} local rules in '{file_path}' to {parent}...")
+    try:
+        summary = sync_autolabel_rules(
+            client=client,
+            file_path=file_path,
+            parent=parent,
+            force=force,
+            dry_run=dry_run,
+        )
+        if not dry_run:
+            print("\n--- Sync Summary ---")
+            created_str = (
+                ", ".join(summary["created"]) if summary["created"] else "none"
+            )
+            updated_str = (
+                ", ".join(summary["updated"]) if summary["updated"] else "none"
+            )
+            deleted_str = (
+                ", ".join(summary["deleted"]) if summary["deleted"] else "none"
+            )
+            print(f"Created : {len(summary['created'])} ({created_str})")
+            print(f"Updated : {len(summary['updated'])} ({updated_str})")
+            print(f"Deleted : {len(summary['deleted'])} ({deleted_str})")
+            if summary.get("skipped_delete"):
+                print(
+                    f"Skipped Deletions (use --force to delete) : {len(summary['skipped_delete'])}"
+                )
+        else:
+            print(summary["diff_report"])
+    except Exception as e:
+        print(f"Failed to push autolabeling rules: {e}")
+        sys.exit(1)
+
+
+def handle_list_autolabel_rules(args: argparse.Namespace) -> None:
+    """Handles the 'insights list-autolabel-rules' command."""
+    from cxas_scrapi.core.insights import Insights
+
+    project_id, location = _get_project_and_location_from_parent(args.parent)
+    client = Insights(project_id=project_id, location=location)
+
+    print(f"Listing autolabeling rules under {args.parent}...")
+    try:
+        rules = client.list_autolabeling_rules(parent=args.parent)
+        print(f"Found {len(rules)} rule(s):")
+        for r in rules:
+            rid = r.get("name", "").split("/")[-1]
+            status = "ACTIVE" if r.get("active", True) else "INACTIVE"
+            print(
+                f" - [{status}] {rid}: '{r.get('displayName', '')}' (Key: {r.get('labelKey')}, Conditions: {len(r.get('conditions', []))})"
+            )
+    except Exception as e:
+        print(f"Failed to list autolabeling rules: {e}")
+        sys.exit(1)
+
+
+def handle_get_autolabel_rule(args: argparse.Namespace) -> None:
+    """Handles the 'insights get-autolabel-rule' command."""
+    from cxas_scrapi.core.insights import Insights
+
+    project_id, location = _get_project_and_location_from_parent(args.rule_name)
+    client = Insights(project_id=project_id, location=location)
+
+    try:
+        rule = client.get_autolabeling_rule(args.rule_name)
+        print(json.dumps(rule, indent=2))
+    except Exception as e:
+        print(f"Failed to get autolabeling rule: {e}")
+        sys.exit(1)
+
+
+def handle_delete_autolabel_rule(args: argparse.Namespace) -> None:
+    """Handles the 'insights delete-autolabel-rule' command."""
+    from cxas_scrapi.core.insights import Insights
+
+    project_id, location = _get_project_and_location_from_parent(args.rule_name)
+    client = Insights(project_id=project_id, location=location)
+
+    try:
+        client.delete_autolabeling_rule(args.rule_name)
+        print(f"Successfully deleted autolabeling rule: {args.rule_name}")
+    except Exception as e:
+        print(f"Failed to delete autolabeling rule: {e}")
+        sys.exit(1)
+
+
 def populate_insights_parser(parser_insights: argparse.ArgumentParser) -> None:
     """Populates the provided insights parser with its subcommands."""
 
@@ -1052,3 +1240,95 @@ def populate_insights_parser(parser_insights: argparse.ArgumentParser) -> None:
         "--json-output", help="Optional output path for JSON metrics report."
     )
     parser_metrics.set_defaults(func=handle_analyze_metrics)
+
+    # 13. AutoLabeling Rules subcommands
+    parser_pull_al = insights_subparsers.add_parser(
+        "pull-autolabel-rules",
+        help="Export all autolabeling rules from project to a declarative YAML file.",
+    )
+    parser_pull_al.add_argument(
+        "--parent",
+        required=True,
+        help="Parent resource name (e.g. projects/*/locations/*).",
+    )
+    parser_pull_al.add_argument(
+        "--out",
+        "--file",
+        dest="out",
+        default="autolabel_rules.yaml",
+        help="Output YAML file path (default: autolabel_rules.yaml).",
+    )
+    parser_pull_al.set_defaults(func=handle_pull_autolabel_rules)
+
+    parser_diff_al = insights_subparsers.add_parser(
+        "diff-autolabel-rules",
+        help="Compare local autolabel_rules.yaml against active rules in GCP.",
+    )
+    parser_diff_al.add_argument(
+        "--file",
+        default="autolabel_rules.yaml",
+        help="Path to local autolabel_rules.yaml (default: autolabel_rules.yaml).",
+    )
+    parser_diff_al.add_argument(
+        "--parent",
+        help="Optional parent resource name override (e.g. projects/*/locations/*).",
+    )
+    parser_diff_al.set_defaults(func=handle_diff_autolabel_rules)
+
+    parser_push_al = insights_subparsers.add_parser(
+        "push-autolabel-rules",
+        help="Deploy and sync local autolabel_rules.yaml to GCP project.",
+    )
+    parser_push_al.add_argument(
+        "--file",
+        default="autolabel_rules.yaml",
+        help="Path to local autolabel_rules.yaml (default: autolabel_rules.yaml).",
+    )
+    parser_push_al.add_argument(
+        "--parent",
+        help="Optional parent resource name override (e.g. projects/*/locations/*).",
+    )
+    parser_push_al.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview changes without creating, updating, or deleting remote rules.",
+    )
+    parser_push_al.add_argument(
+        "--force",
+        action="store_true",
+        help="Delete remote rules that are missing from local YAML.",
+    )
+    parser_push_al.set_defaults(func=handle_push_autolabel_rules)
+
+    parser_list_al = insights_subparsers.add_parser(
+        "list-autolabel-rules",
+        help="List autolabeling rules under a parent project/location.",
+    )
+    parser_list_al.add_argument(
+        "--parent",
+        required=True,
+        help="Parent resource name (e.g. projects/*/locations/*).",
+    )
+    parser_list_al.set_defaults(func=handle_list_autolabel_rules)
+
+    parser_get_al = insights_subparsers.add_parser(
+        "get-autolabel-rule",
+        help="Get full details of a specific autolabeling rule.",
+    )
+    parser_get_al.add_argument(
+        "--rule-name",
+        required=True,
+        help="Full resource name of the autolabeling rule.",
+    )
+    parser_get_al.set_defaults(func=handle_get_autolabel_rule)
+
+    parser_del_al = insights_subparsers.add_parser(
+        "delete-autolabel-rule",
+        help="Delete an autolabeling rule by resource name.",
+    )
+    parser_del_al.add_argument(
+        "--rule-name",
+        required=True,
+        help="Full resource name of the autolabeling rule to delete.",
+    )
+    parser_del_al.set_defaults(func=handle_delete_autolabel_rule)

--- a/src/cxas_scrapi/core/autolabel_sync.py
+++ b/src/cxas_scrapi/core/autolabel_sync.py
@@ -1,0 +1,513 @@
+"""Declarative YAML sync and diff engine for CCAI Insights rules."""
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import difflib
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+if TYPE_CHECKING:
+    from cxas_scrapi.core.insights import Insights
+
+logger = logging.getLogger(__name__)
+
+
+def validate_autolabel_rules_dict(data: dict[str, Any]) -> list[str]:
+    """Validates autolabel rules YAML dictionary against schema requirements.
+
+    Args:
+        data: The dictionary structure loaded from YAML.
+
+    Returns:
+        A list of validation error strings. Returns empty list if valid.
+    """
+    errors: list[str] = []
+    if not isinstance(data, dict):
+        return ["Root content must be a mapping/dictionary."]
+
+    rules = data.get("autolabeling_rules")
+    if not isinstance(rules, list):
+        return ["'autolabeling_rules' must be a list."]
+
+    if not rules:
+        return ["'autolabeling_rules' list is empty."]
+
+    seen_ids: set[str] = set()
+    for idx, rule in enumerate(rules):
+        if not isinstance(rule, dict):
+            errors.append(f"Rule at index {idx} must be a dictionary.")
+            continue
+
+        rule_id = (
+            rule.get("rule_id")
+            or rule.get("label_key")
+            or rule.get("labelKey")
+            or rule.get("display_name")
+            or f"rule_{idx}"
+        )
+
+        if str(rule_id) in seen_ids:
+            errors.append(f"Duplicate rule_id or label_key found: '{rule_id}'")
+        seen_ids.add(str(rule_id))
+
+        if not rule.get("label_key") and not rule.get("labelKey"):
+            errors.append(f"Rule '{rule_id}' is missing required 'label_key'.")
+
+        conditions = rule.get("conditions")
+        if not isinstance(conditions, list) or not conditions:
+            errors.append(
+                f"Rule '{rule_id}' must contain a non-empty 'conditions' list."
+            )
+        else:
+            has_fallback = False
+            for c_idx, cond in enumerate(conditions):
+                if not isinstance(cond, dict):
+                    errors.append(
+                        f"Rule '{rule_id}' condition #{c_idx} "
+                        "must be a dictionary."
+                    )
+                    continue
+                if "value" not in cond:
+                    errors.append(
+                        f"Rule '{rule_id}' condition #{c_idx} "
+                        "is missing 'value'."
+                    )
+                if cond.get("condition", None) == "":
+                    has_fallback = True
+
+            if not has_fallback:
+                logger.debug(
+                    "Rule '%s' does not specify an explicit default "
+                    "fallback condition (condition: '').",
+                    rule_id,
+                )
+
+    return errors
+
+
+def yaml_rule_to_api_payload(
+    rule_dict: dict[str, Any],
+) -> tuple[str, dict[str, Any]]:
+    """Converts a declarative YAML rule dictionary to a CCAI API payload.
+
+    Args:
+        rule_dict: The dictionary representation of a single rule from YAML.
+
+    Returns:
+        A tuple of (rule_id, api_payload_dict).
+    """
+    rule_id = (
+        rule_dict.get("rule_id")
+        or rule_dict.get("label_key")
+        or rule_dict.get("labelKey")
+        or (
+            rule_dict.get("name", "").split("/")[-1]
+            if rule_dict.get("name")
+            else "rule"
+        )
+    )
+
+    display_name = (
+        rule_dict.get("display_name")
+        or rule_dict.get("displayName")
+        or str(rule_id)
+    )
+    label_key = (
+        rule_dict.get("label_key") or rule_dict.get("labelKey") or str(rule_id)
+    )
+
+    payload: dict[str, Any] = {
+        "displayName": display_name,
+        "labelKey": label_key,
+        "active": rule_dict.get("active", True),
+    }
+
+    if "label_key_type" in rule_dict or "labelKeyType" in rule_dict:
+        payload["labelKeyType"] = rule_dict.get(
+            "label_key_type"
+        ) or rule_dict.get("labelKeyType")
+
+    raw_conditions = rule_dict.get("conditions", [])
+    payload["conditions"] = [
+        {
+            "condition": str(c.get("condition", "")),
+            "value": str(c.get("value", "")),
+        }
+        for c in raw_conditions
+        if isinstance(c, dict)
+    ]
+
+    return str(rule_id), payload
+
+
+def api_rule_to_yaml_rule(api_rule: dict[str, Any]) -> dict[str, Any]:
+    """Converts an API response dictionary to a clean YAML dictionary.
+
+    Args:
+        api_rule: The dictionary response from the CCAI Insights API.
+
+    Returns:
+        A formatted YAML rule dictionary.
+    """
+    name = api_rule.get("name", "")
+    rule_id = name.split("/")[-1] if name else api_rule.get("labelKey", "rule")
+
+    yaml_rule: dict[str, Any] = {
+        "rule_id": rule_id,
+        "display_name": api_rule.get("displayName", rule_id),
+        "label_key": api_rule.get("labelKey", rule_id),
+        "label_key_type": api_rule.get("labelKeyType", "LABEL_KEY_TYPE_CUSTOM"),
+        "active": api_rule.get("active", True),
+        "conditions": [
+            {
+                "condition": c.get("condition", ""),
+                "value": c.get("value", ""),
+            }
+            for c in api_rule.get("conditions", [])
+        ],
+    }
+    return yaml_rule
+
+
+def load_autolabel_rules_yaml(file_path: str | Path) -> dict[str, Any]:
+    """Loads and validates an autolabel rules YAML file.
+
+    Args:
+        file_path: Path to the YAML file.
+
+    Returns:
+        The loaded dictionary.
+
+    Raises:
+        ValueError: If file is invalid or fails schema validation.
+        FileNotFoundError: If file does not exist.
+    """
+    path = Path(file_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Autolabel rules file not found: {file_path}")
+
+    with open(path, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"Invalid YAML content in {file_path}: Expected a mapping at root."
+        )
+
+    errors = validate_autolabel_rules_dict(data)
+    if errors:
+        raise ValueError(
+            f"Schema validation errors in {file_path}:\n - "
+            + "\n - ".join(errors)
+        )
+
+    return data
+
+
+def dump_autolabel_rules_yaml(
+    data: dict[str, Any], file_path: str | Path
+) -> None:
+    """Dumps an autolabel rules dictionary to a cleanly formatted YAML file.
+
+    Args:
+        data: The dictionary structure to serialize.
+        file_path: Destination path for the YAML file.
+    """
+    path = Path(file_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(
+            data,
+            f,
+            sort_keys=False,
+            default_flow_style=False,
+            allow_unicode=True,
+        )
+
+
+def export_remote_rules_to_yaml_dict(
+    remote_rules: list[dict[str, Any]],
+    project_id: str,
+    location: str,
+) -> dict[str, Any]:
+    """Packages remote API rules into the standard declarative YAML format.
+
+    Args:
+        remote_rules: List of rules returned from Insights client.
+        project_id: GCP project ID.
+        location: GCP location.
+
+    Returns:
+        The declarative dictionary.
+    """
+    rules_yaml = [api_rule_to_yaml_rule(r) for r in remote_rules]
+    return {
+        "version": "1.0",
+        "project_id": project_id,
+        "location": location,
+        "autolabeling_rules": rules_yaml,
+    }
+
+
+def diff_autolabel_rules(
+    local_data: dict[str, Any],
+    remote_rules: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Compares local YAML rules against active remote rules in GCP.
+
+    Args:
+        local_data: Parsed local YAML dictionary.
+        remote_rules: List of active rules from CCAI Insights API.
+
+    Returns:
+        A diff dictionary with keys:
+            - 'to_create': list of (rule_id, payload) to create
+            - 'to_update': list of (rule_id, payload, mask, name) to update
+            - 'to_delete': list of remote_name to delete
+            - 'unchanged': list of rule_id that are already in sync
+            - 'report': Human-readable formatted summary string
+    """
+    local_rules = local_data.get("autolabeling_rules", [])
+
+    # Map remote rules by their terminal ID and labelKey
+    remote_by_id: dict[str, dict[str, Any]] = {}
+    for r in remote_rules:
+        name = r.get("name", "")
+        rule_id = name.split("/")[-1] if name else r.get("labelKey", "")
+        if rule_id:
+            remote_by_id[rule_id] = r
+
+    to_create: list[tuple[str, dict[str, Any]]] = []
+    to_update: list[tuple[str, dict[str, Any], list[str], str]] = []
+    unchanged: list[str] = []
+    seen_remote_ids: set[str] = set()
+
+    for r in local_rules:
+        rule_id, payload = yaml_rule_to_api_payload(r)
+        if rule_id not in remote_by_id:
+            to_create.append((rule_id, payload))
+        else:
+            seen_remote_ids.add(rule_id)
+            remote = remote_by_id[rule_id]
+            remote_name = remote.get("name", "")
+            changed_fields: list[str] = []
+
+            if payload.get("displayName") != remote.get("displayName"):
+                changed_fields.append("displayName")
+            if payload.get("labelKey") != remote.get("labelKey"):
+                changed_fields.append("labelKey")
+            if "labelKeyType" in payload and payload.get(
+                "labelKeyType"
+            ) != remote.get("labelKeyType"):
+                changed_fields.append("labelKeyType")
+            if payload.get("active") != remote.get("active", True):
+                changed_fields.append("active")
+
+            # Compare conditions list
+            local_conds = payload.get("conditions", [])
+            remote_conds = [
+                {
+                    "condition": c.get("condition", ""),
+                    "value": c.get("value", ""),
+                }
+                for c in remote.get("conditions", [])
+            ]
+            if local_conds != remote_conds:
+                changed_fields.append("conditions")
+
+            if changed_fields:
+                to_update.append(
+                    (rule_id, payload, changed_fields, remote_name)
+                )
+            else:
+                unchanged.append(rule_id)
+
+    to_delete = [
+        remote.get("name", "")
+        for rid, remote in remote_by_id.items()
+        if rid not in seen_remote_ids and remote.get("name")
+    ]
+
+    report = format_diff_report(
+        to_create=to_create,
+        to_update=to_update,
+        to_delete=to_delete,
+        unchanged=unchanged,
+        remote_by_id=remote_by_id,
+    )
+
+    return {
+        "to_create": to_create,
+        "to_update": to_update,
+        "to_delete": to_delete,
+        "unchanged": unchanged,
+        "report": report,
+    }
+
+
+def format_diff_report(
+    to_create: list[tuple[str, dict[str, Any]]],
+    to_update: list[tuple[str, dict[str, Any], list[str], str]],
+    to_delete: list[str],
+    unchanged: list[str],
+    remote_by_id: dict[str, dict[str, Any]],
+) -> str:
+    """Formats a diff breakdown into a readable multi-line summary."""
+    lines: list[str] = ["=== AutoLabeling Rules Diff ==="]
+
+    if not to_create and not to_update and not to_delete:
+        lines.append(
+            f"All {len(unchanged)} rule(s) are in sync with remote project."
+        )
+        return "\n".join(lines)
+
+    if to_create:
+        lines.append(f"\n[+] To Create ({len(to_create)}):")
+        for rid, payload in to_create:
+            key = payload.get("labelKey")
+            num_cond = len(payload.get("conditions", []))
+            lines.append(f"  + {rid} (Label: {key}, Conditions: {num_cond})")
+
+    if to_update:
+        lines.append(f"\n[~] To Update ({len(to_update)}):")
+        for rid, payload, fields, _ in to_update:
+            lines.append(f"  ~ {rid} (Fields changed: {', '.join(fields)})")
+            remote = remote_by_id.get(rid, {})
+            if "conditions" in fields:
+                local_json = json.dumps(
+                    payload.get("conditions", []), indent=2
+                ).splitlines()
+                remote_json = json.dumps(
+                    remote.get("conditions", []), indent=2
+                ).splitlines()
+                diff = list(
+                    difflib.unified_diff(
+                        remote_json,
+                        local_json,
+                        fromfile="remote",
+                        tofile="local",
+                        lineterm="",
+                    )
+                )
+                for d in diff[:12]:
+                    lines.append(f"      {d}")
+
+    if to_delete:
+        lines.append(f"\n[-] To Delete from remote ({len(to_delete)}):")
+        for name in to_delete:
+            lines.append(f"  - {name}")
+
+    if unchanged:
+        lines.append(
+            f"\n[=] Unchanged ({len(unchanged)}): {', '.join(unchanged)}"
+        )
+
+    return "\n".join(lines)
+
+
+def sync_autolabel_rules(
+    client: Insights,
+    file_path: str | Path,
+    parent: str | None = None,
+    force: bool = False,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Synchronizes local YAML rules to GCP Contact Center Insights.
+
+    Args:
+        client: The initialized Insights client.
+        file_path: Path to the local autolabel_rules.yaml file.
+        parent: Optional parent override (e.g. projects/P/locations/L).
+        force: If True, deletes remote rules missing from local YAML.
+        dry_run: If True, calculates and prints diff without API calls.
+
+    Returns:
+        A dictionary summarizing executed actions:
+            - 'created': list of created rule IDs
+            - 'updated': list of updated rule IDs
+            - 'deleted': list of deleted rule names
+            - 'skipped_delete': list of remote rule names kept when force=False
+    """
+    local_data = load_autolabel_rules_yaml(file_path)
+    target_parent = parent or client.parent
+
+    remote_rules = client.list_autolabeling_rules(parent=target_parent)
+    diff_res = diff_autolabel_rules(local_data, remote_rules)
+
+    summary: dict[str, Any] = {
+        "created": [],
+        "updated": [],
+        "deleted": [],
+        "skipped_delete": [],
+        "diff_report": diff_res["report"],
+    }
+
+    if dry_run:
+        logger.info(
+            "Dry run complete. No modifications applied.\n%s",
+            diff_res["report"],
+        )
+        return summary
+
+    # Execute Creations
+    for rule_id, payload in diff_res["to_create"]:
+        logger.info("Creating autolabeling rule '%s'...", rule_id)
+        client.create_autolabeling_rule(
+            auto_labeling_rule=payload,
+            auto_labeling_rule_id=rule_id,
+            parent=target_parent,
+        )
+        summary["created"].append(rule_id)
+
+    # Execute Updates
+    for rule_id, payload, update_mask, remote_name in diff_res["to_update"]:
+        logger.info(
+            "Updating autolabeling rule '%s' (fields: %s)...",
+            rule_id,
+            update_mask,
+        )
+        client.update_autolabeling_rule(
+            name=remote_name,
+            auto_labeling_rule=payload,
+            update_mask=update_mask,
+        )
+        summary["updated"].append(rule_id)
+
+    # Execute Deletions
+    if diff_res["to_delete"]:
+        if force:
+            for remote_name in diff_res["to_delete"]:
+                logger.info(
+                    "Deleting remote autolabeling rule '%s' (--force)...",
+                    remote_name,
+                )
+                client.delete_autolabeling_rule(remote_name)
+                summary["deleted"].append(remote_name)
+        else:
+            logger.warning(
+                "Remote autolabeling rules exist that are not in "
+                "local YAML (%d rules). Use --force to delete remote rules.",
+                len(diff_res["to_delete"]),
+            )
+            summary["skipped_delete"] = diff_res["to_delete"]
+
+    return summary

--- a/src/cxas_scrapi/core/autolabel_sync.py
+++ b/src/cxas_scrapi/core/autolabel_sync.py
@@ -116,13 +116,14 @@ def yaml_rule_to_api_payload(
     """
     rule_id = (
         rule_dict.get("rule_id")
-        or rule_dict.get("label_key")
-        or rule_dict.get("labelKey")
         or (
             rule_dict.get("name", "").split("/")[-1]
             if rule_dict.get("name")
-            else "rule"
+            else None
         )
+        or rule_dict.get("label_key")
+        or rule_dict.get("labelKey")
+        or "rule"
     )
 
     display_name = (

--- a/src/cxas_scrapi/core/insights.py
+++ b/src/cxas_scrapi/core/insights.py
@@ -375,3 +375,65 @@ class Insights(Common):
         if not name.startswith("projects/"):
             name = f"{self.parent}/analysisRules/{name}"
         self._request("DELETE", name)
+
+    # --- AutoLabeling Rules Operations ---
+
+    def list_autolabeling_rules(
+        self, parent: str | None = None
+    ) -> list[dict[str, Any]]:
+        """Lists autolabeling rules in the specified parent."""
+        parent = parent or self.parent
+        return self._list_paginated(
+            f"{parent}/autoLabelingRules", "autoLabelingRules"
+        )
+
+    def get_autolabeling_rule(self, name: str) -> dict[str, Any]:
+        """Gets an autolabeling rule by name or ID."""
+        if not name.startswith("projects/"):
+            name = f"{self.parent}/autoLabelingRules/{name}"
+        return self._request("GET", name)
+
+    def create_autolabeling_rule(
+        self,
+        auto_labeling_rule: dict[str, Any],
+        auto_labeling_rule_id: str | None = None,
+        parent: str | None = None,
+    ) -> dict[str, Any]:
+        """Creates a new autolabeling rule."""
+        parent = parent or self.parent
+        params = (
+            {"autoLabelingRuleId": auto_labeling_rule_id}
+            if auto_labeling_rule_id
+            else None
+        )
+        return self._request(
+            "POST",
+            f"{parent}/autoLabelingRules",
+            data=auto_labeling_rule,
+            params=params,
+        )
+
+    def update_autolabeling_rule(
+        self,
+        name: str,
+        auto_labeling_rule: dict[str, Any],
+        update_mask: str | list[str] = "*",
+    ) -> dict[str, Any]:
+        """Updates an autolabeling rule."""
+        if not name.startswith("projects/"):
+            name = f"{self.parent}/autoLabelingRules/{name}"
+        mask_str = (
+            ",".join(update_mask)
+            if isinstance(update_mask, (list, tuple))
+            else update_mask
+        )
+        params = {"updateMask": mask_str}
+        return self._request(
+            "PATCH", name, data=auto_labeling_rule, params=params
+        )
+
+    def delete_autolabeling_rule(self, name: str) -> None:
+        """Deletes an autolabeling rule."""
+        if not name.startswith("projects/"):
+            name = f"{self.parent}/autoLabelingRules/{name}"
+        self._request("DELETE", name)

--- a/tests/cxas_scrapi/cli/test_insights_cli.py
+++ b/tests/cxas_scrapi/cli/test_insights_cli.py
@@ -22,9 +22,16 @@ from cxas_scrapi.cli.insights_cli import (
     handle_create_analysis_rule,
     handle_create_scorecard,
     handle_create_topic_model,
+    handle_delete_autolabel_rule,
+    handle_diff_autolabel_rules,
+    handle_get_autolabel_rule,
+    handle_list_autolabel_rules,
+    handle_pull_autolabel_rules,
+    handle_push_autolabel_rules,
     handle_smoke_test_scorecard,
     populate_insights_parser,
 )
+from cxas_scrapi.core.autolabel_sync import dump_autolabel_rules_yaml
 
 
 def test_populate_insights_parser() -> None:
@@ -219,3 +226,187 @@ def test_handle_analyze_metrics(
     handle_analyze_metrics(args)
     mock_inst.aggregate_metrics.assert_called_once()
     assert html_file.read_text() == "<html>Dashboard</html>"
+
+
+def test_populate_insights_parser_autolabel_commands() -> None:
+    parser = argparse.ArgumentParser()
+    populate_insights_parser(parser)
+
+    # pull-autolabel-rules
+    args = parser.parse_args(
+        [
+            "pull-autolabel-rules",
+            "--parent",
+            "projects/p/locations/l",
+            "--out",
+            "rules.yaml",
+        ]
+    )
+    assert args.insights_command == "pull-autolabel-rules"
+    assert args.out == "rules.yaml"
+
+    # diff-autolabel-rules
+    args = parser.parse_args(["diff-autolabel-rules", "--file", "rules.yaml"])
+    assert args.insights_command == "diff-autolabel-rules"
+
+    # push-autolabel-rules
+    args = parser.parse_args(
+        ["push-autolabel-rules", "--file", "rules.yaml", "--dry-run", "--force"]
+    )
+    assert args.insights_command == "push-autolabel-rules"
+    assert args.dry_run is True
+    assert args.force is True
+
+    # list-autolabel-rules
+    args = parser.parse_args(
+        ["list-autolabel-rules", "--parent", "projects/p/locations/l"]
+    )
+    assert args.insights_command == "list-autolabel-rules"
+
+    # get-autolabel-rule
+    args = parser.parse_args(
+        [
+            "get-autolabel-rule",
+            "--rule-name",
+            "projects/p/locations/l/autoLabelingRules/r1",
+        ]
+    )
+    assert args.insights_command == "get-autolabel-rule"
+
+    # delete-autolabel-rule
+    args = parser.parse_args(
+        [
+            "delete-autolabel-rule",
+            "--rule-name",
+            "projects/p/locations/l/autoLabelingRules/r1",
+        ]
+    )
+    assert args.insights_command == "delete-autolabel-rule"
+
+
+@patch("cxas_scrapi.core.insights.Insights")
+def test_handle_pull_autolabel_rules(
+    mock_insights_cls: typing.Any, tmp_path: typing.Any
+) -> None:
+    mock_client = mock_insights_cls.return_value
+    mock_client.list_autolabeling_rules.return_value = [
+        {
+            "name": "projects/p/locations/l/autoLabelingRules/r1",
+            "displayName": "Rule 1",
+            "labelKey": "k1",
+            "conditions": [],
+        }
+    ]
+
+    out_file = tmp_path / "pulled_rules.yaml"
+    args = argparse.Namespace(
+        parent="projects/p/locations/l",
+        out=str(out_file),
+    )
+    handle_pull_autolabel_rules(args)
+    assert out_file.exists()
+    assert "Rule 1" in out_file.read_text()
+
+
+@patch("cxas_scrapi.core.insights.Insights")
+def test_handle_diff_autolabel_rules(
+    mock_insights_cls: typing.Any, tmp_path: typing.Any
+) -> None:
+    mock_client = mock_insights_cls.return_value
+    mock_client.list_autolabeling_rules.return_value = []
+
+    file_path = tmp_path / "rules.yaml"
+    dump_autolabel_rules_yaml(
+        {
+            "version": "1.0",
+            "project_id": "p",
+            "location": "l",
+            "autolabeling_rules": [
+                {
+                    "rule_id": "r1",
+                    "label_key": "k",
+                    "conditions": [{"condition": "", "value": "'v'"}],
+                }
+            ],
+        },
+        file_path,
+    )
+
+    args = argparse.Namespace(
+        file=str(file_path),
+        parent=None,
+    )
+    handle_diff_autolabel_rules(args)
+    mock_client.list_autolabeling_rules.assert_called_once()
+
+
+@patch("cxas_scrapi.core.insights.Insights")
+def test_handle_push_autolabel_rules(
+    mock_insights_cls: typing.Any, tmp_path: typing.Any
+) -> None:
+    mock_client = mock_insights_cls.return_value
+    mock_client.list_autolabeling_rules.return_value = []
+
+    file_path = tmp_path / "rules.yaml"
+    dump_autolabel_rules_yaml(
+        {
+            "version": "1.0",
+            "project_id": "p",
+            "location": "l",
+            "autolabeling_rules": [
+                {
+                    "rule_id": "r1",
+                    "label_key": "k",
+                    "conditions": [{"condition": "", "value": "'v'"}],
+                }
+            ],
+        },
+        file_path,
+    )
+
+    args = argparse.Namespace(
+        file=str(file_path),
+        parent="projects/p/locations/l",
+        dry_run=False,
+        force=False,
+    )
+    handle_push_autolabel_rules(args)
+    mock_client.create_autolabeling_rule.assert_called_once()
+
+
+@patch("cxas_scrapi.core.insights.Insights")
+def test_handle_list_and_get_and_delete_autolabel(
+    mock_insights_cls: typing.Any,
+) -> None:
+    mock_client = mock_insights_cls.return_value
+    mock_client.list_autolabeling_rules.return_value = [
+        {
+            "name": "projects/p/locations/l/autoLabelingRules/r1",
+            "displayName": "R1",
+        }
+    ]
+    mock_client.get_autolabeling_rule.return_value = {
+        "name": "projects/p/locations/l/autoLabelingRules/r1"
+    }
+
+    # list
+    handle_list_autolabel_rules(
+        argparse.Namespace(parent="projects/p/locations/l")
+    )
+    mock_client.list_autolabeling_rules.assert_called_once()
+
+    # get
+    handle_get_autolabel_rule(
+        argparse.Namespace(
+            rule_name="projects/p/locations/l/autoLabelingRules/r1"
+        )
+    )
+    mock_client.get_autolabeling_rule.assert_called_once()
+
+    # delete
+    handle_delete_autolabel_rule(
+        argparse.Namespace(
+            rule_name="projects/p/locations/l/autoLabelingRules/r1"
+        )
+    )
+    mock_client.delete_autolabeling_rule.assert_called_once()

--- a/tests/cxas_scrapi/core/test_autolabel_sync.py
+++ b/tests/cxas_scrapi/core/test_autolabel_sync.py
@@ -1,0 +1,282 @@
+"""Unit tests for autolabel_sync module."""
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from cxas_scrapi.core.autolabel_sync import (
+    api_rule_to_yaml_rule,
+    diff_autolabel_rules,
+    dump_autolabel_rules_yaml,
+    export_remote_rules_to_yaml_dict,
+    load_autolabel_rules_yaml,
+    sync_autolabel_rules,
+    validate_autolabel_rules_dict,
+    yaml_rule_to_api_payload,
+)
+
+
+def test_validate_autolabel_rules_dict_valid() -> None:
+    valid_data = {
+        "version": "1.0",
+        "project_id": "p",
+        "location": "l",
+        "autolabeling_rules": [
+            {
+                "rule_id": "category",
+                "label_key": "category",
+                "conditions": [
+                    {
+                        "condition": "conversation.agent_id == 'vip'",
+                        "value": "'vip'",
+                    },
+                    {"condition": "", "value": "'default'"},
+                ],
+            }
+        ],
+    }
+    errors = validate_autolabel_rules_dict(valid_data)
+    assert errors == []
+
+
+def test_validate_autolabel_rules_dict_invalid() -> None:
+    # Not a dict
+    assert "mapping" in validate_autolabel_rules_dict([])[0]
+
+    # Missing autolabeling_rules
+    assert "list" in validate_autolabel_rules_dict({})[0]
+
+    # Empty rules
+    assert (
+        "empty" in validate_autolabel_rules_dict({"autolabeling_rules": []})[0]
+    )
+
+    # Missing label_key & missing conditions
+    invalid = {
+        "autolabeling_rules": [
+            {"rule_id": "r1"},
+            {"rule_id": "r1", "label_key": "k", "conditions": []},
+        ]
+    }
+    errors = validate_autolabel_rules_dict(invalid)
+    assert any("missing required 'label_key'" in e for e in errors)
+    assert any("Duplicate rule_id" in e for e in errors)
+    assert any("non-empty 'conditions'" in e for e in errors)
+
+
+def test_yaml_rule_to_api_payload_and_back() -> None:
+    rule_dict = {
+        "rule_id": "r1",
+        "display_name": "Rule 1",
+        "label_key": "category",
+        "label_key_type": "LABEL_KEY_TYPE_CUSTOM",
+        "active": True,
+        "conditions": [{"condition": "", "value": "'general'"}],
+    }
+    rule_id, payload = yaml_rule_to_api_payload(rule_dict)
+    assert rule_id == "r1"
+    assert payload["displayName"] == "Rule 1"
+    assert payload["labelKey"] == "category"
+    assert payload["conditions"] == [{"condition": "", "value": "'general'"}]
+
+    # API back to YAML
+    api_resp = {
+        "name": "projects/p/locations/l/autoLabelingRules/r1",
+        "displayName": "Rule 1",
+        "labelKey": "category",
+        "labelKeyType": "LABEL_KEY_TYPE_CUSTOM",
+        "active": True,
+        "conditions": [{"condition": "", "value": "'general'"}],
+    }
+    yaml_res = api_rule_to_yaml_rule(api_resp)
+    assert yaml_res["rule_id"] == "r1"
+    assert yaml_res["display_name"] == "Rule 1"
+
+
+def test_load_and_dump_yaml(tmp_path: Path) -> None:
+    data = {
+        "version": "1.0",
+        "project_id": "my-project",
+        "location": "us-central1",
+        "autolabeling_rules": [
+            {
+                "rule_id": "escalation",
+                "label_key": "escalation",
+                "conditions": [{"condition": "", "value": "'low'"}],
+            }
+        ],
+    }
+    file_path = tmp_path / "autolabel_rules.yaml"
+    dump_autolabel_rules_yaml(data, file_path)
+
+    loaded = load_autolabel_rules_yaml(file_path)
+    assert loaded["project_id"] == "my-project"
+    assert len(loaded["autolabeling_rules"]) == 1
+
+
+def test_load_yaml_errors(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        load_autolabel_rules_yaml(tmp_path / "non_existent.yaml")
+
+    bad_file = tmp_path / "bad.yaml"
+    bad_file.write_text("invalid_list:\n  - item\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="Schema validation errors"):
+        load_autolabel_rules_yaml(bad_file)
+
+
+def test_export_remote_rules_to_yaml_dict() -> None:
+    remote = [
+        {
+            "name": "projects/p/locations/l/autoLabelingRules/r1",
+            "displayName": "Rule 1",
+            "labelKey": "cat",
+            "conditions": [],
+        }
+    ]
+    data = export_remote_rules_to_yaml_dict(remote, "p", "l")
+    assert data["version"] == "1.0"
+    assert data["project_id"] == "p"
+    assert len(data["autolabeling_rules"]) == 1
+    assert data["autolabeling_rules"][0]["rule_id"] == "r1"
+
+
+def test_diff_autolabel_rules() -> None:
+    local_data = {
+        "autolabeling_rules": [
+            {
+                "rule_id": "r1",
+                "display_name": "Rule 1 Updated",
+                "label_key": "cat",
+                "active": True,
+                "conditions": [{"condition": "", "value": "'new'"}],
+            },
+            {
+                "rule_id": "r2_new",
+                "display_name": "New Rule",
+                "label_key": "new_key",
+                "conditions": [{"condition": "", "value": "'v'"}],
+            },
+            {
+                "rule_id": "r3_same",
+                "display_name": "Unchanged Rule",
+                "label_key": "k3",
+                "conditions": [{"condition": "", "value": "'same'"}],
+            },
+        ]
+    }
+
+    remote_rules = [
+        {
+            "name": "projects/p/locations/l/autoLabelingRules/r1",
+            "displayName": "Rule 1 Old",
+            "labelKey": "cat",
+            "active": True,
+            "conditions": [{"condition": "", "value": "'old'"}],
+        },
+        {
+            "name": "projects/p/locations/l/autoLabelingRules/r3_same",
+            "displayName": "Unchanged Rule",
+            "labelKey": "k3",
+            "active": True,
+            "conditions": [{"condition": "", "value": "'same'"}],
+        },
+        {
+            "name": "projects/p/locations/l/autoLabelingRules/r4_orphan",
+            "displayName": "Orphan Rule",
+            "labelKey": "k4",
+            "conditions": [],
+        },
+    ]
+
+    diff_res = diff_autolabel_rules(local_data, remote_rules)
+
+    # To create
+    assert len(diff_res["to_create"]) == 1
+    assert diff_res["to_create"][0][0] == "r2_new"
+
+    # To update
+    assert len(diff_res["to_update"]) == 1
+    assert diff_res["to_update"][0][0] == "r1"
+    assert "displayName" in diff_res["to_update"][0][2]
+    assert "conditions" in diff_res["to_update"][0][2]
+
+    # To delete
+    assert diff_res["to_delete"] == [
+        "projects/p/locations/l/autoLabelingRules/r4_orphan"
+    ]
+
+    # Unchanged
+    assert diff_res["unchanged"] == ["r3_same"]
+    assert "=== AutoLabeling Rules Diff ===" in diff_res["report"]
+
+
+def test_sync_autolabel_rules(tmp_path: Path) -> None:
+    data = {
+        "version": "1.0",
+        "project_id": "p",
+        "location": "l",
+        "autolabeling_rules": [
+            {
+                "rule_id": "r1",
+                "display_name": "Rule 1",
+                "label_key": "cat",
+                "conditions": [{"condition": "", "value": "'v'"}],
+            }
+        ],
+    }
+    file_path = tmp_path / "autolabel_rules.yaml"
+    dump_autolabel_rules_yaml(data, file_path)
+
+    mock_client = MagicMock()
+    mock_client.parent = "projects/p/locations/l"
+
+    # 1. Dry run
+    mock_client.list_autolabeling_rules.return_value = []
+    summary_dry = sync_autolabel_rules(mock_client, file_path, dry_run=True)
+    assert mock_client.create_autolabeling_rule.call_count == 0
+    assert summary_dry["created"] == []
+
+    # 2. Live run creating r1
+    summary_live = sync_autolabel_rules(mock_client, file_path, dry_run=False)
+    assert mock_client.create_autolabeling_rule.call_count == 1
+    assert summary_live["created"] == ["r1"]
+
+    # 3. Live run with update and delete (force=True)
+    mock_client.list_autolabeling_rules.return_value = [
+        {
+            "name": "projects/p/locations/l/autoLabelingRules/r1",
+            "displayName": "Old Name",
+            "labelKey": "cat",
+            "conditions": [{"condition": "", "value": "'v'"}],
+        },
+        {
+            "name": "projects/p/locations/l/autoLabelingRules/old_rule",
+            "displayName": "Old Rule",
+            "labelKey": "old",
+            "conditions": [],
+        },
+    ]
+    summary_update = sync_autolabel_rules(
+        mock_client, file_path, force=True, dry_run=False
+    )
+    assert mock_client.update_autolabeling_rule.call_count == 1
+    assert mock_client.delete_autolabeling_rule.call_count == 1
+    assert summary_update["updated"] == ["r1"]
+    assert summary_update["deleted"] == [
+        "projects/p/locations/l/autoLabelingRules/old_rule"
+    ]

--- a/tests/cxas_scrapi/core/test_autolabel_sync.py
+++ b/tests/cxas_scrapi/core/test_autolabel_sync.py
@@ -24,6 +24,7 @@ from cxas_scrapi.core.autolabel_sync import (
     diff_autolabel_rules,
     dump_autolabel_rules_yaml,
     export_remote_rules_to_yaml_dict,
+    format_diff_report,
     load_autolabel_rules_yaml,
     sync_autolabel_rules,
     validate_autolabel_rules_dict,
@@ -54,23 +55,37 @@ def test_validate_autolabel_rules_dict_valid() -> None:
     assert errors == []
 
 
-def test_validate_autolabel_rules_dict_invalid() -> None:
+def test_validate_autolabel_rules_dict_invalid_root_and_list() -> None:
     # Not a dict
     assert "mapping" in validate_autolabel_rules_dict([])[0]
+    assert "mapping" in validate_autolabel_rules_dict("invalid")[0]
 
-    # Missing autolabeling_rules
-    assert "list" in validate_autolabel_rules_dict({})[0]
-
-    # Empty rules
+    # Missing or non-list autolabeling_rules
+    assert "must be a list" in validate_autolabel_rules_dict({})[0]
     assert (
-        "empty" in validate_autolabel_rules_dict({"autolabeling_rules": []})[0]
+        "must be a list"
+        in validate_autolabel_rules_dict({"autolabeling_rules": "str"})[0]
     )
+
+    # Empty rules list
+    assert (
+        "is empty"
+        in validate_autolabel_rules_dict({"autolabeling_rules": []})[0]
+    )
+
+
+def test_validate_autolabel_rules_dict_invalid_rule_structures() -> None:
+    # Non-dictionary rule item
+    data_with_non_dict_rule = {"autolabeling_rules": ["not_a_dict"]}
+    errors = validate_autolabel_rules_dict(data_with_non_dict_rule)
+    assert any("must be a dictionary" in e for e in errors)
 
     # Missing label_key & missing conditions
     invalid = {
         "autolabeling_rules": [
             {"rule_id": "r1"},
             {"rule_id": "r1", "label_key": "k", "conditions": []},
+            {"rule_id": "r2", "label_key": "k2", "conditions": "not_a_list"},
         ]
     }
     errors = validate_autolabel_rules_dict(invalid)
@@ -78,8 +93,46 @@ def test_validate_autolabel_rules_dict_invalid() -> None:
     assert any("Duplicate rule_id" in e for e in errors)
     assert any("non-empty 'conditions'" in e for e in errors)
 
+    # Conditions with non-dict item and missing value
+    invalid_conds = {
+        "autolabeling_rules": [
+            {
+                "rule_id": "r3",
+                "label_key": "k3",
+                "conditions": [
+                    "not_a_dict",
+                    {"condition": "c1"},  # missing value
+                ],
+            }
+        ]
+    }
+    errors_conds = validate_autolabel_rules_dict(invalid_conds)
+    assert any("condition #0 must be a dictionary" in e for e in errors_conds)
+    assert any("condition #1 is missing 'value'" in e for e in errors_conds)
 
-def test_yaml_rule_to_api_payload_and_back() -> None:
+
+def test_validate_autolabel_rules_dict_no_fallback_log(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    data_no_fallback = {
+        "version": "1.0",
+        "autolabeling_rules": [
+            {
+                "rule_id": "r_no_fb",
+                "label_key": "k_fb",
+                "conditions": [
+                    {"condition": "conversation.turns > 5", "value": "'long'"}
+                ],
+            }
+        ],
+    }
+    with caplog.at_level("DEBUG"):
+        errors = validate_autolabel_rules_dict(data_no_fallback)
+    assert errors == []
+    assert "does not specify an explicit default fallback" in caplog.text
+
+
+def test_yaml_rule_to_api_payload_full_and_fallback_fields() -> None:
     rule_dict = {
         "rule_id": "r1",
         "display_name": "Rule 1",
@@ -92,20 +145,59 @@ def test_yaml_rule_to_api_payload_and_back() -> None:
     assert rule_id == "r1"
     assert payload["displayName"] == "Rule 1"
     assert payload["labelKey"] == "category"
+    assert payload["labelKeyType"] == "LABEL_KEY_TYPE_CUSTOM"
+    assert payload["active"] is True
     assert payload["conditions"] == [{"condition": "", "value": "'general'"}]
 
-    # API back to YAML
+    # Fallback to name extraction and labelKey camelCase
+    rule_dict_alt = {
+        "name": "projects/p/locations/l/autoLabelingRules/extracted_id",
+        "displayName": "Extracted Display",
+        "labelKey": "extracted_key",
+        "labelKeyType": "LABEL_KEY_TYPE_SYSTEM",
+        "conditions": [{"condition": "c", "value": 123}],
+    }
+    rule_id_alt, payload_alt = yaml_rule_to_api_payload(rule_dict_alt)
+    assert rule_id_alt == "extracted_id"
+    assert payload_alt["displayName"] == "Extracted Display"
+    assert payload_alt["labelKey"] == "extracted_key"
+    assert payload_alt["labelKeyType"] == "LABEL_KEY_TYPE_SYSTEM"
+    assert payload_alt["conditions"] == [{"condition": "c", "value": "123"}]
+
+    # Minimal rule with only label_key
+    min_rule = {"label_key": "only_key"}
+    min_id, min_payload = yaml_rule_to_api_payload(min_rule)
+    assert min_id == "only_key"
+    assert min_payload["displayName"] == "only_key"
+    assert min_payload["labelKey"] == "only_key"
+    assert min_payload["active"] is True
+    assert min_payload["conditions"] == []
+
+
+def test_api_rule_to_yaml_rule_variations() -> None:
     api_resp = {
         "name": "projects/p/locations/l/autoLabelingRules/r1",
         "displayName": "Rule 1",
         "labelKey": "category",
         "labelKeyType": "LABEL_KEY_TYPE_CUSTOM",
-        "active": True,
+        "active": False,
         "conditions": [{"condition": "", "value": "'general'"}],
     }
     yaml_res = api_rule_to_yaml_rule(api_resp)
     assert yaml_res["rule_id"] == "r1"
     assert yaml_res["display_name"] == "Rule 1"
+    assert yaml_res["label_key"] == "category"
+    assert yaml_res["label_key_type"] == "LABEL_KEY_TYPE_CUSTOM"
+    assert yaml_res["active"] is False
+
+    # API response without name (falling back to labelKey)
+    api_resp_no_name = {
+        "displayName": "No Name Rule",
+        "labelKey": "fallback_key",
+    }
+    yaml_res_no_name = api_rule_to_yaml_rule(api_resp_no_name)
+    assert yaml_res_no_name["rule_id"] == "fallback_key"
+    assert yaml_res_no_name["conditions"] == []
 
 
 def test_load_and_dump_yaml(tmp_path: Path) -> None:
@@ -121,8 +213,10 @@ def test_load_and_dump_yaml(tmp_path: Path) -> None:
             }
         ],
     }
-    file_path = tmp_path / "autolabel_rules.yaml"
+    # Test directory creation when nested parent does not exist
+    file_path = tmp_path / "nested" / "dir" / "autolabel_rules.yaml"
     dump_autolabel_rules_yaml(data, file_path)
+    assert file_path.exists()
 
     loaded = load_autolabel_rules_yaml(file_path)
     assert loaded["project_id"] == "my-project"
@@ -130,13 +224,20 @@ def test_load_and_dump_yaml(tmp_path: Path) -> None:
 
 
 def test_load_yaml_errors(tmp_path: Path) -> None:
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(
+        FileNotFoundError, match="Autolabel rules file not found"
+    ):
         load_autolabel_rules_yaml(tmp_path / "non_existent.yaml")
 
-    bad_file = tmp_path / "bad.yaml"
-    bad_file.write_text("invalid_list:\n  - item\n", encoding="utf-8")
+    bad_non_dict = tmp_path / "bad_list.yaml"
+    bad_non_dict.write_text("- item1\n- item2\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="Expected a mapping at root"):
+        load_autolabel_rules_yaml(bad_non_dict)
+
+    bad_schema = tmp_path / "bad_schema.yaml"
+    bad_schema.write_text("invalid_key:\n  - item\n", encoding="utf-8")
     with pytest.raises(ValueError, match="Schema validation errors"):
-        load_autolabel_rules_yaml(bad_file)
+        load_autolabel_rules_yaml(bad_schema)
 
 
 def test_export_remote_rules_to_yaml_dict() -> None:
@@ -155,14 +256,15 @@ def test_export_remote_rules_to_yaml_dict() -> None:
     assert data["autolabeling_rules"][0]["rule_id"] == "r1"
 
 
-def test_diff_autolabel_rules() -> None:
+def test_diff_autolabel_rules_and_report() -> None:
     local_data = {
         "autolabeling_rules": [
             {
                 "rule_id": "r1",
                 "display_name": "Rule 1 Updated",
-                "label_key": "cat",
-                "active": True,
+                "label_key": "cat_updated",
+                "label_key_type": "LABEL_KEY_TYPE_SYSTEM",
+                "active": False,
                 "conditions": [{"condition": "", "value": "'new'"}],
             },
             {
@@ -175,6 +277,8 @@ def test_diff_autolabel_rules() -> None:
                 "rule_id": "r3_same",
                 "display_name": "Unchanged Rule",
                 "label_key": "k3",
+                "label_key_type": "LABEL_KEY_TYPE_CUSTOM",
+                "active": True,
                 "conditions": [{"condition": "", "value": "'same'"}],
             },
         ]
@@ -184,7 +288,8 @@ def test_diff_autolabel_rules() -> None:
         {
             "name": "projects/p/locations/l/autoLabelingRules/r1",
             "displayName": "Rule 1 Old",
-            "labelKey": "cat",
+            "labelKey": "cat_old",
+            "labelKeyType": "LABEL_KEY_TYPE_CUSTOM",
             "active": True,
             "conditions": [{"condition": "", "value": "'old'"}],
         },
@@ -192,6 +297,7 @@ def test_diff_autolabel_rules() -> None:
             "name": "projects/p/locations/l/autoLabelingRules/r3_same",
             "displayName": "Unchanged Rule",
             "labelKey": "k3",
+            "labelKeyType": "LABEL_KEY_TYPE_CUSTOM",
             "active": True,
             "conditions": [{"condition": "", "value": "'same'"}],
         },
@@ -211,9 +317,15 @@ def test_diff_autolabel_rules() -> None:
 
     # To update
     assert len(diff_res["to_update"]) == 1
-    assert diff_res["to_update"][0][0] == "r1"
-    assert "displayName" in diff_res["to_update"][0][2]
-    assert "conditions" in diff_res["to_update"][0][2]
+    rule_id, payload, fields, remote_name = diff_res["to_update"][0]
+    assert rule_id == "r1"
+    assert payload["displayName"] == "Rule 1 Updated"
+    assert "displayName" in fields
+    assert "labelKey" in fields
+    assert "labelKeyType" in fields
+    assert "active" in fields
+    assert "conditions" in fields
+    assert remote_name == "projects/p/locations/l/autoLabelingRules/r1"
 
     # To delete
     assert diff_res["to_delete"] == [
@@ -222,10 +334,24 @@ def test_diff_autolabel_rules() -> None:
 
     # Unchanged
     assert diff_res["unchanged"] == ["r3_same"]
-    assert "=== AutoLabeling Rules Diff ===" in diff_res["report"]
+    assert "[+] To Create" in diff_res["report"]
+    assert "[~] To Update" in diff_res["report"]
+    assert "[-] To Delete" in diff_res["report"]
+    assert "[=] Unchanged" in diff_res["report"]
 
 
-def test_sync_autolabel_rules(tmp_path: Path) -> None:
+def test_format_diff_report_all_in_sync() -> None:
+    report = format_diff_report(
+        to_create=[],
+        to_update=[],
+        to_delete=[],
+        unchanged=["r1", "r2"],
+        remote_by_id={},
+    )
+    assert "All 2 rule(s) are in sync" in report
+
+
+def test_sync_autolabel_rules_workflows(tmp_path: Path) -> None:
     data = {
         "version": "1.0",
         "project_id": "p",
@@ -250,13 +376,29 @@ def test_sync_autolabel_rules(tmp_path: Path) -> None:
     summary_dry = sync_autolabel_rules(mock_client, file_path, dry_run=True)
     assert mock_client.create_autolabeling_rule.call_count == 0
     assert summary_dry["created"] == []
+    assert summary_dry["diff_report"] != ""
 
-    # 2. Live run creating r1
-    summary_live = sync_autolabel_rules(mock_client, file_path, dry_run=False)
+    # 2. Live run creating r1 with custom parent
+    summary_live = sync_autolabel_rules(
+        mock_client,
+        file_path,
+        parent="projects/other/locations/global",
+        dry_run=False,
+    )
     assert mock_client.create_autolabeling_rule.call_count == 1
+    mock_client.create_autolabeling_rule.assert_called_with(
+        auto_labeling_rule={
+            "displayName": "Rule 1",
+            "labelKey": "cat",
+            "active": True,
+            "conditions": [{"condition": "", "value": "'v'"}],
+        },
+        auto_labeling_rule_id="r1",
+        parent="projects/other/locations/global",
+    )
     assert summary_live["created"] == ["r1"]
 
-    # 3. Live run with update and delete (force=True)
+    # 3. Live run with update and skip deletion (force=False)
     mock_client.list_autolabeling_rules.return_value = [
         {
             "name": "projects/p/locations/l/autoLabelingRules/r1",
@@ -271,12 +413,22 @@ def test_sync_autolabel_rules(tmp_path: Path) -> None:
             "conditions": [],
         },
     ]
-    summary_update = sync_autolabel_rules(
-        mock_client, file_path, force=True, dry_run=False
+    summary_skip_del = sync_autolabel_rules(
+        mock_client, file_path, force=False, dry_run=False
     )
     assert mock_client.update_autolabeling_rule.call_count == 1
+    assert mock_client.delete_autolabeling_rule.call_count == 0
+    assert summary_skip_del["updated"] == ["r1"]
+    assert summary_skip_del["deleted"] == []
+    assert summary_skip_del["skipped_delete"] == [
+        "projects/p/locations/l/autoLabelingRules/old_rule"
+    ]
+
+    # 4. Live run with force=True deletion
+    summary_force_del = sync_autolabel_rules(
+        mock_client, file_path, force=True, dry_run=False
+    )
     assert mock_client.delete_autolabeling_rule.call_count == 1
-    assert summary_update["updated"] == ["r1"]
-    assert summary_update["deleted"] == [
+    assert summary_force_del["deleted"] == [
         "projects/p/locations/l/autoLabelingRules/old_rule"
     ]

--- a/tests/cxas_scrapi/core/test_insights.py
+++ b/tests/cxas_scrapi/core/test_insights.py
@@ -169,3 +169,155 @@ def test_insights_request_retry_on_failure(
 
     assert res == {"name": "test-resource"}
     assert mock_make_request.call_count == 3
+
+
+@patch("requests.Session.request")
+def test_list_autolabeling_rules(
+    mock_request: typing.Any, mock_google_auth: typing.Any
+) -> None:
+    """Test Insights.list_autolabeling_rules."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "autoLabelingRules": [
+            {
+                "name": "projects/p/locations/l/autoLabelingRules/r1",
+                "displayName": "Rule 1",
+            }
+        ],
+        "nextPageToken": None,
+    }
+    mock_request.return_value = mock_response
+
+    client = Insights(project_id="p", location="l")
+    rules = client.list_autolabeling_rules()
+
+    assert len(rules) == 1
+    assert rules[0]["displayName"] == "Rule 1"
+    mock_request.assert_called_once()
+    called_args = mock_request.call_args
+    assert called_args[1]["method"] == "GET"
+    assert (
+        called_args[1]["url"]
+        == "https://l-contactcenterinsights.googleapis.com/v1/projects/p/locations/l/autoLabelingRules"
+    )
+
+
+@patch("requests.Session.request")
+def test_get_autolabeling_rule(
+    mock_request: typing.Any, mock_google_auth: typing.Any
+) -> None:
+    """Test Insights.get_autolabeling_rule."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "name": "projects/p/locations/l/autoLabelingRules/r1",
+        "displayName": "Rule 1",
+    }
+    mock_request.return_value = mock_response
+
+    client = Insights(project_id="p", location="l")
+
+    # With relative ID
+    res1 = client.get_autolabeling_rule("r1")
+    assert res1["displayName"] == "Rule 1"
+    assert (
+        mock_request.call_args[1]["url"]
+        == "https://l-contactcenterinsights.googleapis.com/v1/projects/p/locations/l/autoLabelingRules/r1"
+    )
+
+    # With full resource name
+    res2 = client.get_autolabeling_rule(
+        "projects/p/locations/l/autoLabelingRules/r1"
+    )
+    assert res2["displayName"] == "Rule 1"
+
+
+@patch("requests.Session.request")
+def test_create_autolabeling_rule(
+    mock_request: typing.Any, mock_google_auth: typing.Any
+) -> None:
+    """Test Insights.create_autolabeling_rule."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "name": "projects/p/locations/l/autoLabelingRules/r1",
+        "displayName": "Rule 1",
+    }
+    mock_request.return_value = mock_response
+
+    client = Insights(project_id="p", location="l")
+    payload = {
+        "displayName": "Rule 1",
+        "labelKey": "category",
+        "conditions": [{"condition": "", "value": "'default'"}],
+    }
+    rule = client.create_autolabeling_rule(payload, auto_labeling_rule_id="r1")
+
+    assert rule["name"] == "projects/p/locations/l/autoLabelingRules/r1"
+    mock_request.assert_called_once()
+    called_args = mock_request.call_args
+    assert called_args[1]["method"] == "POST"
+    assert (
+        called_args[1]["url"]
+        == "https://l-contactcenterinsights.googleapis.com/v1/projects/p/locations/l/autoLabelingRules"
+    )
+    assert called_args[1]["params"] == {"autoLabelingRuleId": "r1"}
+    assert called_args[1]["json"]["labelKey"] == "category"
+
+
+@patch("requests.Session.request")
+def test_update_autolabeling_rule(
+    mock_request: typing.Any, mock_google_auth: typing.Any
+) -> None:
+    """Test Insights.update_autolabeling_rule."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "name": "projects/p/locations/l/autoLabelingRules/r1",
+        "displayName": "Updated Rule",
+    }
+    mock_request.return_value = mock_response
+
+    client = Insights(project_id="p", location="l")
+    payload = {"displayName": "Updated Rule"}
+
+    # With string mask
+    res1 = client.update_autolabeling_rule(
+        "r1", payload, update_mask="displayName"
+    )
+    assert res1["displayName"] == "Updated Rule"
+    assert mock_request.call_args[1]["params"] == {"updateMask": "displayName"}
+
+    # With list mask
+    res2 = client.update_autolabeling_rule(
+        "projects/p/locations/l/autoLabelingRules/r1",
+        payload,
+        update_mask=["displayName", "active"],
+    )
+    assert res2["displayName"] == "Updated Rule"
+    assert mock_request.call_args[1]["params"] == {
+        "updateMask": "displayName,active"
+    }
+
+
+@patch("requests.Session.request")
+def test_delete_autolabeling_rule(
+    mock_request: typing.Any, mock_google_auth: typing.Any
+) -> None:
+    """Test Insights.delete_autolabeling_rule."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {}
+    mock_request.return_value = mock_response
+
+    client = Insights(project_id="p", location="l")
+    client.delete_autolabeling_rule("r1")
+
+    mock_request.assert_called_once()
+    called_args = mock_request.call_args
+    assert called_args[1]["method"] == "DELETE"
+    assert (
+        called_args[1]["url"]
+        == "https://l-contactcenterinsights.googleapis.com/v1/projects/p/locations/l/autoLabelingRules/r1"
+    )


### PR DESCRIPTION
## Summary

Adds end-to-end support for Contact Center AI (CCAI) Insights Autolabeling Rules, including Core SDK REST CRUD methods, a declarative YAML sync/diff engine, CLI commands (`pull`, `diff`, `push`), 100% coverage unit tests, and the `cxas-autolabel-rules` skill with comprehensive CEL documentation and recipes.

### Key Changes

1. **Core SDK Extensions (`src/cxas_scrapi/core/insights.py`)**:
   - Implemented `list_autolabeling_rules`, `get_autolabeling_rule`, `create_autolabeling_rule`, `update_autolabeling_rule`, and `delete_autolabeling_rule`.

2. **Declarative YAML Engine (`src/cxas_scrapi/core/autolabel_sync.py`)**:
   - Schema validation for declarative `autolabel_rules.yaml`.
   - Bidirectional API <-> YAML converters with condition mapping.
   - Smart `diff_autolabel_rules` with unified condition diffs.
   - `sync_autolabel_rules` supporting `--dry-run` and `--force` deletion protection.

3. **CLI Commands (`src/cxas_scrapi/cli/insights_cli.py`)**:
   - `cxas insights pull-autolabel-rules`
   - `cxas insights diff-autolabel-rules`
   - `cxas insights push-autolabel-rules` (`--dry-run`, `--force`)
   - `cxas insights list-autolabel-rules`, `get-autolabel-rule`, `delete-autolabel-rule`.

4. **AI Skill & Documentation (`.agents/skills/cxas-autolabel-rules/`)**:
   - `SKILL.md`: Step-by-step guidance for translating natural language logic to CEL.
   - `references/cel_cookbook.md`: Deep `google.cloud.contactcenterinsights.v1.Conversation` protobuf reference with camelCase field mappings, `runtimeAnnotations.cesTurnAnnotation` inspection recipes, regex patterns, and built-in helper functions (`containsSubAgent`, `hasSessionParam`, `hasCallerSentiment`).
   - `references/schema.json`: JSON Schema specification for `autolabel_rules.yaml`.
   - `scripts/sync_rules.py`: Standalone CLI helper for automated pipelines.
   - Registered skill in `AGENTS.md`.

5. **Testing & Quality Assurance**:
   - Added 12 unit tests with **100% statement and branch coverage** on `autolabel_sync.py`.
   - Added full test suite for CLI subparsers and Core SDK CRUD methods.
   - Verified 120/120 markdown files with `test_markdown_links.py`.
   - Passed brand compliance checks and ruff formatting/linting.