### PR TITLE
fix(evals): keep expectation display name when sideloading export

### DIFF
--- a/src/cxas_scrapi/core/evaluations.py
+++ b/src/cxas_scrapi/core/evaluations.py
@@ -598,8 +598,12 @@ class Evaluations(Common):
                                     eval_exp_dir, f"{exp_id}.json"
                                 )
 
+                                exp_display_name = (
+                                    getattr(exp_obj, "display_name", None)
+                                    or exp_id
+                                )
                                 exp_content = {
-                                    "displayName": exp_id,
+                                    "displayName": exp_display_name,
                                     "llmCriteria": {"prompt": prompt_text},
                                 }
                                 with open(

--- a/tests/cxas_scrapi/core/test_evaluations.py
+++ b/tests/cxas_scrapi/core/test_evaluations.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import typing
 from unittest.mock import MagicMock, mock_open, patch
 
@@ -256,6 +257,48 @@ def test_export_evaluation(mock_get_eval: typing.Any) -> None:
                 output_format=ExportFormat.JSON,
             )
             assert '"conversation": "Exported Eval"' in json_str
+
+
+@patch("cxas_scrapi.core.evaluations.Evaluations.get_evaluation_expectation")
+@patch("cxas_scrapi.core.evaluations.Evaluations.get_evaluation")
+def test_export_evaluation_sideload_keeps_display_name(
+    mock_get_eval: typing.Any,
+    mock_get_exp: typing.Any,
+    tmp_path: typing.Any,
+) -> None:
+    """Sideloaded expectations keep the platform display name."""
+    exp_ref = "projects/p/locations/l/apps/a/evaluationExpectations/exp-1"
+    prompt = "Is the agent reply grounded in the tool response?"
+
+    mock_exp = MagicMock()
+    mock_exp.display_name = "grounding-check"
+    mock_exp.llm_criteria.prompt = prompt
+    mock_get_exp.return_value = mock_exp
+
+    with patch("cxas_scrapi.core.evaluations.type") as mock_type:
+        mock_type.return_value.to_dict = MagicMock(
+            return_value={
+                "display_name": "Exported Eval",
+                "golden": {
+                    "turns": [],
+                    "evaluation_expectations": [exp_ref],
+                },
+            }
+        )
+
+        evals_client = Evaluations(app_name="projects/p/locations/l/apps/a")
+        with patch("cxas_scrapi.core.evaluations.EvaluationServiceClient"):
+            evals_client.export_evaluation(
+                "projects/p/locations/l/apps/a/evaluations/e1",
+                output_path=str(tmp_path / "golden.yaml"),
+            )
+
+    sideloaded = list((tmp_path / "evaluationExpectations").glob("*.json"))
+    assert len(sideloaded) == 1
+
+    content = json.loads(sideloaded[0].read_text(encoding="utf-8"))
+    assert content["displayName"] == "grounding-check"
+    assert content["llmCriteria"]["prompt"] == prompt
 
 
 @patch("cxas_scrapi.core.evaluations.EvaluationServiceClient")


### PR DESCRIPTION
Fixes #444

## Problem

`export_evaluation(output_path=...)` sideloads each evaluation expectation to
`evaluationExpectations/<md5>.json`, but writes `md5(prompt)` into the
`displayName` field — discarding the display name it just fetched from the
platform.

The impact is on the round trip. `push-eval` resolves expectations through
`find_or_create_evaluation_expectation`, which matches an existing resource
**by display name**. Since export rewrote the name to a hash, re-importing an
exported file no longer matches the original expectation and creates a
duplicate resource for the same prompt.

## Change

```diff
+ exp_display_name = (
+     getattr(exp_obj, "display_name", None)
+     or exp_id
+ )
  exp_content = {
-     "displayName": exp_id,
+     "displayName": exp_display_name,
      "llmCriteria": {"prompt": prompt_text},
  }
```

The filename stays `<md5>.json` — it is stable and collision free, so nothing
downstream that globs the directory changes. Only the field carries the real
name now, and it falls back to the hash when the resource has no display name.

## Test

Adds `test_export_evaluation_sideload_keeps_display_name`, which exports an
evaluation whose expectation is named `grounding-check` and asserts the
sideloaded JSON carries that name.

Verified the test fails without the fix (it reads back
`f29fee909c890e0853189f4521faa907`) and passes with it.

```
21 passed  tests/cxas_scrapi/core/test_evaluations.py
ruff check / ruff format  clean
```

https://claude.ai/code/session_01GossTWwycF9NKKpBjonvqv
