### PR TITLE
fix(ci): use built-in GITHUB_TOKEN for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,7 +19,7 @@ jobs:
         id: release
         with:
           release-type: python
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   publish-pypi:
     needs: release-please

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,16 +6,18 @@ on:
       - main
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
     steps:
-      - uses: googleapis/release-please-action@v5
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
           release-type: python
@@ -29,14 +31,18 @@ jobs:
       name: pypi
       url: https://pypi.org/p/cxas-scrapi
     permissions:
+      contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
+          enable-cache: false
           python-version: '3.12'
       - name: Build package
         run: uv build
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2


### PR DESCRIPTION
The release-please workflow passed a personal access token via secrets.GH_TOKEN. That PAT expired, so every Release Please run since ~Aug 25 failed with 'Bad credentials' and no releases have been cut.

Switch to the built-in secrets.GITHUB_TOKEN, which never expires. The workflow's permissions block already grants contents:write and pull-requests:write, which is all release-please needs to open the release PR and publish GitHub releases (and gate the PyPI job).