### PR TITLE
fix(bidi): end sim session on self-terminating transfer payload

### DIFF
--- a/src/cxas_scrapi/core/response_parser.py
+++ b/src/cxas_scrapi/core/response_parser.py
@@ -23,6 +23,19 @@ from google.protobuf.json_format import MessageToDict
 
 logger = logging.getLogger(__name__)
 
+# Transfer directives that hand the session off to another agent with no
+# paired end_session (self-terminating vendors, flows >= 0.42.0): the directive
+# IS the teardown. Callers waiting on a bidi stream must treat one as the end of
+# the session, or they block for an end_session that never arrives and time out.
+SELF_TERMINATING_TRANSFER_KEYS = ("transferToNga", "transferToDialogflow")
+
+
+def payload_ends_session(payload_val: Any) -> bool:
+    """True if a custom payload carries a self-terminating transfer."""
+    return isinstance(payload_val, dict) and any(
+        key in payload_val for key in SELF_TERMINATING_TRANSFER_KEYS
+    )
+
 
 def expand_pb_struct(pb_struct: Any) -> Any:
     """Helper to recursively convert protobuf Struct/Map/Message to standard
@@ -238,6 +251,8 @@ class ParsedSessionResponse:
                 self.detailed_trace.append(
                     f"Custom Payload (Output): {payload_val}"
                 )
+                if payload_ends_session(payload_val):
+                    self.session_ended = True
 
             # Top-level tool calls
             tc_msg = getattr(output, "tool_calls", None)
@@ -392,6 +407,8 @@ class ParsedSessionResponse:
                                 self.detailed_trace.append(
                                     f"Custom Payload: {payload_val}"
                                 )
+                                if payload_ends_session(payload_val):
+                                    self.session_ended = True
 
                     # Also check action transfer at the message level
                     actions = getattr(message, "actions", None)

--- a/src/cxas_scrapi/core/sessions.py
+++ b/src/cxas_scrapi/core/sessions.py
@@ -60,7 +60,11 @@ import contextlib
 
 from cxas_scrapi.core.common import DEFAULT_API_ENDPOINT, Common
 from cxas_scrapi.core.conversation_history import ConversationHistory
-from cxas_scrapi.core.response_parser import ParsedSessionResponse
+from cxas_scrapi.core.response_parser import (
+    ParsedSessionResponse,
+    expand_pb_struct,
+    payload_ends_session,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -342,6 +346,9 @@ class BidiSessionHandler:
         self._close_status_code: int | None = None
         self._close_msg: str | None = None
         self._connection_error: BaseException | None = None
+        # Set once a self-terminating transfer payload is seen: the session is
+        # over, so the socket close that follows is the expected teardown.
+        self._self_terminated_transfer = False
 
         # Setup continuous background noise segment if provided
         self.bg_noise_segment = None
@@ -829,8 +836,44 @@ class BidiSessionHandler:
                         }
                     )
 
+            # A self-terminating transfer (transferToNga /
+            # transferToDialogflow) hands off with the payload ALONE and no
+            # end_session; the server then closes the socket
+            # (failed_precondition "goodbye"). turn_completed may or may not
+            # fire first, so emit the turn here (if not already flushed) to
+            # capture the transfer, end the session, and mark it so the
+            # impending close reads as a clean teardown, not a connection
+            # error.
+            if (
+                self.interactive
+                and not self._self_terminated_transfer
+                and self.response_queue is not None
+                and response.session_output
+                and self._output_ends_session(response.session_output)
+            ):
+                self._self_terminated_transfer = True
+                if self.current_turn_outputs:
+                    self.response_queue.put(
+                        ScrapiRunSessionResponse(
+                            original_response=types.RunSessionResponse(
+                                outputs=list(self.current_turn_outputs)
+                            ),
+                            agent_audio_paths={},
+                        )
+                    )
+                    self.current_turn_outputs = []
+                self.response_queue.put({"session_ended": True})
+
         except Exception as e:
             logging.debug("Failed to parse message: %s", e)
+
+    @staticmethod
+    def _output_ends_session(session_output: typing.Any) -> bool:
+        """True if a session_output carries a self-terminating transfer."""
+        payload = getattr(session_output, "payload", None)
+        if not payload:
+            return False
+        return payload_ends_session(expand_pb_struct(payload))
 
     def _should_skip_output(self, response: typing.Any) -> bool:
         """Filters comfort-noise/ack packets and stale-turn output.
@@ -899,12 +942,19 @@ class BidiSessionHandler:
         # Stash connection-level errors
         self._connection_error = error
         if self.response_queue is not None:
-            self.response_queue.put(
-                {
-                    "session_ended": True,
-                    "connection_error": error,
-                }
-            )
+            if self._self_terminated_transfer:
+                # A self-terminating transfer already ended the session; the
+                # socket close that follows (failed_precondition "goodbye") is
+                # the expected teardown, not a connection failure -- report a
+                # clean end.
+                self.response_queue.put({"session_ended": True})
+            else:
+                self.response_queue.put(
+                    {
+                        "session_ended": True,
+                        "connection_error": error,
+                    }
+                )
 
     def _on_close(
         self,

--- a/tests/cxas_scrapi/core/test_response_parser.py
+++ b/tests/cxas_scrapi/core/test_response_parser.py
@@ -16,7 +16,10 @@ from types import SimpleNamespace
 
 from google.cloud.ces_v1beta import types
 
-from cxas_scrapi.core.response_parser import ParsedSessionResponse
+from cxas_scrapi.core.response_parser import (
+    ParsedSessionResponse,
+    payload_ends_session,
+)
 
 
 def test_parser_basic_text() -> None:
@@ -308,3 +311,39 @@ def test_parser_top_level_citations_and_payload() -> None:
     assert parsed.custom_payloads[0] == {"custom_field": "custom_value"}
     expected_trace = "Custom Payload (Output): {'custom_field': 'custom_value'}"
     assert expected_trace in parsed.detailed_trace
+
+
+def test_payload_ends_session_helper() -> None:
+    """The helper recognizes self-terminating transfer directives only."""
+    assert payload_ends_session({"transferToNga": "projects/p/.../apps/a"})
+    assert payload_ends_session(
+        {"transferToDialogflow": "projects/p/.../agents/a", "variables": {}}
+    )
+    assert not payload_ends_session({"custom_field": "custom_value"})
+    assert not payload_ends_session("not-a-dict")
+    assert not payload_ends_session(None)
+
+
+def test_parser_self_terminating_transfer_ends_session() -> None:
+    """A transfer custom payload ends the session even without end_session.
+
+    Self-terminating transfers (transferToNga / transferToDialogflow, flows
+    >= 0.42.0) hand off with the directive alone and no paired end_session; a
+    bidi caller that waits for end_session would otherwise hang until timeout.
+    """
+    output = SimpleNamespace(
+        citations=None,
+        payload={
+            "transferToNga": "projects/p/locations/us/apps/a",
+            "variables": {"skip_greeting": "true"},
+        },
+        text=None,
+        end_session=None,
+        tool_calls=None,
+        diagnostic_info=None,
+    )
+
+    parsed = ParsedSessionResponse([output])
+    assert parsed.session_ended is True
+    assert len(parsed.custom_payloads) == 1
+    assert "transferToNga" in parsed.custom_payloads[0]

--- a/tests/cxas_scrapi/core/test_sessions.py
+++ b/tests/cxas_scrapi/core/test_sessions.py
@@ -1140,3 +1140,66 @@ def test_bidi_session_handler_with_proto_session_config(
     handler._send_inputs()
 
     assert mock_message_to_json.call_count >= 1
+
+
+def test_output_ends_session_recognizes_self_terminating_transfer() -> None:
+    """_output_ends_session is True only for a self-terminating transfer payload."""
+    transfer = types.SessionOutput()
+    json_format.ParseDict(
+        {"payload": {"transferToNga": "projects/p/locations/us/apps/a"}},
+        transfer._pb,
+        ignore_unknown_fields=True,
+    )
+    assert BidiSessionHandler._output_ends_session(transfer) is True
+
+    plain_payload = types.SessionOutput()
+    json_format.ParseDict(
+        {"payload": {"custom_field": "custom_value"}},
+        plain_payload._pb,
+        ignore_unknown_fields=True,
+    )
+    assert BidiSessionHandler._output_ends_session(plain_payload) is False
+
+    text_only = types.SessionOutput(text="hello")
+    assert BidiSessionHandler._output_ends_session(text_only) is False
+
+
+def test_bidi_session_handler_transfer_ends_session() -> None:
+    """A self-terminating transfer payload ends an interactive session.
+
+    Since flows >= 0.42.0 a transfer (transferToNga / transferToDialogflow)
+    hands off with the payload alone and no paired end_session. An interactive
+    bidi handler must treat it as the end of the session and enqueue the turn,
+    or a caller waiting for end_session would hang until the socket close.
+    """
+    handler = BidiSessionHandler(
+        location="us",
+        token="fake",
+        config={"session": "s"},
+        input_queue=queue.Queue(),
+        response_queue=queue.Queue(),
+    )
+
+    message = types.BidiSessionServerMessage(
+        session_output=types.SessionOutput(turn_completed=True)
+    )
+    json_format.ParseDict(
+        {
+            "sessionOutput": {
+                "payload": {"transferToNga": "projects/p/locations/us/apps/a"}
+            }
+        },
+        message._pb,
+        ignore_unknown_fields=True,
+    )
+    json_data = json_format.MessageToJson(
+        message._pb, preserving_proto_field_name=False
+    )
+
+    handler._on_message(MagicMock(), json_data)
+
+    assert handler._self_terminated_transfer is True
+    drained = []
+    while not handler.response_queue.empty():
+        drained.append(handler.response_queue.get_nowait())
+    assert {"session_ended": True} in drained


### PR DESCRIPTION
Self-terminating transfers (transferToNga / transferToDialogflow) hand the session off with the directive alone and no paired end_session. The bidi interactive harness waits for an end_session that never arrives and times out after 90s ("Timeout waiting for agent response via WebSocket"), so every transfer, handoff, and escalation audio sim fails as a transport timeout instead of being graded.