### PR TITLE
feat(evals): support configurable vertex location parameter

### DIFF
--- a/src/cxas_scrapi/cli/main.py
+++ b/src/cxas_scrapi/cli/main.py
@@ -670,6 +670,7 @@ def combined_evals_report_cmd(args: argparse.Namespace) -> None:
         capture_agent_audio=getattr(args, "capture_agent_audio", False),
         single_bidi_stream=getattr(args, "single_bidi_stream", False),
         report_format=getattr(args, "format", "html") or "html",
+        vertex_location=getattr(args, "vertex_location", "global") or "global",
     )
     print(f"Combined report generated at {actual_output_path}")
 
@@ -1856,6 +1857,11 @@ def get_parser() -> argparse.ArgumentParser:
         "--single-bidi-stream",
         action="store_true",
         help="Keep one persistent bidi WebSocket open per audio simulation instead of one connection per turn.",
+    )
+    parser_report.add_argument(
+        "--vertex-location",
+        default="global",
+        help="Vertex AI location for evaluation LLM models. Defaults to 'global'.",
     )
     parser_report.set_defaults(func=combined_evals_report_cmd)
 

--- a/src/cxas_scrapi/evals/runner.py
+++ b/src/cxas_scrapi/evals/runner.py
@@ -72,6 +72,7 @@ def run_all_evals(
     single_bidi_stream: bool = False,
     progress_callback: Callable[[str, int, int], None] | None = None,
     capture_agent_audio: bool = False,
+    vertex_location: str = "global",
 ) -> typing.Any:
     """Runs all 4 types of evaluations and returns aggregated results.
 
@@ -239,6 +240,7 @@ def run_all_evals(
                     rate_limiter=rate_limiter,
                     expectations_only=expectations_only,
                     deployment_id=deployment_id,
+                    vertex_location=vertex_location,
                 )
                 test_cases = []
                 for sf in sim_files:

--- a/src/cxas_scrapi/evals/simulation_evals.py
+++ b/src/cxas_scrapi/evals/simulation_evals.py
@@ -404,10 +404,12 @@ class SimulationEvals(Apps):
         rate_limiter: RateLimiter | None = None,
         expectations_only: bool = False,
         deployment_id: str | None = None,
+        vertex_location: str = "global",
         **kwargs: typing.Any,
     ) -> None:
         self.app_name = app_name
         self.expectations_only = expectations_only
+        self.vertex_location = vertex_location
         project_id = app_name.split("/")[1]
         location = app_name.split("/")[3]
         super().__init__(project_id=project_id, location=location, **kwargs)
@@ -419,13 +421,9 @@ class SimulationEvals(Apps):
         )
         self.tools_map = Tools(app_name=app_name, **kwargs).get_tools_map()
 
-        # Vertex AI requires a specific region (e.g. global), whereas CXAS
-        # Apps use 'us' or 'eu'
-        vertex_location = "global"
-
         self.genai_client = GeminiGenerate(
             project_id=self.project_id,
-            location=vertex_location,
+            location=self.vertex_location,
             credentials=self.creds,
         )
 

--- a/src/cxas_scrapi/evals/turn_evals.py
+++ b/src/cxas_scrapi/evals/turn_evals.py
@@ -132,6 +132,7 @@ class TurnEvals:
         app_name: str,
         creds: typing.Any = None,
         rate_limiter: RateLimiter | None = None,
+        vertex_location: str = "global",
     ) -> None:
         """Initializes the TurnEvals class.
 
@@ -139,9 +140,12 @@ class TurnEvals:
             app_name: CXAS App Name
             creds: Optional Google Cloud credentials
             rate_limiter: Optional RateLimiter for API calls
+            vertex_location: Vertex AI location for evaluation LLM calls.
+              Defaults to 'global'.
         """
         self.app_name = app_name
         self.creds = creds
+        self.vertex_location = vertex_location
         self.sessions_client = Sessions(
             app_name=self.app_name,
             creds=self.creds,
@@ -151,11 +155,10 @@ class TurnEvals:
 
         # Initialize GenAI Client
         project_id = app_name.split("/")[1]
-        vertex_location = "global"
 
         self.genai_client = GeminiGenerate(
             project_id=project_id,
-            location=vertex_location,
+            location=self.vertex_location,
             credentials=self.creds,
         )
 

--- a/src/cxas_scrapi/utils/reporting.py
+++ b/src/cxas_scrapi/utils/reporting.py
@@ -1574,6 +1574,7 @@ def generate_combined_report_from_dir(
     progress_callback: Callable[[str, int, int], None] | None = None,
     capture_agent_audio: bool = False,
     report_format: str = "html",
+    vertex_location: str = "global",
 ) -> str:
     """Load results from directory and generate a combined report.
 
@@ -1654,6 +1655,7 @@ def generate_combined_report_from_dir(
             single_bidi_stream=single_bidi_stream,
             progress_callback=progress_callback,
             capture_agent_audio=capture_agent_audio,
+            vertex_location=vertex_location,
         )
         sim_results = run_results["simulation"] if "sims" in include else []
         # Map tool results to expected format if needed
@@ -1857,6 +1859,7 @@ def run_all_evals(
     single_bidi_stream: bool = False,
     progress_callback: Callable[[str, int, int], None] | None = None,
     capture_agent_audio: bool = False,
+    vertex_location: str = "global",
 ) -> dict[str, Any]:
     """Runs all 4 types of evaluations and returns aggregated results.
 
@@ -1884,6 +1887,8 @@ def run_all_evals(
       use_tool_fakes: Use fake tools for the session if available.
       timestamp: Optional timestamp to append to result filenames.
       expectations_only: Run simulations checking expectations only.
+      vertex_location: Vertex AI location for evaluation LLM models.
+        Defaults to 'global'.
 
     Returns:
       A dict containing lists of results for 'simulation', 'golden', 'tool', and
@@ -1917,4 +1922,5 @@ def run_all_evals(
         single_bidi_stream=single_bidi_stream,
         progress_callback=progress_callback,
         capture_agent_audio=capture_agent_audio,
+        vertex_location=vertex_location,
     )

--- a/tests/cxas_scrapi/cli/test_cli_reporting.py
+++ b/tests/cxas_scrapi/cli/test_cli_reporting.py
@@ -101,6 +101,7 @@ def test_combined_evals_report_cmd(tmp_path: typing.Any) -> None:
             capture_agent_audio=False,
             single_bidi_stream=False,
             report_format="html",
+            vertex_location="global",
         )
 
 
@@ -167,6 +168,7 @@ def test_combined_evals_report_cmd_with_modality_and_runs(
             capture_agent_audio=False,
             single_bidi_stream=False,
             report_format="html",
+            vertex_location="global",
         )
 
 
@@ -238,6 +240,7 @@ def test_combined_evals_report_cmd_timestamped(
             capture_agent_audio=False,
             single_bidi_stream=False,
             report_format="html",
+            vertex_location="global",
         )
 
 
@@ -361,3 +364,43 @@ def test_combined_evals_report_cmd_with_deployment_id(
         mock_report.assert_called_once()
         call_kwargs = mock_report.call_args[1]
         assert call_kwargs["deployment_id"] == "test-dep-id"
+
+
+def test_combined_evals_report_cmd_with_vertex_location(
+    tmp_path: typing.Any,
+) -> None:
+    evals_dir = tmp_path / "evals"
+    evals_dir.mkdir()
+
+    class Args(argparse.Namespace):
+        def __init__(self) -> None:
+            self.output_dir = str(evals_dir)
+            self.output = None
+            self.gcs_path = None
+            self.golden_run = None
+            self.app_name = None
+            self.run = False
+            self.app_dir = None
+            self.tool_test_file = None
+            self.goldens_dir = None
+            self.simulation_dir = None
+            self.include = "sims"
+            self.input_dir = None
+            self.modality = "text"
+            self.runs = 1
+            self.use_tool_fakes = False
+            self.deployment_id = None
+            self.sim_user_model = None
+            self.eval_model = None
+            self.vertex_location = "europe-west4"
+
+    args = Args()
+
+    with patch(
+        "cxas_scrapi.utils.reporting.generate_combined_report_from_dir"
+    ) as mock_report:
+        combined_evals_report_cmd(args)
+
+        mock_report.assert_called_once()
+        call_kwargs = mock_report.call_args[1]
+        assert call_kwargs["vertex_location"] == "europe-west4"

--- a/tests/cxas_scrapi/evals/test_simulation_evals.py
+++ b/tests/cxas_scrapi/evals/test_simulation_evals.py
@@ -1790,3 +1790,39 @@ def test_simulation_evals_escalation_transfer_handling(
     assert (
         "Agent ended session via escalation/transfer" in step_prog.justification
     )
+
+
+def test_simulation_evals_default_vertex_location() -> None:
+    app_name = "projects/test/locations/us/apps/123-abc"
+    with (
+        patch(
+            "cxas_scrapi.evals.simulation_evals.GeminiGenerate"
+        ) as mock_gemini,
+        patch("cxas_scrapi.core.apps.AgentServiceClient"),
+    ):
+        simulator = SimulationEvals(app_name=app_name)
+    assert simulator.vertex_location == "global"
+    mock_gemini.assert_called_once_with(
+        project_id="test",
+        location="global",
+        credentials=simulator.creds,
+    )
+
+
+def test_simulation_evals_custom_vertex_location() -> None:
+    app_name = "projects/test/locations/us/apps/123-abc"
+    with (
+        patch(
+            "cxas_scrapi.evals.simulation_evals.GeminiGenerate"
+        ) as mock_gemini,
+        patch("cxas_scrapi.core.apps.AgentServiceClient"),
+    ):
+        simulator = SimulationEvals(
+            app_name=app_name, vertex_location="us-central1"
+        )
+    assert simulator.vertex_location == "us-central1"
+    mock_gemini.assert_called_once_with(
+        project_id="test",
+        location="us-central1",
+        credentials=simulator.creds,
+    )

--- a/tests/cxas_scrapi/evals/test_turn_evals.py
+++ b/tests/cxas_scrapi/evals/test_turn_evals.py
@@ -504,3 +504,40 @@ def test_turn_evals_init_with_rate_limiter(
         creds=None,
         rate_limiter=mock_rate_limiter,
     )
+
+
+@patch("cxas_scrapi.evals.turn_evals.GeminiGenerate")
+@patch("cxas_scrapi.evals.turn_evals.Variables")
+@patch("cxas_scrapi.evals.turn_evals.Sessions")
+def test_turn_evals_default_vertex_location(
+    mock_sessions: typing.Any,
+    mock_variables: typing.Any,
+    mock_gemini: typing.Any,
+) -> None:
+    evals = TurnEvals(app_name="projects/p/locations/l/apps/a")
+    assert evals.vertex_location == "global"
+    mock_gemini.assert_called_once_with(
+        project_id="p",
+        location="global",
+        credentials=None,
+    )
+
+
+@patch("cxas_scrapi.evals.turn_evals.GeminiGenerate")
+@patch("cxas_scrapi.evals.turn_evals.Variables")
+@patch("cxas_scrapi.evals.turn_evals.Sessions")
+def test_turn_evals_custom_vertex_location(
+    mock_sessions: typing.Any,
+    mock_variables: typing.Any,
+    mock_gemini: typing.Any,
+) -> None:
+    evals = TurnEvals(
+        app_name="projects/p/locations/l/apps/a",
+        vertex_location="us-central1",
+    )
+    assert evals.vertex_location == "us-central1"
+    mock_gemini.assert_called_once_with(
+        project_id="p",
+        location="us-central1",
+        credentials=None,
+    )

--- a/tests/cxas_scrapi/utils/test_reporting.py
+++ b/tests/cxas_scrapi/utils/test_reporting.py
@@ -885,6 +885,7 @@ def test_run_all_evals_include_filtering(
         rate_limiter=None,
         expectations_only=False,
         deployment_id=None,
+        vertex_location="global",
     )
     mock_sim_evals.return_value.run_simulations.assert_called_once()
 
@@ -1022,6 +1023,7 @@ def test_run_all_evals_dict_based_simulations(
         rate_limiter=None,
         expectations_only=False,
         deployment_id=None,
+        vertex_location="global",
     )
     mock_sim_evals.return_value.run_simulations.assert_called_once_with(
         [
@@ -1088,6 +1090,52 @@ def test_run_all_evals_with_deployment_id(
         rate_limiter=None,
         expectations_only=False,
         deployment_id="dep123",
+        vertex_location="global",
+    )
+
+
+@patch("cxas_scrapi.evals.runner.Evaluations")
+@patch("cxas_scrapi.evals.runner.ToolEvals")
+@patch("cxas_scrapi.evals.runner.SimulationEvals")
+@patch("cxas_scrapi.evals.runner.CallbackEvals")
+@patch("cxas_scrapi.evals.runner.EvalUtils")
+@patch("glob.glob")
+@patch("os.path.exists")
+@patch("os.path.isdir")
+@patch("yaml.safe_load")
+@patch("builtins.open", new_callable=mock_open)
+def test_run_all_evals_custom_vertex_location(
+    mock_open_file: typing.Any,
+    mock_yaml_load: typing.Any,
+    mock_isdir: typing.Any,
+    mock_exists: typing.Any,
+    mock_glob: typing.Any,
+    mock_eval_utils: typing.Any,
+    mock_callback_evals: typing.Any,
+    mock_sim_evals: typing.Any,
+    mock_tool_evals: typing.Any,
+    mock_evaluations: typing.Any,
+) -> None:
+    mock_exists.return_value = True
+    mock_isdir.return_value = True
+    mock_glob.side_effect = [
+        ["evals/simulations/sim1.yaml"],
+    ]
+    mock_yaml_load.return_value = [{"name": "sim1"}]
+
+    run_all_evals(
+        app_name="projects/p",
+        include=["sims"],
+        simulation_dir="evals/simulations/",
+        vertex_location="europe-west1",
+    )
+
+    mock_sim_evals.assert_called_once_with(
+        app_name="projects/p",
+        rate_limiter=None,
+        expectations_only=False,
+        deployment_id=None,
+        vertex_location="europe-west1",
     )
 
 
@@ -1292,6 +1340,7 @@ def test_run_all_evals_expectations_only(
         single_bidi_stream=False,
         progress_callback=None,
         capture_agent_audio=False,
+        vertex_location="global",
     )
 
 


### PR DESCRIPTION
## Summary

Adds support for configuring the Vertex AI location parameter across evaluation modules (`SimulationEvals`, `TurnEvals`, `run_all_evals`, `generate_combined_report_from_dir`) and the `cxas evals report` CLI command, defaulting to `"global"` to preserve existing behavior.

Previously, `vertex_location` was hardcoded to `"global"` when initializing `GeminiGenerate` for evaluation models in `SimulationEvals` and `TurnEvals`.

## Changes

- **`SimulationEvals`**: Added `vertex_location: str = "global"` parameter to `__init__`, stored on `self.vertex_location`, and passed to `GeminiGenerate`.
- **`TurnEvals`**: Added `vertex_location: str = "global"` parameter to `__init__`, stored on `self.vertex_location`, and passed to `GeminiGenerate`.
- **`runner.py` / `reporting.py`**: Added `vertex_location: str = "global"` parameter to `run_all_evals` and `generate_combined_report_from_dir` and passed it down to `SimulationEvals`.
- **CLI (`main.py`)**: Added `--vertex-location` flag to `cxas evals report` (defaults to `"global"`).
- **Tests**: Added unit tests covering default and custom `vertex_location` parameters across all modified components.

## Testing

- Ran `uv run pytest tests/cxas_scrapi/evals/test_simulation_evals.py tests/cxas_scrapi/evals/test_turn_evals.py tests/cxas_scrapi/utils/test_reporting.py tests/cxas_scrapi/cli/test_cli_reporting.py` (116 passed).
- Verified linting and formatting with `.venv/bin/ruff check` and `.venv/bin/ruff format --check`.